### PR TITLE
chore: bump fastify multipart patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11306,7 +11306,7 @@
     },
     "node_modules/@fastify/multipart": {
       "version": "8.3.1",
-      "resolved": "git+ssh://git@github.com/supabase/fastify-multipart.git#79cc473d42a225319546ee1f9f8fcc411b27aaee",
+      "resolved": "git+ssh://git@github.com/supabase/fastify-multipart.git#e088f333c71ce41439deccca5b015caceec9162a",
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -31601,7 +31601,7 @@
       }
     },
     "@fastify/multipart": {
-      "version": "git+ssh://git@github.com/supabase/fastify-multipart.git#79cc473d42a225319546ee1f9f8fcc411b27aaee",
+      "version": "git+ssh://git@github.com/supabase/fastify-multipart.git#e088f333c71ce41439deccca5b015caceec9162a",
       "from": "@fastify/multipart@github:supabase/fastify-multipart#v8.3.1-patched",
       "requires": {
         "@fastify/busboy": "^3.0.0",


### PR DESCRIPTION
Use updated [fastify/multipart patch ](https://github.com/supabase/fastify-multipart/commit/e088f333c71ce41439deccca5b015caceec9162a) that mirrors the fix logic from the upstream fix

