### PR TITLE
fix: exclude network metric

### DIFF
--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -231,6 +231,7 @@ if (otelMetricsEnabled) {
   const hostMetrics = new HostMetrics({
     meterProvider,
     name: 'storage-api-host-metrics',
+    metricGroups: ['system.cpu', 'system.memory', 'process.cpu', 'process.memory'],
   })
   hostMetrics.start()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Network metrics are using a library that uses sync function blocking the event loop

## What is the new behavior?

- Disable network metrics
