### PR TITLE
chore: use node24 for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: |
@@ -151,4 +151,3 @@ jobs:
             public.ecr.aws/supabase/storage-api:latest
             docker.io/supabase/storage-api:latest
             ghcr.io/supabase/storage-api:latest
-    


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump node version for semantic release left over from [node24 change](https://github.com/supabase/storage/pull/841)

## What is the current behavior?

Semantic release runs with node20

## What is the new behavior?

Semantic release runs with node24

## Additional context

https://nodejs.org/en/about/eol