### PR TITLE
fix: improve migrations of prefixes

### DIFF
--- a/migrations/tenant/0028-object-bucket-name-sorting.sql
+++ b/migrations/tenant/0028-object-bucket-name-sorting.sql
@@ -1,2 +1,2 @@
 -- postgres-migrations disable-transaction
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_name_bucket_unique on storage.objects (name COLLATE "C", bucket_id);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_name_bucket_level_unique on storage.objects (name COLLATE "C", bucket_id, level);

--- a/migrations/tenant/0029-create-prefixes.sql
+++ b/migrations/tenant/0029-create-prefixes.sql
@@ -3,13 +3,19 @@
 -- We run this with 50k batch size to avoid long running transaction
 DO $$
     DECLARE
-        batch_size INTEGER := 50000;
+        batch_size INTEGER := 10000;
         total_scanned INTEGER := 0;
         row_returned INTEGER := 0;
         last_name TEXT COLLATE "C" := NULL;
         last_bucket_id TEXT COLLATE "C" := NULL;
+        delay INTEGER := 1;
+        start_time TIMESTAMPTZ;
+        end_time TIMESTAMPTZ;
+        exec_duration INTERVAL;
     BEGIN
         LOOP
+            start_time := clock_timestamp();  -- Start time of batch
+
             -- Fetch a batch of objects ordered by name COLLATE "C"
             WITH batch as (
                 SELECT id, bucket_id, name, owner
@@ -37,8 +43,15 @@ DO $$
             )
             SELECT count, cursor.last_name, cursor.last_bucket FROM cursor, batch_count INTO row_returned, last_name, last_bucket_id;
 
+            end_time := clock_timestamp();  -- End time after batch processing
+            exec_duration := end_time - start_time;  -- Calculate elapsed time
+
             RAISE NOTICE 'Object Row returned: %', row_returned;
             RAISE NOTICE 'Last Object: %', last_name;
+            RAISE NOTICE 'Execution time for this batch: %', exec_duration;
+            RAISE NOTICE 'Delay: %', delay;
+            RAISE NOTICE 'Batch size: %', batch_size;
+            RAISE NOTICE '-------------------------------------------------';
 
             total_scanned := total_scanned + row_returned;
 
@@ -48,6 +61,24 @@ DO $$
                 EXIT;
             ELSE
                 COMMIT;
+                PERFORM pg_sleep(delay);
+                -- Increase delay by 1 second for each iteration until 30
+                -- then reset it back to 1
+                SELECT CASE WHEN delay >= 10 THEN 1 ELSE delay + 1 END INTO delay;
+
+                -- Update the batch size:
+                -- If execution time > 3 seconds, reset batch_size to 20k.
+                -- If the batch size is already 20k, decrease it by 1k until 5k.
+                -- Otherwise, increase batch_size by 5000 up to a maximum of 50k.
+                IF exec_duration > interval '3 seconds' THEN
+                    IF batch_size <= 20000 THEN
+                        batch_size := GREATEST(batch_size - 1000, 5000);
+                    ELSE
+                        batch_size := 20000;
+                    END IF;
+                ELSE
+                    batch_size := LEAST(batch_size + 5000, 50000);
+                END IF;
             END IF;
     END LOOP;
 END;

--- a/migrations/tenant/0030-update-object-levels.sql
+++ b/migrations/tenant/0030-update-object-levels.sql
@@ -8,8 +8,14 @@ DO $$
         row_returned INTEGER := 0;
         last_name TEXT COLLATE "C" := NULL;
         last_bucket_id TEXT COLLATE "C" := NULL;
+        delay INTEGER := 1;
+        start_time TIMESTAMPTZ;
+        end_time TIMESTAMPTZ;
+        exec_duration INTERVAL;
     BEGIN
         LOOP
+            start_time := clock_timestamp();  -- Start time of batch
+
             -- Fetch a batch of objects ordered by name COLLATE "C"
             WITH batch as (
                 SELECT id, bucket_id, name, storage.get_level(name) as level
@@ -33,8 +39,15 @@ DO $$
             )
             SELECT count, cursor.last_name, cursor.last_bucket FROM cursor, batch_count INTO row_returned, last_name, last_bucket_id;
 
