### PR TITLE
fix: gracefully handle incomplete multipart uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/lib-storage": "3.654.0",
         "@aws-sdk/s3-request-presigner": "3.654.0",
         "@fastify/accepts": "^4.3.0",
-        "@fastify/multipart": "^8.3.1",
+        "@fastify/multipart": "github:supabase/fastify-multipart#v8.3.1-patched",
         "@fastify/rate-limit": "^7.6.0",
         "@fastify/swagger": "^8.3.1",
         "@fastify/swagger-ui": "^4.1.0",
@@ -11306,8 +11306,7 @@
     },
     "node_modules/@fastify/multipart": {
       "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-8.3.1.tgz",
-      "integrity": "sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==",
+      "resolved": "git+ssh://git@github.com/supabase/fastify-multipart.git#79cc473d42a225319546ee1f9f8fcc411b27aaee",
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -31602,9 +31601,8 @@
       }
     },
     "@fastify/multipart": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-8.3.1.tgz",
-      "integrity": "sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==",
+      "version": "git+ssh://git@github.com/supabase/fastify-multipart.git#79cc473d42a225319546ee1f9f8fcc411b27aaee",
+      "from": "@fastify/multipart@github:supabase/fastify-multipart#v8.3.1-patched",
       "requires": {
         "@fastify/busboy": "^3.0.0",
         "@fastify/deepmerge": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/lib-storage": "3.654.0",
     "@aws-sdk/s3-request-presigner": "3.654.0",
     "@fastify/accepts": "^4.3.0",
-    "@fastify/multipart": "^8.3.1",
+    "@fastify/multipart": "github:supabase/fastify-multipart#v8.3.1-patched",
     "@fastify/rate-limit": "^7.6.0",
     "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^4.1.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an upload stream closes prematurely the exception is not caught in the uploader

## What is the new behavior?

Detect closed stream in uploader and return 400 error:

```json
{"statusCode":"400","error":"InvalidRequest","message":"Request stream closed before upload could begin"}
```

## Additional context

Uses patched fork of [fastify/multipart v8.3.1 (patched)](https://github.com/fastify/fastify-multipart/compare/v8.3.1...supabase:fastify-multipart:v8.3.1-patched) which prevents emitting unhandled errors