### PR TITLE
Change HTTP status code from 200 to 201 on object creation

### DIFF
--- a/src/http/routes/object/createObject.ts
+++ b/src/http/routes/object/createObject.ts
@@ -84,7 +84,7 @@ export default async function routes(fastify: FastifyInstance) {
           isUpsert,
         })
 
-      return response.status(objectMetadata?.httpStatusCode ?? 200).send({
+      return response.status(objectMetadata?.httpStatusCode ?? 201).send({
         Id: id,
         Key: path,
       })


### PR DESCRIPTION
A bit pedantic, however while I was making a small wrapper in rust i mistakenly matched for 201 status code, to me it's just intuitive for this to return 201

## What kind of change does this PR introduce?

HTTP Status Code response change

## What is the current behavior?
Currently on object creation, 200 is returned, http spec indicated that 201 should be used when a resource is created and or returned


## What is the new behavior?
Returns 201 CREATED instead

## Additional context

kindof a nothing burger pr but i was scratching my head for a second while making my rust wrapper, checking for 201 after uploading an image
