### PR TITLE
fix: check for proxied host before appending port

### DIFF
--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -106,7 +106,7 @@ export function generateUrl(
     const port = req.headers['x-forwarded-port']
 
     if (typeof port === 'string' && port && !['443', '80'].includes(port)) {
-      if (!host.includes(':')) {
+      if (!host.includes(':') && !host.includes('/')) {
         host += `:${req.headers['x-forwarded-port']}`
       } else {
         host = host.replace(/:\d+$/, `:${req.headers['x-forwarded-port']}`)

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -329,7 +329,7 @@ export class SignatureV4 {
       const host = `host:${xForwardedHost.toLowerCase()}`
 
       if (port && !['443', '80'].includes(port)) {
-        if (!xForwardedHost.includes(':')) {
+        if (!xForwardedHost.includes(':') && !xForwardedHost.includes('/')) {
           return host + ':' + port
         } else {
           return 'host:' + xForwardedHost.replace(/:\d+$/, `:${port}`)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes https://github.com/supabase/storage/issues/543

## What is the new behavior?

Avoids invalid URLs such as `https://gateway.example.com/storage/v1:8000/upload/resumable/bWxxx` where the `":8000"` is inserted incorrectly.

## Additional context

https://github.com/supabase/storage/pull/545 had partially fixed this
