### PR TITLE
fix: allow to control imgproxy local path

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -112,6 +112,7 @@ IMAGE_TRANSFORMATION_LIMIT_MAX_SIZE=2000
 IMGPROXY_URL=http://localhost:50020
 IMGPROXY_REQUEST_TIMEOUT=15
 IMGPROXY_HTTP_MAX_SOCKETS=500
+IMGPROXY_LOCAL_FILE_PATH=./data
 
 #######################################
 # Image Transformation - Rate Limiter

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,6 +130,7 @@ type StorageConfigType = {
   adminDeleteConcurrency?: number
   imageTransformationEnabled: boolean
   imgProxyURL?: string
+  imgProxyLocalFilePath: string
   imgProxyRequestTimeout: number
   imgProxyHttpMaxSockets: number
   imgProxyHttpKeepAlive: number
@@ -472,6 +473,10 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       10
     ),
     imgProxyURL: getOptionalConfigFromEnv('IMGPROXY_URL'),
+    imgProxyLocalFilePath:
+      getOptionalConfigFromEnv('IMGPROXY_LOCAL_FILE_PATH') ||
+      getOptionalConfigFromEnv('STORAGE_FILE_BACKEND_PATH') ||
+      './data',
     imgLimits: {
       size: {
         min: parseInt(

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -38,6 +38,8 @@ const METADATA_ATTR_KEYS = {
   },
 }
 
+const { imgProxyLocalFilePath } = getConfig()
+
 /**
  * FileBackend
  * Interacts with the file system with this FileBackend adapter
@@ -532,7 +534,10 @@ export class FileBackend implements StorageBackendAdapter {
    * @param version
    */
   async privateAssetUrl(bucket: string, key: string, version: string | undefined): Promise<string> {
-    return 'local:///' + path.join(this.filePath, withOptionalVersion(`${bucket}/${key}`, version))
+    return (
+      'local:///' +
+      path.join(imgProxyLocalFilePath, withOptionalVersion(`${bucket}/${key}`, version))
+    )
   }
 
   async setFileMetadata(file: string, { contentType, cacheControl }: FileMetadata) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When running storage with docker, the mounting point absolute path defer.
Resulting in imgproxy not being able to look up for the correct asset path. 

## What is the new behavior?

Allow customising imgproxy lookup path
