### PR TITLE
Use drop trigger if exists to support pg12

### DIFF
--- a/migrations/tenant/0026-objects-prefixes.sql
+++ b/migrations/tenant/0026-objects-prefixes.sql
@@ -146,24 +146,28 @@ END;
 $func$ LANGUAGE plpgsql VOLATILE;
 
 -- "storage"."prefixes"
-CREATE OR REPLACE TRIGGER "prefixes_delete_hierarchy"
+DROP TRIGGER IF EXISTS "prefixes_delete_hierarchy" ON "storage"."prefixes";
+CREATE TRIGGER "prefixes_delete_hierarchy"
     AFTER DELETE ON "storage"."prefixes"
     FOR EACH ROW
 EXECUTE FUNCTION "storage"."delete_prefix_hierarchy_trigger"();
 
 -- "storage"."objects"
-CREATE OR REPLACE TRIGGER "objects_insert_create_prefix"
+DROP TRIGGER IF EXISTS "objects_insert_create_prefix" ON "storage"."objects";
+CREATE TRIGGER "objects_insert_create_prefix"
     BEFORE INSERT ON "storage"."objects"
     FOR EACH ROW
 EXECUTE FUNCTION "storage"."objects_insert_prefix_trigger"();
 
-CREATE OR REPLACE TRIGGER "objects_update_create_prefix"
+DROP TRIGGER IF EXISTS "objects_update_create_prefix" ON "storage"."objects";
+CREATE TRIGGER "objects_update_create_prefix"
     BEFORE UPDATE ON "storage"."objects"
     FOR EACH ROW
     WHEN (NEW.name != OLD.name)
 EXECUTE FUNCTION "storage"."objects_insert_prefix_trigger"();
 
-CREATE OR REPLACE TRIGGER "objects_delete_delete_prefix"
+DROP TRIGGER IF EXISTS "objects_delete_delete_prefix" ON "storage"."objects";
+CREATE TRIGGER "objects_delete_delete_prefix"
     AFTER DELETE ON "storage"."objects"
     FOR EACH ROW
 EXECUTE FUNCTION "storage"."delete_prefix_hierarchy_trigger"();

--- a/migrations/tenant/0035-add-insert-trigger-prefixes.sql
+++ b/migrations/tenant/0035-add-insert-trigger-prefixes.sql
@@ -1,7 +1,8 @@
 
 -- This trigger is used to create the hierarchy of prefixes
 -- When writing directly in the prefixes table
-CREATE OR REPLACE TRIGGER "prefixes_create_hierarchy"
+DROP TRIGGER IF EXISTS "prefixes_create_hierarchy" ON "storage"."prefixes";
+CREATE TRIGGER "prefixes_create_hierarchy"
     BEFORE INSERT ON "storage"."prefixes"
     FOR EACH ROW
     WHEN (pg_trigger_depth() < 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`create or replace trigger` only available up from PG14. When I connect to PG12, migration fails as https://github.com/supabase/storage/blob/37be2a349bb95be654da7c750e1dd1cf5812f55b/migrations/tenant/0026-objects-prefixes.sql#L148-L169

https://github.com/supabase/storage/blob/37be2a349bb95be654da7c750e1dd1cf5812f55b/migrations/tenant/0035-add-insert-trigger-prefixes.sql#L2-L8

contains unsupported syntax.

## What is the new behavior?

Use `drop trigger if exists / create trigger` instead of `create or replace trigger` to support pg12.

## Additional context

Add any other context or screenshots.
