### PR TITLE
feat: add pagination to getAllBuckets

### DIFF
--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -28,9 +28,10 @@ const requestQuerySchema = {
   type: 'object',
   properties: {
     limit: { type: 'integer', minimum: 1, examples: [10] },
-    offset: { type: 'integer', minimum: 0, examples: [0] },
+    offset: { type: 'integer', minimum: 1, examples: [1] },
     sortColumn: { type: 'string', enum: ['id', 'name', 'created_at', 'updated_at'] },
     sortOrder: { type: 'string', enum: ['asc', 'desc'] },
+    search: { type: 'string', examples: ["my-bucket"] }
   },
 } as const
 
@@ -55,10 +56,10 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      const { limit, offset, sortColumn, sortOrder } = request.query
+      const { limit, offset, sortColumn, sortOrder, search } = request.query
       const results = await request.storage.listBuckets(
         'id, name, public, owner, created_at, updated_at, file_size_limit, allowed_mime_types',
-        { limit, offset, sortColumn, sortOrder }
+        { limit, offset, sortColumn, sortOrder, search }
       )
 
       return response.send(results)

--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -28,7 +28,7 @@ const requestQuerySchema = {
   type: 'object',
   properties: {
     limit: { type: 'integer', minimum: 1, examples: [10] },
-    offset: { type: 'integer', minimum: 1, examples: [1] },
+    offset: { type: 'integer', minimum: 0, examples: [0] },
     sortColumn: { type: 'string', enum: ['id', 'name', 'created_at', 'updated_at'] },
     sortOrder: { type: 'string', enum: ['asc', 'desc'] },
     search: { type: 'string', examples: ["my-bucket"] }

--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -31,7 +31,7 @@ const requestQuerySchema = {
     offset: { type: 'integer', minimum: 0, examples: [0] },
     sortColumn: { type: 'string', enum: ['id', 'name', 'created_at', 'updated_at'] },
     sortOrder: { type: 'string', enum: ['asc', 'desc'] },
-    search: { type: 'string', examples: ["my-bucket"] }
+    search: { type: 'string', examples: ['my-bucket'] },
   },
 } as const
 

--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { bucketSchema } from '@storage/schemas'
@@ -23,14 +24,29 @@ const successResponseSchema = {
   ],
 }
 
+const requestQuerySchema = {
+  type: 'object',
+  properties: {
+    limit: { type: 'integer', minimum: 1, examples: [10] },
+    offset: { type: 'integer', minimum: 0, examples: [0] },
+    sortColumn: { type: 'string', enum: ['id', 'name', 'created_at', 'updated_at'] },
+    sortOrder: { type: 'string', enum: ['asc', 'desc'] },
+  },
+} as const
+
+interface GetAllBucketsRequest extends AuthenticatedRequest {
+  Querystring: FromSchema<typeof requestQuerySchema>
+}
+
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Gets all buckets'
   const schema = createDefaultSchema(successResponseSchema, {
+    querystring: requestQuerySchema,
     summary,
     tags: ['bucket'],
   })
 