+            end_time := clock_timestamp();  -- End time after batch processing
+            exec_duration := end_time - start_time;  -- Calculate elapsed time
+
             RAISE NOTICE 'Object Row returned: %', row_returned;
             RAISE NOTICE 'Last Object: %', last_name;
+            RAISE NOTICE 'Execution time for this batch: %', exec_duration;
+            RAISE NOTICE 'Delay: %', delay;
+            RAISE NOTICE 'Batch size: %', batch_size;
+            RAISE NOTICE '-------------------------------------------------';
 
             total_scanned := total_scanned + row_returned;
 
@@ -44,6 +57,24 @@ DO $$
                 EXIT;
             ELSE
                 COMMIT;
+                PERFORM pg_sleep(delay);
+                -- Increase delay by 1 second for each iteration until 30
+                -- then reset it back to 1
+                SELECT CASE WHEN delay >= 10 THEN 1 ELSE delay + 1 END INTO delay;
+
+                -- Update the batch size:
+                -- If execution time > 3 seconds, reset batch_size to 10k.
+                -- If the batch size is already 10k, decrease it by 1k until 5k.
+                -- Otherwise, increase batch_size by 5000 up to a maximum of 50k.
+                IF exec_duration > interval '3 seconds' THEN
+                    IF batch_size <= 10000 THEN
+                        batch_size := GREATEST(batch_size - 1000, 5000);
+                    ELSE
+                        batch_size := 10000;
+                    END IF;
+                ELSE
+                    batch_size := LEAST(batch_size + 5000, 50000);
+                END IF;
             END IF;
         END LOOP;
     END;

--- a/migrations/tenant/0036-optimise-existing-functions.sql
+++ b/migrations/tenant/0036-optimise-existing-functions.sql
@@ -1,0 +1,144 @@
+create or replace function storage.search (
+    prefix text,
+    bucketname text,
+    limits int default 100,
+    levels int default 1,
+    offsets int default 0,
+    search text default '',
+    sortcolumn text default 'name',
+    sortorder text default 'asc'
+) returns table (
+    name text,
+    id uuid,
+    updated_at timestamptz,
+    created_at timestamptz,
+    last_accessed_at timestamptz,
+    metadata jsonb
+)
+as $$
+declare
+    can_bypass_rls BOOLEAN;
+begin
+    SELECT rolbypassrls
+    INTO can_bypass_rls
+    FROM pg_roles
+    WHERE rolname = coalesce(nullif(current_setting('role', true), 'none'), current_user);
+
+    IF can_bypass_rls THEN
+        RETURN QUERY SELECT * FROM storage.search_v1_optimised(prefix, bucketname, limits, levels, offsets, search, sortcolumn, sortorder);
+    ELSE
+        RETURN QUERY SELECT * FROM storage.search_legacy_v1(prefix, bucketname, limits, levels, offsets, search, sortcolumn, sortorder);
+    END IF;
+end;
+$$ language plpgsql volatile;
+
+
+CREATE OR REPLACE FUNCTION storage.extension(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+    _filename text;
+BEGIN
+    -- Split on "/" to get path segments
+    SELECT string_to_array(name, '/') INTO _parts;
+    -- Get the last path segment (the actual filename)
+    SELECT _parts[array_length(_parts, 1)] INTO _filename;
+    -- Extract extension: reverse, split on '.', then reverse again
+    RETURN reverse(split_part(reverse(_filename), '.', 1));
+END
+$function$;
+
+
+CREATE OR REPLACE FUNCTION storage.foldername(name text)
+    RETURNS text[]
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+BEGIN
+    -- Split on "/" to get path segments
+    SELECT string_to_array(name, '/') INTO _parts;
+    -- Return everything except the last segment
+    RETURN _parts[1 : array_length(_parts,1) - 1];
+END
+$function$;
+
+
+CREATE OR REPLACE FUNCTION storage.extension(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+    _filename text;
+BEGIN
+    SELECT string_to_array(name, '/') INTO _parts;
+    SELECT _parts[array_length(_parts,1)] INTO _filename;
+    RETURN reverse(split_part(reverse(_filename), '.', 1));
+END
+$function$;
+
+DROP FUNCTION storage.get_size_by_bucket();
+CREATE OR REPLACE FUNCTION storage.get_size_by_bucket()
+    RETURNS TABLE (
+          size BIGINT,
+          bucket_id text
+    )
+    LANGUAGE plpgsql
+    STABLE
+AS $function$
+BEGIN
+    return query
+        select sum((metadata->>'size')::bigint) as size, obj.bucket_id
+        from "storage".objects as obj
+        group by obj.bucket_id;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION "storage"."objects_update_prefix_trigger"()
+    RETURNS trigger
+AS $func$
+DECLARE
+    old_prefixes TEXT[];
+BEGIN
+    -- Ensure this is an update operation and the name has changed
+    IF TG_OP = 'UPDATE' AND (NEW."name" <> OLD."name" OR NEW."bucket_id" <> OLD."bucket_id") THEN
+        -- Retrieve old prefixes
+        old_prefixes := "storage"."get_prefixes"(OLD."name");
+
+        -- Remove old prefixes that are only used by this object
+        WITH all_prefixes as (
+            SELECT unnest(old_prefixes) as prefix
+        ),
+        can_delete_prefixes as (
+             SELECT prefix
+             FROM all_prefixes
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM "storage"."objects"
+                 WHERE "bucket_id" = OLD."bucket_id"
+                   AND "name" <> OLD."name"
+                   AND "name" LIKE (prefix || '%')
+             )
+         )
+        DELETE FROM "storage"."prefixes" WHERE name IN (SELECT prefix FROM can_delete_prefixes);
+
+        -- Add new prefixes
+        PERFORM "storage"."add_prefixes"(NEW."bucket_id", NEW."name");
+    END IF;
+    -- Set the new level
+    NEW."level" := "storage"."get_level"(NEW."name");
+
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql VOLATILE;
+
+CREATE OR REPLACE TRIGGER "objects_update_create_prefix"
+    BEFORE UPDATE ON "storage"."objects"
+    FOR EACH ROW
+    WHEN (NEW.name != OLD.name OR NEW.bucket_id != OLD.bucket_id)
+EXECUTE FUNCTION "storage"."objects_update_prefix_trigger"();

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -25,35 +25,6 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send({ message: 'Migrations scheduled' })
   })
 
