### PR TITLE
fix: optionally freeze migrations when running migrate-call script

### DIFF
--- a/src/scripts/migrate-call.ts
+++ b/src/scripts/migrate-call.ts
@@ -1,10 +1,11 @@
 import dotenv from 'dotenv'
 dotenv.config()
 
-import { runMigrationsOnTenant } from '@internal/database/migrations'
+import { getConfig, runMigrationsOnTenant } from '@internal/database/migrations'
 ;(async () => {
+  const { databaseURL, dbMigrationFreezeAt } = getConfig()
   await runMigrationsOnTenant({
-    databaseUrl: process.env.DATABASE_URL as string,
-    upToMigration: process.env.DB_MIGRATIONS_FREEZE_AT,
+    databaseUrl: databaseURL,
+    upToMigration: dbMigrationFreezeAt,
   })
 })()

--- a/src/scripts/migrate-call.ts
+++ b/src/scripts/migrate-call.ts
@@ -1,7 +1,8 @@
 import dotenv from 'dotenv'
 dotenv.config()
 
-import { getConfig, runMigrationsOnTenant } from '@internal/database/migrations'
+import { runMigrationsOnTenant } from '@internal/database/migrations'
+import { getConfig } from '../config'
 ;(async () => {
   const { databaseURL, dbMigrationFreezeAt } = getConfig()
   await runMigrationsOnTenant({

--- a/src/scripts/migrate-call.ts
+++ b/src/scripts/migrate-call.ts
@@ -5,5 +5,6 @@ import { runMigrationsOnTenant } from '@internal/database/migrations'
 ;(async () => {
   await runMigrationsOnTenant({
     databaseUrl: process.env.DATABASE_URL as string,
+    upToMigration: process.env.DB_MIGRATIONS_FREEZE_AT,
   })
 })()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Allows CLI to freeze migrations at a specific version.

## Additional context

Add any other context or screenshots.
