### PR TITLE
fix: validate bucket name before attempting to access

### DIFF
--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -51,11 +51,12 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
       const { download } = request.query
 
+      const bucketRef = request.storage.asSuperUser().from(bucketName)
       const [, obj] = await Promise.all([
         request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
           isPublic: true,
         }),
-        request.storage.asSuperUser().from(bucketName).findObject(objectName, 'id,version'),
+        bucketRef.findObject(objectName, 'id,version'),
       ])
 
       // send the object from s3

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -51,11 +51,12 @@ export default async function routes(fastify: FastifyInstance) {
       const { bucketName } = request.params
       const objectName = request.params['*']
 
+      const bucketRef = request.storage.asSuperUser().from(bucketName)
       const [, obj] = await Promise.all([
         request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
           isPublic: true,
         }),
-        request.storage.asSuperUser().from(bucketName).findObject(objectName, 'id,version'),
+        bucketRef.findObject(objectName, 'id,version'),
       ])
 
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Requests to GetPublicObject with an invalid bucket name results in an uncaught exception due to synchronous validation in promise.all

## What is the new behavior?

Ensure bucket name is valid before Promise.all
