### PR TITLE
fix: omit nextcontinuation token when empty

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -291,8 +291,11 @@ export class S3ProtocolHandler {
         EncodingType: encodingType,
         KeyCount: results.length,
         CommonPrefixes: commonPrefixes,
-        NextContinuationToken: nextContinuationToken,
       },
+    }
+
+    if (nextContinuationToken) {
+      response.ListBucketResult.NextContinuationToken = nextContinuationToken
     }
 
     return {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Do not return the `NextContinuationToken` if empty. Some clients such as mountpoint-s3 doeasn't handle this field gracefully when empty
