### PR TITLE
fix: Ensure Content-Disposition Header conforms to RFC6266

### DIFF
--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -107,7 +107,7 @@ export abstract class Renderer {
 
         response.header(
           'Content-Disposition',
-          `attachment; filename=${encodedFileName}; filename*=UTF-8''${encodedFileName};`
+          `attachment; filename=${encodedFileName}; filename*=UTF-8''${encodedFileName}`
         )
       }
     }

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -197,7 +197,7 @@ describe('testing GET object', () => {
     expect(S3Backend.prototype.getObject).toBeCalled()
     expect(response.headers).toEqual(
       expect.objectContaining({
-        'content-disposition': `attachment; filename=testname.png; filename*=UTF-8''testname.png;`,
+        'content-disposition': `attachment; filename=testname.png; filename*=UTF-8''testname.png`,
       })
     )
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. 

## What is the current behavior?

When a filename is specified, the `content-disposition` header is added. Currently the header will have  content like this: 
```
attachment; filename=file.txt; filename*=UTF-8''file.txt;
```

RFC6266 specifies the valid formats for this header, and a trailing semi-colon is not allowed per the grammar at  https://datatracker.ietf.org/doc/html/rfc6266#page-4

I was prompted to raise this PR when I ran into the same issue discussed here: https://github.com/jshttp/content-disposition/issues/11

## What is the new behavior?

The PR removes the trailing semi-colon and updates the test for it. 
```
attachment; filename=file.txt; filename*=UTF-8''file.txt
```
