### PR TITLE
docs: fix coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supabase Storage Engine
 
-[![Coverage Status](https://coveralls.io/repos/github/supabase/storage-api/badge.svg?branch=master)](https://coveralls.io/github/supabase/storage-api?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/supabase/storage/badge.svg?branch=master)](https://coveralls.io/github/supabase/storage?branch=master)
 
 A scalable, lightweight object storage service.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Coveralls badge in README.md is point to the wrong project

## What is the current behavior?



## What is the new behavior?



## Additional context


