### PR TITLE
fix: remove prefixes at application layer instead of db query to avoid concurrency issue

### DIFF
--- a/migrations/tenant/0040-disable-prefix-delete-trigger.sql
+++ b/migrations/tenant/0040-disable-prefix-delete-trigger.sql
@@ -1,0 +1,4 @@
+-- Disable the objects delete trigger to prevent race conditions
+-- Prefix cleanup is now handled at the application level with proper locking
+-- Drop the trigger that causes race conditions during concurrent deletions
+DROP TRIGGER IF EXISTS "objects_delete_delete_prefix" ON "storage"."objects";


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

rows are removed from the objects.prefixes table via a trigger in objects delete. This is not thread safe and can result in orphan prefixes

## What is the new behavior?

Remove prefixes in the application code and use a lock to avoid the concurrency issue

