### PR TITLE
fix: onSend hook

### DIFF
--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -81,8 +81,9 @@ export const logRequest = (options: RequestLoggerOptions) =>
         }
       })
 
-      fastify.addHook('onSend', async (req) => {
+      fastify.addHook('onSend', async (req, _, payload) => {
         req.executionTime = Date.now() - req.startTime
+        return payload
       })
 
       fastify.addHook('onResponse', async (req, reply) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Correctly return current payload on onSend hook
