### PR TITLE
feat: handle authentication on top level routes

### DIFF
--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -7,9 +7,14 @@ import { ERRORS } from '@internal/errors'
 
 declare module 'fastify' {
   interface FastifyRequest {
+    isAuthenticated: boolean
     jwt: string
     jwtPayload?: JwtPayload & { role?: string }
     owner?: string
+  }
+
+  interface FastifyContextConfig {
+    allowInvalidJwt?: boolean
   }
 }
 
@@ -22,13 +27,25 @@ export const jwt = fastifyPlugin(async (fastify) => {
   fastify.addHook('preHandler', async (request, reply) => {
     request.jwt = (request.headers.authorization || '').replace(BEARER, '')
 
+    if (!request.jwt && request.routeConfig.allowInvalidJwt) {
+      request.jwtPayload = { role: 'anon' }
+      request.isAuthenticated = false
+      return
+    }
+
     const { secret, jwks } = await getJwtSecret(request.tenantId)
 
     try {
       const payload = await verifyJWT(request.jwt, secret, jwks || null)
       request.jwtPayload = payload
       request.owner = payload.sub
+      request.isAuthenticated = true
     } catch (err: any) {
+      request.isAuthenticated = false
+
+      if (request.routeConfig.allowInvalidJwt) {
+        return
+      }
       throw ERRORS.AccessDenied(err.message, err)
     }
   })

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -17,7 +17,7 @@ import {
   SearchObjectOption,
 } from './adapter'
 import { DatabaseError } from 'pg'
-import { DBMigration, getTenantConfig, TenantConnection } from '@internal/database'
+import { DBMigration, TenantConnection } from '@internal/database'
 import { DbQueryPerformance } from '@internal/monitoring/metrics'
 import { isUuid } from '../limits'
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -6,6 +6,7 @@ import { getFileSizeLimit, mustBeValidBucketName, parseFileSizeToBytes } from '.
 import { getConfig } from '../config'
 import { ObjectStorage } from './object'
 import { InfoRenderer } from '@storage/renderer/info'
+import { logger, logSchema } from '@internal/monitoring'
 
 const { requestUrlLengthLimit, storageS3Bucket } = getConfig()
 
@@ -206,7 +207,9 @@ export class Storage {
           return all
         }, [] as string[])
         // delete files from s3 asynchronously
-        this.backend.deleteObjects(storageS3Bucket, params)
+        this.backend.deleteObjects(storageS3Bucket, params).catch((e) => {
+          logSchema.error(logger, 'Failed to delete objects from s3', { type: 's3', error: e })
+        })
       }
 
       if (deleted?.length !== objects.length) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, we use `/public` and `/authenticated` endpoints to determine the access control

## What is the new behavior?

This PR modifies the route without the `/public` or `/authenticated` endpoint, which allows authentication to happen at the route level.

This fixes many issues on downloading objects or fetching info without knowing their privacy control
