### PR TITLE
fix: improve error message for insufficient privilege

### DIFF
--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -1108,10 +1108,7 @@ export class DBError extends StorageBackendError implements RenderableError {
   static fromDBError(pgError: DatabaseError, query?: string) {
     switch (pgError.code) {
       case '42501':
-        return ERRORS.AccessDenied(
-          'new row violates row-level security policy',
-          pgError
-        ).withMetadata({
+        return ERRORS.AccessDenied('Database error: insufficient privilege', pgError).withMetadata({
           query,
           code: pgError.code,
         })

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -322,7 +322,7 @@ describe('testing POST object via multipart upload', () => {
       JSON.stringify({
         statusCode: '403',
         error: 'Unauthorized',
-        message: 'new row violates row-level security policy',
+        message: 'Database error: insufficient privilege',
       })
     )
   })
@@ -808,7 +808,7 @@ describe('testing POST object via binary upload', () => {
       JSON.stringify({
         statusCode: '403',
         error: 'Unauthorized',
-        message: 'new row violates row-level security policy',
+        message: 'Database error: insufficient privilege',
       })
     )
   })
@@ -1778,7 +1778,7 @@ describe('testing generating signed URL for upload', () => {
       JSON.stringify({
         statusCode: '403',
         error: 'Unauthorized',
-        message: 'new row violates row-level security policy',
+        message: 'Database error: insufficient privilege',
       })
     )
     // Ensure that row does not exist in database.

--- a/src/test/rls_tests.yaml
+++ b/src/test/rls_tests.yaml
@@ -54,15 +54,15 @@ tests:
     asserts:
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: bucket.delete
         status: 400
@@ -113,15 +113,15 @@ tests:
     asserts:
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: bucket.delete
         status: 400
@@ -199,11 +199,11 @@ tests:
 
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         policies:
@@ -240,7 +240,7 @@ tests:
     asserts:
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: bucket.delete
         status: 400
@@ -248,11 +248,11 @@ tests:
 
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         policies:
@@ -281,7 +281,7 @@ tests:
     asserts:
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: bucket.delete
         status: 400
@@ -322,15 +322,15 @@ tests:
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         policies:
@@ -363,15 +363,15 @@ tests:
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         bucketName: 'bucket_delete_test_{{runId}}'
@@ -406,15 +406,15 @@ tests:
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload.upsert
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         bucketName: 'bucket_to_move_{{runId}}'
@@ -446,7 +446,7 @@ tests:
 
       - operation: bucket.create
         status: 400
-        error: 'new row violates row-level security policy'
+        error: 'Database error: insufficient privilege'
 
       - operation: upload
         bucketName: 'bucket_{{runId}}'
@@ -457,7 +457,7 @@ tests:
         useExistingBucketName: 'bucket_{{runId}}'
         objectName: 'object_{{runId}}.txt'
         status: 400
-        message: 'new row violates row-level security policy'
+        message: 'Database error: insufficient privilege'
 
       - operation: upload
         bucketName: 'bucket_to_copy_{{runId}}'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Make the error message more descriptive when insufficient privileges error is thrown by postgres
