### PR TITLE
fix: storage encoding on copy

### DIFF
--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -402,7 +402,9 @@ export class ObjectStorage {
     mustBeValidKey(destinationObjectName)
 
     const newVersion = randomUUID()
-    const s3SourceKey = `${this.db.tenantId}/${this.bucketId}/${sourceObjectName}`
+    const s3SourceKey = encodeURIComponent(
+      `${this.db.tenantId}/${this.bucketId}/${sourceObjectName}`
+    )
     const s3DestinationKey = `${this.db.tenantId}/${destinationBucket}/${destinationObjectName}`
 
     await this.db.testPermission((db) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using special characters such as the `+` S3 treats it as a space

## What is the new behavior?

By encoding the key on copy S3 correctly identify the object key correctly

