### PR TITLE
fix: add bucket name length constraint

### DIFF
--- a/migrations/tenant/0037-add-bucket-name-length-constraint.sql
+++ b/migrations/tenant/0037-add-bucket-name-length-constraint.sql
@@ -1,0 +1,6 @@
+alter table
+    "storage"."buckets"
+add constraint 
+    "buckets_name_length_check" 
+check
+    (length(name) > 0 AND length(name) < 64);

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -35,4 +35,5 @@ export const DBMigration = {
   'optimize-search-function-v1': 34,
   'add-insert-trigger-prefixes': 35,
   'optimise-existing-functions': 36,
+  'add-bucket-name-length-constraint': 37,
 }

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -901,6 +901,13 @@ export class DBError extends StorageBackendError implements RenderableError {
           query,
           code: pgError.code,
         })
+      case '23514': {
+        const bucketName = pgError.detail ? pgError.detail.split(' ')[4]?.slice(0, -1) : 'unknown'
+        return ERRORS.InvalidBucketName(bucketName, pgError).withMetadata({
+          query,
+          code: pgError.code,
+        })
+      }
       default:
         return ERRORS.DatabaseError(pgError.message, pgError).withMetadata({
           query,

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -59,9 +59,12 @@ export function isValidKey(key: string): boolean {
 export function isValidBucketName(bucketName: string): boolean {
   // only allow s3 safe characters and characters which require special handling for now
   // https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+  // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
   // excluding / for bucketName
   return (
-    bucketName.length > 0 && /^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/.test(bucketName)
+    bucketName.length > 0 &&
+    bucketName.length < 64 &&
+    /^(\w|!|-|\.|\*|'|\(|\)| |&|\$|@|=|;|:|\+|,|\?)*$/.test(bucketName)
   )
 }
 

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -211,6 +211,25 @@ describe('testing POST bucket', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('user is not able to create a bucket with a name longer than 63 characters', async () => {
+    const longBucketName = 'a'.repeat(64)
+    const response = await app().inject({
+      method: 'POST',
+      url: `/bucket`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        name: longBucketName,
+      },
+    })
+    expect(response.json()).toEqual({
+      error: 'Invalid Input',
+      message: 'Bucket name invalid',
+      statusCode: '400',
+    })
+  })
 })
 
 /*


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, restricting bucket name length to a max of 63 characters to adhere to [S3 Bucket naming rules
](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)

## What is the current behavior?

No restrictions on the length of bucket name

## What is the new behavior?

Added Postgres buckets name length check constraint and updated `isValidBucketName` function. Also added test in `bucket.test.ts` to verify `400` is being returned when issuing a `POST` request with name longer than 63 characters.

## Additional context

I updated the `fromDBerror` switch statement to include the new pgError.code for the buckets name length check constraint. The `ERRORS.InvalidBucketName` error requires the bucket name I opted to parse it from the `pgError.detail` Example `pgError.detail`:

`'Failing row contains (asdfasssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, asdfasssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, null, 2025-05-03 21:04:15.907656+00, 2025-05-03 21:04:15.907656+00, f, f, null, null, null).'`
