### PR TITLE
fix: knexjs edge case on transaction

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -19,6 +19,7 @@ export const setErrorHandler = (app: FastifyInstance) => {
     if (
       error instanceof DatabaseError &&
       [
+        'Authentication error', // supavisor specific
         'Max client connections reached',
         'remaining connection slots are reserved for non-replication superuser connections',
         'no more connections allowed',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

When there is an error during the creation of a transaction, there is a bug in knex https://github.com/knex/knex/issues/4709 where the error is not consistent and propagated.

## What is the new behaviour?

This PR patches this weird behaviour by awaiting the `exectionPromise` if the transaction is already marked as completed. Forcing the exception to bubble up.