### PR TITLE
fix: s3 delete reponse typo

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -970,7 +970,7 @@ export class S3ProtocolHandler {
 
     return {
       responseBody: {
-        DeletedResult: {
+        DeleteResult: {
           Deleted: deleted,
           Error: errors,
         },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix


## What is the new behavior?

Fixes a typo in the response for the DeleteObjects command of the S3 protocol