-  fastify.get('/active', async (req, reply) => {
-    if (!pgQueueEnable) {
-      return reply.code(400).send({ message: 'Queue is not enabled' })
-    }
-    const data = await multitenantKnex
-      .table('pgboss.job')
-      .where('state', 'active')
-      .where('name', 'tenants-migrations')
-      .orderBy('createdon', 'desc')
-      .limit(2000)
-
-    return reply.send(data)
-  })
-
-  fastify.delete('/active', async (req, reply) => {
-    if (!pgQueueEnable) {
-      return reply.code(400).send({ message: 'Queue is not enabled' })
-    }
-    const data = await multitenantKnex
-      .table('pgboss.job')
-      .where('state', 'active')
-      .where('name', 'tenants-migrations')
-      .orderBy('createdon', 'desc')
-      .update({ state: 'completed' })
-      .limit(2000)
-
-    return reply.send(data)
-  })
-
   fastify.post('/reset/fleet', async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.status(400).send({ message: 'Queue is not enabled' })
@@ -84,6 +55,35 @@ export default async function routes(fastify: FastifyInstance) {
     })
 
     return reply.send({ message: 'Migrations scheduled' })
+  })
+
+  fastify.get('/active', async (req, reply) => {
+    if (!pgQueueEnable) {
+      return reply.code(400).send({ message: 'Queue is not enabled' })
+    }
+    const data = await multitenantKnex
+      .table('pgboss.job')
+      .where('state', 'active')
+      .where('name', 'tenants-migrations')
+      .orderBy('createdon', 'desc')
+      .limit(2000)
+
+    return reply.send(data)
+  })
+
+  fastify.delete('/active', async (req, reply) => {
+    if (!pgQueueEnable) {
+      return reply.code(400).send({ message: 'Queue is not enabled' })
+    }
+    const data = await multitenantKnex
+      .table('pgboss.job')
+      .where('state', 'active')
+      .where('name', 'tenants-migrations')
+      .orderBy('createdon', 'desc')
+      .update({ state: 'completed' })
+      .limit(2000)
+
+    return reply.send(data)
   })
 
   fastify.get('/progress', async (req, reply) => {

--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -103,7 +103,7 @@ export default async function routes(fastify: FastifyInstance) {
         keepTmpTable: Boolean(req.query.keepTmpTable),
       })
 
-      reply.header('Content-Type', 'application/json; charset=utf-8')
+      reply.header('Content-Type', 'application/x-ndjson; charset=utf-8')
 
       // Do not let the connection time out, periodically send
       // a ping message to keep the connection alive
@@ -117,7 +117,7 @@ export default async function routes(fastify: FastifyInstance) {
               JSON.stringify({
                 ...result,
                 event: 'data',
-              })
+              }) + '\n'
             )
           }
         }
