### PR TITLE
fix: cleanup imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "tsx watch src/start/server.ts | pino-pretty",
-    "build": "node ./build.js && resolve-tspaths",
+    "build": "tsc -noEmit && node ./build.js && resolve-tspaths",
     "start": "NODE_ENV=production node dist/start/server.js",
     "format": "prettier -c --write src/**",
     "lint": "prettier -v && prettier -c src/**",

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -1,22 +1,24 @@
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig, MultitenantMigrationStrategy } from '../../config'
 import {
-  areMigrationsUpToDate,
   getServiceKeyUser,
   getTenantConfig,
   TenantMigrationStatus,
-  updateTenantMigrationsState,
   TenantConnection,
   getPostgresConnection,
-  progressiveMigrations,
-  runMigrationsOnTenant,
-  hasMissingSyncMigration,
-  DBMigration,
-  lastMigrationName,
 } from '@internal/database'
 import { verifyJWT } from '@internal/auth'
 import { logSchema } from '@internal/monitoring'
 import { createMutexByKey } from '@internal/concurrency'
+import {
+  areMigrationsUpToDate,
+  DBMigration,
+  hasMissingSyncMigration,
+  lastMigrationName,
+  progressiveMigrations,
+  runMigrationsOnTenant,
+  updateTenantMigrationsState,
+} from '@internal/database/migrations'
 
 declare module 'fastify' {
   interface FastifyRequest {

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -1,9 +1,10 @@
 import { FastifyInstance } from 'fastify'
 import { Queue } from '@internal/queue'
-import { multitenantKnex, runMigrationsOnAllTenants } from '@internal/database'
+import { multitenantKnex } from '@internal/database'
 import { RunMigrationsOnTenants } from '@storage/events'
 import apiKey from '../../plugins/apikey'
 import { getConfig } from '../../../config'
+import { runMigrationsOnAllTenants } from '@internal/database/migrations'
 
 const { pgQueueEnable } = getConfig()
 

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -2,15 +2,13 @@ import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import apiKey from '../../plugins/apikey'
 import { decrypt, encrypt } from '@internal/auth'
-import {
-  deleteTenantConfig,
-  TenantMigrationStatus,
-  multitenantKnex,
-  lastMigrationName,
-  runMigrationsOnTenant,
-  progressiveMigrations,
-} from '@internal/database'
+import { deleteTenantConfig, TenantMigrationStatus, multitenantKnex } from '@internal/database'
 import { dbSuperUser, storage } from '../../plugins'
+import {
+  lastMigrationName,
+  progressiveMigrations,
+  runMigrationsOnTenant,
+} from '@internal/database/migrations'
 
 const patchSchema = {
   body: {
@@ -292,6 +290,9 @@ export default async function routes(fastify: FastifyInstance) {
               migrations_status: TenantMigrationStatus.COMPLETED,
             })
         } catch (e) {
+          if (e instanceof Error) {
+            request.executionError = e
+          }
           progressiveMigrations.addTenant(tenantId)
         }
       }

--- a/src/internal/database/index.ts
+++ b/src/internal/database/index.ts
@@ -1,6 +1,5 @@
 export * from './multitenant-db'
 export * from './tenant'
 export * from './connection'
-export * from './migrations'
 export * from './client'
 export * from './pubsub'

--- a/src/internal/database/migrations/progressive.ts
+++ b/src/internal/database/migrations/progressive.ts
@@ -1,6 +1,7 @@
 import { logger, logSchema } from '../../monitoring'
-import { areMigrationsUpToDate, getTenantConfig, TenantMigrationStatus } from '../tenant'
+import { getTenantConfig, TenantMigrationStatus } from '../tenant'
 import { RunMigrationsOnTenants } from '@storage/events'
+import { areMigrationsUpToDate } from '@internal/database/migrations/migrate'
 
 export class ProgressiveMigrations {
   protected tenants: string[] = []

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -7,7 +7,6 @@ import { PubSubAdapter } from '../pubsub'
 import { createMutexByKey } from '../concurrency'
 import { LRUCache } from 'lru-cache'
 import objectSizeOf from 'object-sizeof'
-import { lastMigrationName } from './migrations/migrate'
 import { ERRORS } from '@internal/errors'
 import { DBMigration } from '@internal/database/migrations'
 
@@ -87,86 +86,6 @@ const singleTenantServiceKey:
       },
     }
   : undefined
