### PR TITLE
fix: escape wildcard characters for list

### DIFF
--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -28,6 +28,10 @@ import {
 
 const { isMultitenant } = getConfig()
 
+export function escapeLike(str: string) {
+  return str.replace(/([%_])/g, '\\$1')
+}
+
 /**
  * Database
  * the only source of truth for interacting with the storage database
@@ -150,7 +154,7 @@ export class StorageKnexDB implements Database {
         .whereNull('deleted_at')
 
       if (options?.search !== undefined && options.search.length > 0) {
-        query.where('name', 'like', `%${options.search}%`)
+        query.where('name', 'like', `%${escapeLike(options.search)}%`)
       }
 
       if (options?.sortColumn !== undefined) {
@@ -392,7 +396,7 @@ export class StorageKnexDB implements Database {
         query.orderBy(knex.raw(`name COLLATE "C"`), sortOrder)
 
         if (options?.prefix) {
-          query.where('name', 'like', `${options.prefix}%`)
+          query.where('name', 'like', `${escapeLike(options.prefix)}%`)
         }
 
         if (options?.startAfter && !options?.nextToken) {
@@ -482,7 +486,7 @@ export class StorageKnexDB implements Database {
       const query = knex.from<Bucket>('buckets').select(selectColumns)
 
       if (options?.search !== undefined && options.search.length > 0) {
-        query.where('name', 'ilike', `%${options.search}%`)
+        query.where('name', 'ilike', `%${escapeLike(options.search)}%`)
       }
 
       if (options?.sortColumn !== undefined) {
@@ -526,7 +530,7 @@ export class StorageKnexDB implements Database {
         query.orderBy(knex.raw('key COLLATE "C", created_at'))
 
         if (options?.prefix) {
-          query.where('key', 'ilike', `${options.prefix}%`)
+          query.where('key', 'ilike', `${escapeLike(options.prefix)}%`)
         }
 
         if (options?.nextUploadKeyToken && !options.nextUploadToken) {
@@ -543,7 +547,7 @@ export class StorageKnexDB implements Database {
       const result = await knex
         .raw('select * from storage.list_multipart_uploads_with_delimiter(?,?,?,?,?,?)', [
           bucketId,
-          options?.prefix,
+          options?.prefix ? escapeLike(options.prefix) : options?.prefix,
           options?.deltimeter,
           options?.maxKeys,
           options?.nextUploadKeyToken || '',
@@ -878,15 +882,22 @@ export class StorageKnexDB implements Database {
 
   async searchObjects(bucketId: string, prefix: string, options: SearchObjectOption) {
     return this.runQuery('SearchObjects', async (knex, signal) => {
+      const sortColumn = options.sortBy?.column ?? 'name'
+      const shouldEscapePattern = sortColumn !== 'name'
+      const safePrefix = shouldEscapePattern ? escapeLike(prefix) : prefix
+      const safeSearch = shouldEscapePattern
+        ? escapeLike(options.search || '')
+        : options.search || ''
+
       const result = await knex
         .raw<{ rows: Obj[] }>('select * from storage.search(?,?,?,?,?,?,?,?)', [
-          prefix,
+          safePrefix,
           bucketId,
           options.limit || 100,
-          prefix.split('/').length,
+          safePrefix.split('/').length,
           options.offset || 0,
-          options.search || '',
-          options.sortBy?.column ?? 'name',
+          safeSearch,
+          sortColumn,
           options.sortBy?.order ?? 'asc',
         ])
         .abortOnSignal(signal)

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1,5 +1,6 @@
 'use strict'
 
+import { randomUUID } from 'node:crypto'
 import { ListObjectsV2Result } from '@storage/object'
 import { FastifyInstance } from 'fastify'
 import { Knex } from 'knex'
@@ -574,4 +575,128 @@ describe('objects - list v2 sorting tests', () => {
       expect(pageCount).toBe(Math.ceil((expected.objects.length + expected.folders.length) / limit))
     })
   }
+})
+
+const LIST_V2_WILDCARD_BUCKET = `list-v2-wildcard-${randomUUID()}`
+
+describe('objects - list v2 prefix wildcard handling', () => {
+  beforeAll(async () => {
+    appInstance = app()
+    await appInstance.inject({
+      method: 'POST',
+      url: `/bucket`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+      payload: {
+        name: LIST_V2_WILDCARD_BUCKET,
+      },
+    })
+    await appInstance.close()
+  })
+
+  afterAll(async () => {
+    appInstance = app()
+    await appInstance.inject({
+      method: 'POST',
+      url: `/bucket/${LIST_V2_WILDCARD_BUCKET}/empty`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    await appInstance.inject({
+      method: 'DELETE',
+      url: `/bucket/${LIST_V2_WILDCARD_BUCKET}`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    await appInstance.close()
+  })
+
+  test('treats % as a literal character in list-v2 prefix filters', async () => {
+    const runId = Date.now().toString(36)
+    const firstObject = `percent-${runId}/first.txt`
+    const secondObject = `percent-${runId}/second.txt`
+
+    await appInstance.inject({
+      method: 'POST',
+      url: `/object/${LIST_V2_WILDCARD_BUCKET}/${firstObject}`,
+      payload: createUpload('first.txt', 'first'),
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    await appInstance.inject({
+      method: 'POST',
+      url: `/object/${LIST_V2_WILDCARD_BUCKET}/${secondObject}`,
+      payload: createUpload('second.txt', 'second'),
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: `/object/list-v2/${LIST_V2_WILDCARD_BUCKET}`,
+      payload: {
+        with_delimiter: false,
+        prefix: '%',
+        limit: 100,
+      },
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const data = response.json<ListObjectsV2Result>()
+    expect(data.folders).toHaveLength(0)
+    expect(data.objects).toHaveLength(0)
+  })
+
+  test('treats _ as a literal character in list-v2 prefix filters', async () => {
+    const runId = randomUUID()
+    const literalMatch = `wild_${runId}/hit.txt`
+    const wildcardOnlyMatch = `wildX${runId}/miss.txt`
+
+    await appInstance.inject({
+      method: 'POST',
+      url: `/object/${LIST_V2_WILDCARD_BUCKET}/${literalMatch}`,
+      payload: createUpload('hit.txt', 'hit'),
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    await appInstance.inject({
+      method: 'POST',
+      url: `/object/${LIST_V2_WILDCARD_BUCKET}/${wildcardOnlyMatch}`,
+      payload: createUpload('miss.txt', 'miss'),
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: `/object/list-v2/${LIST_V2_WILDCARD_BUCKET}`,
+      payload: {
+        with_delimiter: false,
+        prefix: `wild_${runId}/`,
+        limit: 100,
+      },
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const data = response.json<ListObjectsV2Result>()
+    expect(data.folders).toHaveLength(0)
+    expect(data.objects.map((obj) => obj.name)).toEqual([literalMatch])
+  })
 })

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -2576,6 +2576,132 @@ describe('testing list objects', () => {
     expect(responseJSON[0].name).toBe('sadcat-upload23.png')
     expect(responseJSON[1].name).toBe('sadcat-upload.png')
   })
+
+  test('list-v1 should treat % as a literal character when using non-name sorting', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const objectNames = [`percent-${runId}/first.txt`, `percent-${runId}/second.txt`]
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await seedTx.from<Obj>('objects').insert(
+      objectNames.map((name, idx) => ({
+        bucket_id: bucketName,
+        name,
+        owner: '317eadce-631a-4429-a0bb-f19a7a517b4a',
+        version: `${runId}-${idx}`,
+        metadata: {
+          eTag: `${runId}-${idx}`,
+          size: idx + 1,
+          mimetype: 'text/plain',
+        },
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        payload: {
+          prefix: '%',
+          limit: 100,
+          offset: 0,
+          sortBy: {
+            column: 'created_at',
+            order: 'asc',
+          },
+        },
+        headers: {
+          authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const responseJSON = response.json()
+      expect(responseJSON).toHaveLength(0)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await db
+          .from<Obj>('objects')
+          .where({ bucket_id: bucketName })
+          .whereIn('name', objectNames)
+          .delete()
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('list-v1 should treat _ as a literal character when using non-name sorting', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const literalMatch = `wild_${runId}/hit.txt`
+    const wildcardOnlyMatch = `wildX${runId}/miss.txt`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await seedTx.from<Obj>('objects').insert([
+      {
+        bucket_id: bucketName,
+        name: literalMatch,
+        owner: '317eadce-631a-4429-a0bb-f19a7a517b4a',
+        version: `${runId}-literal`,
+        metadata: {
+          eTag: `${runId}-literal`,
+          size: 1,
+          mimetype: 'text/plain',
+        },
+      },
+      {
+        bucket_id: bucketName,
+        name: wildcardOnlyMatch,
+        owner: '317eadce-631a-4429-a0bb-f19a7a517b4a',
+        version: `${runId}-wildcard`,
+        metadata: {
+          eTag: `${runId}-wildcard`,
+          size: 2,
+          mimetype: 'text/plain',
+        },
+      },
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        payload: {
+          prefix: `wild_${runId}/`,
+          limit: 100,
+          offset: 0,
+          sortBy: {
+            column: 'created_at',
+            order: 'asc',
+          },
+        },
+        headers: {
+          authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const responseJSON = response.json<{ name: string }[]>()
+      expect(responseJSON.map((obj) => obj.name)).toEqual(['hit.txt'])
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await db
+          .from<Obj>('objects')
+          .where({ bucket_id: bucketName })
+          .whereIn('name', [literalMatch, wildcardOnlyMatch])
+          .delete()
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
 })
 
 describe('x-robots-tag header', () => {

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -1221,6 +1221,62 @@ describe('S3 Protocol', () => {
         expect(resp.Uploads?.[2].Key).toBe('test-3.jpg')
         expect(resp.CommonPrefixes?.[0].Prefix).toBe('nested/')
       })
+
+      it('treats % as a literal character in multipart prefix filtering with delimiter', async () => {
+        const bucketName = await createBucket(client)
+        const createMultiPartUpload = (key: string) =>
+          new CreateMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentType: 'image/jpg',
+            CacheControl: 'max-age=2000',
+          })
+
+        await Promise.all([
+          client.send(createMultiPartUpload(`percent-${randomUUID()}.jpg`)),
+          client.send(createMultiPartUpload(`percent-${randomUUID()}.jpg`)),
+        ])
+
+        const listMultipartUploads = new ListMultipartUploadsCommand({
+          Bucket: bucketName,
+          Delimiter: '/',
+          Prefix: '%',
+        })
+
+        const resp = await client.send(listMultipartUploads)
+        expect(resp.Uploads).toBeUndefined()
+        expect(resp.CommonPrefixes).toBeUndefined()
+      })
+
+      it('treats _ as a literal character in multipart prefix filtering with delimiter', async () => {
+        const bucketName = await createBucket(client)
+        const runId = randomUUID()
+        const literalMatchKey = `wild_${runId}/hit.jpg`
+        const wildcardOnlyMatchKey = `wildX${runId}/miss.jpg`
+        const createMultiPartUpload = (key: string) =>
+          new CreateMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentType: 'image/jpg',
+            CacheControl: 'max-age=2000',
+          })
+
+        await Promise.all([
+          client.send(createMultiPartUpload(literalMatchKey)),
+          client.send(createMultiPartUpload(wildcardOnlyMatchKey)),
+        ])
+
+        const listMultipartUploads = new ListMultipartUploadsCommand({
+          Bucket: bucketName,
+          Delimiter: '/',
+          Prefix: `wild_${runId}/`,
+        })
+
+        const resp = await client.send(listMultipartUploads)
+        expect(resp.CommonPrefixes).toBeUndefined()
+        expect(resp.Uploads?.length).toBe(1)
+        expect(resp.Uploads?.[0].Key).toBe(literalMatchKey)
+      })
     })
 
     it('will list multipart uploads with delimiter and pagination', async () => {

--- a/src/test/search-filters.test.ts
+++ b/src/test/search-filters.test.ts
@@ -1,0 +1,150 @@
+'use strict'
+
+import { randomUUID } from 'crypto'
+import { FastifyInstance } from 'fastify'
+import app from '../app'
+import { getConfig } from '../config'
+import { escapeLike } from '../storage/database/knex'
+
+const { serviceKeyAsync } = getConfig()
+
+describe('search filter wildcard escaping', () => {
+  let appInstance: FastifyInstance
+  let serviceKey: string
+
+  beforeAll(async () => {
+    serviceKey = await serviceKeyAsync
+    appInstance = app()
+  })
+
+  afterAll(async () => {
+    await appInstance.close()
+  })
+
+  test('escapeLike should escape SQL wildcard characters', () => {
+    expect(escapeLike('%_abc')).toBe('\\%\\_abc')
+    expect(escapeLike('a%b_c')).toBe('a\\%b\\_c')
+    expect(escapeLike('plain-text')).toBe('plain-text')
+  })
+
+  test('bucket search should treat % as a literal character', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/bucket?search=%25',
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const buckets = response.json<{ name: string }[]>()
+    expect(buckets).toHaveLength(0)
+  })
+
+  test('bucket search should treat _ as a literal character', async () => {
+    const runId = randomUUID().slice(0, 8)
+    const literalMatch = `escwild_${runId}`
+    const wildcardOnlyMatch = `escwildX${runId}`
+
+    const createBucket = async (name: string) =>
+      appInstance.inject({
+        method: 'POST',
+        url: '/bucket',
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+        payload: { name },
+      })
+
+    const deleteBucket = async (name: string) =>
+      appInstance.inject({
+        method: 'DELETE',
+        url: `/bucket/${name}`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+
+    await createBucket(literalMatch)
+    await createBucket(wildcardOnlyMatch)
+
+    try {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/bucket?search=${encodeURIComponent(`escwild_${runId}`)}`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const names = response.json<{ name: string }[]>().map((bucket) => bucket.name)
+      expect(names).toContain(literalMatch)
+      expect(names).not.toContain(wildcardOnlyMatch)
+    } finally {
+      await deleteBucket(literalMatch)
+      await deleteBucket(wildcardOnlyMatch)
+    }
+  })
+
+  test('analytics bucket search should treat % as a literal character', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/iceberg/bucket?search=%25',
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const buckets = response.json<{ name: string }[]>()
+    expect(buckets).toHaveLength(0)
+  })
+
+  test('analytics bucket search should treat _ as a literal character', async () => {
+    const runId = randomUUID().slice(0, 8)
+    const literalMatch = `icewild_${runId}`
+    const wildcardOnlyMatch = `icewildX${runId}`
+
+    const createBucket = async (name: string) =>
+      appInstance.inject({
+        method: 'POST',
+        url: '/iceberg/bucket',
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+          'Content-Type': 'application/json',
+        },
+        payload: { name },
+      })
+
+    const deleteBucket = async (name: string) =>
+      appInstance.inject({
+        method: 'DELETE',
+        url: `/iceberg/bucket/${name}`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+
+    await createBucket(literalMatch)
+    await createBucket(wildcardOnlyMatch)
+
+    try {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/iceberg/bucket?search=${encodeURIComponent(`icewild_${runId}`)}`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const names = response.json<{ name: string }[]>().map((bucket) => bucket.name)
+      expect(names).toContain(literalMatch)
+      expect(names).not.toContain(wildcardOnlyMatch)
+    } finally {
+      await deleteBucket(literalMatch)
+      await deleteBucket(wildcardOnlyMatch)
+    }
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Like operator wildcards aren't escaped. It can return wrong results or cause performance issues.

## What is the new behavior?

* add escapeLike helper for escaping % and _ in like sql operator

* use it in
  - object list v2 non-delimiter prefix filtering
  - list v1 non-name sort
  - s3 multipart list
  - bucket / analytics search filters

## Additional context

None
