### PR TITLE
Accept forwarded header on S3 signature

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,7 @@ type StorageConfigType = {
   tusUseFileVersionSeparator: boolean
   defaultMetricsEnabled: boolean
   s3ProtocolPrefix: string
+  s3ProtocolAllowForwardedHeader: boolean
   s3ProtocolEnforceRegion: boolean
   s3ProtocolAccessKeyId?: string
   s3ProtocolAccessKeySecret?: string
@@ -223,6 +224,8 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
 
     // S3 Protocol
     s3ProtocolPrefix: getOptionalConfigFromEnv('S3_PROTOCOL_PREFIX') || '',
+    s3ProtocolAllowForwardedHeader:
+      getOptionalConfigFromEnv('S3_ALLOW_FORWARDED_HEADER') === 'true',
     s3ProtocolEnforceRegion: getOptionalConfigFromEnv('S3_PROTOCOL_ENFORCE_REGION') === 'true',
     s3ProtocolAccessKeyId: getOptionalConfigFromEnv('S3_PROTOCOL_ACCESS_KEY_ID'),
     s3ProtocolAccessKeySecret: getOptionalConfigFromEnv('S3_PROTOCOL_ACCESS_KEY_SECRET'),

--- a/src/database/migrations/migrate.ts
+++ b/src/database/migrations/migrate.ts
@@ -187,7 +187,7 @@ async function connectAndMigrate(options: {
 
   const dbConfig: ClientConfig = {
     connectionString: databaseUrl,
-    connectionTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 60_000,
     options: `-c search_path=${searchPath}`,
     ssl,
   }

--- a/src/queue/events/base-event.ts
+++ b/src/queue/events/base-event.ts
@@ -166,6 +166,7 @@ export abstract class BaseEvent<T extends Omit<BasePayload, '$version'>> {
       superUser: adminUser,
       host: payload.tenant.host,
       tenantId: payload.tenant.ref,
+      disableHostCheck: true,
     })
 
     const db = new StorageKnexDB(client, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Not possible to run the S3 protocol on CLI, the x-forwarded-header is always overwritten from kong

## What is the new behavior?

- Allow using the arbitrary `Forwarded` header to determine the host
- Increase database migrations timeout to 60s
- disable host check on queue events