### PR TITLE
fix: path traversal in file backend

### DIFF
--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -202,6 +202,9 @@ export class FileBackend implements StorageBackendAdapter {
         httpStatusCode: 200,
       }
     } catch (err: any) {
+      if (err instanceof StorageBackendError) {
+        throw err
+      }
       throw StorageBackendError.fromError(err)
     }
   }
@@ -341,15 +344,18 @@ export class FileBackend implements StorageBackendAdapter {
     cacheControl: string
   ): Promise<string | undefined> {
     const uploadId = randomUUID()
-    const multiPartFolder = path.join(
-      this.filePath,
-      'multiparts',
-      uploadId,
-      bucketName,
-      withOptionalVersion(key, version)
+    const multiPartFolder = this.resolveSecurePath(
+      path.join('multiparts', uploadId, bucketName, withOptionalVersion(key, version))
     )
-
-    const multipartFile = path.join(multiPartFolder, 'metadata.json')
+    const multipartFile = this.resolveSecurePath(
+      path.join(
+        'multiparts',
+        uploadId,
+        bucketName,
+        withOptionalVersion(key, version),
+        'metadata.json'
+      )
+    )
     await fsExtra.ensureDir(multiPartFolder)
     await fsExtra.writeFile(multipartFile, JSON.stringify({ contentType, cacheControl }))
 
@@ -364,15 +370,15 @@ export class FileBackend implements StorageBackendAdapter {
     partNumber: number,
     body: stream.Readable
   ): Promise<{ ETag?: string }> {
-    const multiPartFolder = path.join(
-      this.filePath,
-      'multiparts',
-      uploadId,
-      bucketName,
-      withOptionalVersion(key, version)
+    const partPath = this.resolveSecurePath(
+      path.join(
+        'multiparts',
+        uploadId,
+        bucketName,
+        withOptionalVersion(key, version),
+        `part-${partNumber}`
+      )
     )
-
-    const partPath = path.join(multiPartFolder, `part-${partNumber}`)
 
     const writeStream = fsExtra.createWriteStream(partPath)
 
@@ -399,16 +405,16 @@ export class FileBackend implements StorageBackendAdapter {
       version: string
     }
   > {
-    const multiPartFolder = path.join(
-      this.filePath,
-      'multiparts',
-      uploadId,
-      bucketName,
-      withOptionalVersion(key, version)
-    )
-
     const partsByEtags = parts.map(async (part) => {
-      const partFilePath = path.join(multiPartFolder, `part-${part.PartNumber}`)
+      const partFilePath = this.resolveSecurePath(
+        path.join(
+          'multiparts',
+          uploadId,
+          bucketName,
+          withOptionalVersion(key, version),
+          `part-${part.PartNumber}`
+        )
+      )
       const partExists = await fsExtra.pathExists(partFilePath)
 
       if (partExists) {
@@ -432,7 +438,15 @@ export class FileBackend implements StorageBackendAdapter {
 
     const multistream = new MultiStream(fileStreams)
     const metadataContent = await fsExtra.readFile(
-      path.join(multiPartFolder, 'metadata.json'),
+      this.resolveSecurePath(
+        path.join(
+          'multiparts',
+          uploadId,
+          bucketName,
+          withOptionalVersion(key, version),
+          'metadata.json'
+        )
+      ),
       'utf-8'
     )
 
@@ -447,7 +461,7 @@ export class FileBackend implements StorageBackendAdapter {
       metadata.cacheControl
     )
 
-    fsExtra.remove(path.join(this.filePath, 'multiparts', uploadId)).catch(() => {
+    fsExtra.remove(this.resolveSecurePath(path.join('multiparts', uploadId))).catch(() => {
       // no-op
     })
 
@@ -465,7 +479,7 @@ export class FileBackend implements StorageBackendAdapter {
     uploadId: string,
     version?: string
   ): Promise<void> {
-    const multiPartFolder = path.join(this.filePath, 'multiparts', uploadId)
+    const multiPartFolder = this.resolveSecurePath(path.join('multiparts', uploadId))
 
     await fsExtra.remove(multiPartFolder)
 
@@ -487,15 +501,15 @@ export class FileBackend implements StorageBackendAdapter {
     sourceVersion?: string,
     rangeBytes?: { fromByte: number; toByte: number }
   ): Promise<{ eTag?: string; lastModified?: Date }> {
-    const multiPartFolder = path.join(
-      this.filePath,
-      'multiparts',
-      UploadId,
-      storageS3Bucket,
-      withOptionalVersion(key, version)
+    const partFilePath = this.resolveSecurePath(
+      path.join(
+        'multiparts',
+        UploadId,
+        storageS3Bucket,
+        withOptionalVersion(key, version),
+        `part-${PartNumber}`
+      )
     )
-
-    const partFilePath = path.join(multiPartFolder, `part-${PartNumber}`)
     const sourceFilePath = this.resolveSecurePath(
       `${storageS3Bucket}/${withOptionalVersion(sourceKey, sourceVersion)}`
     )
@@ -624,6 +638,29 @@ export class FileBackend implements StorageBackendAdapter {
    * @throws {StorageBackendError} If the resolved path escapes the storage directory
    */
   private resolveSecurePath(relativePath: string): string {
+    if (relativePath.includes('\0')) {
+      throw ERRORS.InvalidKey(`Invalid key: ${relativePath} contains null byte`)
+    }
+
+    if (path.isAbsolute(relativePath)) {
+      throw ERRORS.InvalidKey(`Invalid key: ${relativePath} must be a relative path`)
+    }
+
+    const isWindowsDriveAbsolutePath = /^[a-zA-Z]:[\\/]/.test(relativePath)
+    const isWindowsUncPath = /^\\\\[^\\/]+[\\/][^\\/]+/.test(relativePath)
+    if (isWindowsDriveAbsolutePath || isWindowsUncPath) {
+      throw ERRORS.InvalidKey(`Invalid key: ${relativePath} must not be an absolute Windows path`)
+    }
+
+    const hasDotTraversalSegment = relativePath
+      .split(/[\\/]+/)
+      .filter(Boolean)
+      .some((segment) => segment === '.' || segment === '..')
+
+    if (hasDotTraversalSegment) {
+      throw ERRORS.InvalidKey(`Path traversal detected: ${relativePath} contains dot path segment`)
+    }
+
     const resolvedPath = path.resolve(this.filePath, relativePath)
     const normalizedPath = path.normalize(resolvedPath)
 

--- a/src/test/file-backend.test.ts
+++ b/src/test/file-backend.test.ts
@@ -158,6 +158,258 @@ describe('FileBackend xattr metadata', () => {
   })
 })
 
+describe('FileBackend resolveSecurePath unit', () => {
+  let tmpDir: string
+  let backend: FileBackend
+  let originalStoragePath: string | undefined
+  let originalFilePath: string | undefined
+
+  const resolveSecurePath = (relativePath: string) =>
+    (
+      backend as unknown as {
+        resolveSecurePath: (relativePath: string) => string
+      }
+    ).resolveSecurePath(relativePath)
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'storage-file-backend-'))
+    originalStoragePath = process.env.STORAGE_FILE_BACKEND_PATH
+    originalFilePath = process.env.FILE_STORAGE_BACKEND_PATH
+    process.env.STORAGE_FILE_BACKEND_PATH = tmpDir
+    process.env.FILE_STORAGE_BACKEND_PATH = tmpDir
+    getConfig({ reload: true })
+    backend = new FileBackend()
+  })
+
+  afterEach(async () => {
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_FILE_BACKEND_PATH
+    } else {
+      process.env.STORAGE_FILE_BACKEND_PATH = originalStoragePath
+    }
+    if (originalFilePath === undefined) {
+      delete process.env.FILE_STORAGE_BACKEND_PATH
+    } else {
+      process.env.FILE_STORAGE_BACKEND_PATH = originalFilePath
+    }
+
+    await fs.remove(tmpDir)
+  })
+
+  it('resolves safe paths under storage root', () => {
+    expect(resolveSecurePath('bucket/folder/file.txt')).toBe(
+      path.join(tmpDir, 'bucket', 'folder', 'file.txt')
+    )
+  })
+
+  it('rejects parent-directory segments even if they normalize within storage root', () => {
+    expect(() => resolveSecurePath('bucket/dir/../file.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+
+  it('allows double-dot in file names when not a path segment', () => {
+    expect(resolveSecurePath('bucket/file..name.txt')).toBe(
+      path.join(tmpDir, 'bucket', 'file..name.txt')
+    )
+  })
+
+  it('rejects current-directory segments', () => {
+    expect(() => resolveSecurePath('.')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+
+  it('rejects absolute paths', () => {
+    expect(() => resolveSecurePath('/tmp/escape.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+
+  it('rejects Windows absolute path formats', () => {
+    expect(() => resolveSecurePath('C:\\temp\\escape.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+    expect(() => resolveSecurePath('\\\\server\\share\\escape.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+
+  it('rejects null bytes', () => {
+    expect(() => resolveSecurePath('bucket/\0escape.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+
+  it('rejects traversal outside storage root', () => {
+    expect(() => resolveSecurePath('../escape.txt')).toThrow(
+      expect.objectContaining({
+        code: 'InvalidKey',
+      })
+    )
+  })
+})
+
+describe('FileBackend traversal protection', () => {
+  let tmpDir: string
+  let backend: FileBackend
+  let originalStoragePath: string | undefined
+  let originalFilePath: string | undefined
+  let escapePrefix: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'storage-file-backend-'))
+    originalStoragePath = process.env.STORAGE_FILE_BACKEND_PATH
+    originalFilePath = process.env.FILE_STORAGE_BACKEND_PATH
+    process.env.STORAGE_FILE_BACKEND_PATH = tmpDir
+    process.env.FILE_STORAGE_BACKEND_PATH = tmpDir
+    getConfig({ reload: true })
+    backend = new FileBackend()
+    escapePrefix = `storage-traversal-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  })
+
+  afterEach(async () => {
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_FILE_BACKEND_PATH
+    } else {
+      process.env.STORAGE_FILE_BACKEND_PATH = originalStoragePath
+    }
+    if (originalFilePath === undefined) {
+      delete process.env.FILE_STORAGE_BACKEND_PATH
+    } else {
+      process.env.FILE_STORAGE_BACKEND_PATH = originalFilePath
+    }
+
+    await fs.remove(tmpDir)
+    await fs.remove(path.join('/tmp', escapePrefix))
+  })
+
+  it('rejects traversal key in multipart create with InvalidKey', async () => {
+    const traversalKey = `${'../'.repeat(20)}tmp/${escapePrefix}/multipart-escape.txt`
+    await expect(
+      backend.createMultiPartUpload('bucket', traversalKey, 'v1', 'text/plain', 'no-cache')
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+  })
+
+  it('rejects traversal key in multipart upload-part with InvalidKey', async () => {
+    const traversalKey = `${'../'.repeat(20)}tmp/${escapePrefix}/multipart-escape.txt`
+    await expect(
+      backend.uploadPart('bucket', traversalKey, 'v1', 'upload-id', 1, Readable.from('escape-part'))
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+  })
+
+  it('rejects traversal key in object operations with InvalidKey', async () => {
+    const traversalKey = `${'../'.repeat(20)}tmp/${escapePrefix}/object-escape.txt`
+
+    await expect(
+      backend.uploadObject(
+        'bucket',
+        traversalKey,
+        'v1',
+        Readable.from('escape'),
+        'text/plain',
+        'no-cache'
+      )
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(backend.headObject('bucket', traversalKey, 'v1')).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(backend.getObject('bucket', traversalKey, 'v1')).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(backend.deleteObject('bucket', traversalKey, 'v1')).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(backend.privateAssetUrl('bucket', traversalKey, 'v1')).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+  })
+
+  it('rejects traversal key in copy/delete list operations with InvalidKey', async () => {
+    const traversalKey = `${'../'.repeat(20)}tmp/${escapePrefix}/copy-escape.txt`
+
+    await backend.uploadObject(
+      'bucket',
+      'safe-source.txt',
+      'v1',
+      Readable.from('safe-source'),
+      'text/plain',
+      'no-cache'
+    )
+
+    await expect(
+      backend.copyObject('bucket', 'safe-source.txt', 'v1', traversalKey, 'v2', {})
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(backend.deleteObjects('bucket', [traversalKey])).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+  })
+
+  it('rejects traversal key in multipart auxiliary operations with InvalidKey', async () => {
+    const traversalDestKey = `${'../'.repeat(20)}tmp/${escapePrefix}/multipart-dest-escape.txt`
+    const traversalSourceKey = `${'../'.repeat(20)}tmp/${escapePrefix}/multipart-source-escape.txt`
+
+    await expect(
+      backend.abortMultipartUpload('bucket', 'key', traversalDestKey)
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(
+      backend.uploadPartCopy(
+        'bucket',
+        traversalDestKey,
+        'v1',
+        'upload-id',
+        1,
+        'safe-source.txt',
+        'v1'
+      )
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+
+    await expect(
+      backend.uploadPartCopy(
+        'bucket',
+        'safe-dest.txt',
+        'v1',
+        'upload-id',
+        1,
+        traversalSourceKey,
+        'v1'
+      )
+    ).rejects.toMatchObject({
+      code: 'InvalidKey',
+    })
+  })
+})
+
 describe('FileBackend lastModified', () => {
   let tmpDir: string
   let backend: FileBackend


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Path traversal is possible in multipart with file backend

## What is the new behavior?

Path traversal isn't possible. 

Additionally, reject paths with segments (`.`, `..`), absolute paths, windows drive/UNC, containing null bytes.

## Additional context

related to #818 and builds on it
