### PR TITLE
fix: use bigint for file sizes to avoid overflow with large files

### DIFF
--- a/migrations/tenant/0036-use-big-int-for-size-function.sql
+++ b/migrations/tenant/0036-use-big-int-for-size-function.sql
@@ -1,0 +1,15 @@
+DROP FUNCTION storage.get_size_by_bucket();
+CREATE OR REPLACE FUNCTION storage.get_size_by_bucket()
+ RETURNS TABLE (
+    size BIGINT,
+    bucket_id text
+  )
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    return query
+        select sum((metadata->>'size')::bigint) as size, obj.bucket_id
+        from "storage".objects as obj
+        group by obj.bucket_id;
+END
+$function$;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -34,4 +34,5 @@ export const DBMigration = {
   'backward-compatible-index-on-prefixes': 33,
   'optimize-search-function-v1': 34,
   'add-insert-trigger-prefixes': 35,
+  'use-big-int-for-size-function': 36,
 }

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -19,7 +19,7 @@ const payload = {
   jwtSecret: 'c',
   serviceKey: 'd',
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'add-insert-trigger-prefixes',
+  migrationVersion: 'use-big-int-for-size-function',
   tracingMode: 'basic',
   features: {
     imageTransformation: {
@@ -45,7 +45,7 @@ const payload2 = {
   jwtSecret: 'g',
   serviceKey: 'h',
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'add-insert-trigger-prefixes',
+  migrationVersion: 'use-big-int-for-size-function',
   tracingMode: 'basic',
   features: {
     imageTransformation: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Uses INT instead of BIGINT in `get_size_by_bucket` which causes an overflow for large files

## What is the new behavior?

Use BIGINT in sum query to avoid overflow
