### PR TITLE
feat: add buckets & objects grants for `postgres`

### DIFF
--- a/migrations/tenant/0049-buckets-objects-grants-postgres.sql
+++ b/migrations/tenant/0049-buckets-objects-grants-postgres.sql
@@ -1,0 +1,6 @@
+do $$
+begin
+  if exists (select from pg_roles where rolname = 'postgres') then
+    grant all on storage.buckets, storage.objects to postgres with grant option;
+  end if;
+end $$;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -47,4 +47,5 @@ export const DBMigration = {
   'buckets-objects-grants': 46,
   'iceberg-table-metadata': 47,
   'iceberg-catalog-ids': 48,
+  'buckets-objects-grants-postgres': 49,
 }


### PR DESCRIPTION
In [this change](https://github.com/supabase/storage/pull/710/files#diff-94ae05714be9fe18b41f2af695b6e3b9cc5cc651995a63d2976e6b2538fd017eR5), the grant is actually performed for `supabase_storage_admin` because `DB_SUPER_USER` is not `postgres`. We add another migration to perform the grant for `postgres`.