### PR TITLE
fix: handle timeout expired errors (connectionTimeoutMillis) as 544s

### DIFF
--- a/src/internal/database/connection.ts
+++ b/src/internal/database/connection.ts
@@ -98,6 +98,12 @@ export class TenantConnection {
         throw ERRORS.DatabaseTimeout(e)
       }
 
+      // Handle pg client connectionTimeoutMillis timeout
+      // This fires when the connection timeout happens before pool acquisition timeout
+      if (e instanceof Error && e.message === 'timeout expired') {
+        throw ERRORS.DatabaseTimeout(e)
+      }
+
       throw e
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `connectionTimeoutMillis` elapses a "timeout expired" error is thrown resulting in an incorrect 500 error

## What is the new behavior?

Catch the "timeout expired" error and throw it as a 544 instead

## Additional context

```
Error: timeout expired
              at Timeout._onTimeout (/Users/lenny/also-work/storage/node_modules/pg/lib/client.js:108:28)
              at listOnTimeout (node:internal/timers:588:17)
              at process.processTimers (node:internal/timers:523:7)
```

This error is thrown here in the node-postres lib: https://github.com/brianc/node-postgres/blob/8d493f3b5531bfe226d40c1d64d1d020ee33fd6f/packages/pg/lib/client.js#L147

