### PR TITLE
fix: use pino file to log to stdout when logflare is disabled (uses a…

### DIFF
--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -100,8 +100,15 @@ export const logSchema = {
 }
 
 export function buildTransport(): pino.TransportMultiOptions | undefined {
+  const stdOutTarget = {
+    level: logLevel || 'info',
+    target: 'pino/file',
+    // omitting options.destination logs to stdout using a worker thread
+    options: {},
+  }
+
   if (!logflareEnabled) {
-    return undefined
+    return { targets: [stdOutTarget] }
   }
 
   if (!logflareApiKey) {
@@ -119,11 +126,7 @@ export function buildTransport(): pino.TransportMultiOptions | undefined {
         target: './logflare',
         options: {},
       },
-      {
-        level: logLevel || 'info',
-        target: 'pino/file',
-        options: {},
-      },
+      stdOutTarget,
     ],
   }
 }


### PR DESCRIPTION
… worker thread)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When logflare is disabled pino uses no transport which logs form the main event loop

## What is the new behavior?

Use pino/file when logflare is disabled so logs are emitted from a worker thread
