### PR TITLE
fix: typo in user facing error message

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1015,7 +1015,7 @@ export class S3ProtocolHandler {
       (o) => ({
         Key: o.Key,
         Code: 'AccessDenied',
-        Message: "You do not have permission to delete this object or the object doesn't exists",
+        Message: "You do not have permission to delete this object or the object doesn't exist",
       })
     )
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -1006,7 +1006,7 @@ describe('S3 Protocol', () => {
         expect(resp.Contents).toBe(undefined)
       })
 
-      it('try to delete multiple objects that dont exists', async () => {
+      it('try to delete multiple objects that dont exist', async () => {
         const bucketName = await createBucket(client)
 
         await uploadFile(client, bucketName, 'test-1.jpg', 1)
@@ -1038,14 +1038,12 @@ describe('S3 Protocol', () => {
           {
             Key: 'test-2.jpg',
             Code: 'AccessDenied',
-            Message:
-              "You do not have permission to delete this object or the object doesn't exists",
+            Message: "You do not have permission to delete this object or the object doesn't exist",
           },
           {
             Key: 'test-3.jpg',
             Code: 'AccessDenied',
-            Message:
-              "You do not have permission to delete this object or the object doesn't exists",
+            Message: "You do not have permission to delete this object or the object doesn't exist",
           },
         ])
 
@@ -1142,14 +1140,14 @@ describe('S3 Protocol', () => {
         expect(headObj.CacheControl).toBe('max-age=2009')
       })
 
-      it('will not be able to copy an object that doesnt exists', async () => {
+      it('will not be able to copy an object that doesnt exist', async () => {
         const bucketName1 = await createBucket(client)
         await uploadFile(client, bucketName1, 'test-copy-1.jpg', 1)
 
         const copyObjectCommand = new CopyObjectCommand({
           Bucket: bucketName1,
           Key: 'test-copied-2.jpg',
-          CopySource: `${bucketName1}/test-dont-exists.jpg`,
+          CopySource: `${bucketName1}/test-doesnt-exist.jpg`,
         })
 
         try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fix in error message text.

## What is the current behavior?

Text isn't correct grammatically (`doesn't exists` vs `doesn't exist`).

## What is the new behavior?

Grammar is fixed.

## Additional context

None
