### PR TITLE
fix: use destinationBucket on copy

### DIFF
--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -333,7 +333,7 @@ export class ObjectStorage {
         })
 
         const existingDestObject = await db.findObject(
-          this.bucketId,
+          destinationBucket,
           destinationKey,
           'id,name,metadata,version,bucket_id',
           {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

When copying across buckets, there was a bug in the edge case where you are:

- copying across buckets
- the destination key already exists
- the destination key is the same name as the source

When all of the 3 scenario happens,
It would cause the file to be copied just fine, but it would delete the original.

This PR fixes this unwanted behaviour, and will correctly not delete the original file
