### PR TITLE
fix: log when unable to send logs to logflare

### DIFF
--- a/src/internal/monitoring/logflare.ts
+++ b/src/internal/monitoring/logflare.ts
@@ -22,6 +22,9 @@ export default function () {
   return createLogFlareWriteStream({
     apiKey: logflareApiKey,
     sourceToken: logflareSourceToken,
+    onError: (err: Error) => {
+      console.error(`[Logflare][Error] ${err.message} - ${err.stack}`)
+    },
     onPreparePayload: (payload: any, meta: any) => {
       const item = defaultPreparePayload(payload, meta)
       item.project = payload.project


### PR DESCRIPTION
## What kind of change does this PR introduce?

Monitoring

## What is the new behavior?

Log an error to Stderr when storage is unable to push logs to logflare
