### PR TITLE
Feat: stale-while-revalidate

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,8 @@ type StorageConfigType = {
   tusPath: string
   tusUseFileVersionSeparator: boolean
   enableDefaultMetrics: boolean
+  sMaxAge: number
+  etagHeaders: string[]
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -246,5 +248,7 @@ export function getConfig(): StorageConfigType {
     tusUseFileVersionSeparator:
       getOptionalConfigFromEnv('TUS_USE_FILE_VERSION_SEPARATOR') === 'true',
     enableDefaultMetrics: getOptionalConfigFromEnv('ENABLE_DEFAULT_METRICS') === 'true',
+    sMaxAge: parseInt(getOptionalConfigFromEnv('S_MAXAGE') || '0', 10),
+    etagHeaders: getOptionalConfigFromEnv('ETAG_HEADERS')?.trim().split(',') || ['if-none-match'],
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

This PR implements a couple of interesting features

- allow the CDN to cache assets for longer useing the `s-maxage` directive configurable with `S_MAXAGE` env (default 0)
- use `stale-while-revalidate` when the origin detects that the requested etag header doesn't match with what we have in the metadata, resulting in the CDN serving stale content for 30s after the initial fetch. This will increase performance.
- the HEAD rendered will now instruct the CDN that `must-revalidate` when a request is sent to origin with a different etag

## Additional context

Unlocks Smart-CDN-V2
