### PR TITLE
fix: do not drop jwks column just yet

### DIFF
--- a/migrations/multitenant/0016-tenants-jwks.sql
+++ b/migrations/multitenant/0016-tenants-jwks.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS tenants_jwks (
     active boolean NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
-ALTER TABLE tenants DROP COLUMN IF EXISTS jwks;
 
 CREATE INDEX IF NOT EXISTS tenants_jwks_tenant_id_idx ON tenants_jwks(tenant_id);
 CREATE INDEX IF NOT EXISTS tenants_jwks_active_idx ON tenants_jwks(tenant_id, active);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently we drop the `jwks` column in favour of using a new table

## What is the new behavior?

Do not drop the `jwks` just yet

## Additional context

This column is safe to be dropped; however, for a smooth deployment where the old version and new version of the containers are running, the creation of the tenant might fail if the new container is starting up and a tenant is created in the old container.

We will drop this column in a different PR
