### PR TITLE
fix: update IP address literals detection routines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "fs-xattr": "0.3.1",
         "glob": "^11.0.0",
         "ioredis": "^5.2.4",
+        "ip-address": "^10.0.1",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "lru-cache": "^10.2.0",
@@ -9332,6 +9333,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -20239,6 +20248,11 @@
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.1.0"
       }
+    },
+    "ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "fs-xattr": "0.3.1",
     "glob": "^11.0.0",
     "ioredis": "^5.2.4",
+    "ip-address": "^10.0.1",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "lru-cache": "^10.2.0",

--- a/src/internal/database/util.ts
+++ b/src/internal/database/util.ts
@@ -1,5 +1,6 @@
 import { logger } from '@internal/monitoring'
 import { ConnectionOptions } from 'tls'
+import ipAddr from 'ip-address'
 
 export function getSslSettings({
   connectionString,
@@ -27,10 +28,7 @@ export function getSslSettings({
 }
 
 export function isIpAddress(ip: string) {
-  const ipv4Pattern = /^(\d{1,3}\.){3}\d{1,3}$/
-  const ipv6Pattern = /^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$/
-
-  // IP might be URL-encoded and won't match the regex unless we decode first
+  // IP might be URL-encoded
   const decodedIp = decodeURIComponent(ip)
-  return ipv4Pattern.test(decodedIp) || ipv6Pattern.test(decodedIp)
+  return ipAddr.Address6.isValid(decodedIp) || ipAddr.Address4.isValid(decodedIp)
 }


### PR DESCRIPTION
The simpler regexps used earlier supported one of numerous IPv6 literal formats. The updated implementation uses a more comprehensive library.