### PR TITLE
fix: expose etag headers required for s3 multipart uploads in browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         node: ['20']
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 # Base stage for shared environment setup
-FROM node:22-alpine3.21 as base
+FROM node:22-alpine3.21 AS base
 RUN apk add --no-cache g++ make python3
 WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Dependencies stage - install and cache all dependencies
-FROM base as dependencies
+FROM base AS dependencies
 RUN npm ci
 # Cache the installed node_modules for later stages
 RUN cp -R node_modules /node_modules_cache
 
 # Build stage - use cached node_modules for building the application
-FROM base as build
+FROM base AS build
 COPY --from=dependencies /node_modules_cache ./node_modules
 COPY . .
 RUN npm run build
 
 # Production dependencies stage - use npm cache to install only production dependencies
-FROM base as production-deps
+FROM base AS production-deps
 COPY --from=dependencies /node_modules_cache ./node_modules
 RUN npm ci --production
 
 # Final stage - for the production build
-FROM base as final
+FROM base AS final
 ARG VERSION
 ENV VERSION=$VERSION
 COPY migrations migrations

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -618,6 +618,7 @@ export class S3ProtocolHandler {
       return {
         headers: {
           etag: uploadPart.ETag || '',
+          'Access-Control-Expose-Headers': 'etag',
         },
       }
     } catch (e) {

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -222,7 +222,7 @@ describe('testing POST bucket', () => {
 
   test('user is not able to create a bucket with a name longer than 100 characters', async () => {
     const longBucketName = 'a'.repeat(101)
-    const response = await app().inject({
+    const response = await appInstance.inject({
       method: 'POST',
       url: `/bucket`,
       headers: {

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -10,10 +10,13 @@ import {
   getTenantConfig,
 } from '@internal/database/tenant'
 import { signJWT } from '@internal/auth'
+import { DBMigration } from '@internal/database/migrations'
 
 dotenv.config({ path: '.env.test' })
 
 const serviceKeyPayload = { abc: 123 }
+
+const migrationVersion = Object.entries(DBMigration).sort(([_, a], [__, b]) => b - a)[0][0]
 
 const payload = {
   anonKey: 'a',
@@ -26,7 +29,7 @@ const payload = {
   serviceKey: 'd',
   jwks: { keys: [] },
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'optimise-existing-functions',
+  migrationVersion,
   tracingMode: 'basic',
   features: {
     imageTransformation: {
@@ -54,7 +57,7 @@ const payload2 = {
   serviceKey: 'h',
   jwks: null,
   migrationStatus: 'COMPLETED',
-  migrationVersion: 'optimise-existing-functions',
+  migrationVersion,
   tracingMode: 'basic',
   features: {
     imageTransformation: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 multipart uploads cannot complete in browser because they are unable to access the etag header since it is not included in the `Access-Control-Expose-Headers` of the response headers

## What is the new behavior?

Include etag in the `Access-Control-Expose-Headers` for only the S3 multipart upload requests. This allows using S3 multipart upload in browser.

## Additional context

- Fix for this issue: https://github.com/supabase/supabase-js/issues/1362
- capitalize "AS" in docker file to stop warning when building docker images
