### PR TITLE
fix: added cache headers to file backend

### DIFF
--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -88,6 +88,41 @@ export class FileBackend implements StorageBackendAdapter {
     const lastModified = new Date(0)
     lastModified.setUTCMilliseconds(data.mtimeMs)
 
+    if (headers?.ifNoneMatch && headers.ifNoneMatch === eTag) {
+      return {
+        metadata: {
+          cacheControl: cacheControl || 'no-cache',
+          mimetype: contentType || 'application/octet-stream',
+          lastModified: lastModified,
+          httpStatusCode: 304,
+          size: data.size,
+          eTag,
+          contentLength: 0,
+        },
+        body: undefined,
+        httpStatusCode: 304,
+      }
+    }
+
+    if (headers?.ifModifiedSince) {
+      const ifModifiedSince = new Date(headers.ifModifiedSince)
+      if (lastModified <= ifModifiedSince) {
+        return {
+          metadata: {
+            cacheControl: cacheControl || 'no-cache',
+            mimetype: contentType || 'application/octet-stream',
+            lastModified: lastModified,
+            httpStatusCode: 304,
+            size: data.size,
+            eTag,
+            contentLength: 0,
+          },
+          body: undefined,
+          httpStatusCode: 304,
+        }
+      }
+    }
+
     if (headers?.range) {
       const parts = headers.range.replace(/bytes=/, '').split('-')
       const startRange = parseInt(parts[0], 10)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Earlier cache headers were only working with S3 backend added them to file backend too.

## What is the current behavior?
On S3 backend respond with correctly if-none-match and if-modified-since headers added.

## What is the new behavior?
Added these changes to file backend too.

## Additional context

Add any other context or screenshots.
