### PR TITLE
fix: remove fastify deprecated properties

### DIFF
--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -28,7 +28,7 @@ export const jwt = fastifyPlugin(
     fastify.addHook('preHandler', async (request, reply) => {
       request.jwt = (request.headers.authorization || '').replace(BEARER, '')
 
-      if (!request.jwt && request.routeConfig.allowInvalidJwt) {
+      if (!request.jwt && request.routeOptions.config.allowInvalidJwt) {
         request.jwtPayload = { role: 'anon' }
         request.isAuthenticated = false
         return
@@ -45,7 +45,7 @@ export const jwt = fastifyPlugin(
         request.jwtPayload = { role: 'anon' }
         request.isAuthenticated = false
 
-        if (request.routeConfig.allowInvalidJwt) {
+        if (request.routeOptions.config.allowInvalidJwt) {
           return
         }
         throw ERRORS.AccessDenied(err.message, err)

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -59,7 +59,7 @@ export const logRequest = (options: RequestLoggerOptions) =>
         const resourceFromParams = Object.values(req.params || {}).join('/')
         const resources = getFirstDefined<string[]>(
           req.resources,
-          req.routeConfig.resources?.(req),
+          req.routeOptions.config.resources?.(req),
           (req.raw as any).resources,
           resourceFromParams ? [resourceFromParams] : ([] as string[])
         )
@@ -73,7 +73,7 @@ export const logRequest = (options: RequestLoggerOptions) =>
         }
 
         req.resources = resources
-        req.operation = req.routeConfig.operation
+        req.operation = req.routeOptions.config.operation
 
         if (req.operation) {
           trace.getActiveSpan()?.setAttribute('http.operation', req.operation.type)
@@ -129,7 +129,7 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
     owner: req.owner,
     role: req.jwtPayload?.role,
     resources: req.resources,
-    operation: req.operation?.type ?? req.routeConfig.operation?.type,
+    operation: req.operation?.type ?? req.routeOptions.config.operation?.type,
     serverTimes: req.serverTimings,
   })
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR removes deprecated properties from fastify. Currently we are getting this waring while running the server and tests

(node:55925) [FSTDEP016] DeprecationWarning: You are accessing the deprecated "request.routeConfig" property. Use "request.routeOptions.config" instead. Property "req.routeConfig" will be removed in fastify@5.

## What is the current behavior?
Deprecated warnings are shown while running the server

## What is the new behavior?
Deprecated warnings are removed while running the server

