### PR TITLE
fix: db install roles default env to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           GLOBAL_S3_ENDPOINT: http://127.0.0.1:9000
           GLOBAL_S3_PROTOCOL: http
           GLOBAL_S3_FORCE_PATH_STYLE: true
+          DB_INSTALL_ROLES: true
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,7 +225,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     dbAnonRole: getOptionalConfigFromEnv('DB_ANON_ROLE') || 'anon',
     dbServiceRole: getOptionalConfigFromEnv('DB_SERVICE_ROLE') || 'service_role',
     dbAuthenticatedRole: getOptionalConfigFromEnv('DB_AUTHENTICATED_ROLE') || 'authenticated',
-    dbInstallRoles: !(getOptionalConfigFromEnv('DB_INSTALL_ROLES') === 'false'),
+    dbInstallRoles: getOptionalConfigFromEnv('DB_INSTALL_ROLES') === 'true',
     dbRefreshMigrationHashesOnMismatch: !(
       getOptionalConfigFromEnv('DB_ALLOW_MIGRATION_REFRESH') === 'false'
     ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

DB_INSTALL_ROLES default to true

## What is the new behavior?

DB_INSTALL_ROLES default to false
