### PR TITLE
fix: header validation always string

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1251,12 +1251,12 @@ const HEADER_NAME_RE = /^[!#$%&'*+\-.\^_`|~0-9A-Za-z]+$/
 const HEADER_VALUE_RE = /^[\t\x20-\x7e\x80-\xff]+$/
 
 export function isValidHeader(name: string, value: string | string[]): boolean {
-  if (Buffer.from(name).byteLength < MAX_HEADER_NAME_LENGTH && !HEADER_NAME_RE.test(name)) {
+  if (Buffer.from(`${name}`).byteLength < MAX_HEADER_NAME_LENGTH && !HEADER_NAME_RE.test(name)) {
     return false
   }
   const values = Array.isArray(value) ? value : [value]
   return values.every(
-    (v) => Buffer.from(v).byteLength <= MAX_HEADER_VALUE_LENGTH && HEADER_VALUE_RE.test(v)
+    (v) => Buffer.from(`${v}`).byteLength <= MAX_HEADER_VALUE_LENGTH && HEADER_VALUE_RE.test(v)
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Always determine the size of the header by casting it to string

## Additional context

Add any other context or screenshots.
