### PR TITLE
storage/renderer: Set status code to 404 if not found

### DIFF
--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -44,7 +44,7 @@ export abstract class Renderer {
 
       if (err.$metadata?.httpStatusCode === 404) {
         response.header('cache-control', 'no-store')
-        return response.status(400).send({
+        return response.status(404).send({
           error: 'Not found',
           message: 'The resource was not found',
           statusCode: '404',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Return 400 if object not found

## What is the new behavior?

Return 404 instead

## Additional context

Fix https://github.com/supabase/storage-api/issues/323