### PR TITLE
fix: updated spelling of function from meatadata to metadata

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -808,7 +808,7 @@ export class S3ProtocolHandler {
     let metadataHeaders: Record<string, any> = {}
 
     if (object.user_metadata) {
-      metadataHeaders = toAwsMeatadataHeaders(object.user_metadata)
+      metadataHeaders = toAwsMetadataHeaders(object.user_metadata)
     }
 
     return {
@@ -880,7 +880,7 @@ export class S3ProtocolHandler {
     let metadataHeaders: Record<string, any> = {}
 
     if (object.user_metadata) {
-      metadataHeaders = toAwsMeatadataHeaders(object.user_metadata)
+      metadataHeaders = toAwsMetadataHeaders(object.user_metadata)
     }
 
     return {
@@ -1280,7 +1280,7 @@ export class S3ProtocolHandler {
   }
 }
 
-function toAwsMeatadataHeaders(records: Record<string, any>) {
+function toAwsMetadataHeaders(records: Record<string, any>) {
   const metadataHeaders: Record<string, any> = {}
   let missingCount = 0
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
There were some spelling mistakes I came accross while reading the codebase. There was an extra a while writing metadata

## What is the current behavior?
earlier function name was toAwsMeatadataHeaders

## What is the new behavior?
updated function name to toAwsMetadataHeaders. 

## Additional context

Add any other context or screenshots.
