### PR TITLE
fix: check local migrations in tenantHasLocalMigrations()

### DIFF
--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -80,16 +80,14 @@ export function startAsyncMigrations(signal: AbortSignal) {
 }
 
 export async function tenantHasMigrations(tenantId: string, migration: keyof typeof DBMigration) {
-  if (isMultitenant) {
-    const { migrationVersion } = await getTenantConfig(tenantId)
-    if (migrationVersion) {
-      return DBMigration[migrationVersion] >= DBMigration[migration]
-    }
+  const migrationVersion = isMultitenant
+    ? (await getTenantConfig(tenantId)).migrationVersion
+    : await lastLocalMigrationName()
 
-    return false
+  if (migrationVersion) {
+    return DBMigration[migrationVersion] >= DBMigration[migration]
   }
-
-  return true
+  return false
 }
 
 /**

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -1,5 +1,5 @@
 import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
-import { decrypt, verifyJWT } from '../auth'
+import { decrypt } from '../auth'
 import { JWKSManager, JWKSManagerStoreKnex } from '../auth/jwks'
 import { multitenantKnex } from './multitenant-db'
 import { JWTPayload } from 'jose'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `tenantHasMigrations()` function only checks migrations when running in multi-tenant mode 

## What is the new behavior?

Ensure we check for migrations when running in single-tenant / local mode too

