### PR TITLE
fix: check migration on create bucket

### DIFF
--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -148,7 +148,10 @@ export class StorageKnexDB implements Database {
       public: data.public,
       allowed_mime_types: data.allowed_mime_types,
       file_size_limit: data.file_size_limit,
-      type: 'STANDARD',
+    }
+
+    if (await tenantHasMigrations(this.tenantId, 'iceberg-catalog-flag-on-buckets')) {
+      bucketData.type = 'STANDARD'
     }
 
     try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Check if the migration is available before trying to store the `type` field
