### PR TITLE
fix: add object tagging stub endpoint

### DIFF
--- a/src/http/routes/s3/commands/get-object.ts
+++ b/src/http/routes/s3/commands/get-object.ts
@@ -1,7 +1,7 @@
 import { S3ProtocolHandler } from '../../../../storage/protocols/s3/s3-handler'
 import { S3Router } from '../router'
 
-const ListObjectsInput = {
+const GetObjectInput = {
   summary: 'Get Object',
   Params: {
     type: 'object',
@@ -22,8 +22,36 @@ const ListObjectsInput = {
   Querystring: {},
 } as const
 
-export default function ListObjects(s3Router: S3Router) {
-  s3Router.get('/:Bucket/*', ListObjectsInput, (req, ctx) => {
+const GetObjectTagging = {
+  summary: 'Get Object Tagging',
+  Params: {
+    type: 'object',
+    properties: {
+      Bucket: { type: 'string' },
+      '*': { type: 'string' },
+    },
+    required: ['Bucket', '*'],
+  },
+  Querystring: {
+    type: 'object',
+    properties: {
+      tagging: { type: 'string' },
+    },
+    required: ['tagging'],
+  },
+} as const
+
+export default function GetObject(s3Router: S3Router) {
+  s3Router.get('/:Bucket/*?tagging', GetObjectTagging, (req, ctx) => {
+    const s3Protocol = new S3ProtocolHandler(ctx.storage, ctx.tenantId, ctx.owner)
+
+    return s3Protocol.getObjectTagging({
+      Bucket: req.Params.Bucket,
+      Key: req.Params['*'],
+    })
+  })
+
+  s3Router.get('/:Bucket/*', GetObjectInput, (req, ctx) => {
     const s3Protocol = new S3ProtocolHandler(ctx.storage, ctx.tenantId, ctx.owner)
     const ifModifiedSince = req.Headers?.['if-modified-since']
 

--- a/src/http/routes/s3/commands/upload-part.ts
+++ b/src/http/routes/s3/commands/upload-part.ts
@@ -22,6 +22,11 @@ const PutObjectInput = {
       'x-amz-content-sha256': { type: 'string' },
       'x-amz-date': { type: 'string' },
       'content-type': { type: 'string' },
+      'content-length': { type: 'integer' },
+      'cache-control': { type: 'string' },
+      'content-disposition': { type: 'string' },
+      'content-encoding': { type: 'string' },
+      expires: { type: 'string' },
     },
   },
 } as const
@@ -85,6 +90,10 @@ export default function UploadPart(s3Router: S3Router) {
         Body: ctx.req as any,
         Bucket: req.Params.Bucket,
         Key: req.Params['*'],
+        CacheControl: req.Headers?.['cache-control'],
+        ContentType: req.Headers?.['content-type'],
+        Expires: req.Headers?.['expires'] ? new Date(req.Headers?.['expires']) : undefined,
+        ContentEncoding: req.Headers?.['content-encoding'],
       })
     },
     { disableContentTypeParser: true }

--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -207,7 +207,8 @@ export abstract class StorageBackendAdapter {
     UploadId: string,
     PartNumber: number,
     sourceKey: string,
-    sourceKeyVersion?: string
+    sourceKeyVersion?: string,
+    bytes?: { fromByte: number; toByte: number }
   ): Promise<{ eTag?: string; lastModified?: Date }> {
     throw new Error('not implemented')
   }

--- a/src/storage/backend/s3.ts
+++ b/src/storage/backend/s3.ts
@@ -9,9 +9,7 @@ import {
   GetObjectCommand,
   GetObjectCommandInput,
   HeadObjectCommand,
-  ListMultipartUploadsCommand,
   ListPartsCommand,
-  PutObjectCommand,
   S3Client,
   S3ClientConfig,
   UploadPartCommand,
@@ -417,7 +415,8 @@ export class S3Backend implements StorageBackendAdapter {
     UploadId: string,
     PartNumber: number,
     sourceKey: string,
-    sourceKeyVersion?: string
+    sourceKeyVersion?: string,
+    bytesRange?: { fromByte: number; toByte: number }
   ) {
     const uploadPartCopy = new UploadPartCopyCommand({
       Bucket: storageS3Bucket,
@@ -425,6 +424,7 @@ export class S3Backend implements StorageBackendAdapter {
       UploadId,
       PartNumber,
       CopySource: `${storageS3Bucket}/${withOptionalVersion(sourceKey, sourceKeyVersion)}`,
+      CopySourceRange: bytesRange ? `bytes=${bytesRange.fromByte}-${bytesRange.toByte}` : undefined,
     })
 
     const part = await this.client.send(uploadPartCopy)

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -38,7 +38,6 @@ interface Credentials {
  */
 export const ALWAYS_UNSIGNABLE_HEADERS = {
   authorization: true,
-  'cache-control': true,
   connection: true,
   expect: true,
   from: true,

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -231,7 +231,10 @@ export class ImageRenderer extends Renderer {
       }
     } catch (e) {
       if (e instanceof AxiosError) {
-        await this.handleRequestError(e)
+        const error = await this.handleRequestError(e)
+        throw error.withMetadata({
+          transformations,
+        })
       }
 
       throw e
@@ -241,7 +244,7 @@ export class ImageRenderer extends Renderer {
   protected async handleRequestError(error: AxiosError) {
     const stream = error.response?.data as Stream
     if (!stream) {
-      throw ERRORS.InternalError(error)
+      throw ERRORS.InternalError(undefined, error.message)
     }
 
     const errorResponse = await new Promise<string>((resolve) => {
@@ -257,7 +260,7 @@ export class ImageRenderer extends Renderer {
     })
 
     const statusCode = error.response?.status || 500
-    throw ERRORS.ImageProcessingError(statusCode, errorResponse, error)
+    return ERRORS.ImageProcessingError(statusCode, errorResponse)
   }
 }
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -1081,20 +1081,6 @@ describe('S3 Protocol', () => {
 
         const parts = await client.send(listPartsCmd)
         expect(parts.Parts?.length).toBe(1)
-
-        const completeMultiPartUpload = new CompleteMultipartUploadCommand({
-          Bucket: bucket,
-          Key: newKey,
-          UploadId: resp.UploadId,
-          MultipartUpload: {
-            Parts: [
-              {
-                PartNumber: 1,
-                ETag: copyResp.CopyPartResult?.ETag,
-              },
-            ],
-          },
-        })
       })
     })
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- Add object tagging stub endpoint so that aws cli works as intended when copying across buckets
- Whitelist additional headers
- remove cache-control from non-signable headers (aws SDK actually signs it)
- Implemented PartCopy command on file driver
