### PR TITLE
feat: allow disabling s3 protocol

### DIFF
--- a/migrations/multitenant/0013-s3-protocol-toggle.sql
+++ b/migrations/multitenant/0013-s3-protocol-toggle.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS feature_s3_protocol boolean DEFAULT true NOT NULL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ type StorageConfigType = {
   tusPartSize: number
   tusUseFileVersionSeparator: boolean
   defaultMetricsEnabled: boolean
+  s3ProtocolEnabled: boolean
   s3ProtocolPrefix: string
   s3ProtocolAllowForwardedHeader: boolean
   s3ProtocolEnforceRegion: boolean
@@ -252,6 +253,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       getOptionalConfigFromEnv('TUS_USE_FILE_VERSION_SEPARATOR') === 'true',
 
     // S3 Protocol
+    s3ProtocolEnabled: getOptionalConfigFromEnv('S3_PROTOCOL_ENABLED') !== 'false',
     s3ProtocolPrefix: getOptionalConfigFromEnv('S3_PROTOCOL_PREFIX') || '',
     s3ProtocolAllowForwardedHeader:
       getOptionalConfigFromEnv('S3_ALLOW_FORWARDED_HEADER') === 'true',

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -41,6 +41,9 @@ export interface Features {
     enabled: boolean
     maxResolution?: number
   }
+  s3Protocol: {
+    enabled: boolean
+  }
 }
 
 export enum TenantMigrationStatus {
@@ -203,6 +206,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
       jwks,
       service_key,
       feature_image_transformation,
+      feature_s3_protocol,
       image_transformation_max_resolution,
       database_pool_url,
       max_connections,
@@ -230,6 +234,9 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
         imageTransformation: {
           enabled: feature_image_transformation,
           maxResolution: image_transformation_max_resolution,
+        },
+        s3Protocol: {
+          enabled: feature_s3_protocol,
         },
       },
       migrationVersion: migrations_version,

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -23,6 +23,9 @@ const payload = {
       enabled: true,
       maxResolution: null,
     },
+    s3Protocol: {
+      enabled: true,
+    },
   },
 }
 
@@ -42,6 +45,9 @@ const payload2 = {
     imageTransformation: {
       enabled: false,
       maxResolution: null,
+    },
+    s3Protocol: {
+      enabled: true,
     },
   },
 }

--- a/src/test/x-forwarded-host.test.ts
+++ b/src/test/x-forwarded-host.test.ts
@@ -26,6 +26,9 @@ beforeAll(async () => {
       imageTransformation: {
         enabled: true,
       },
+      s3Protocol: {
+        enabled: true,
+      },
     },
   }))
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

Allow disabling the S3 protocol on a per-tenant basis as well as when running Storage in single tenant mode using `S3_PROTOCOL_ENABLED=false` 
