### PR TITLE
fix: increase put vectors body limit

### DIFF
--- a/src/http/routes/vector/put-vectors.ts
+++ b/src/http/routes/vector/put-vectors.ts
@@ -56,6 +56,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.post<putVectorRequest>(
     '/PutVectors',
     {
+      bodyLimit: 20 * 1024 * 1024, // 20 MB
       config: {
         operation: { type: ROUTE_OPERATIONS.PUT_VECTORS },
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Uses default body limit of 1.6MB

## What is the new behavior?

Overwrite the max body limit for the PutVector endpoint to 20MB
