### PR TITLE
fix(uploader): mime type invalid http status code

### DIFF
--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -246,7 +246,7 @@ export class Uploader {
       }
     }
 
-    throw new StorageBackendError('invalid_mime_type', 422, 'mime type not supported')
+    throw new StorageBackendError('invalid_mime_type', 415, 'mime type not supported')
   }
 
   protected async incomingFileInfo(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Aligns with proper status codes, to return a 415 on unsupported mime types instead of 422.

## What is the current behavior?

Failing with a 422 status code.
Closes: #329 

## What is the new behavior?

Failing with a 415 status code.
