### PR TITLE
fix: return content-type if missing

### DIFF
--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -105,7 +105,7 @@ export class S3Backend implements StorageBackendAdapter {
     return {
       metadata: {
         cacheControl: data.CacheControl || 'no-cache',
-        mimetype: data.ContentType || 'application/octa-stream',
+        mimetype: data.ContentType || 'application/octet-stream',
         eTag: data.ETag || '',
         lastModified: data.LastModified,
         contentRange: data.ContentRange,

--- a/src/test/s3-adapter.test.ts
+++ b/src/test/s3-adapter.test.ts
@@ -1,0 +1,77 @@
+'use strict'
+
+import { S3Backend } from '../storage/backend/s3/adapter'
+import { S3Client } from '@aws-sdk/client-s3'
+import { Readable } from 'stream'
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const originalModule = jest.requireActual('@aws-sdk/client-s3')
+  return {
+    ...originalModule,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: jest.fn(),
+    })),
+  }
+})
+
+describe('S3Backend', () => {
+  let mockSend: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSend = jest.fn()
+    ;(S3Client as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+  })
+
+  describe('getObject', () => {
+    test('should return correct default MIME type when S3 returns no ContentType', async () => {
+      mockSend.mockResolvedValue({
+        Body: Readable.from(['test content']),
+        CacheControl: 'max-age=3600',
+        ETag: '"abc123"',
+        LastModified: new Date('2024-01-01'),
+        ContentLength: 12,
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      })
+
+      const backend = new S3Backend({
+        region: 'us-east-1',
+        endpoint: 'http://localhost:9000',
+      })
+
+      const result = await backend.getObject('test-bucket', 'test-key', undefined)
+
+      expect(result.metadata.mimetype).toBe('application/octet-stream')
+      expect(result.metadata.cacheControl).toBe('max-age=3600')
+      expect(result.metadata.eTag).toBe('"abc123"')
+      expect(result.httpStatusCode).toBe(200)
+    })
+
+    test('should use ContentType from S3 when provided', async () => {
+      mockSend.mockResolvedValue({
+        Body: Readable.from(['test content']),
+        ContentType: 'image/png',
+        CacheControl: 'no-cache',
+        ETag: '"def456"',
+        LastModified: new Date('2024-01-01'),
+        ContentLength: 12,
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      })
+
+      const backend = new S3Backend({
+        region: 'us-east-1',
+        endpoint: 'http://localhost:9000',
+      })
+
+      const result = await backend.getObject('test-bucket', 'test-key', undefined)
+
+      expect(result.metadata.mimetype).toBe('image/png')
+    })
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

returns `application/octa-stream` if upstream returns no content-type

## What is the new behavior?

returns `application/octet-stream` as expected 

## Additional context

none