### PR TITLE
fix: minor orphan object client minor fixes and enhancements

### DIFF
--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -293,7 +293,8 @@ export class S3Backend implements StorageBackendAdapter {
         }).map((ele) => {
           if (options?.prefix) {
             return {
-              name: (ele.Key as string).replace(options.prefix, '').replace('/', ''),
+              // remove prefix and leading slash if present
+              name: (ele.Key as string).replace(options.prefix, '').replace(/^\//, ''),
               size: ele.Size as number,
             }
           }

--- a/src/storage/scanner/scanner.ts
+++ b/src/storage/scanner/scanner.ts
@@ -37,7 +37,6 @@ export class ObjectScanner {
     const localDBKeys = this.syncS3KeysToDB(tmpTable, prefix, options)
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for await (const _ of localDBKeys) {
         // await all of the operation finished
         if (options.signal.aborted) {
@@ -47,7 +46,7 @@ export class ObjectScanner {
 
       const s3Keys = this.listS3Orphans(tmpTable, {
         bucket: bucket,
-        prefix: `${this.storage.db.tenantId}/${bucket}`,
+        prefix,
         signal: options.signal,
       })
 
@@ -307,7 +306,7 @@ export class ObjectScanner {
       }
 
       const result = await this.storage.backend.list(storageS3Bucket, {
-        prefix,
+        prefix: prefix + '/',
         nextToken,
         beforeDate: options.before,
       })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and minor enhancements to the orphan object scanner and client

## What is the current behavior?

The orphan object scanner does not use a trailing slash in the prefix when loading objects from S3. This causes it to include partial prefixes which can cause it to find many false orphans

For example, if a project has buckets "images", "images2", "images3" and we attempt to find orphans in the "images" bucket it will return all of the items in "images2" and "images3" considering them orphans in the "images" bucket

## What is the new behavior?

Include trailing slash when loading objects from S3

Fix list operation on S3 adapter to only remove leading slash. Previously it would remove the "first slash after the prefix" which breaks if the prefix ends with a slash

Add DELETE_LIMIT to limit the number of orphans removed per run. This allows doing multiple batches to limit the strain on the queue

Add ability to pass multiple bucket ids (comma delimited). This saves a lot of time when checking for orphans in multiple buckets.

Include orphan type (S3 or DB) in the log files generated by the orphan object scanner
