### PR TITLE
fix: added bucket_id and updated_at on object info

### DIFF
--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -61,11 +61,17 @@ async function requestHandler(
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(objectName, 'id,name,version,metadata,user_metadata,created_at')
+      .findObject(
+        objectName,
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+      )
   } else {
     obj = await request.storage
       .from(bucketName)
-      .findObject(objectName, 'id,name,version,metadata,user_metadata,created_at')
+      .findObject(
+        objectName,
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+      )
   }
 
   return request.storage.renderer(method).render(request, response, {


### PR DESCRIPTION
## What kind of change does this PR introduce?
This is a bug fix in which in Object info did not return bucket_id, last_accessed_at, last_modified which is present in interface FileObjectV2 {
  id: string
  version: string
  name: string
  bucket_id: string
  updated_at: string
  created_at: string
  last_accessed_at: string
  size?: number
  cache_control?: string
  content_type?: string
  etag?: string
  last_modified?: string
  metadata?: Record<string, any>
}

## What is the current behavior?
In the current behavior bucket_id, last_accessed_at, last_modified were not returned.
https://github.com/supabase/storage/issues/591
https://github.com/supabase/storage/issues/541

## What is the new behavior?
In the new behavior these will be returned

## Additional context