@@ -150,6 +150,8 @@ export default async function routes(fastify: FastifyInstance) {
         before.setHours(before.getHours() - 1)
       }
 
+      reply.header('Content-Type', 'application/x-ndjson; charset=utf-8')
+
       const respPing = ping(reply)
 
       try {
@@ -168,7 +170,7 @@ export default async function routes(fastify: FastifyInstance) {
             JSON.stringify({
               ...deleted,
               event: 'data',
-            })
+            }) + '\n'
           )
         }
       } catch (e) {
@@ -193,7 +195,7 @@ function ping(reply: FastifyReply) {
       reply.raw.write(
         JSON.stringify({
           event: 'ping',
-        })
+        }) + '\n'
       )
     }
   }, 1000 * 10)

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -508,6 +508,30 @@ export default async function routes(fastify: FastifyInstance) {
     }
   })
 
+  fastify.get<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
+    const data = await multitenantKnex
+      .table('pgboss.job')
+      .select('*')
+      .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
+      .where('name', 'tenants-migrations')
+      .orderBy('createdon', 'desc')
+      .limit(100)
+
+    reply.send(data)
+  })
+
+  fastify.delete<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
+    const data = await multitenantKnex
+      .table('pgboss.job')
+      .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
+      .where('name', 'tenants-migrations')
+      .orderBy('createdon', 'desc')
+      .limit(100)
+      .delete()
+
+    reply.send(data)
+  })
+
   fastify.register(async (fastify) => {
     fastify.register(dbSuperUser, {
       disableHostCheck: true,

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -34,4 +34,5 @@ export const DBMigration = {
   'backward-compatible-index-on-prefixes': 33,
   'optimize-search-function-v1': 34,
   'add-insert-trigger-prefixes': 35,
+  'optimise-existing-functions': 36,
 }

--- a/src/storage/events/run-migrations.ts
+++ b/src/storage/events/run-migrations.ts
@@ -18,19 +18,22 @@ interface RunMigrationsPayload extends BasePayload {
 
 export class RunMigrationsOnTenants extends BaseEvent<RunMigrationsPayload> {
   static queueName = 'tenants-migrations'
+  static allowSync = false
 
   static getWorkerOptions(): WorkOptions {
     return {
       teamSize: 200,
       teamConcurrency: 10,
       includeMetadata: true,
+      enforceSingletonQueueActiveLimit: true,
     }
   }
 
   static getQueueOptions(payload: RunMigrationsPayload): SendOptions {
     return {
-      expireInHours: 2,
-      singletonKey: payload.tenantId,
+      expireInHours: 48,
+      singletonKey: `migrations_${payload.tenantId}`,
+      singletonHours: 1,
       useSingletonQueue: true,
       retryLimit: 3,
       retryDelay: 5,

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -19,7 +19,7 @@ const payload = {
   jwtSecret: 'c',
   serviceKey: 'd',
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'add-insert-trigger-prefixes',
+  migrationVersion: 'optimise-existing-functions',
   tracingMode: 'basic',
   features: {
     imageTransformation: {
@@ -45,7 +45,7 @@ const payload2 = {
   jwtSecret: 'g',
   serviceKey: 'h',
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'add-insert-trigger-prefixes',
+  migrationVersion: 'optimise-existing-functions',
   tracingMode: 'basic',
   features: {
     imageTransformation: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Make sure only 1 jobs for migration is ever run
- Batch migration is now using an algorithm to increase / decrease delays and batch size depending on performance

#### Batch Size algorithm
- Starting batch size 10k
- Have batch size increase by 5k every iteration
- Measure execution time of each batch if it is over 3s reduce back to 10k
- If 10k is still slow decrease batch size -1k for each iteration until 5k

#### Delay algorithm:
- Start with 1s delay
- Increase the delay to 1s for every iteration
- When reaches 30s reset back to 1s
