### PR TITLE
fix: allow sync migrations

### DIFF
--- a/migrations/tenant/0025-custom-metadata.sql
+++ b/migrations/tenant/0025-custom-metadata.sql
@@ -1,2 +1,3 @@
+---SYNC---
 ALTER TABLE storage.objects ADD COLUMN user_metadata jsonb NULL;
 ALTER TABLE storage.s3_multipart_uploads ADD COLUMN user_metadata jsonb NULL;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the new behavior?

This PR introduces a new `---SYNC---` token in the migrations files which will force the migrations to run before the request  is handled.

Once the migrations have run, the service will continue to use progressive migrations.
