### PR TITLE
fix: gracefully handle missing metadata in file adapter

### DIFF
--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -189,8 +189,8 @@ export class FileBackend implements StorageBackendAdapter {
       await pipeline(body, destFile)
 
       await this.setFileMetadata(file, {
-        contentType,
-        cacheControl,
+        contentType: contentType || 'application/octet-stream',
+        cacheControl: cacheControl || 'no-cache',
       })
 
       const metadata = await this.headObject(bucketName, key, version)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Uploads fail when using file adapter if `content-type` or `cache-control` is not specified.

## What is the new behavior?

Use default values if `content-type` or `cache-control` is undefined to avoid error

## Additional context

Fixes: #719 
