### PR TITLE
fix: split s3 client into 3 separate clients

### DIFF
--- a/src/http/routes/s3/commands/create-multipart-upload.ts
+++ b/src/http/routes/s3/commands/create-multipart-upload.ts
@@ -1,7 +1,6 @@
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { S3Router } from '../router'
 import { ROUTE_OPERATIONS } from '../../operations'
-import { S3Backend } from '@storage/backend'
 import { ERRORS } from '@internal/errors'
 
 const CreateMultiPartUploadInput = {

--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -46,11 +46,10 @@ export type UploadPart = {
 /**
  * A generic storage Adapter to interact with files
  */
-export abstract class StorageBackendAdapter {
-  client: any
-  constructor() {
-    this.client = null
-  }
+export abstract class StorageBackendAdapter<T = unknown> {
+  constructor() {}
+
+  abstract getClient(): T
 
   async list(
     bucket: string,

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -58,6 +58,10 @@ export class FileBackend implements StorageBackendAdapter {
     this.etagAlgorithm = storageFileEtagAlgorithm
   }
 
+  getClient(): unknown {
+    return null
+  }
+
   async list(
     bucket: string,
     options?: {

--- a/src/storage/backend/index.ts
+++ b/src/storage/backend/index.ts
@@ -2,6 +2,7 @@ import { StorageBackendAdapter } from './adapter'
 import { FileBackend } from './file'
 import { S3Backend, S3ClientOptions } from './s3/adapter'
 import { getConfig, StorageBackendType } from '../../config'
+import { S3Client } from '@aws-sdk/client-s3'
 
 export * from './s3'
 export * from './file'
@@ -14,14 +15,18 @@ type ConfigForStorage<Type extends StorageBackendType> = Type extends 's3'
   ? S3ClientOptions
   : undefined
 
+type BackendAdapterForType<Type extends StorageBackendType> = Type extends 's3'
+  ? StorageBackendAdapter<S3Client>
+  : StorageBackendAdapter
+
 export function createStorageBackend<Type extends StorageBackendType>(
   type: Type,
   config?: ConfigForStorage<Type>
 ) {
-  let storageBackend: StorageBackendAdapter
+  let storageBackend: BackendAdapterForType<Type>
 
   if (type === 'file') {
-    storageBackend = new FileBackend()
+    storageBackend = new FileBackend() as BackendAdapterForType<Type>
   } else {
     const defaultOptions: S3ClientOptions = {
       region: storageS3Region,

--- a/src/storage/events/base-event.ts
+++ b/src/storage/events/base-event.ts
@@ -80,22 +80,26 @@ export abstract class BaseEvent<T extends Omit<BasePayload, '$version'>> extends
     return new Storage(this.getOrCreateStorageBackend(), db, new TenantLocation(storageS3Bucket))
   }
 
-  protected static getOrCreateStorageBackend(monitor = false) {
+  protected static getOrCreateStorageBackend() {
     if (storageBackend) {
       return storageBackend
     }
 
-    const httpAgent = createAgent('s3_worker', {
-      maxSockets: storageS3MaxSockets,
-    })
+    const httpAgents = {
+      api: createAgent('s3_worker_api', {
+        maxSockets: storageS3MaxSockets,
+      }),
+      download: createAgent('s3_worker_download', {
+        maxSockets: storageS3MaxSockets,
+      }),
+      upload: createAgent('s3_worker_upload', {
+        maxSockets: storageS3MaxSockets,
+      }),
+    }
 
     storageBackend = createStorageBackend(storageBackendType, {
-      httpAgent: httpAgent,
+      httpAgents,
     })
-
-    if (monitor) {
-      httpAgent.monitor()
-    }
 
     return storageBackend
   }

--- a/src/test/rls.test.ts
+++ b/src/test/rls.test.ts
@@ -74,7 +74,7 @@ const testSpec = yaml.load(
 const { serviceKeyAsync, tenantId, jwtSecret, databaseURL, storageS3Bucket, storageBackendType } =
   getConfig()
 const backend = createStorageBackend(storageBackendType)
-const client = backend.client
+const client = backend.getClient()
 let appInstance: FastifyInstance
 
 jest.setTimeout(10000)

--- a/src/test/s3-locker.test.ts
+++ b/src/test/s3-locker.test.ts
@@ -18,7 +18,7 @@ import { backends } from '../storage'
 
 const { storageS3Bucket, storageBackendType } = getConfig()
 const backend = backends.createStorageBackend(storageBackendType)
-const s3ClientFromBackend = backend.client
+const s3ClientFromBackend = backend.getClient()
 
 describe('S3Locker', () => {
   let s3Client: S3Client

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -23,7 +23,7 @@ const oneChunkFile = fs.createReadStream(path.resolve(__dirname, 'assets', 'sadc
 const localServerAddress = 'http://127.0.0.1:8999'
 
 const backend = backends.createStorageBackend(storageBackendType)
-const client = backend.client
+const client = backend.getClient()
 
 describe('Tus multipart', () => {
   let db: StorageKnexDB


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

A single S3 client for all operations.

## What is the new behavior?

Split the S3 client into 3 separate instances:

- Api calls
- Uploads
- Download

This allows for granular scaling and granular timeouts on different types of operations 

