### PR TITLE
fix: start tracing only if enabled and endpoint exists

### DIFF
--- a/src/internal/monitoring/otel-tracing.ts
+++ b/src/internal/monitoring/otel-tracing.ts
@@ -56,20 +56,22 @@ if (tracingEnabled && endpoint) {
   })
 }
 
-// Create a BatchSpanProcessor using the trace exporter
-const batchProcessor = traceExporter ? new BatchSpanProcessor(traceExporter) : undefined
-
 const spanProcessors: SpanProcessor[] = []
 
-if (tracingEnabled) {
+if (tracingEnabled && traceExporter) {
   spanProcessors.push(new TenantSpanProcessor())
+  spanProcessors.push(new BatchSpanProcessor(traceExporter))
+} else if (tracingEnabled) {
+  logSchema.warning(
+    logger,
+    '[Otel] TRACING_ENABLED=true but no OTLP trace endpoint configured; skipping tracing SDK startup',
+    {
+      type: 'otel',
+    }
+  )
 }
 
-if (batchProcessor) {
-  spanProcessors.push(batchProcessor)
-}
-
-if (tracingEnabled && spanProcessors.length > 0) {
+if (tracingEnabled && traceExporter && spanProcessors.length > 0) {
   // Configure the OpenTelemetry Node SDK
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If tracing is enabled but endpoint is missing, instrumentation will start but won't export anything. Pure overhead.

## What is the new behavior?

Start tracing only if enabled and exporter endpoint is given.

## Additional context

None