### PR TITLE
feat: allow upload signed url to overwrite files

### DIFF
--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -24,6 +24,7 @@ export type SignedToken = {
 
 export type SignedUploadToken = {
   owner: string | undefined
+  upsert: boolean
   url: string
   exp: number
 }

--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -15,6 +15,15 @@ const getSignedUploadURLParamsSchema = {
   required: ['bucketName', '*'],
 } as const
 
+const getSignedUploadURLHeadersSchema = {
+  type: 'object',
+  properties: {
+    'x-upsert': { type: 'string' },
+    authorization: { type: 'string' },
+  },
+  required: ['authorization'],
+} as const
+
 const successResponseSchema = {
   type: 'object',
   properties: {
@@ -29,6 +38,7 @@ const successResponseSchema = {
 }
 interface getSignedURLRequestInterface extends AuthenticatedRequest {
   Params: FromSchema<typeof getSignedUploadURLParamsSchema>
+  Headers: FromSchema<typeof getSignedUploadURLHeadersSchema>
 }
 
 export default async function routes(fastify: FastifyInstance) {
@@ -54,7 +64,9 @@ export default async function routes(fastify: FastifyInstance) {
 
       const signedUploadURL = await request.storage
         .from(bucketName)
-        .signUploadObjectUrl(objectName, urlPath as string, uploadSignedUrlExpirationTime, owner)
+        .signUploadObjectUrl(objectName, urlPath as string, uploadSignedUrlExpirationTime, owner, {
+          upsert: request.headers['x-upsert'] === 'true',
+        })
 
       return response.status(200).send({ url: signedUploadURL })
     }

--- a/src/http/routes/object/uploadSignedObject.ts
+++ b/src/http/routes/object/uploadSignedObject.ts
@@ -99,6 +99,7 @@ export default async function routes(fastify: FastifyInstance) {
         .uploadNewObject(request, {
           owner,
           objectName,
+          isUpsert: payload.upsert,
         })
 
       return response.status(objectMetadata?.httpStatusCode ?? 200).send({


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Currently is not possible to use signed upload URL to overwrite files

## What is the new behavior?

Allows providing x-upsert header for signed upload URL and overwrite files

Closes #380 
