### PR TITLE
feat: prevent passing in `role` claim in presigned URL JWTs

### DIFF
--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -540,6 +540,10 @@ export class ObjectStorage {
       return all
     }, metadata || {})
 
+    // security-in-depth: as signObjectUrl could be used as a signing oracle,
+    // make sure it's never able to specify a role JWT claim
+    delete metadata['role']
+
     const urlParts = url.split('/')
     const urlToSign = decodeURI(urlParts.splice(3).join('/'))
     const { secret: jwtSecret } = await getJwtSecret(this.db.tenantId)


### PR DESCRIPTION
Just adds defense-in-depth that Storage can't be used as a signing oracle (an all-knowing entity you can tell to "sign" things for you) that would allow bypassing PostgREST RLS.

It achieves this by disallowing any `role` metadata to ever be supplied to the `signObjectUrl` method.