### PR TITLE
fix: skip Mime type check for .emptyFolderPlaceholder

### DIFF
--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -14,6 +14,7 @@ interface UploaderOptions extends UploadObjectOptions {
 }
 
 const { storageS3Bucket, uploadFileSizeLimitStandard } = getConfig()
+const EMPTY_FOLDER_PLACEHOLDER = ".emptyFolderPlaceholder"
 
 export interface UploadObjectOptions {
   bucketId: string
@@ -82,7 +83,8 @@ export class Uploader {
     try {
       const file = await this.incomingFileInfo(request, options)
 
-      if (options.allowedMimeTypes) {
+      if (options.allowedMimeTypes && 
+        !options.objectName.endsWith(EMPTY_FOLDER_PLACEHOLDER)) {
         this.validateMimeType(file.mimeType, options.allowedMimeTypes)
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

when MIME type is enabled, Folders can't be created.

## What is the new behavior?

for .emptyFolderPlaceholder files, will skip MIME type check

## Additional context

closes: https://github.com/supabase/supabase/issues/26359
