### PR TITLE
Allow creating folders even if the mime type validation is set

### DIFF
--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -115,3 +115,7 @@ export function parseFileSizeToBytes(valueWithUnit: string) {
 export function isUuid(value: string) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
 }
+
+export function isEmptyFolder(object: string) {
+  return object.endsWith('.emptyFolderPlaceholder')
+}

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -380,6 +380,43 @@ describe('testing POST object via multipart upload', () => {
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
 
+  test('can create an empty folder when mime-type is set', async () => {
+    const form = new FormData()
+    const headers = Object.assign({}, form.getHeaders(), {
+      authorization: `Bearer ${serviceKey}`,
+      'x-upsert': 'true',
+    })
+
+    form.append('file', Buffer.alloc(0))
+
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/public-limit-mime-types/nested/.emptyFolderPlaceholder',
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.uploadObject).toHaveBeenCalled()
+  })
+
+  test('cannot create an empty folder with more than 0kb', async () => {
+    const form = new FormData()
+    const headers = Object.assign({}, form.getHeaders(), {
+      authorization: `Bearer ${serviceKey}`,
+      'x-upsert': 'true',
+    })
+
+    form.append('file', Buffer.alloc(1))
+
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/public-limit-mime-types/nested-2/.emptyFolderPlaceholder',
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
   test('return 422 when uploading an object with a malformed mime-type', async () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the mime-type is set, creating empty folders fails

## What is the new behavior?

Empty folders can still be created

Closes #503 this PR also restricts `emptyFolders` to 0kb 
