### PR TITLE
fix: default 5GB limit as max-file size

### DIFF
--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -123,6 +123,7 @@ async function extractSignature(req: AWSRequest) {
       limits: {
         fields: 20,
         files: 1,
+        fileSize: 5 * (1024 * 1024 * 1024),
       },
     })
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -385,6 +385,7 @@ describe('S3 Protocol', () => {
           Expires: 5000,
           Fields: {
             'Content-Type': 'image/jpg',
+            'X-Amz-Meta-Custom': 'meta-field',
           },
         })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Modifying the default (10MB) of fastify multipart to 5GB as the maximum limit accepted.
Downstream we have the right file size validation
