### PR TITLE
fix: exclude empty headers on S3 protocol

### DIFF
--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -62,7 +62,9 @@ export default async function routes(fastify: FastifyInstance) {
 
               if (headers) {
                 Object.keys(headers).forEach((header) => {
-                  reply.header(header, headers[header])
+                  if (headers[header]) {
+                    reply.header(header, headers[header])
+                  }
                 })
               }
               return reply.status(output.statusCode || 200).send(output.responseBody)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some S3 Clients tries to parse headers if returned as empty causing issues.

## What is the new behavior?

Empty headers are not returned
