### PR TITLE
feat: Signed Upload URL for TUS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -62,7 +62,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(plugins.metrics({ enabledEndpoint: !isMultitenant }))
   app.register(plugins.logTenantId)
   app.register(plugins.logRequest({ excludeUrls: ['/status', '/metrics', '/health'] }))
-  app.register(routes.multiPart, { prefix: 'upload/resumable' })
+  app.register(routes.tus, { prefix: 'upload/resumable' })
   app.register(routes.bucket, { prefix: 'bucket' })
   app.register(routes.object, { prefix: 'object' })
   app.register(routes.render, { prefix: 'render/image' })

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -11,11 +11,6 @@ const JWT_RSA_ALGOS: jwt.Algorithm[] = ['RS256', 'RS384', 'RS512']
 const JWT_ECC_ALGOS: jwt.Algorithm[] = ['ES256', 'ES384', 'ES512']
 const JWT_ED_ALGOS: jwt.Algorithm[] = ['EdDSA'] as unknown as jwt.Algorithm[] // types for EdDSA not yet updated
 
-interface jwtInterface {
-  sub?: string
-  role?: string
-}
-
 export type SignedToken = {
   url: string
   transformations?: string

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -113,6 +113,7 @@ export class TenantConnection {
       },
       connection: {
         connectionString: connectionString,
+        connectionTimeoutMillis: databaseConnectionTimeout,
         ...this.sslSettings(),
       },
       acquireConnectionTimeout: databaseConnectionTimeout,

--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -1,8 +1,8 @@
 import fastifyPlugin from 'fastify-plugin'
-import { createResponse } from '../generic-routes'
 import { verifyJWT } from '../../auth'
 import { getJwtSecret } from '../../database'
 import { JwtPayload } from 'jsonwebtoken'
+import { ERRORS } from '../../storage'
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -28,8 +28,7 @@ export const jwt = fastifyPlugin(async (fastify) => {
       request.jwtPayload = payload
       request.owner = payload.sub
     } catch (err: any) {
-      request.log.error({ error: err }, 'unable to get owner')
-      return reply.status(400).send(createResponse(err.message, '400', err.message))
+      throw ERRORS.AccessDenied(err.message, err)
     }
   })
 })

--- a/src/http/routes/index.ts
+++ b/src/http/routes/index.ts
@@ -1,7 +1,7 @@
 export { default as bucket } from './bucket'
 export { default as object } from './object'
 export { default as render } from './render'
-export { default as multiPart } from './tus'
+export { default as tus } from './tus'
 export { default as healthcheck } from './health'
 export { default as s3 } from './s3'
 export * from './admin'

--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -33,6 +33,9 @@ const successResponseSchema = {
         '/object/sign/upload/avatars/folder/cat.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJhdmF0YXJzL2ZvbGRlci9jYXQucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.s7Gt8ME80iREVxPhH01ZNv8oUn4XtaWsmiQ5csiUHn4',
       ],
     },
+    token: {
+      type: 'string',
+    },
   },
   required: ['url'],
 }
@@ -60,15 +63,15 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
       const owner = request.owner
 
-      const urlPath = request.url.split('?').shift()
+      const urlPath = `${bucketName}/${objectName}`
 
-      const signedUploadURL = await request.storage
+      const signedUpload = await request.storage
         .from(bucketName)
         .signUploadObjectUrl(objectName, urlPath as string, uploadSignedUrlExpirationTime, owner, {
           upsert: request.headers['x-upsert'] === 'true',
         })
 
-      return response.status(200).send({ url: signedUploadURL })
+      return response.status(200).send({ url: signedUpload.url, token: signedUpload.token })
     }
   )
 }

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -41,6 +41,7 @@ export enum ErrorCode {
   InvalidChecksum = 'InvalidChecksum',
   MissingPart = 'MissingPart',
   SlowDown = 'SlowDown',
+  TusError = 'TusError',
 }
 
 export const ERRORS = {
@@ -172,6 +173,13 @@ export const ERRORS = {
       httpStatusCode: 400,
       message: message || 'Invalid upload id',
       originalError: e,
+    }),
+
+  TusError: (message: string, statusCode: number) =>
+    new StorageBackendError({
+      code: ErrorCode.TusError,
+      httpStatusCode: statusCode,
+      message: message,
     }),
 
   MissingTenantConfig: (tenantId: string) =>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Signed upload URL were not supported for the TUS protocol

## What is the new behavior?

Supporting signed upload URL for the TUS protocol, allowing non-authenticated users to upload via TUS by having this time-limited URL

Example client implementation:

```ts
const { data, error } = await supabase
  .storage
  .from('avatars')
  .createSignedUploadUrl('folder/cat.jpg')


const upload = new tus.Upload(file, {
  endpoint: `${localServerAddress}/upload/resumable/sign`,
  headers: {
    'x-signature': data.token,
  },
  metadata: {
    bucketName: 'avatars',
    objectName: 'folder/cat.jpg',
    contentType: 'image/jpeg',
    cacheControl: '3600',
  },
  onError: function (error) {
    console.log('Failed because: ' + error)
  },
  onSuccess: () => {
    console.log('success')
  },
})

upload.start()
```

## Additional context

Implementation details:

Tus URL for signed uploads: `/upload/resumable/sign`
Signature header: `x-signature`
