### PR TITLE
feat: allow passing authorization via query string

### DIFF
--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -60,10 +60,13 @@ export default async function routes(fastify: FastifyInstance) {
     '/authenticated/:bucketName/*',
     {
       exposeHeadRoute: false,
+      config: {
+        allowQueryStringToken: true,
+      },
       // @todo add success response schema here
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary,
         response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
         tags: ['object'],
@@ -78,10 +81,13 @@ export default async function routes(fastify: FastifyInstance) {
     '/:bucketName/*',
     {
       exposeHeadRoute: false,
+      config: {
+        allowQueryStringToken: true,
+      },
       // @todo add success response schema here
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary: 'Get object',
         description: 'use GET /object/authenticated/{bucketName} instead',
         response: { '4xx': { $ref: 'errorSchema#' } },

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -93,9 +93,12 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
   fastify.head<getObjectRequestInterface>(
     '/authenticated/:bucketName/*',
     {
+      config: {
+        allowQueryStringToken: true,
+      },
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary,
         response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
         tags: ['object'],
@@ -109,9 +112,12 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
   fastify.get<getObjectRequestInterface>(
     '/info/authenticated/:bucketName/*',
     {
+      config: {
+        allowQueryStringToken: true,
+      },
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary,
         response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
         tags: ['object'],
@@ -125,9 +131,12 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
   fastify.get<getObjectRequestInterface>(
     '/info/:bucketName/*',
     {
+      config: {
+        allowQueryStringToken: true,
+      },
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary,
         description: 'use HEAD /object/authenticated/{bucketName} instead',
         response: { '4xx': { $ref: 'errorSchema#' } },
@@ -142,9 +151,12 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
   fastify.head<getObjectRequestInterface>(
     '/:bucketName/*',
     {
+      config: {
+        allowQueryStringToken: true,
+      },
       schema: {
         params: getObjectParamsSchema,
-        headers: { $ref: 'authSchema#' },
+        headers: { type: 'object', properties: { authorization: { type: 'string' } } },
         summary,
         description: 'use HEAD /object/authenticated/{bucketName} instead',
         response: { '4xx': { $ref: 'errorSchema#' } },

--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -23,7 +23,7 @@ export const logger = pino({
         region,
         traceId: request.id,
         method: request.method,
-        url: redactQueryParamFromRequest(request, ['token']),
+        url: redactQueryParamFromRequest(request, ['token', 'authorization']),
         headers: whitelistHeaders(request.headers),
         hostname: request.hostname,
         remoteAddress: request.ip,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

This PR allows passing the `?authorization` param as a query string param. Specifically, this behaviour is only enabled on the GET requests for fetching the asset: `/authenticated/:bucketName/*`

## Additional context

This functionality allows to embedding of authenticated images directly in HTML tags
