### PR TITLE
ci: bump node to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-20.04]
-        node: ['18']
+        node: ['20']
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
18 is no longer LTS.