### PR TITLE
fix: operation on s3 protocol

### DIFF
--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -49,7 +49,7 @@ export const db = fastifyPlugin(
         headers: request.headers,
         path: request.url,
         method: request.method,
-        operation: request.operation?.type,
+        operation: () => request.operation?.type,
       })
     })
 
@@ -111,6 +111,7 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
         method: request.method,
         headers: request.headers,
         disableHostCheck: opts.disableHostCheck,
+        operation: () => request.operation?.type,
       })
     })
 

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -12,7 +12,7 @@ interface ConnectionOptions {
   user: User
   superUser: User
   disableHostCheck?: boolean
-  operation?: string
+  operation?: () => string | undefined
 }
 
 /**

--- a/src/internal/database/connection.ts
+++ b/src/internal/database/connection.ts
@@ -34,7 +34,7 @@ interface TenantConnectionOptions {
   headers?: Record<string, string | undefined | string[]>
   method?: string
   path?: string
-  operation?: string
+  operation?: () => string | undefined
 }
 
 export interface User {
@@ -252,7 +252,7 @@ export class TenantConnection {
         headers,
         this.options.method || '',
         this.options.path || '',
-        this.options.operation || '',
+        this.options.operation?.() || '',
       ]
     )
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

At times the `storage.operation` flag is not passed as a config when using the S3 protocol

## What is the new behavior?

This PR fixes this inconsistency by using a function to compute the value when necessary
