### PR TITLE
fix: allow copying objects to same destination and overwrite metadata

### DIFF
--- a/src/http/routes/s3/commands/copy-object.ts
+++ b/src/http/routes/s3/commands/copy-object.ts
@@ -1,6 +1,7 @@
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { S3Router } from '../router'
 import { ROUTE_OPERATIONS } from '../../operations'
+import { MetadataDirective } from '@aws-sdk/client-s3'
 
 const CopyObjectInput = {
   summary: 'Copy Object',
@@ -20,6 +21,7 @@ const CopyObjectInput = {
       'x-amz-copy-source-if-modified-since': { type: 'string' },
       'x-amz-copy-source-if-none-match': { type: 'string' },
       'x-amz-copy-source-if-unmodified-since': { type: 'string' },
+      'x-amz-metadata-directive': { type: 'string' },
       'content-encoding': { type: 'string' },
       'content-type': { type: 'string' },
       'cache-control': { type: 'string' },
@@ -42,6 +44,7 @@ export default function CopyObject(s3Router: S3Router) {
         CopySource: req.Headers['x-amz-copy-source'],
         ContentType: req.Headers['content-type'],
         CacheControl: req.Headers['cache-control'],
+        MetadataDirective: req.Headers['x-amz-metadata-directive'] as MetadataDirective | undefined,
         Expires: req.Headers.expires ? new Date(req.Headers.expires) : undefined,
         ContentEncoding: req.Headers['content-encoding'],
         CopySourceIfMatch: req.Headers['x-amz-copy-source-if-match'],

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -231,7 +231,7 @@ export class S3Backend implements StorageBackendAdapter {
     try {
       const command = new CopyObjectCommand({
         Bucket: bucket,
-        CopySource: `${bucket}/${withOptionalVersion(source, version)}`,
+        CopySource: encodeURIComponent(`${bucket}/${withOptionalVersion(source, version)}`),
         Key: withOptionalVersion(destination, destinationVersion),
         CopySourceIfMatch: conditions?.ifMatch,
         CopySourceIfNoneMatch: conditions?.ifNoneMatch,

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1012,6 +1012,11 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingParameter('CopySource')
     }
 
+    if (!command.MetadataDirective) {
+      // default metadata directive is copy
+      command.MetadataDirective = 'COPY'
+    }
+
     const copyResult = await this.storage.from(sourceBucket).copyObject({
       sourceKey,
       destinationBucket: Bucket,

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -354,8 +354,6 @@ export async function fileUploadFromRequest(
     mimeType = request.headers['content-type'] || 'application/octet-stream'
     cacheControl = request.headers['cache-control'] ?? 'no-cache'
 
-    const customMd = request.headers['x-metadata']
-
     if (
       options.allowedMimeTypes &&
       options.allowedMimeTypes.length > 0 &&
@@ -364,13 +362,10 @@ export async function fileUploadFromRequest(
       validateMimeType(mimeType, options.allowedMimeTypes)
     }
 
+    const customMd = request.headers['x-metadata']
+
     if (typeof customMd === 'string') {
-      try {
-        const json = Buffer.from(customMd, 'base64').toString('utf8')
-        userMetadata = JSON.parse(json)
-      } catch (e) {
-        // no-op
-      }
+      userMetadata = parseUserMetadata(customMd)
     }
     isTruncated = () => {
       // @todo more secure to get this from the stream or from s3 in the next step
@@ -384,6 +379,16 @@ export async function fileUploadFromRequest(
     cacheControl,
     isTruncated,
     userMetadata,
+  }
+}
+
+export function parseUserMetadata(metadata: string) {
+  try {
+    const json = Buffer.from(metadata, 'base64').toString('utf8')
+    return JSON.parse(json) as Record<string, string>
+  } catch (e) {
+    // no-op
+    return undefined
   }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Feature

## What is the current behavior?

Copying objects to the same destination is not supported

## What is the new behavior?

- Allow copying objects to same destination
- Allow overwriting cacheControl & mimetype
- Support HTTP protocol and S3 Protocol
- Return copied object in the response

Fixes #611 