### PR TITLE
feat: add queue health monitoring and shutdown when database is unreachable for extended period

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,9 @@ type StorageConfigType = {
   pgQueueArchiveCompletedAfterSeconds?: number
   pgQueueRetentionDays?: number
   pgQueueConcurrentTasksPerQueue: number
+  pgQueueHealthCheckMaxConsecutiveErrors: number
+  pgQueueHealthCheckUnhealthyTimeoutMs: number
+  pgQueueHealthCheckEnabled: boolean
   webhookURL?: string
   webhookApiKey?: string
   webhookQueuePullInterval?: number
@@ -441,6 +444,15 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       getOptionalConfigFromEnv('PG_QUEUE_CONCURRENT_TASKS_PER_QUEUE') || '50',
       10
     ),
+    pgQueueHealthCheckMaxConsecutiveErrors: parseInt(
+      getOptionalConfigFromEnv('PG_QUEUE_HEALTH_CHECK_MAX_CONSECUTIVE_ERRORS') || '10',
+      10
+    ),
+    pgQueueHealthCheckUnhealthyTimeoutMs: parseInt(
+      getOptionalConfigFromEnv('PG_QUEUE_HEALTH_CHECK_UNHEALTHY_TIMEOUT_MS') || '300000',
+      10
+    ),
+    pgQueueHealthCheckEnabled: getOptionalConfigFromEnv('PG_QUEUE_HEALTH_CHECK_ENABLED') === 'true',
 
     // Webhooks
     webhookURL: getOptionalConfigFromEnv('WEBHOOK_URL'),

--- a/src/internal/queue/database.ts
+++ b/src/internal/queue/database.ts
@@ -33,9 +33,11 @@ export class QueueDB extends EventEmitter implements Db {
     await this.pool?.end()
   }
 
