### PR TITLE
fix: drop unused connection-string dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "aws-sigv4-sign": "^1.2.1",
         "axios": "^1.12.0",
         "axios-retry": "^3.9.1",
-        "connection-string": "^4.3.6",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
         "fastify": "^4.28.1",
@@ -13052,15 +13051,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "node_modules/connection-string": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/connection-string/-/connection-string-4.3.6.tgz",
-      "integrity": "sha512-dwaq4BMeiIIWry/oQxjstPB7Xp0K1nGjaY8p6PHQB+J9ZJuIvNp7ux3Noupq0hMd/dqEHXkfdmmGFOKTbGKWmw==",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -27868,11 +27858,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "connection-string": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/connection-string/-/connection-string-4.3.6.tgz",
-      "integrity": "sha512-dwaq4BMeiIIWry/oQxjstPB7Xp0K1nGjaY8p6PHQB+J9ZJuIvNp7ux3Noupq0hMd/dqEHXkfdmmGFOKTbGKWmw=="
     },
     "content-disposition": {
       "version": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "aws-sigv4-sign": "^1.2.1",
     "axios": "^1.12.0",
     "axios-retry": "^3.9.1",
-    "connection-string": "^4.3.6",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
     "fastify": "^4.28.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the current behavior?

`connection-string` dependency in package.json but actually not used.

## What is the new behavior?

Drop it.

## Additional context

Was added in https://github.com/supabase/storage/pull/288
