### PR TITLE
fix: run migrations after tenant creation

### DIFF
--- a/src/database/migrations/migrate.ts
+++ b/src/database/migrations/migrate.ts
@@ -40,7 +40,7 @@ const backportMigrations = [
 
 export const progressiveMigrations = new ProgressiveMigrations({
   maxSize: 200,
-  interval: 1000 * 60, // 1m
+  interval: 1000 * 5, // 5s
   watch: pgQueueEnable,
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a tenant is being created, we first try to run the migrations and then register the target.
This sometimes causes the tenant to never be added if the database is not currently reachable

## What is the new behavior?

Migrations are now run after the tenant creation.
If an error occur during the migrations, we schedule a job to re-run async with a queue job