### PR TITLE
Fix/metadata input names

### DIFF
--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -46,11 +46,11 @@ async function requestHandler(
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(objectName, 'id,version,metadata,user_metadata,created_at')
+      .findObject(objectName, 'id,name,version,metadata,user_metadata,created_at')
   } else {
     obj = await request.storage
       .from(bucketName)
-      .findObject(objectName, 'id,version,metadata,user_metadata,created_at')
+      .findObject(objectName, 'id,name,version,metadata,user_metadata,created_at')
   }
 
   return request.storage.renderer(method).render(request, response, {

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -204,9 +204,9 @@ export async function onUploadFinish(
 
     const uploader = new Uploader(req.upload.storage.backend, req.upload.storage.db)
     let customMd: undefined | Record<string, string> = undefined
-    if (upload.metadata?.userMetadata) {
+    if (upload.metadata?.metadata) {
       try {
-        customMd = JSON.parse(upload.metadata.userMetadata)
+        customMd = JSON.parse(upload.metadata.metadata)
       } catch (e) {
         // no-op
       }

--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -15,6 +15,7 @@ export interface BrowserCacheHeaders {
  */
 export type ObjectResponse = {
   metadata: ObjectMetadata
+  httpStatusCode: number
   body?: ReadableStream<any> | Readable | Blob | Buffer
 }
 
@@ -29,7 +30,7 @@ export type ObjectMetadata = {
   lastModified?: Date
   eTag: string
   contentRange?: string
-  httpStatusCode: number
+  httpStatusCode?: number
 }
 
 export type UploadPart = {

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -95,6 +95,7 @@ export class FileBackend implements StorageBackendAdapter {
           eTag: checksum,
           contentLength: chunkSize,
         },
+        httpStatusCode: 206,
         body,
       }
     } else {
@@ -110,6 +111,7 @@ export class FileBackend implements StorageBackendAdapter {
           contentLength: fileSize,
         },
         body,
+        httpStatusCode: 200,
       }
     }
   }

--- a/src/storage/backend/s3.ts
+++ b/src/storage/backend/s3.ts
@@ -60,7 +60,7 @@ export interface S3ClientOptions {
 
 /**
  * S3Backend
- * Interacts with an s3-compatible file system with this S3Adapter
+ * Interacts with a s3-compatible file system with this S3Adapter
  */
 export class S3Backend implements StorageBackendAdapter {
   client: S3Client
@@ -118,9 +118,10 @@ export class S3Backend implements StorageBackendAdapter {
         lastModified: data.LastModified,
         contentRange: data.ContentRange,
         contentLength: data.ContentLength || 0,
-        httpStatusCode: data.$metadata.httpStatusCode || 200,
         size: data.ContentLength || 0,
+        httpStatusCode: data.$metadata.httpStatusCode || 200,
       },
+      httpStatusCode: data.$metadata.httpStatusCode || 200,
       body: data.Body,
     }
   }

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -540,6 +540,10 @@ export class ObjectStorage {
       return all
     }, metadata || {})
 
+    // security-in-depth: as signObjectUrl could be used as a signing oracle,
+    // make sure it's never able to specify a role JWT claim
+    delete metadata['role']
+
     const urlParts = url.split('/')
     const urlToSign = decodeURI(urlParts.splice(3).join('/'))
     const { secret: jwtSecret } = await getJwtSecret(this.db.tenantId)

--- a/src/storage/renderer/info.ts
+++ b/src/storage/renderer/info.ts
@@ -1,8 +1,7 @@
-import { HeadRenderer } from './head'
-import { FastifyRequest } from 'fastify'
-import { AssetResponse, RenderOptions } from './renderer'
 import { Obj } from '@storage/schemas'
-import { FastifyReply } from 'fastify/types/reply'
+import { HeadRenderer } from './head'
+import { FastifyRequest, FastifyReply } from 'fastify'
+import { AssetResponse, RenderOptions } from './renderer'
 
 /**
  * HeadRenderer
@@ -16,7 +15,18 @@ export class InfoRenderer extends HeadRenderer {
 
     return {
       ...headAsset,
-      body: obj,
+      body: {
+        id: obj.id,
+        name: obj.name,
+        version: obj.version,
+        size: obj.metadata?.size ?? null,
+        content_type: obj.metadata?.mimetype ?? null,
+        cache_control: obj.metadata?.cacheControl ?? null,
+        etag: obj.metadata?.eTag ?? null,
+        metadata: obj.user_metadata,
+        last_modified: obj.metadata?.lastModified ?? null,
+        created_at: obj.created_at,
+      },
     }
   }
 
@@ -26,6 +36,12 @@ export class InfoRenderer extends HeadRenderer {
     data: AssetResponse,
     options: RenderOptions
   ) {
-    // no-op
+    response
+      .status(data.metadata.httpStatusCode ?? 200)
+      .header('Content-Type', 'application/json')
+      .header('ETag', data.metadata.eTag)
+      .header('Content-Length', data.metadata.contentLength)
+      .header('Last-Modified', data.metadata.lastModified?.toUTCString())
+      .header('CacheControl', data.metadata.cacheControl)
   }
 }

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -297,7 +297,7 @@ export class Uploader {
 
         body = formData.file
         /* @ts-expect-error: https://github.com/aws/aws-sdk-js-v3/issues/2085 */
-        const customMd = formData.fields.userMetadata?.value
+        const customMd = formData.fields.metadata?.value ?? formData.fields.userMetadata?.value
         /* @ts-expect-error: https://github.com/aws/aws-sdk-js-v3/issues/2085 */
         mimeType = formData.fields.contentType?.value || formData.mimetype
         cacheControl = cacheTime ? `max-age=${cacheTime}` : 'no-cache'

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -22,6 +22,7 @@ beforeAll(() => {
         cacheControl: 'no-cache',
         contentLength: 3746,
       },
+      httpStatusCode: 200,
       body: Buffer.from(''),
     })
   })

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -42,6 +42,7 @@ export function useMockObject() {
         cacheControl: 'no-cache',
         contentLength: 3746,
       },
