### PR TITLE
fix: disable hostname verification if connecting over an IP literal

### DIFF
--- a/src/internal/database/util.ts
+++ b/src/internal/database/util.ts
@@ -1,4 +1,5 @@
 import { logger } from '@internal/monitoring'
+import { ConnectionOptions } from 'tls'
 
 export function getSslSettings({
   connectionString,
@@ -6,7 +7,7 @@ export function getSslSettings({
 }: {
   connectionString: string
   databaseSSLRootCert: string | undefined
-}): { ca: string } | undefined {
+}): ConnectionOptions | undefined {
   if (!databaseSSLRootCert) return undefined
 
   try {
@@ -15,7 +16,7 @@ export function getSslSettings({
     // in case the hostname is an IP address
     const url = new URL(connectionString)
     if (url.hostname && isIpAddress(url.hostname)) {
-      return undefined
+      return { ca: databaseSSLRootCert, rejectUnauthorized: false }
     }
   } catch (err) {
     // ignore to ensure this never breaks the connection in case of an invalid URL

--- a/src/test/database/util.test.ts
+++ b/src/test/database/util.test.ts
@@ -23,13 +23,13 @@ describe('database utils', () => {
       ).toBeUndefined()
     })
 
-    test('should return no SSL settings if hostname is an IP address', () => {
+    test('should return SSL settings if hostname is an IP address', () => {
       expect(
         getSslSettings({
           connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
           databaseSSLRootCert: '<cert>',
         })
-      ).toBeUndefined()
+      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
     })
 
     test('should return SSL settings if hostname is not an IP address', () => {


### PR DESCRIPTION
When storage is connecting via PgBouncer, we connect with an IPv6 address to keep traffic internal and avoid potential issues with network restrictions.

When customers enforce SSL verifications and we connect via IP address as hostname, requests will fail with an "SSL required" error. To address this, we do not let the requests fail, if the hostname cannot be validated, but we still connect via SSL. When using a regular domain/hostname (not an IP), we retain the old behaviour and verify the hostname as we usually do