### PR TITLE
fix: base event storage initialisation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           output: swagger-ui
           spec-file: static/api.json
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -67,27 +67,23 @@ export const db = fastifyPlugin(
 
     fastify.addHook('onTimeout', async (request) => {
       if (request.db) {
-        try {
-          await request.db.dispose()
-        } catch (e) {
+        request.db.dispose().catch((e) => {
           logSchema.error(request.log, 'Error disposing db connection', {
             type: 'db-connection',
             error: e,
           })
-        }
+        })
       }
     })
 
     fastify.addHook('onRequestAbort', async (request) => {
       if (request.db) {
-        try {
-          await request.db.dispose()
-        } catch (e) {
+        request.db.dispose().catch((e) => {
           logSchema.error(request.log, 'Error disposing db connection', {
             type: 'db-connection',
             error: e,
           })
-        }
+        })
       }
     })
   },
@@ -133,27 +129,23 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
 
     fastify.addHook('onTimeout', async (request) => {
       if (request.db) {
-        try {
-          await request.db.dispose()
-        } catch (e) {
+        request.db.dispose().catch((e) => {
           logSchema.error(request.log, 'Error disposing db connection', {
             type: 'db-connection',
             error: e,
           })
-        }
+        })
       }
     })
 
     fastify.addHook('onRequestAbort', async (request) => {
       if (request.db) {
-        try {
-          await request.db.dispose()
-        } catch (e) {
+        request.db.dispose().catch((e) => {
           logSchema.error(request.log, 'Error disposing db connection', {
             type: 'db-connection',
             error: e,
           })
-        }
+        })
       }
     })
   },

--- a/src/internal/queue/queue.ts
+++ b/src/internal/queue/queue.ts
@@ -98,7 +98,6 @@ export abstract class Queue {
           })
           return Queue.stop()
             .then(async () => {
-              await Queue.callClose()
               logSchema.info(logger, '[Queue] Exited', {
                 type: 'queue',
               })
@@ -107,6 +106,11 @@ export abstract class Queue {
               logSchema.error(logger, '[Queue] Error while stopping queue', {
                 error: e,
                 type: 'queue',
+              })
+            })
+            .finally(async () => {
+              await Queue.callClose().catch(() => {
+                // no-op
               })
             })
         },

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -384,7 +384,7 @@ export class ObjectStorage {
     } catch (e) {
       await ObjectAdminDelete.send({
         name: destinationKey,
-        bucketId: this.bucketId,
+        bucketId: destinationBucket,
         tenant: this.db.tenant(),
         version: newVersion,
         reqId: this.db.reqId,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- Fixed an issue where the migrate-call was initialising the Storage Adapter causing the script to fail
- Fixed Docs push
- do not await promises on errors hooks

## Additional context

Add any other context or screenshots.
