### PR TITLE
fix: optional debug telemetry

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,9 @@ type StorageConfigType = {
   tracingMode?: string
   tracingTimeMinDuration: number
   tracingReturnServerTimings: boolean
+  tracingFeatures?: {
+    upload: boolean
+  }
 }
 
 function getOptionalConfigFromEnv(key: string, fallback?: string): string | undefined {
@@ -326,6 +329,9 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     tracingReturnServerTimings:
       getOptionalConfigFromEnv('TRACING_RETURN_SERVER_TIMINGS') === 'true',
+    tracingFeatures: {
+      upload: getOptionalConfigFromEnv('TRACING_FEATURE_UPLOAD') === 'true',
+    },
 
     // Queue
     pgQueueEnable: getOptionalConfigFromEnv('PG_QUEUE_ENABLE', 'ENABLE_QUEUE_EVENTS') === 'true',

--- a/src/storage/renderer/info.ts
+++ b/src/storage/renderer/info.ts
@@ -45,7 +45,7 @@ export class InfoRenderer extends HeadRenderer {
       .header('ETag', data.metadata.eTag)
       .header('Content-Length', data.metadata.contentLength)
       .header('Last-Modified', data.metadata.lastModified?.toUTCString())
-      .header('CacheControl', data.metadata.cacheControl)
+      .header('Cache-Control', data.metadata.cacheControl)
 
     if (data.transformations && data.transformations.length > 0) {
       response.header('X-Transformations', data.transformations.join(','))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the new behavior?

- Only enable telemetry in logs when `TRACING_MODE=debug|logs` - we should turn this off when not needed.
- Allow to toggle on / off telemetry for upload