-  fastify.get<AuthenticatedRequest>(
+  fastify.get<GetAllBucketsRequest>(
     '/',
     {
       schema,
@@ -39,8 +55,10 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
+      const { limit, offset, sortColumn, sortOrder } = request.query
       const results = await request.storage.listBuckets(
-        'id, name, public, owner, created_at, updated_at, file_size_limit, allowed_mime_types'
+        'id, name, public, owner, created_at, updated_at, file_size_limit, allowed_mime_types',
+        { limit, offset, sortColumn, sortOrder }
       )
 
       return response.send(results)

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -44,6 +44,13 @@ export interface DatabaseOptions<TNX> {
   parentConnection?: TenantConnection
 }
 
+export interface ListBucketOptions {
+  limit?: number
+  offset?: number
+  sortColumn?: string
+  sortOrder?: string
+}
+
 export interface Database {
   tenantHost: string
   tenantId: string
@@ -108,7 +115,7 @@ export interface Database {
     }
   ): Promise<S3MultipartUpload[]>
 
-  listBuckets(columns: string): Promise<Bucket[]>
+  listBuckets(columns: string, options?: ListBucketOptions): Promise<Bucket[]>
   mustLockObject(bucketId: string, objectName: string, version?: string): Promise<boolean>
   waitObjectLock(
     bucketId: string,

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -49,6 +49,7 @@ export interface ListBucketOptions {
   offset?: number
   sortColumn?: string
   sortOrder?: string
+  search?: string
 }
 
 export interface Database {

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -593,8 +593,8 @@ export class StorageKnexDB implements Database {
 
     return object as typeof filters extends FindObjectFilters
       ? FindObjectFilters['dontErrorOnEmpty'] extends true
-      ? Obj | undefined
-      : Obj
+        ? Obj | undefined
+        : Obj
       : Obj
   }
 
@@ -847,7 +847,7 @@ export class StorageKnexDB implements Database {
 
     const differentScopes = Boolean(
       this.options.parentConnection?.role &&
-      this.connection.role !== this.options.parentConnection?.role
+        this.connection.role !== this.options.parentConnection?.role
     )
     const needsNewTransaction = !tnx || differentScopes
 

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -15,6 +15,7 @@ import {
   FindBucketFilters,
   FindObjectFilters,
   SearchObjectOption,
+  ListBucketOptions,
 } from './adapter'
 import { DatabaseError } from 'pg'
 import { getTenantConfig, TenantConnection } from '@internal/database'
@@ -283,9 +284,23 @@ export class StorageKnexDB implements Database {
     })
   }
 
-  async listBuckets(columns = 'id') {
+  async listBuckets(columns = 'id', options?: ListBucketOptions) {
     const data = await this.runQuery('ListBuckets', (knex) => {
-      return knex.from<Bucket>('buckets').select(columns.split(','))
+      const query = knex.from<Bucket>('buckets').select(columns.split(','))
+
+      if (options?.sortColumn) {
+        query.orderBy(options.sortColumn, options.sortOrder || 'asc')
+      }
+
+      if (options?.limit) {
+        query.limit(options.limit)
+      }
+
+      if (options?.offset) {
+        query.offset(options.offset)
+      }
+
+      return query
     })
 
     return data as Bucket[]

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -288,15 +288,19 @@ export class StorageKnexDB implements Database {
     const data = await this.runQuery('ListBuckets', (knex) => {
       const query = knex.from<Bucket>('buckets').select(columns.split(','))
 
-      if (options?.sortColumn) {
+      if (options?.search !== undefined) {
+        query.where('name', 'like', `${options.search}%`)
+      } 
+
+      if (options?.sortColumn !== undefined) {
         query.orderBy(options.sortColumn, options.sortOrder || 'asc')
       }
 
-      if (options?.limit) {
+      if (options?.limit !== undefined) {
         query.limit(options.limit)
       }
 
-      if (options?.offset) {
+      if (options?.offset !== undefined) {
         query.offset(options.offset)
       }
 

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -288,9 +288,9 @@ export class StorageKnexDB implements Database {
     const data = await this.runQuery('ListBuckets', (knex) => {
       const query = knex.from<Bucket>('buckets').select(columns.split(','))
 
-      if (options?.search !== undefined) {
-        query.where('name', 'like', `${options.search}%`)
-      } 
+      if (options?.search !== undefined && options.search.length > 0) {
+        query.where('name', 'ilike', `%${options.search}%`)
+      }
 
       if (options?.sortColumn !== undefined) {
         query.orderBy(options.sortColumn, options.sortOrder || 'asc')
@@ -593,8 +593,8 @@ export class StorageKnexDB implements Database {
 
     return object as typeof filters extends FindObjectFilters
       ? FindObjectFilters['dontErrorOnEmpty'] extends true
-        ? Obj | undefined
-        : Obj
+      ? Obj | undefined
+      : Obj
       : Obj
   }
 
@@ -847,7 +847,7 @@ export class StorageKnexDB implements Database {
 
     const differentScopes = Boolean(
       this.options.parentConnection?.role &&
-        this.connection.role !== this.options.parentConnection?.role
+      this.connection.role !== this.options.parentConnection?.role
     )
     const needsNewTransaction = !tnx || differentScopes
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,5 @@
 import { StorageBackendAdapter, withOptionalVersion } from './backend'
-import { Database, FindBucketFilters } from './database'
+import { Database, FindBucketFilters, ListBucketOptions } from './database'
 import { ERRORS } from '@internal/errors'
 import { AssetRenderer, HeadRenderer, ImageRenderer } from './renderer'
 import { getFileSizeLimit, mustBeValidBucketName, parseFileSizeToBytes } from './limits'
@@ -68,9 +68,10 @@ export class Storage {
   /**
    * List buckets
    * @param columns
+   * @param options
    */
-  listBuckets(columns = 'id') {
-    return this.db.listBuckets(columns)
+  listBuckets(columns = 'id', options?: ListBucketOptions) {
+    return this.db.listBuckets(columns, options)
   }
 
   /**

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -173,10 +173,10 @@ describe('testing GET all buckets', () => {
     expect(response.statusCode).toBe(400)
   })
 
-  test('offset=0 returns 400', async () => {
+  test('offset=-1 returns 400', async () => {
     const response = await appInstance.inject({
       method: 'GET',
-      url: `/bucket?offset=0`,
+      url: `/bucket?offset=-1`,
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -141,7 +141,29 @@ describe('testing GET all buckets', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('user is able to get buckets with limit, offset and sorting', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/bucket?limit=1&offset=2&sortColumn=name&sortOrder=asc`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    const responseJSON = JSON.parse(response.body)
+    expect(responseJSON.length).toEqual(1)
+    expect(responseJSON[0]).toMatchObject({
+      id: "bucket4",
+      name: "bucket4",
+      public: false, 
+      file_size_limit: null,
+      allowed_mime_types: null,
+    })
+  })
+
 })
+
 /*
  * POST /bucket
  */

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -142,10 +142,10 @@ describe('testing GET all buckets', () => {
     expect(response.statusCode).toBe(400)
   })
 
-  test('user is able to get buckets with limit, offset and sorting', async () => {
+  test('user is able to get buckets with limit, offset, search and sorting', async () => {
     const response = await appInstance.inject({
       method: 'GET',
-      url: `/bucket?limit=1&offset=2&sortColumn=name&sortOrder=asc`,
+      url: `/bucket?limit=1&offset=2&sortColumn=name&sortOrder=asc&search=bucket`,
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
@@ -160,6 +160,28 @@ describe('testing GET all buckets', () => {
       file_size_limit: null,
       allowed_mime_types: null,
     })
+  })
+
+  test('limit=0 returns 400', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/bucket?limit=0`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('offset=0 returns 400', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/bucket?offset=0`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
   })
 })
 

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -154,14 +154,13 @@ describe('testing GET all buckets', () => {
     const responseJSON = JSON.parse(response.body)
     expect(responseJSON.length).toEqual(1)
     expect(responseJSON[0]).toMatchObject({
-      id: "bucket4",
-      name: "bucket4",
-      public: false, 
+      id: 'bucket4',
+      name: 'bucket4',
+      public: false,
       file_size_limit: null,
       allowed_mime_types: null,
     })
   })
-
 })
 
 /*


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature to add pagination to the GET buckets endpoint by introducing optional query parameters `limit`, `offset`, `sortColumn` and `sortOrder`

## What is the current behavior?

Currently, we do not allow pagination for GET buckets endpoint.

## What is the new behavior?

Now we allow optional query parameters to be passed in to allow pagination.

## Additional context


