### PR TITLE
Remove postgres extensions dependencies

### DIFF
--- a/migrations/tenant/0002-storage-schema.sql
+++ b/migrations/tenant/0002-storage-schema.sql
@@ -6,10 +6,6 @@ BEGIN
     END IF;
 END$$;
 
-
-create extension if not exists "uuid-ossp" WITH schema storage;
-create extension if not exists pgcrypto WITH schema storage;
-
 DO $$
 DECLARE
     install_roles text = COALESCE(current_setting('storage.install_roles', true), 'true');
@@ -58,7 +54,7 @@ CREATE TABLE IF NOT EXISTS "storage"."buckets" (
 CREATE UNIQUE INDEX IF NOT EXISTS "bname" ON "storage"."buckets" USING BTREE ("name");
 
 CREATE TABLE IF NOT EXISTS "storage"."objects" (
-    "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
     "bucket_id" text,
     "name" text,
     "owner" uuid,

--- a/migrations/tenant/0019-alter-default-value-objects-id.sql
+++ b/migrations/tenant/0019-alter-default-value-objects-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE storage.objects ALTER COLUMN id SET DEFAULT gen_random_uuid();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, the storage schema relies on the `ossd-uuid` extension specifically on the `uuid_generate_v4()` function.

## What is the new behavior?

Storage drops support for PG 12 - and is now only compatible with > PG 13, which allows us to use the built-in function `gen_random_uuid` and remove dependencies on other extensions.

pgcrypto extension was also removed since there was no usage in the code-base
