### PR TITLE
feat: Add `mtime` as optional ETag algorithm in file backend alongside default `md5`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -100,7 +100,7 @@ AWS_SECRET_ACCESS_KEY=secret1234
 # File Backend
 #######################################
 STORAGE_FILE_BACKEND_PATH=./data
-
+STORAGE_FILE_ETAG_ALGORITHM=md5
 
 #######################################
 # Image Transformation

--- a/src/config.ts
+++ b/src/config.ts
@@ -274,7 +274,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       'STORAGE_FILE_BACKEND_PATH',
       'FILE_STORAGE_BACKEND_PATH'
     ),
-    storageFileEtagAlgorithm: getOptionalConfigFromEnv('STORAGE_FILE_ETAG_ALGORITHM') || 'mtime',
+    storageFileEtagAlgorithm: getOptionalConfigFromEnv('STORAGE_FILE_ETAG_ALGORITHM') || 'md5',
 
     // Storage - S3
     storageS3MaxSockets: parseInt(

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ type StorageConfigType = {
   uploadFileSizeLimit: number
   uploadFileSizeLimitStandard?: number
   storageFilePath?: string
+  storageFileEtagAlgorithm: 'mtime' | 'md5'
   storageS3MaxSockets: number
   storageS3Bucket: string
   storageS3Endpoint?: string
@@ -273,6 +274,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       'STORAGE_FILE_BACKEND_PATH',
       'FILE_STORAGE_BACKEND_PATH'
     ),
+    storageFileEtagAlgorithm: getOptionalConfigFromEnv('STORAGE_FILE_ETAG_ALGORITHM') || 'mtime',
 
     // Storage - S3
     storageS3MaxSockets: parseInt(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #612 

## What is the current behavior?

#612

In the file backend, ETags are generated by calculating the MD5 hash of the entire file contents, which can take several seconds or even more than 10 seconds for larger files. This becomes particularly problematic when utilizing Range requests.

## What is the new behavior?

The ETag in the file backend is now generated using only a file's modification time (`mtime`) and `size`. I believe this is sufficient as it follows the same [approach used by Nginx](https://github.com/nginx/nginx/blob/57d54fd922e7ecbebb78598d13adc9df1a4b69c0/src/http/ngx_http_core_module.c#L1701C23-L1706) (and moreover, the file backend is primarily used in local development).
