### PR TITLE
fix: correctly compose sign v4 to compare on chunked uploads

### DIFF
--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -248,7 +248,6 @@ function createStreamingSignatureV4Parser(opts: CreateSignatureV3ParserOpts) {
     'signatureReadyForVerification',
     (signature: string, _: number, hash: string, previousSign) => {
       const isValid = opts.signatureV4.validateChunkSignature(
-        algorithm,
         opts.clientSignature,
         hash,
         signature,

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -279,7 +279,6 @@ export class SignatureV4 {
   }
 
   public validateChunkSignature(
-    algorithm: V4StreamingAlgorithm,
     clientSignature: ClientSignature,
     chunkHash: string,
     chunkSignature: string,
@@ -300,7 +299,7 @@ export class SignatureV4 {
     //    SHA256(chunkData)
     const scope = `${shortDate}/${region}/${service}/aws4_request`
     const stringToSign = [
-      algorithm,
+      'AWS4-HMAC-SHA256-PAYLOAD',
       clientSignature.longDate,
       scope,
       prevSignature,
@@ -311,7 +310,7 @@ export class SignatureV4 {
     // 4) HMAC it with the derived key and compare
     const expected = this.hmac(signingKey, stringToSign)
 
-    return crypto.timingSafeEqual(expected, Buffer.from(chunkSignature))
+    return crypto.timingSafeEqual(expected, Buffer.from(chunkSignature, 'hex'))
   }
 
   signPostPolicy(clientSignature: ClientSignature, policy: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Currently, it would always reject the request when sent with STREAMING-HMAC-256-TRAILER 

## What is the new behavior?

Validates correctly each incoming chunk signature and allows to proceed with the upload using this method

## Additional context

Add any other context or screenshots.
