### PR TITLE
feat: allow increasing resolution on a per tenant basis

### DIFF
--- a/migrations/multitenant/0012-image-transformation-limits.sql
+++ b/migrations/multitenant/0012-image-transformation-limits.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE tenants ADD COLUMN image_transformation_max_resolution int NULL;

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -32,13 +32,14 @@ const patchSchema = {
             type: 'object',
             properties: {
               enabled: { type: 'boolean' },
+              maxResolution: { type: 'number', nullable: true },
             },
           },
         },
       },
     },
   },
-  optional: ['tracingMode'],
+  optional: ['tracingMode', 'maxResolution'],
 } as const
 
 const schema = {
@@ -75,6 +76,7 @@ interface tenantDBInterface {
   service_key: string
   file_size_limit?: number
   feature_image_transformation?: boolean
+  image_transformation_max_resolution?: number
 }
 
 export default async function routes(fastify: FastifyInstance) {
@@ -94,6 +96,7 @@ export default async function routes(fastify: FastifyInstance) {
         jwks,
         service_key,
         feature_image_transformation,
+        image_transformation_max_resolution,
         migrations_version,
         migrations_status,
         tracing_mode,
@@ -113,6 +116,7 @@ export default async function routes(fastify: FastifyInstance) {
         features: {
           imageTransformation: {
             enabled: feature_image_transformation,
+            maxResolution: image_transformation_max_resolution,
           },
         },
       })
@@ -134,6 +138,7 @@ export default async function routes(fastify: FastifyInstance) {
         jwks,
         service_key,
         feature_image_transformation,
+        image_transformation_max_resolution,
         migrations_version,
         migrations_status,
         tracing_mode,
@@ -156,6 +161,7 @@ export default async function routes(fastify: FastifyInstance) {
         features: {
           imageTransformation: {
             enabled: feature_image_transformation,
+            maxResolution: image_transformation_max_resolution,
           },
         },
         migrationVersion: migrations_version,
@@ -244,6 +250,10 @@ export default async function routes(fastify: FastifyInstance) {
           jwks,
           service_key: serviceKey !== undefined ? encrypt(serviceKey) : undefined,
           feature_image_transformation: features?.imageTransformation?.enabled,
+          image_transformation_max_resolution:
+            features?.imageTransformation?.maxResolution === null
+              ? null
+              : features?.imageTransformation?.maxResolution,
           tracing_mode: tracingMode,
         })
         .where('id', tenantId)
@@ -298,6 +308,11 @@ export default async function routes(fastify: FastifyInstance) {
 
     if (typeof features?.imageTransformation?.enabled !== 'undefined') {
       tenantInfo.feature_image_transformation = features?.imageTransformation?.enabled
+    }
+
+    if (typeof features?.imageTransformation?.maxResolution !== 'undefined') {
+      tenantInfo.image_transformation_max_resolution = features?.imageTransformation
+        ?.image_transformation_max_resolution as number | undefined
     }
 
     if (databasePoolUrl) {

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -4,8 +4,9 @@ import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '@storage/renderer'
 import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
+import { getTenantConfig } from '@internal/database'
 
-const { storageS3Bucket } = getConfig()
+const { storageS3Bucket, isMultitenant } = getConfig()
 
 const renderAuthenticatedImageParamsSchema = {
   type: 'object',
@@ -55,6 +56,13 @@ export default async function routes(fastify: FastifyInstance) {
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`
 
       const renderer = request.storage.renderer('image') as ImageRenderer
+
+      if (isMultitenant) {
+        const tenantConfig = await getTenantConfig(request.tenantId)
+        renderer.setLimits({
+          maxResolution: tenantConfig.features.imageTransformation.maxResolution,
+        })
+      }
 
       return renderer.setTransformations(request.query).render(request, response, {
         bucket: storageS3Bucket,

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -4,8 +4,9 @@ import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '@storage/renderer'
 import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
+import { getTenantConfig } from '@internal/database'
 
-const { storageS3Bucket } = getConfig()
+const { storageS3Bucket, isMultitenant } = getConfig()
 
 const renderPublicImageParamsSchema = {
   type: 'object',
@@ -60,6 +61,13 @@ export default async function routes(fastify: FastifyInstance) {
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`
 
       const renderer = request.storage.renderer('image') as ImageRenderer
+
+      if (isMultitenant) {
+        const tenantConfig = await getTenantConfig(request.tenantId)
+        renderer.setLimits({
+          maxResolution: tenantConfig.features.imageTransformation.maxResolution,
+        })
+      }
 
       return renderer.setTransformations(request.query).render(request, response, {
         bucket: storageS3Bucket,

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -39,6 +39,7 @@ interface TenantConfig {
 export interface Features {
   imageTransformation: {
     enabled: boolean
+    maxResolution?: number
   }
 }
 
@@ -202,6 +203,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
       jwks,
       service_key,
       feature_image_transformation,
+      image_transformation_max_resolution,
       database_pool_url,
       max_connections,
       migrations_version,
@@ -227,6 +229,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
       features: {
         imageTransformation: {
           enabled: feature_image_transformation,
+          maxResolution: image_transformation_max_resolution,
         },
       },
       migrationVersion: migrations_version,

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -68,6 +68,10 @@ axiosRetry(client, {
   },
 })
 
+interface TransformLimits {
+  maxResolution?: number
+}
+
 /**
  * ImageRenderer
  * renders an image by applying transformations
@@ -77,6 +81,7 @@ axiosRetry(client, {
 export class ImageRenderer extends Renderer {
   private readonly client: Axios
   private transformOptions?: TransformOptions
+  private limits?: TransformLimits
 
   constructor(private readonly backend: StorageBackendAdapter) {
     super()
@@ -118,6 +123,15 @@ export class ImageRenderer extends Renderer {
     return segments
   }
 
+  static applyTransformationLimits(limits: TransformLimits) {
+    const transforms: string[] = []
+    if (typeof limits?.maxResolution === 'number') {
+      transforms.push(`max_src_resolution:${limits.maxResolution}`)
+    }
+
+    return transforms
+  }
+
   protected static formatResizeType(resize: TransformOptions['resize']) {
     const defaultResize = 'fill'
 
@@ -146,6 +160,11 @@ export class ImageRenderer extends Renderer {
    */
   setTransformations(transformations: TransformOptions) {
     this.transformOptions = transformations
+    return this
+  }
+
+  setLimits(limits: TransformLimits) {
+    this.limits = limits
     return this
   }
 
@@ -190,10 +209,12 @@ export class ImageRenderer extends Renderer {
       this.backend.headObject(options.bucket, options.key, options.version),
     ])
     const transformations = ImageRenderer.applyTransformation(this.transformOptions || {})
+    const transformLimits = ImageRenderer.applyTransformationLimits(this.limits || {})
 
     const url = [
       '/public',
       ...transformations,
+      ...transformLimits,
       'plain',
       privateURL.startsWith('local://') ? privateURL : encodeURIComponent(privateURL),
     ]

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -21,6 +21,7 @@ const payload = {
   features: {
     imageTransformation: {
       enabled: true,
+      maxResolution: null,
     },
   },
 }
@@ -40,6 +41,7 @@ const payload2 = {
   features: {
     imageTransformation: {
       enabled: false,
+      maxResolution: null,
     },
   },
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

Allow customising the max_resolution limit that imgproxy will impose for specific tenants.
Default is `NULL` (default)


this env `IMGPROXY_ALLOW_SECURITY_OPTIONS` is necessary in imgproxy for this to work