### PR TITLE
fix: update level on object update

### DIFF
--- a/migrations/tenant/0041-add-object-level-update-trigger.sql
+++ b/migrations/tenant/0041-add-object-level-update-trigger.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE FUNCTION "storage"."objects_update_level_trigger"()
+    RETURNS trigger
+AS $func$
+BEGIN
+    -- Ensure this is an update operation and the name has changed
+    IF TG_OP = 'UPDATE' AND (NEW."name" <> OLD."name" OR NEW."bucket_id" <> OLD."bucket_id") THEN
+        -- Set the new level
+        NEW."level" := "storage"."get_level"(NEW."name");
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql VOLATILE;
+
+CREATE OR REPLACE TRIGGER "objects_update_level_trigger"
+BEFORE UPDATE ON "storage"."objects"
+FOR EACH ROW
+WHEN (NEW.name != OLD.name OR NEW.bucket_id != OLD.bucket_id)
+EXECUTE FUNCTION "storage"."objects_update_level_trigger"();
+
+
+CREATE OR REPLACE FUNCTION storage.delete_leaf_prefixes(bucket_ids text[], names text[])
+    RETURNS void
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+AS $$
+DECLARE
+    v_rows_deleted integer;
+BEGIN
+    LOOP
+        WITH candidates AS (
+            SELECT DISTINCT
+                t.bucket_id,
+                unnest(storage.get_prefixes(t.name)) AS name
+            FROM unnest(bucket_ids, names) AS t(bucket_id, name)
+        ),
+        uniq AS (
+             SELECT
+                 bucket_id,
+                 name,
+                 storage.get_level(name) AS level
+             FROM candidates
+             WHERE name <> ''
+             GROUP BY bucket_id, name
+        ),
+        leaf AS (
+             SELECT
+                 p.bucket_id,
+                 p.name,
+                 p.level
+             FROM storage.prefixes AS p
+                  JOIN uniq AS u
+                       ON u.bucket_id = p.bucket_id
+                           AND u.name = p.name
+                           AND u.level = p.level
+             WHERE NOT EXISTS (
+                 SELECT 1
+                 FROM storage.objects AS o
+                 WHERE o.bucket_id = p.bucket_id
+                   AND o.level = p.level + 1
+                   AND o.name COLLATE "C" LIKE p.name || '/%'
+             )
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM storage.prefixes AS c
+                 WHERE c.bucket_id = p.bucket_id
+                   AND c.level = p.level + 1
+                   AND c.name COLLATE "C" LIKE p.name || '/%'
+             )
+        )
+        DELETE
+        FROM storage.prefixes AS p
+            USING leaf AS l
+        WHERE p.bucket_id = l.bucket_id
+          AND p.name = l.name
+          AND p.level = l.level;
+
+        GET DIAGNOSTICS v_rows_deleted = ROW_COUNT;
+        EXIT WHEN v_rows_deleted = 0;
+    END LOOP;
+END;
+$$;

--- a/migrations/tenant/0042-fix-object-level.sql
+++ b/migrations/tenant/0042-fix-object-level.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+    IF EXISTS(
+        SELECT id FROM storage.migrations
+          WHERE name = 'fix-prefix-race-conditions-optimized'
+          AND executed_at >= now() - interval '1 minutes'
+    ) THEN
+        RETURN;
+    END IF;
+
+    -- Update all object levels based on their names that are incorrect
+    UPDATE storage.objects SET level = storage.get_level(name)
+    WHERE level != storage.get_level(name);
+END$$;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -39,4 +39,6 @@ export const DBMigration = {
   'iceberg-catalog-flag-on-buckets': 38,
   'add-search-v2-sort-support': 39,
   'fix-prefix-race-conditions-optimized': 40,
+  'add-object-level-update-trigger': 41,
+  'fix-object-level': 42,
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

The object-level column is always kept updated via a row level trigger

