### PR TITLE
fix: upgrade cross-spawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7724,9 +7724,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -18997,9 +18997,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Deps update

## What is the new behavior?

Cross-spawn regex vulnerability: https://github.com/supabase/storage/security/dependabot/51
old version: 7.0.3 -> fixed vulnerability 7.0.6

Severity: Low
code paths doesn't allow inputs from `glob` and the rest of the dependencies are dev-dependencies as listed below

```
 storage-api % npm ls cross-spawn                      
supa-storage@1.11.2 /Users/fenos/Documents/Code/storage-api
├─┬ eslint@8.57.1
│ └── cross-spawn@7.0.6
├─┬ glob@11.0.0
│ └─┬ foreground-child@3.3.0
│   └── cross-spawn@7.0.6 deduped
└─┬ jest@29.2.2
  └─┬ @jest/core@29.2.2
    └─┬ jest-changed-files@29.2.0
      └─┬ execa@5.1.1
        └── cross-spawn@7.0.6 deduped
```
