### PR TITLE
fix: imgproxy volume binding

### DIFF
--- a/.docker/docker-compose-infra.yml
+++ b/.docker/docker-compose-infra.yml
@@ -151,12 +151,12 @@ services:
     ports:
       - '50020:8080'
     volumes:
-      - ./data:/images/data
+      - ${PWD}/data:${PWD}/data
     environment:
       - IMGPROXY_WRITE_TIMEOUT=20
       - IMGPROXY_READ_TIMEOUT=20
       - IMGPROXY_REQUESTS_QUEUE_SIZE=24
-      - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/images
+      - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
       - IMGPROXY_ENABLE_WEBP_DETECTION=true
       - IMGPROXY_PRESETS=default=width:3000/height:8192

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -3,10 +3,12 @@ import app from '../admin-app'
 import { S3Backend } from '../storage/backend'
 import { Queue } from '@internal/queue'
 import { isS3Error } from '@internal/errors'
+import path from 'path'
 
 export const adminApp = app({})
 
 const ENV = process.env
+const projectRoot = path.join(__dirname, '..', '..')
 
 export function useMockQueue() {
   const queueSpy: jest.SpyInstance | undefined = undefined
@@ -78,7 +80,9 @@ export function useMockObject() {
       contentLength: 3746,
     })
 
-    jest.spyOn(S3Backend.prototype, 'privateAssetUrl').mockResolvedValue('local:///data/sadcat.jpg')
+    jest
+      .spyOn(S3Backend.prototype, 'privateAssetUrl')
+      .mockResolvedValue(`local:///${projectRoot}/data/sadcat.jpg`)
   })
 
   afterEach(() => {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -14,6 +14,8 @@ dotenv.config({ path: '.env.test' })
 const { imgProxyURL, jwtSecret } = getConfig()
 let appInstance: FastifyInstance
 
+const projectRoot = path.join(__dirname, '..', '..')
+
 describe('image rendering routes', () => {
   beforeAll(async () => {
     await fs.mkdir(path.join(__dirname, '..', '..', 'data'), { recursive: true })
@@ -51,7 +53,7 @@ describe('image rendering routes', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
     expect(axiosSpy).toBeCalledWith(
-      '/public/height:100/width:100/resizing_type:fill/plain/local:///data/sadcat.jpg',
+      `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
       { responseType: 'stream', signal: expect.any(AbortSignal) }
     )
   })
@@ -69,7 +71,7 @@ describe('image rendering routes', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
     expect(axiosSpy).toBeCalledWith(
-      '/public/height:100/width:100/resizing_type:fill/plain/local:///data/sadcat.jpg',
+      `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
       { responseType: 'stream', signal: expect.any(AbortSignal) }
     )
   })
@@ -112,7 +114,7 @@ describe('image rendering routes', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
     expect(axiosSpy).toBeCalledWith(
-      '/public/height:100/width:100/resizing_type:fit/plain/local:///data/sadcat.jpg',
+      `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
       { responseType: 'stream', signal: expect.any(AbortSignal) }
     )
   })
@@ -159,7 +161,7 @@ describe('image rendering routes', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
     expect(axiosSpy).toBeCalledWith(
-      '/public/height:100/width:100/resizing_type:fit/plain/local:///data/sadcat.jpg',
+      `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
       { responseType: 'stream', signal: expect.any(AbortSignal) }
     )
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Imgproxy uses absolute path for lookup but can't find it

## What is the new behavior?

Make sure the volume is bound to the exact absolute path
