### PR TITLE
fix: content-type charset

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -237,7 +237,9 @@ export class Storage {
         )
       }
 
-      if (!type.match(/^[a-zA-Z0-9\-\+]+\/([a-zA-Z0-9\-\+\.]+$)|\*$/)) {
+      if (
+        !type.match(/^([a-zA-Z0-9\-+.]+)\/([a-zA-Z0-9\-+.]+)(;\s*charset=[a-zA-Z0-9\-]+)?$|\*$/)
+      ) {
         throw new StorageBackendError(
           'invalid_mime_type',
           422,

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -226,11 +226,13 @@ export class Uploader {
         continue
       }
 
-      if (allowedMime[0] === type && allowedMime[1] === '*') {
+      const [allowedType, allowedExtension] = allowedMime
+
+      if (allowedType === type && allowedExtension === '*') {
         return true
       }
 
-      if (allowedMime[0] === type && allowedMime[1] === ext) {
+      if (allowedType === type && allowedExtension === ext) {
         return true
       }
     }
@@ -267,7 +269,8 @@ export class Uploader {
         const cacheTime = formData.fields.cacheControl?.value
 
         body = formData.file
-        mimeType = formData.mimetype
+        /* @ts-expect-error: https://github.com/aws/aws-sdk-js-v3/issues/2085 */
+        mimeType = formData.fields.contentType?.value || formData.mimetype
         cacheControl = cacheTime ? `max-age=${cacheTime}` : 'no-cache'
         isTruncated = () => formData.file.truncated
       } catch (e) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When explicitly passing `contentType: text/vtt;charset=utf-8` the charset is not retained in the response

## What is the new behavior?

honor the content type provided in the form data

## Additional context

Fixes #366 