### PR TITLE
fix: check for public bucket on info request

### DIFF
--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -38,6 +38,9 @@ async function requestHandler(
 
   let obj: Obj
   if (publicRoute) {
+    await request.storage.asSuperUser().findBucket(bucketName, 'id', {
+      isPublic: true,
+    })
     obj = await request.storage.asSuperUser().from(bucketName).findObject(objectName, 'id,version')
   } else {
     obj = await request.storage.from(bucketName).findObject(objectName, 'id,version')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Always check if the bucket is public on info requests
