### PR TITLE
fix: allow UTF-8 encoded object names

### DIFF
--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { getConfig } from '../config'
 import {
   getFileSizeLimit as getFileSizeLimitForTenant,
@@ -47,9 +48,10 @@ export async function isImageTransformationEnabled(tenantId: string) {
  * @param key
  */
 export function isValidKey(key: string): boolean {
-  // only allow s3 safe characters and characters which require special handling for now
+  // Allow any sequence of Unicode characters with UTF-8 encoding.
   // https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-  return key.length > 0 && /^(\w|\/|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/.test(key)
+  const utfEncoded = Buffer.from(key, 'utf8')
+  return key.length > 0 && utfEncoded.toString('utf8') === key
 }
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix 

## What is the current behavior?

Object names are restricted and Unicode non-ASCII characters are not allowed. See #133.

## What is the new behavior?

Allow any sequence of Unicode characters with UTF-8 encoding.

## Additional context

Add any other context or screenshots.
