### PR TITLE
Consistent RLS access for S3 session token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       IMAGE_TRANSFORMATION_ENABLED: "true"
       IMGPROXY_URL: http://imgproxy:8080
       IMGPROXY_REQUEST_TIMEOUT: 15
+      # S3 Protocol
+      S3_PROTOCOL_ACCESS_KEY_ID: 625729a08b95bf1b7ff351a663f3a23c
+      S3_PROTOCOL_ACCESS_KEY_SECRET: 850181e4652dd023b7a98c58ae0d2d34bd487ee0cc3254aed6eda37307425907
 
   tenant_db:
     extends:

--- a/src/http/plugins/xml.ts
+++ b/src/http/plugins/xml.ts
@@ -19,10 +19,8 @@ export const jsonToXml = fastifyPlugin(async function (
   }
   fastify.addHook('preSerialization', async (req, res, payload) => {
     const accept = req.accepts()
-    if (
-      res.getHeader('content-type')?.toString()?.includes('application/json') &&
-      accept.types(['application/xml', 'application/json']) === 'application/xml'
-    ) {
+
+    if (accept.types(['application/xml', 'application/json']) === 'application/xml') {
       res.serializer((payload) => payload)
 
       const xmlBuilder = new xml.Builder({

--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -4,7 +4,7 @@ import { FastifyReply, FastifyRequest } from 'fastify'
 import { URL } from 'url'
 import { normalizeRawError } from '../storage'
 
-const { logLevel, logflareApiKey, logflareSourceToken, logflareEnabled } = getConfig()
+const { logLevel, logflareApiKey, logflareSourceToken, logflareEnabled, region } = getConfig()
 
 export const logger = pino({
   transport: buildTransport(),
@@ -20,6 +20,7 @@ export const logger = pino({
     },
     req(request) {
       return {
+        region,
         traceId: request.id,
         method: request.method,
         url: redactQueryParamFromRequest(request, ['token']),
@@ -138,10 +139,13 @@ const whitelistHeaders = (headers: Record<string, unknown>) => {
     'upload-length',
     'upload-offset',
     'tus-resumable',
+    'range',
   ]
   const allowlistedResponseHeaders = [
     'cf-cache-status',
     'cf-ray',
+    'location',
+    'cache-control',
     'content-location',
     'content-range',
     'content-type',
@@ -152,6 +156,11 @@ const whitelistHeaders = (headers: Record<string, unknown>) => {
     'x-kong-upstream-latency',
     'sb-gateway-mode',
     'sb-gateway-version',
+    'x-transformations',
+    'expires',
+    'etag',
+    'content-disposition',
+    'last-modified',
   ]
   Object.keys(headers)
     .filter(

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -392,6 +392,8 @@ export class ObjectStorage {
       const metadata = await this.backend.headObject(storageS3Bucket, s3DestinationKey, newVersion)
 
       return this.db.asSuperUser().withTransaction(async (db) => {
+        await db.waitObjectLock(this.bucketId, destinationObjectName)
+
         const sourceObject = await db.findObject(this.bucketId, sourceObjectName, 'id', {
           forUpdate: true,
           dontErrorOnEmpty: false,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- S3 Upload Multipart requires RLS policies on the `s3_multipart_uploads` and `s3_multipart_uploads_parts` tables
- Move object command required SELECT + UPDATE + INSERT

## What is the new behavior?

- Removed the need for RLS policies in `s3_multipart_uploads` and `s3_multipart_uploads_parts`
- Only policies to the `objects` table are required to derive the access control for the MultiPart upload
- Move object command only requires SELECT source + INSERT destination RLS policy