-  async executeSql(text: string, values: any[]) {
+  async executeSql(text: string, values: unknown[]) {
     if (this.opened && this.pool) {
-      return await this.pool.query(text, values)
+      const result = await this.pool.query(text, values)
+      this.emit('success')
+      return result
     }
 
     throw ERRORS.InternalError(undefined, `QueueDB not opened ${this.opened} ${text}`)
@@ -51,9 +53,9 @@ export class KnexQueueDB extends EventEmitter implements Db {
     super()
   }
 
-  async executeSql(text: string, values: any[]): Promise<{ rows: any[] }> {
+  async executeSql(text: string, values: unknown[]): Promise<{ rows: unknown[] }> {
     const knexQuery = text.replaceAll('$', ':')
-    const params: Record<string, any> = {}
+    const params: Record<string, unknown> = {}
 
     values.forEach((value, index) => {
       const key = (index + 1).toString()

--- a/src/internal/queue/health-monitor.ts
+++ b/src/internal/queue/health-monitor.ts
@@ -1,0 +1,129 @@
+import { logger, logSchema } from '../monitoring'
+import { Queue } from './queue'
+
+export interface QueueHealthConfig {
+  maxConsecutiveErrors: number
+  unhealthyTimeoutMs: number
+}
+
+interface ConnectionError {
+  code?: string
+  message?: string
+}
+
+export class QueueHealthMonitor {
+  private consecutiveConnectionErrors = 0
+  private lastSuccessfulOperation = Date.now()
+  private lastError = 0
+  private shutdownStarted = false
+
+  constructor(private config: QueueHealthConfig) {}
+
+  trackConnectionError(error: ConnectionError): void {
+    const isConnectionError = error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT'
+    if (!isConnectionError) {
+      return
+    }
+
+    this.consecutiveConnectionErrors++
+    this.lastError = Date.now()
+
+    logSchema.warning(logger, '[Queue Health] Connection error detected', {
+      type: 'queue',
+      metadata: JSON.stringify({
+        consecutiveErrors: this.consecutiveConnectionErrors,
+        timeSinceLastSuccess: Date.now() - this.lastSuccessfulOperation,
+        errorCode: error.code,
+        errorMessage: error.message,
+      }),
+    })
+
+    this.checkHealth()
+  }
+
+  trackSuccessfulOperation(): void {
+    if (this.shutdownStarted) {
+      return
+    }
+
+    if (this.consecutiveConnectionErrors > 0) {
+      logSchema.info(logger, '[Queue Health] Connection recovered', {
+        type: 'queue',
+        metadata: JSON.stringify({
+          previousConsecutiveErrors: this.consecutiveConnectionErrors,
+          downtime: Math.floor((Date.now() - this.lastError) / 1000),
+        }),
+      })
+    }
+    this.consecutiveConnectionErrors = 0
+    this.lastSuccessfulOperation = Date.now()
+  }
+
+  private checkHealth(): void {
+    const unhealthyDuration = Date.now() - this.lastSuccessfulOperation
+
+    if (
+      this.consecutiveConnectionErrors >= this.config.maxConsecutiveErrors ||
+      unhealthyDuration >= this.config.unhealthyTimeoutMs
+    ) {
+      logSchema.error(
+        logger,
+        '[Queue Health] FATAL - Queue is unhealthy, initiating graceful shutdown',
+        {
+          type: 'queue',
+          metadata: JSON.stringify({
+            consecutiveErrors: this.consecutiveConnectionErrors,
+            unhealthyDurationSeconds: Math.floor(unhealthyDuration / 1000),
+            maxConsecutiveErrors: this.config.maxConsecutiveErrors,
+            unhealthyTimeoutMs: this.config.unhealthyTimeoutMs,
+          }),
+        }
+      )
+
+      void this.initiateGracefulShutdown()
+    }
+  }
+
+  private async initiateGracefulShutdown(): Promise<void> {
+    if (this.shutdownStarted) {
+      return
+    }
+    this.shutdownStarted = true
+
+    logSchema.info(logger, '[Queue Health] Stopping queue to allow in-flight jobs to complete', {
+      type: 'queue',
+    })
+
+    // Set a timeout for the stop operation in case it hangs
+    // pg-boss.stop() has a 20 second timeout, so we wait 30 seconds total
+    const stopTimeout = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        logSchema.warning(logger, '[Queue Health] Stop operation timed out after 30 seconds', {
+          type: 'queue',
+        })
+        resolve()
+      }, 30000)
+    })
+
+    try {
+      // Race between actual stop and timeout
+      await Promise.race([Queue.stop(), stopTimeout])
+
+      logSchema.error(logger, '[Queue Health] Queue stopped - worker must restart', {
+        type: 'queue',
+      })
+    } catch (error) {
+      logSchema.error(logger, '[Queue Health] Error during graceful shutdown', {
+        type: 'queue',
+        error,
+      })
+    }
+
+    // Emit uncaughtException to trigger worker shutdown
+    // This is caught by bindShutdownSignals() in shutdown.ts
+    const fatalError = new Error('Queue health check failed - database connection unavailable')
+    process.nextTick(() => {
+      process.emit('uncaughtException', fatalError)
+    })
+  }
+}

--- a/src/test/queue-health.test.ts
+++ b/src/test/queue-health.test.ts
@@ -1,0 +1,203 @@
+import { QueueDB } from '@internal/queue/database'
+import { EventEmitter } from 'events'
+
+describe('Queue Health Monitoring', () => {
+  let queueDB: QueueDB
+  let mockPool: any
+
+  beforeEach(() => {
+    queueDB = new QueueDB({
+      connectionString: 'postgresql://test:test@localhost:5432/test',
+      max: 10,
+      min: 0,
+    })
+    mockPool = new EventEmitter()
+    mockPool.query = jest.fn()
+  })
+
+  afterEach(() => {
+    queueDB.removeAllListeners()
+  })
+
+  describe('QueueDB success event emission', () => {
+    it('should emit success event after successful query execution', async () => {
+      const successListener = jest.fn()
+      queueDB.on('success', successListener)
+
+      mockPool.query.mockResolvedValue({ rows: [{ id: 1 }] })
+
+      await queueDB.open()
+      ;(queueDB as any).pool = mockPool
+
+      await queueDB.executeSql('SELECT 1', [])
+
+      expect(successListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not emit success event when query fails', async () => {
+      const successListener = jest.fn()
+      queueDB.on('success', successListener)
+
+      mockPool.query.mockRejectedValue(new Error('Connection refused'))
+
+      await queueDB.open()
+      ;(queueDB as any).pool = mockPool
+
+      await expect(queueDB.executeSql('SELECT 1', [])).rejects.toThrow('Connection refused')
+      expect(successListener).not.toHaveBeenCalled()
+    })
+
+    it('should emit success event for each successful query', async () => {
+      const successListener = jest.fn()
+      queueDB.on('success', successListener)
+
+      mockPool.query.mockResolvedValue({ rows: [] })
+
+      await queueDB.open()
+      ;(queueDB as any).pool = mockPool
+
+      await queueDB.executeSql('SELECT 1', [])
+      await queueDB.executeSql('SELECT 2', [])
+      await queueDB.executeSql('SELECT 3', [])
+
+      expect(successListener).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('QueueDB error event emission', () => {
+    it('should emit error events from pool errors', async () => {
+      const errorListener = jest.fn()
+      queueDB.on('error', errorListener)
+
+      await queueDB.open()
+      mockPool.on('error', (error: Error) => queueDB.emit('error', error))
+      ;(queueDB as any).pool = mockPool
+
+      const testError = new Error('Pool connection error')
+      mockPool.emit('error', testError)
+
+      expect(errorListener).toHaveBeenCalledTimes(1)
+      expect(errorListener).toHaveBeenCalledWith(testError)
+    })
+
+    it('should handle ETIMEDOUT errors', async () => {
+      const errorListener = jest.fn()
+      queueDB.on('error', errorListener)
+
+      await queueDB.open()
+      mockPool.on('error', (error: Error) => queueDB.emit('error', error))
+      ;(queueDB as any).pool = mockPool
+
+      const timeoutError: any = new Error('connect ETIMEDOUT')
+      timeoutError.code = 'ETIMEDOUT'
+
+      mockPool.emit('error', timeoutError)
+
+      expect(errorListener).toHaveBeenCalledTimes(1)
+      expect(errorListener).toHaveBeenCalledWith(timeoutError)
+    })
+
+    it('should handle ECONNREFUSED errors', async () => {
+      const errorListener = jest.fn()
+      queueDB.on('error', errorListener)
+
+      await queueDB.open()
+      mockPool.on('error', (error: Error) => queueDB.emit('error', error))
+      ;(queueDB as any).pool = mockPool
+
+      const connRefusedError: any = new Error('connect ECONNREFUSED 127.0.0.1:5432')
+      connRefusedError.code = 'ECONNREFUSED'
+
+      mockPool.emit('error', connRefusedError)
+
+      expect(errorListener).toHaveBeenCalledTimes(1)
+      expect(errorListener).toHaveBeenCalledWith(connRefusedError)
+    })
+  })
+
+  describe('QueueDB lifecycle', () => {
+    it('should throw error when executing SQL on unopened database', async () => {
+      await expect(queueDB.executeSql('SELECT 1', [])).rejects.toThrow('QueueDB not opened')
+    })
+
+    it('should allow queries after opening', async () => {
+      mockPool.query.mockResolvedValue({ rows: [{ n: 1 }] })
+
+      await queueDB.open()
+      ;(queueDB as any).pool = mockPool
+
+      const result = await queueDB.executeSql('SELECT 1 as n', [])
+      expect(result.rows[0].n).toBe(1)
+    })
+
+    it('should set opened flag correctly', async () => {
+      expect(queueDB.opened).toBe(false)
+
+      await queueDB.open()
+      expect(queueDB.opened).toBe(true)
+
+      await queueDB.close()
+      expect(queueDB.opened).toBe(false)
+    })
+  })
+
+  describe('Connection health simulation', () => {
+    it('should emit multiple errors followed by success on recovery', async () => {
+      const errorListener = jest.fn()
+      const successListener = jest.fn()
+
+      queueDB.on('error', errorListener)
+      queueDB.on('success', successListener)
+
+      await queueDB.open()
+      mockPool.on('error', (error: Error) => queueDB.emit('error', error))
+      ;(queueDB as any).pool = mockPool
+
+      // Simulate 3 ECONNREFUSED errors
+      const error: any = new Error('connect ECONNREFUSED 127.0.0.1:5432')
+      error.code = 'ECONNREFUSED'
+
+      mockPool.emit('error', error)
+      mockPool.emit('error', error)
+      mockPool.emit('error', error)
+
+      expect(errorListener).toHaveBeenCalledTimes(3)
+      expect(successListener).not.toHaveBeenCalled()
+
+      // Simulate recovery with successful query
+      mockPool.query.mockResolvedValue({ rows: [] })
+      await queueDB.executeSql('SELECT 1', [])
+
+      expect(successListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle alternating errors and successes', async () => {
+      const errorListener = jest.fn()
+      const successListener = jest.fn()
+
+      queueDB.on('error', errorListener)
+      queueDB.on('success', successListener)
+
+      await queueDB.open()
+      mockPool.on('error', (error: Error) => queueDB.emit('error', error))
+      ;(queueDB as any).pool = mockPool
+
+      const error: any = new Error('connection error')
+      error.code = 'ECONNREFUSED'
+
+      // Error -> Success -> Error -> Success pattern
+      mockPool.emit('error', error)
+      expect(errorListener).toHaveBeenCalledTimes(1)
+
+      mockPool.query.mockResolvedValue({ rows: [] })
+      await queueDB.executeSql('SELECT 1', [])
+      expect(successListener).toHaveBeenCalledTimes(1)
+
+      mockPool.emit('error', error)
+      expect(errorListener).toHaveBeenCalledTimes(2)
+
+      await queueDB.executeSql('SELECT 2', [])
+      expect(successListener).toHaveBeenCalledTimes(2)
+    })
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Sometimes when the multi-tenant database is modified workers can get stuck unable to reconnect to the instance indefinitely. These connection failure errors do not propagate and the workers will sit forever waiting for jobs that will never come.

## What is the new behavior?

If the worker queue fails to connect to the database for the specified number of tries or specified amount of time throw a fatal error so the container will be restarted. After restart it should be able to connect to the database again.

### Introduces environment variables

* `PG_QUEUE_HEALTH_CHECK_ENABLED` -- default false
* `PG_QUEUE_HEALTH_CHECK_MAX_CONSECUTIVE_ERRORS` -- default 10 (connection retires every 30 seconds = 5 minutes)
* `PG_QUEUE_HEALTH_CHECK_UNHEALTHY_TIMEOUT_MS` -- default 5 minutes


