### PR TITLE
fix: allow disabling tus-s3-tags for better compatibility

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,7 @@ type StorageConfigType = {
   tusPath: string
   tusPartSize: number
   tusUseFileVersionSeparator: boolean
+  tusAllowS3Tags: boolean
   defaultMetricsEnabled: boolean
   s3ProtocolEnabled: boolean
   s3ProtocolPrefix: string
@@ -251,6 +252,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     tusUseFileVersionSeparator:
       getOptionalConfigFromEnv('TUS_USE_FILE_VERSION_SEPARATOR') === 'true',
+    tusAllowS3Tags: getOptionalConfigFromEnv('TUS_ALLOW_S3_TAGS') !== 'false',
 
     // S3 Protocol
     s3ProtocolEnabled: getOptionalConfigFromEnv('S3_PROTOCOL_ENABLED') !== 'false',

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -42,6 +42,7 @@ const {
   tusPath,
   tusPartSize,
   tusMaxConcurrentUploads,
+  tusAllowS3Tags,
   uploadFileSizeLimit,
   storageBackendType,
   storageFilePath,
@@ -66,6 +67,7 @@ function createTusStore(agent: { httpsAgent: https.Agent; httpAgent: http.Agent 
       expirationPeriodInMilliseconds: tusUrlExpiryMs,
       cache: new AlsMemoryKV(),
       maxConcurrentPartUploads: tusMaxConcurrentUploads,
+      useTags: tusAllowS3Tags,
       s3ClientConfig: {
         requestHandler: new NodeHttpHandler({
           ...agent,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the new behavior?

Allow disabling tus aws tags, for better compatibility with other S3 Storages that doesn't support `x-amz-tags`