-
-/**
- * List all tenants that needs to have the migrations run
- */
-export async function* listTenantsToMigrate(signal: AbortSignal) {
-  let lastCursor = 0
-
-  while (true) {
-    if (signal.aborted) {
-      break
-    }
-
-    const migrationVersion = await lastMigrationName()
-
-    const data = await multitenantKnex
-      .table<{ id: string; cursor_id: number }>('tenants')
-      .select('id', 'cursor_id')
-      .where('cursor_id', '>', lastCursor)
-      .where((builder) => {
-        builder
-          .where((whereBuilder) => {
-            whereBuilder
-              .where('migrations_version', '!=', migrationVersion)
-              .whereNotIn('migrations_status', [
-                TenantMigrationStatus.FAILED,
-                TenantMigrationStatus.FAILED_STALE,
-              ])
-          })
-          .orWhere('migrations_status', null)
-      })
-      .orderBy('cursor_id', 'asc')
-      .limit(200)
-
-    if (data.length === 0) {
-      break
-    }
-
-    lastCursor = data[data.length - 1].cursor_id
-    yield data.map((tenant) => tenant.id)
-  }
-}
-
-/**
- * Update tenant migration version and status
- * @param tenantId
- * @param options
- */
-export async function updateTenantMigrationsState(
-  tenantId: string,
-  options?: { state: TenantMigrationStatus }
-) {
-  const migrationVersion = await lastMigrationName()
-  const state = options?.state || TenantMigrationStatus.COMPLETED
-  return multitenantKnex
-    .table('tenants')
-    .where('id', tenantId)
-    .update({
-      migrations_version: [
-        TenantMigrationStatus.FAILED,
-        TenantMigrationStatus.FAILED_STALE,
-      ].includes(state)
-        ? undefined
-        : migrationVersion,
-      migrations_status: state,
-    })
-}
-
-/**
- * Determine if a tenant has the migrations up to date
- * @param tenantId
- */
-export async function areMigrationsUpToDate(tenantId: string) {
-  const latestMigrationVersion = await lastMigrationName()
-  const tenant = await getTenantConfig(tenantId)
-
-  return (
-    latestMigrationVersion === tenant.migrationVersion &&
-    tenant.migrationStatus === TenantMigrationStatus.COMPLETED
-  )
-}
 
 /**
  * Deletes tenants config from the in-memory cache

--- a/src/scripts/migrate-call.ts
+++ b/src/scripts/migrate-call.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 dotenv.config()
 
-import { runMigrationsOnTenant } from '@internal/database'
+import { runMigrationsOnTenant } from '@internal/database/migrations'
 ;(async () => {
   await runMigrationsOnTenant(process.env.DATABASE_URL as string)
 })()

--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -5,19 +5,18 @@ import { IncomingMessage, Server, ServerResponse } from 'node:http'
 import build from '../app'
 import buildAdmin from '../admin-app'
 import { getConfig } from '../config'
-import {
-  runMultitenantMigrations,
-  runMigrationsOnTenant,
-  startAsyncMigrations,
-  listenForTenantUpdate,
-  PubSub,
-} from '@internal/database'
+import { listenForTenantUpdate, PubSub } from '@internal/database'
 import { logger, logSchema } from '@internal/monitoring'
 import { Queue } from '@internal/queue'
 import { registerWorkers } from '@storage/events'
 import { AsyncAbortController } from '@internal/concurrency'
 
 import { bindShutdownSignals, createServerClosedPromise, shutdown } from './shutdown'
+import {
+  runMigrationsOnTenant,
+  runMultitenantMigrations,
+  startAsyncMigrations,
+} from '@internal/database/migrations'
 
 const shutdownSignal = new AsyncAbortController()
 

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -1,6 +1,7 @@
 import { Bucket, S3MultipartUpload, Obj, S3PartUpload } from '../schemas'
 import { ObjectMetadata } from '../backend'
-import { DBMigration, TenantConnection } from '@internal/database'
+import { TenantConnection } from '@internal/database'
+import { DBMigration } from '@internal/database/migrations'
 
 export interface SearchObjectOption {
   search?: string

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -17,9 +17,10 @@ import {
   SearchObjectOption,
 } from './adapter'
 import { DatabaseError } from 'pg'
-import { DBMigration, TenantConnection } from '@internal/database'
+import { TenantConnection } from '@internal/database'
 import { DbQueryPerformance } from '@internal/monitoring/metrics'
 import { isUuid } from '../limits'
+import { DBMigration } from '@internal/database/migrations'
 
 /**
  * Database

--- a/src/storage/events/run-migrations.ts
+++ b/src/storage/events/run-migrations.ts
@@ -1,14 +1,13 @@
 import { BaseEvent } from './base-event'
-import {
-  areMigrationsUpToDate,
-  getTenantConfig,
-  TenantMigrationStatus,
-  updateTenantMigrationsState,
-  runMigrationsOnTenant,
-} from '@internal/database'
+import { getTenantConfig, TenantMigrationStatus } from '@internal/database'
 import { JobWithMetadata, SendOptions, WorkOptions } from 'pg-boss'
 import { logger, logSchema } from '@internal/monitoring'
 import { BasePayload } from '@internal/queue'
+import {
+  areMigrationsUpToDate,
+  runMigrationsOnTenant,
+  updateTenantMigrationsState,
+} from '@internal/database/migrations'
 
 interface RunMigrationsPayload extends BasePayload {
   tenantId: string

--- a/src/storage/events/webhook.ts
+++ b/src/storage/events/webhook.ts
@@ -22,7 +22,7 @@ interface WebhookEvent {
   event: {
     $version: string
     type: string
-    payload: object & { reqId?: string }
+    payload: object & { reqId?: string; bucketId: string; name: string }
     applyTime: number
   }
   sentAt: string
@@ -70,7 +70,12 @@ export class Webhook extends BaseEvent<WebhookEvent> {
       // Do not send an event if disabled for this specific tenant
       const tenant = await getTenantConfig(payload.tenant.ref)
       const disabledEvents = tenant.disableEvents || []
-      if (disabledEvents.includes(`Webhook:${payload.event.type}`)) {
+      if (
+        disabledEvents.includes(`Webhook:${payload.event.type}`) ||
+        disabledEvents.includes(
+          `Webhook:${payload.event.type}:${payload.event.payload.bucketId}/${payload.event.payload.name}`
+        )
+      ) {
         return false
       }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Restructuring imports to prevent import cycles. 
package: `@internal/database/migrations` is now a stand-alone package.

- Moved tenant migrations logic outside of the tenants.ts file
