### PR TITLE
fix: do not allow setting invalid header values via S3 response header overrides

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -916,19 +916,31 @@ export class S3ProtocolHandler {
     }
 
     // Handle response header overrides
-    if (command.ResponseContentDisposition) {
+    if (
+      command.ResponseContentDisposition &&
+      isValidHeader('content-disposition', command.ResponseContentDisposition)
+    ) {
       headers['content-disposition'] = command.ResponseContentDisposition
     }
-    if (command.ResponseContentType) {
+    if (command.ResponseContentType && isValidHeader('content-type', command.ResponseContentType)) {
       headers['content-type'] = command.ResponseContentType
     }
-    if (command.ResponseCacheControl) {
+    if (
+      command.ResponseCacheControl &&
+      isValidHeader('cache-control', command.ResponseCacheControl)
+    ) {
       headers['cache-control'] = command.ResponseCacheControl
     }
-    if (command.ResponseContentEncoding) {
+    if (
+      command.ResponseContentEncoding &&
+      isValidHeader('content-encoding', command.ResponseContentEncoding)
+    ) {
       headers['content-encoding'] = command.ResponseContentEncoding
     }
-    if (command.ResponseContentLanguage) {
+    if (
+      command.ResponseContentLanguage &&
+      isValidHeader('content-language', command.ResponseContentLanguage)
+    ) {
       headers['content-language'] = command.ResponseContentLanguage
     }
     if (command.ResponseExpires) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Invalid response override headers passed via S3 protocol are set on response headers without validation which causes fastify exceptions when attempting to send invalid content.

## What is the new behavior?

Do not attempt to send invalid header values
