### PR TITLE
fix: prevent creating new buckets with the name 'public'

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -88,6 +88,10 @@ export class Storage {
   ) {
     mustBeValidBucketName(data.name)
 
+    if (data.name.toLowerCase() === 'public') {
+      throw ERRORS.InvalidBucketName(data.name)
+    }
+
     const bucketData: Parameters<Database['createBucket']>[0] = data
 
     if (typeof data.fileSizeLimit === 'number' || typeof data.fileSizeLimit === 'string') {

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -234,6 +234,24 @@ describe('testing POST bucket', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('user is not able to create a bucket with the name "public"', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: `/bucket`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        name: 'pUbLiC',
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    const { statusCode, error } = await response.json()
+    expect(statusCode).toBe('400')
+    expect(error).toBe('Invalid Input')
+  })
 })
 
 /*

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -111,6 +111,14 @@ describe('S3 Protocol', () => {
         expect(Location).toBeTruthy()
       })
 
+      it('cannot create a bucket named "public"', async () => {
+        const createBucketRequest = new CreateBucketCommand({
+          Bucket: 'public',
+        })
+
+        await expect(client.send(createBucketRequest)).rejects.toThrow('Bucket name invalid')
+      })
+
       it('can get bucket versioning', async () => {
         const bucket = await createBucket(client)
         const bucketVersioningCommand = new GetBucketVersioningCommand({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Users can create buckets named "public" using the API

## What is the new behavior?

A 400 error is thrown if a user tries to create a bucket named "public" via API or S3 protocol

The studio UI already prevents using "public" as a bucket name. This change mirrors that behavior in the API.

## Additional context

A bucket with the name "public" causes issues with our api route resolution. 

For example, if an object's path is `public/something/file.png`:

A request to `/object/info/:bucketName/*` routes to `/object/info/public/:bucketName/*` and returns a BUCKET NOT FOUND error for the bucket "something"

Also, a request to `/object/:bucketName/*` routes to `/object/public/:bucketName/*` and results in the same error
