### PR TITLE
fix: s3 signature on strict clients

### DIFF
--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -293,6 +293,12 @@ export class SignatureV4 {
           if (header === 'host') {
             return this.getHostHeader(request)
           }
+
+          if (header === 'content-length') {
+            const headerValue = this.getHeader(request, header) ?? '0'
+            return `${header}:${headerValue}`
+          }
+
           return `${header}:${this.getHeader(request, header)}`
         })
         .join('\n') + '\n'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Certain clients expect the content-lenght set to 0 when no body is provided.
This PR set the content-lenght to 0 when not provided
