### PR TITLE
fix: add feature flags to tenants to selectively apply migrations

### DIFF
--- a/migrations/multitenant/0015-migrations-feature-flags.sql
+++ b/migrations/multitenant/0015-migrations-feature-flags.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS migrations_feature_flags text[] NULL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ type StorageConfigType = {
   dbSuperUser: string
   dbSearchPath: string
   dbMigrationStrategy: MultitenantMigrationStrategy
+  dbMigrationFeatureFlagsEnabled: boolean
   dbPostgresVersion?: string
   databaseURL: string
   databaseSSLRootCert?: string
@@ -299,6 +300,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     dbSuperUser: getOptionalConfigFromEnv('DB_SUPER_USER') || 'postgres',
     dbMigrationStrategy: getOptionalConfigFromEnv('DB_MIGRATIONS_STRATEGY') || 'on_request',
+    dbMigrationFeatureFlagsEnabled: getOptionalConfigFromEnv('DB_FEATURE_FLAGS_ENABLED') === 'true',
 
     // Database - Connection
     dbSearchPath: getOptionalConfigFromEnv('DATABASE_SEARCH_PATH', 'DB_SEARCH_PATH') || '',

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -31,6 +31,7 @@ const patchSchema = {
       serviceKey: { type: 'string' },
       tracingMode: { type: 'string' },
       disableEvents: { type: 'array', items: { type: 'string' }, nullable: true },
+      migrationsFeatureFlags: { type: 'array', items: { type: 'string' }, nullable: true },
       features: {
         type: 'object',
         properties: {
@@ -90,6 +91,7 @@ interface tenantDBInterface {
   feature_s3_protocol?: boolean
   feature_image_transformation?: boolean
   image_transformation_max_resolution?: number
+  migrations_feature_flags?: string[]
 }
 
 export default async function routes(fastify: FastifyInstance) {
@@ -163,6 +165,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrations_status,
         tracing_mode,
         disable_events,
+        migrations_feature_flags,
       } = tenant
 
       return {
@@ -192,6 +195,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrationStatus: migrations_status,
         tracingMode: tracing_mode,
         disableEvents: disable_events,
+        migrationsFeatureFlags: migrations_feature_flags,
       }
     }
   })
@@ -259,6 +263,7 @@ export default async function routes(fastify: FastifyInstance) {
         maxConnections,
         tracingMode,
         disableEvents,
+        migrationsFeatureFlags,
       } = request.body
       const { tenantId } = request.params
 
@@ -284,6 +289,7 @@ export default async function routes(fastify: FastifyInstance) {
               : features?.imageTransformation?.maxResolution,
           tracing_mode: tracingMode,
           disable_events: disableEvents,
+          migrations_feature_flags: migrationsFeatureFlags,
         })
         .where('id', tenantId)
 
@@ -300,7 +306,7 @@ export default async function routes(fastify: FastifyInstance) {
           if (e instanceof Error) {
             request.executionError = e
           }
-          progressiveMigrations.addTenant(tenantId)
+          progressiveMigrations.addTenant(tenantId, true)
         }
       }
 

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -31,6 +31,7 @@ interface TenantConfig {
   }
   migrationVersion?: keyof typeof DBMigration
   migrationStatus?: TenantMigrationStatus
+  migrationFeatureFlags?: string[]
   syncMigrationsDone?: boolean
   tracingMode?: string
   disableEvents?: string[]
@@ -134,6 +135,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
       migrations_status,
       tracing_mode,
       disable_events,
+      migrations_feature_flags,
     } = tenant
 
     const serviceKey = decrypt(service_key)
@@ -163,6 +165,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
       migrationVersion: migrations_version,
       migrationStatus: migrations_status,
       migrationsRun: false,
+      migrationFeatureFlags: migrations_feature_flags,
       tracingMode: tracing_mode,
       disableEvents: disable_events,
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the new behaviour?

Add migrationsFeatureFlags to tenant database, to control which tenant should run specific migrations.
Only works for progressive migrations
