### PR TITLE
fix: allow 10,000 parts for s3 uploads

### DIFF
--- a/src/http/routes/s3/commands/upload-part.ts
+++ b/src/http/routes/s3/commands/upload-part.ts
@@ -18,7 +18,7 @@ const UploadPartInput = {
     type: 'object',
     properties: {
       uploadId: { type: 'string' },
-      partNumber: { type: 'number', minimum: 1, maximum: 5000 },
+      partNumber: { type: 'number', minimum: 1, maximum: 10000 },
     },
     required: ['uploadId', 'partNumber'],
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 multi-part upload only allows 5000 parts

## What is the new behavior?

S3 multi-part upload allows 10,000 parts
