### PR TITLE
Watch upload stream + fix duplicate logs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-22.04]
-        node: ['16']
+        node: ['20']
 
     runs-on: ${{ matrix.platform }}
 

--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -43,6 +43,18 @@ export const setErrorHandler = (app: FastifyInstance) => {
         ? 500
         : 400
 
+      if (renderableError.code === ErrorCode.AbortedTerminate) {
+        reply.header('Connection', 'close')
+
+        reply.raw.once('finish', () => {
+          setTimeout(() => {
+            if (!request.raw.closed) {
+              request.raw.destroy()
+            }
+          }, 3000)
+        })
+      }
+
       return reply.status(statusCode).send({
         ...renderableError,
         error: error.error || renderableError.code,
@@ -59,7 +71,7 @@ export const setErrorHandler = (app: FastifyInstance) => {
       })
     }
 
-    reply.status(500).send({
+    return reply.status(500).send({
       statusCode: '500',
       error: 'Internal',
       message: 'Internal Server Error',

--- a/src/http/plugins/tracing.ts
+++ b/src/http/plugins/tracing.ts
@@ -47,7 +47,7 @@ export const tracing = fastifyPlugin(
           if (
             tracingEnabled &&
             request.tracingMode &&
-            !['full', 'logs', 'debug'].includes(request.tracingMode)
+            !['logs', 'debug'].includes(request.tracingMode)
           ) {
             traceCollector.clearTrace(span.spanContext().traceId)
           }

--- a/src/internal/concurrency/index.ts
+++ b/src/internal/concurrency/index.ts
@@ -1,2 +1,3 @@
 export * from './mutex'
+export * from './stream'
 export * from './async-abort-controller'

--- a/src/internal/concurrency/stream.ts
+++ b/src/internal/concurrency/stream.ts
@@ -1,0 +1,40 @@
+import { Transform, TransformCallback } from 'stream'
+
+interface ByteCounterStreamOptions {
+  maxHistory?: number
+  onMaxHistory?: (history: Date[]) => void
+  rewriteHistoryOnMax?: boolean
+}
+
+export const createByteCounterStream = (options: ByteCounterStreamOptions) => {
+  const { maxHistory = 100 } = options
+
+  let bytes = 0
+  let history: Date[] = []
+
+  const transformStream = new Transform({
+    transform(chunk: Buffer, encoding: string, callback: TransformCallback) {
+      bytes += chunk.length
+      history.push(new Date())
+
+      if (history.length === maxHistory) {
+        if (options.rewriteHistoryOnMax) {
+          options.onMaxHistory?.(history)
+          history = []
+        }
+      }
+
+      callback(null, chunk)
+    },
+  })
+
+  return {
+    transformStream,
+    get bytes() {
+      return bytes
+    },
+    get history() {
+      return history
+    },
+  }
+}

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -37,6 +37,7 @@ export enum ErrorCode {
   SlowDown = 'SlowDown',
   TusError = 'TusError',
   Aborted = 'Aborted',
+  AbortedTerminate = 'AbortedTerminate',
 }
 
 export const ERRORS = {
@@ -368,6 +369,13 @@ export const ERRORS = {
   Aborted: (message: string, originalError?: unknown) =>
     new StorageBackendError({
       code: ErrorCode.Aborted,
+      httpStatusCode: 500,
+      message: message,
+      originalError,
+    }),
+  AbortedTerminate: (message: string, originalError?: unknown) =>
+    new StorageBackendError({
+      code: ErrorCode.AbortedTerminate,
       httpStatusCode: 500,
       message: message,
       originalError,

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -329,10 +329,10 @@ export class SignatureV4 {
       const host = `host:${xForwardedHost.toLowerCase()}`
 
       if (port && !['443', '80'].includes(port)) {
-        if (!host.includes(':')) {
+        if (!xForwardedHost.includes(':')) {
           return host + ':' + port
         } else {
-          return host.replace(/:\d+$/, `:${port}`)
+          return 'host:' + xForwardedHost.replace(/:\d+$/, `:${port}`)
         }
       }
       return host


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- This PR fixes the edge case where aborted request prints logs twice
- Add a passthrough stream which watches the data flowing
- on Abort we add to the trace bytes uploaded and bytes read