### PR TITLE
feat: capabilities

### DIFF
--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -8,6 +8,7 @@ import {
   multitenantKnex,
   getTenantConfig,
   jwksManager,
+  getTenantCapabilities,
 } from '@internal/database'
 import { dbSuperUser, storage } from '../../plugins'
 import {
@@ -184,6 +185,8 @@ export default async function routes(fastify: FastifyInstance) {
       disable_events,
     } = tenant
 
+    const capabilities = await getTenantCapabilities(request.params.tenantId)
+
     return {
       anonKey: decrypt(anon_key),
       databaseUrl: decrypt(database_url),
@@ -199,6 +202,7 @@ export default async function routes(fastify: FastifyInstance) {
       jwtSecret: decrypt(jwt_secret),
       jwks,
       serviceKey: decrypt(service_key),
+      capabilities,
       features: {
         imageTransformation: {
           enabled: feature_image_transformation,

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -31,6 +31,9 @@ const payload = {
   migrationStatus: 'COMPLETED',
   migrationVersion,
   tracingMode: 'basic',
+  capabilities: {
+    list_V2: true,
+  },
   features: {
     imageTransformation: {
       enabled: true,
@@ -59,6 +62,9 @@ const payload2 = {
   migrationStatus: 'COMPLETED',
   migrationVersion,
   tracingMode: 'basic',
+  capabilities: {
+    list_V2: true,
+  },
   features: {
     imageTransformation: {
       enabled: false,
@@ -113,10 +119,12 @@ describe('Tenant configs', () => {
     })
     expect(response.statusCode).toBe(200)
     const responseJSON = JSON.parse(response.body)
+    const { capabilities, ...finalPayload } = payload
+
     expect(responseJSON).toEqual([
       {
         id: 'abc',
-        ...payload,
+        ...finalPayload,
       },
     ])
   })

--- a/src/test/x-forwarded-host.test.ts
+++ b/src/test/x-forwarded-host.test.ts
@@ -28,15 +28,17 @@ jest.spyOn(tenant, 'getTenantConfig').mockImplementation(async () => ({
   },
 }))
 
-const mockBucketResult = [{ id: 'abc123', name: 'def456' }]
-const storageDbMock = jest.fn().mockImplementation(() => ({
-  listBuckets: jest.fn().mockResolvedValue(mockBucketResult),
+// Mock module with inline implementation that doesn't depend on variables
+jest.mock('@storage/database', () => ({
+  StorageKnexDB: jest.fn().mockImplementation(() => ({
+    listBuckets: jest.fn().mockResolvedValue([{ id: 'abc123', name: 'def456' }]),
+  })),
 }))
-jest.mock('@storage/database', () => {
-  return {
-    StorageKnexDB: storageDbMock,
-  }
-})
+
+// Access the mock after it's been created by the Jest runtime
+const storageDbMock = require('@storage/database').StorageKnexDB
+
+// Use this reference in tests
 
 getConfig()
 mergeConfig({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

- Expose capabilities of the server on a per tenant based

## Additional context

Adds the `capabilities` object to the admin tenant endpoint:

```json
{
    "capabilities": {
        "list_V2": false
     }
}
```