+      httpStatusCode: 200,
       body: Buffer.from(''),
     })
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -358,7 +358,7 @@ describe('testing POST object via multipart upload', () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
     form.append(
-      'userMetadata',
+      'metadata',
       JSON.stringify({
         test1: 'test1',
         test2: 'test2',
@@ -438,7 +438,7 @@ describe('testing POST object via multipart upload', () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
     form.append(
-      'userMetadata',
+      'metadata',
       JSON.stringify({
         test1: 'test1',
         test2: 'test2',
@@ -468,7 +468,7 @@ describe('testing POST object via multipart upload', () => {
 
     const data = await response.json()
 
-    expect(data.user_metadata).toEqual({
+    expect(data.metadata).toEqual({
       test1: 'test1',
       test2: 'test2',
     })

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -95,7 +95,7 @@ describe('Tus multipart', () => {
           objectName: objectName,
           contentType: 'image/jpeg',
           cacheControl: '3600',
-          userMetadata: JSON.stringify({
+          metadata: JSON.stringify({
             test1: 'test1',
             test2: 'test2',
           }),
@@ -267,7 +267,7 @@ describe('Tus multipart', () => {
             objectName: objectName,
             contentType: 'image/jpeg',
             cacheControl: '3600',
-            userMetadata: JSON.stringify({
+            metadata: JSON.stringify({
               test1: 'test1',
               test3: 'test3',
             }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- accept metadata as input for multi-part uploads
- return object v2 to the GET info request

## Additional context

Object V2:

```ts
export interface FileObjectV2  {
  id: string
  version: string
  name: string
  bucket_id: string
  updated_at: string
  created_at: string
  last_accessed_at: string
  size?: number
  cache_control?: string
  content_type?: string
  etag?: string
  last_modified?: string
  metadata?: Record<string, any>
}
```
