### PR TITLE
fix: S3 Protocol allow overwriting metadata on copy

### DIFF
--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -105,6 +105,7 @@ export abstract class StorageBackendAdapter {
    * @param version
    * @param destination
    * @param destinationVersion
+   * @param metadata
    * @param conditions
    */
   async copyObject(
@@ -113,6 +114,7 @@ export abstract class StorageBackendAdapter {
     version: string | undefined,
     destination: string,
     destinationVersion: string | undefined,
+    metadata?: { cacheControl?: string; mimetype?: string },
     conditions?: {
       ifMatch?: string
       ifNoneMatch?: string

--- a/src/storage/backend/s3.ts
+++ b/src/storage/backend/s3.ts
@@ -209,6 +209,7 @@ export class S3Backend implements StorageBackendAdapter {
    * @param version
    * @param destination
    * @param destinationVersion
+   * @param metadata
    * @param conditions
    */
   async copyObject(
@@ -217,6 +218,7 @@ export class S3Backend implements StorageBackendAdapter {
     version: string | undefined,
     destination: string,
     destinationVersion: string | undefined,
+    metadata?: { cacheControl?: string; mimetype?: string },
     conditions?: {
       ifMatch?: string
       ifNoneMatch?: string
@@ -233,6 +235,8 @@ export class S3Backend implements StorageBackendAdapter {
         CopySourceIfNoneMatch: conditions?.ifNoneMatch,
         CopySourceIfModifiedSince: conditions?.ifModifiedSince,
         CopySourceIfUnmodifiedSince: conditions?.ifUnmodifiedSince,
+        ContentType: metadata?.mimetype,
+        CacheControl: metadata?.cacheControl,
       })
       const data = await this.client.send(command)
       return {

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -35,6 +35,11 @@ interface CopyObjectParams {
   owner?: string
   copyMetadata?: boolean
   upsert?: boolean
+  metadata?: {
+    cacheControl?: string
+    mimetype?: string
+  }
+  userMetadata?: Record<string, any>
   conditions?: {
     ifMatch?: string
     ifNoneMatch?: string
@@ -283,6 +288,8 @@ export class ObjectStorage {
     conditions,
     copyMetadata,
     upsert,
+    metadata: fileMetadata,
+    userMetadata,
   }: CopyObjectParams) {
     mustBeValidKey(destinationKey)
 
@@ -323,6 +330,7 @@ export class ObjectStorage {
         originObject.version,
         s3DestinationKey,
         newVersion,
+        fileMetadata,
         conditions
       )
 
@@ -343,13 +351,15 @@ export class ObjectStorage {
           }
         )
 
+        const destinationMetadata = copyMetadata ? originObject.metadata : fileMetadata || {}
+
         const destinationObject = await db.upsertObject({
           ...originObject,
           bucket_id: destinationBucket,
           name: destinationKey,
           owner,
-          metadata,
-          user_metadata: copyMetadata ? originObject.user_metadata : undefined,
+          metadata: destinationMetadata,
+          user_metadata: copyMetadata ? originObject.user_metadata : userMetadata,
           version: newVersion,
         })
 

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1029,6 +1029,11 @@ export class S3ProtocolHandler {
         ifModifiedSince: command.CopySourceIfModifiedSince,
         ifUnmodifiedSince: command.CopySourceIfUnmodifiedSince,
       },
+      metadata: {
+        cacheControl: command.CacheControl,
+        mimetype: command.ContentType,
+      },
+      userMetadata: command.Metadata,
       copyMetadata: command.MetadataDirective === 'COPY',
     })
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -887,6 +887,31 @@ describe('S3 Protocol', () => {
         expect(resp.CopyObjectResult?.ETag).toBeTruthy()
       })
 
+      it('will copy an object overwriting the metadata', async () => {
+        const bucketName = await createBucket(client)
+        await uploadFile(client, bucketName, 'test-copy-1.jpg', 1)
+
+        const copyObjectCommand = new CopyObjectCommand({
+          Bucket: bucketName,
+          Key: 'test-copied-2.png',
+          CopySource: `${bucketName}/test-copy-1.jpg`,
+          ContentType: 'image/png',
+          CacheControl: 'max-age=2009',
+        })
+
+        const resp = await client.send(copyObjectCommand)
+        expect(resp.CopyObjectResult?.ETag).toBeTruthy()
+
+        const headObjectCommand = new HeadObjectCommand({
+          Bucket: bucketName,
+          Key: 'test-copied-2.png',
+        })
+
+        const headObj = await client.send(headObjectCommand)
+        expect(headObj.ContentType).toBe('image/png')
+        expect(headObj.CacheControl).toBe('max-age=2009')
+      })
+
       it('will not be able to copy an object that doesnt exists', async () => {
         const bucketName1 = await createBucket(client)
         await uploadFile(client, bucketName1, 'test-copy-1.jpg', 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Metadata can now be overwritten when using the CopyObject command

## Additional context

Fixes #580 
