### PR TITLE
fix: docs-export

### DIFF
--- a/src/scripts/export-docs.ts
+++ b/src/scripts/export-docs.ts
@@ -9,4 +9,5 @@ import app from '../app'
   })
 
   await fs.writeFile('static/api.json', response.body)
+  process.exit(0)
 })()


### PR DESCRIPTION
Fixed docs export command to exit gracefully
