### PR TITLE
fix: remanining security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-ecs": "^3.948.0",
-        "@aws-sdk/client-s3": "^3.948.0",
-        "@aws-sdk/client-s3vectors": "^3.948.0",
-        "@aws-sdk/lib-storage": "^3.948.0",
-        "@aws-sdk/s3-request-presigner": "^3.948.0",
+        "@aws-sdk/client-ecs": "^3.979.0",
+        "@aws-sdk/client-s3": "^3.979.0",
+        "@aws-sdk/client-s3vectors": "^3.979.0",
+        "@aws-sdk/lib-storage": "^3.979.0",
+        "@aws-sdk/s3-request-presigner": "^3.979.0",
         "@fastify/accepts": "^5.0.4",
         "@fastify/multipart": "^9.4.0",
         "@fastify/rate-limit": "^10.3.0",
@@ -41,14 +41,14 @@
         "@tus/s3-store": "2.0.0",
         "@tus/server": "2.2.1",
         "agentkeepalive": "^4.5.0",
-        "ajv": "^8.12.0",
+        "ajv": "^8.18.0",
         "async-retry": "^1.3.3",
         "aws-sigv4-sign": "^1.2.1",
-        "axios": "^1.12.0",
+        "axios": "^1.13.6",
         "axios-retry": "^3.9.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
-        "fastify": "^5.7.4",
+        "fastify": "^5.8.1",
         "fastify-plugin": "^5.1.0",
         "fs-extra": "^10.0.1",
         "fs-xattr": "0.3.1",
@@ -71,7 +71,7 @@
         "supa-storage": "dist/server.js"
       },
       "devDependencies": {
-        "@aws-sdk/s3-presigned-post": "^3.948.0",
+        "@aws-sdk/s3-presigned-post": "^3.979.0",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.27.0",
         "@biomejs/biome": "^2.4.4",
@@ -311,468 +311,63 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.948.0.tgz",
-      "integrity": "sha512-JzVENT/6gFL/gKkDQJ+YgyUMBr81zdPX0RUOmLPzujPWumcMo/GqeCA8xorfWW/EDG3CbgaBfDi2hLQO1TNrPg==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.1003.0.tgz",
+      "integrity": "sha512-K7vazGvj5P39g/6DgqB1IHAKM9s7Darm4qKtrGlH6u1FLPEQDRjgVi3mcuk8m6yHx1GtDuNlnS/lVzNcMLmeBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/client-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-      "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-      "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-      "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-      "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-login": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-      "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-      "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-ini": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-      "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-      "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.948.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/token-providers": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-      "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-      "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-      "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-      "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/token-providers": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-      "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-endpoints": "^3.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-      "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -780,9 +375,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -792,15 +387,15 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -808,12 +403,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -821,13 +416,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -835,9 +430,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -847,12 +442,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -860,12 +455,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -873,9 +468,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -885,12 +480,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -898,484 +493,79 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.948.0.tgz",
-      "integrity": "sha512-uvEjds8aYA9SzhBS8RKDtsDUhNV9VhqKiHTcmvhM7gJO92q0WTn8/QeFTdNyLc6RxpiDyz+uBxS7PcdNiZzqfA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1003.0.tgz",
+      "integrity": "sha512-on8GvIWeH1pD0l53NuKbPO84bEC1mk/9zskgU+dVKcVoGxOZI94fVddCJb+IwIUN6rfBHCfXPCVbgVyzsHTAVg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
-        "@aws-sdk/middleware-expect-continue": "3.936.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-location-constraint": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-sdk-s3": "3.947.0",
-        "@aws-sdk/middleware-ssec": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/signature-v4-multi-region": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/eventstream-serde-browser": "^4.2.5",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-        "@smithy/eventstream-serde-node": "^4.2.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-blob-browser": "^4.2.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/hash-stream-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/md5-js": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.7",
+        "@aws-sdk/middleware-expect-continue": "^3.972.7",
+        "@aws-sdk/middleware-flexible-checksums": "^3.973.4",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-location-constraint": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.18",
+        "@aws-sdk/middleware-ssec": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/eventstream-serde-browser": "^4.2.11",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.11",
+        "@smithy/eventstream-serde-node": "^4.2.11",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-blob-browser": "^4.2.12",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/hash-stream-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/md5-js": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-      "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-      "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-      "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-      "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-login": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-      "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-      "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-ini": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-      "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-      "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.948.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/token-providers": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-      "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-      "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-      "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-      "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-      "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-endpoints": "^3.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-      "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1383,9 +573,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1395,15 +585,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1411,12 +601,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1424,13 +614,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1438,9 +628,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1450,12 +640,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1463,12 +653,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1476,9 +666,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1488,12 +678,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1501,467 +691,62 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3vectors/-/client-s3vectors-3.948.0.tgz",
-      "integrity": "sha512-unMSPG+e4uJo72jyUa5bCAy4YWcCNfLS+QdmwVaLVtuU7YvOEH+BkQ70VEyRkhpUFx4e70gGdbZe3nbAy77ZKA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3vectors/-/client-s3vectors-3.1003.0.tgz",
+      "integrity": "sha512-tcmcFN5PjPOo9OeDWURByvd70eI/XgbJr7U8Kqm2rbYr3pIOGGdlUK6atnvihGnB3No4R3I4HPpG8RcxYVZ6Tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/client-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-      "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-      "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-      "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-      "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-login": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-      "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-      "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.947.0",
-        "@aws-sdk/credential-provider-http": "3.947.0",
-        "@aws-sdk/credential-provider-ini": "3.948.0",
-        "@aws-sdk/credential-provider-process": "3.947.0",
-        "@aws-sdk/credential-provider-sso": "3.948.0",
-        "@aws-sdk/credential-provider-web-identity": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-      "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-      "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.948.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/token-providers": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-      "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-      "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-      "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-      "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/token-providers": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-      "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/nested-clients": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-endpoints": "^3.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3vectors/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-      "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1969,9 +754,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1981,15 +766,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1997,12 +782,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2010,13 +795,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2024,9 +809,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2036,12 +821,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2049,12 +834,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2062,9 +847,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2074,229 +859,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3vectors/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.953.0.tgz",
-      "integrity": "sha512-WU8XtORGnhy1JjTLflcGcNGU329pmwl/2claTVGp7vrgUKyreQV9Ke3BkMuUPYLOGO/Znstzc1VbUT9ORH3+WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.3.15",
-        "@smithy/middleware-retry": "^4.4.15",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.14",
-        "@smithy/util-defaults-mode-node": "^4.2.17",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2304,47 +872,33 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
-      "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
+      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "fast-xml-parser": "5.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2354,12 +908,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2367,9 +921,9 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2379,12 +933,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2392,12 +946,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2405,171 +959,65 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.4.tgz",
+      "integrity": "sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
       },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/@aws-sdk/crc64-nvme/node_modules/@smithy/types": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.953.0.tgz",
-      "integrity": "sha512-ahOxDxvaKUf99LU9iRmRtPW2HLmsR+ix2WyzRGl1PpLltiRLMbKJHj5Tu2xyOsgLxs8tefK9D1j0SUgPk8GJ6g==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
+      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2577,82 +1025,33 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.953.0.tgz",
-      "integrity": "sha512-kYQEcJpJLiT+1ZdsQDMrIs2o3YydxdAIDdLUxbIwks1+WQz2sCr9b94ld19aMZ0rejosASO0J3dfY0lt3Tfl+Q==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
+      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-stream": "^4.5.7",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2660,15 +1059,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2676,12 +1075,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2689,13 +1088,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2703,37 +1102,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2741,24 +1114,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2766,137 +1126,36 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.953.0.tgz",
-      "integrity": "sha512-5cy6b3VntBvhRCanwohRtR0wbKKUd6JfIsnuXImB4JcZa2iMW5tDW0LhNangYZ9wrrM7sJol6cKHtUW9LNemFQ==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.16.tgz",
+      "integrity": "sha512-hzAnzNXKV0A4knFRWGu2NCt72P4WWxpEGnOc6H3DptUjC4oX3hGw846oN76M1rTHAOwDdbhjU0GAOWR4OUfTZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/credential-provider-env": "3.953.0",
-        "@aws-sdk/credential-provider-http": "3.953.0",
-        "@aws-sdk/credential-provider-login": "3.953.0",
-        "@aws-sdk/credential-provider-process": "3.953.0",
-        "@aws-sdk/credential-provider-sso": "3.953.0",
-        "@aws-sdk/credential-provider-web-identity": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-login": "^3.972.16",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.16",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2904,80 +1163,31 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.953.0.tgz",
-      "integrity": "sha512-Drf4v7uBKnU/nY/qgQD9ZA2zD5gjQEatxQajQHUN54erDSQ2rB5ApNuTnc2cyNwaxURnQvO1J72mwO6P5lIpsg==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.16.tgz",
+      "integrity": "sha512-VI0kXTlr0o1FTay+Jvx6AKqx5ECBgp7X4VevGBEbuXdCXnNp7SPU0KvjsOLVhIz3OoPK4/lTXphk43t0IVk65w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2985,50 +1195,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3036,45 +1207,32 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.953.0.tgz",
-      "integrity": "sha512-/3gUap/QwAV/U3RPStcSjdiksDboTdcz82qajfhURhtAe9iEdoKJy7vTYqg75eX7IjpgBwLGajt0URasUofrPg==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.17.tgz",
+      "integrity": "sha512-98MAcQ2Dk7zkvgwZ5f6fLX2lTyptC3gTSDx4EpvTdJWET8qs9lBPYggoYx7GmKp/5uk0OwVl0hxIDZsDNS/Y9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.953.0",
-        "@aws-sdk/credential-provider-http": "3.953.0",
-        "@aws-sdk/credential-provider-ini": "3.953.0",
-        "@aws-sdk/credential-provider-process": "3.953.0",
-        "@aws-sdk/credential-provider-sso": "3.953.0",
-        "@aws-sdk/credential-provider-web-identity": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-ini": "^3.972.16",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.16",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3084,129 +1242,28 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.953.0.tgz",
-      "integrity": "sha512-YeqzqxzBzXnqdzn4pBuoXeCmWrXOLIu5owAowUc4dOvHmtlpXxB3beJdQ9g/Ky6fG6iaAPKO1vrCEoHNjM85Dw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
+      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3214,131 +1271,30 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.953.0.tgz",
-      "integrity": "sha512-Kp/49vAJweixMo3q85eVpq1JO9KgKc6A+f8/8WDkN5CkMsfKQcGJZbO5JtuJfzar4pPmRKbgOeOP1qQsOmfyfw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.16.tgz",
+      "integrity": "sha512-b9of7tQgERxgcEcwAFWvRe84ivw+Kw6b3jVuz/6LQzonkomiY5UoWfprkbjc8FSCQ2VjDqKTvIRA9F0KSQ025w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.953.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/token-providers": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/token-providers": "3.1003.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3346,130 +1302,29 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.953.0.tgz",
-      "integrity": "sha512-V8SpGVtNjQZboHjb/GLM4L3/6O/AZJFtwJ8fiBaemKMTntl8haioZlQHDklWixR9s9zthOdFsCDs1+92ndUBRw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.16.tgz",
+      "integrity": "sha512-PaOH5jFoPQX4WkqpKzKh9cM7rieKtbgEGqrZ+ybGmotJhcvhI/xl69yCwMbHGnpQJJmHZIX9q2zaPB7HTBn/4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3477,33 +1332,33 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.948.0.tgz",
-      "integrity": "sha512-dY7wISfWgEqSHGps0DkQiDjHhCqR7bc0mMrBHZ810/j12uzhTakAcb9FlF7mFWkX6zEvz2kjxF4r91lBwNqt5w==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1003.0.tgz",
+      "integrity": "sha512-tyc2WazRhlBNdJu1Vpi7v9Oak8gl4zo0521MYOZustCmdSvGmV8kJdOEa4VK8pUPvm2D7mRgdiNRqesy87gcuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/smithy-client": "^4.12.2",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.948.0"
+        "@aws-sdk/client-s3": "^3.1003.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3511,9 +1366,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3523,30 +1378,30 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
-      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.7.tgz",
+      "integrity": "sha512-goX+axlJ6PQlRnzE2bQisZ8wVrlm6dXJfBzMJhd8LhAIBan/w1Kl73fJnalM/S+18VnpzIHumyV6DtgmvqG5IA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3554,9 +1409,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3566,27 +1421,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
-      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.7.tgz",
+      "integrity": "sha512-mvWqvm61bmZUKmmrtl2uWbokqpenY3Mc3Jf4nXB/Hse6gWxLPaCQThmhPBDzsPSV8/Odn8V6ovWt3pZ7vy4BFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3594,9 +1449,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3606,33 +1461,34 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.947.0.tgz",
-      "integrity": "sha512-kXXxS2raNESNO+zR0L4YInVjhcGGNI2Mx0AE1ThRhDkAt2se3a+rGf9equ9YvOqA1m8Jl/GSI8cXYvSxXmS9Ag==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.4.tgz",
+      "integrity": "sha512-7CH2jcGmkvkHc5Buz9IGbdjq1729AAlgYJiAvGq7qhCHqYleCsriWdSnmsqWTwdAfXHMT+pkxX3w6v5tJNcSug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/crc64-nvme": "^3.972.4",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3642,12 +1498,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3655,9 +1511,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3667,12 +1523,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3680,12 +1536,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3693,12 +1549,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3706,40 +1562,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.953.0.tgz",
-      "integrity": "sha512-jTGhfkONav+r4E6HLOrl5SzBqDmPByUYCkyB/c/3TVb8jX3wAZx8/q9bphKpCh+G5ARi3IdbSisgkZrJYqQ19Q==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3747,9 +1590,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3759,23 +1602,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
-      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.7.tgz",
+      "integrity": "sha512-vdK1LJfffBp87Lj0Bw3WdK1rJk9OLDYdQpqoKgmpIZPe+4+HawZ6THTbvjhJt4C4MNnRrHTKHQjkwBiIpDBoig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3785,36 +1628,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.953.0.tgz",
-      "integrity": "sha512-PlWdVYgcuptkIC0ZKqVUhWNtSHXJSx7U9V8J7dJjRmsXC40X7zpEycvrkzDMJjeTDGcCceYbyYAg/4X1lkcIMw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3824,41 +1654,28 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.953.0.tgz",
-      "integrity": "sha512-cmIJx0gWeesUKK4YwgE+VQL3mpACr3/J24fbwnc1Z5tntC86b+HQFzU5vsBDw6lLwyD46dBgWdsXFh1jL+ZaFw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/types": "^3.973.5",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3866,9 +1683,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3878,34 +1695,34 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.947.0.tgz",
-      "integrity": "sha512-DS2tm5YBKhPW2PthrRBDr6eufChbwXe0NjtTZcYDfUCXf0OR+W6cIqyKguwHMJ+IyYdey30AfVw9/Lb5KB8U8A==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.18.tgz",
+      "integrity": "sha512-5E3XxaElrdyk6ZJ0TjH7Qm6ios4b/qQCiLr6oQ8NK7e4Kn6JBTJCaYioQCQ65BpZ1+l1mK5wTAac2+pEz0Smpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3915,12 +1732,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3928,9 +1745,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3940,12 +1757,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3953,12 +1770,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3966,12 +1783,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3979,23 +1796,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
-      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.7.tgz",
+      "integrity": "sha512-G9clGVuAml7d8DYzY6DnRi7TIIDRvZ3YpqJPz/8wnWS5fYx/FNWNmkO6iJVlVkQg9BfeMzd+bVPtPJOvC4B+nQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4005,79 +1822,30 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.953.0.tgz",
-      "integrity": "sha512-xZSU54cEHlIvRTUewyTAajb4WJPdbBd1mIaDYOzac07+vsfMuCREQ5CheQ3inoBfqske7QOX+mIjLpVV4azAnw==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.18.tgz",
+      "integrity": "sha512-KcqQDs/7WtoEnp52+879f8/i1XAJkgka5i4arOtOCPR10o4wWo3VRecDI9Gxoh6oghmLCnIiOSKyRcXI/50E+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.8",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4085,50 +1853,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4136,98 +1865,61 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.953.0.tgz",
-      "integrity": "sha512-YEBI0b/4ezNkw5W4+RBRUoueFzqEPPrnkh/3LBqeJ7RWZTymBhxlpoLo6Gfxw9LxtDgv2vZ5K5rgC4/6Ly8ADg==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.6.tgz",
+      "integrity": "sha512-blNJ3ugn4gCQ9ZSZi/firzKCvVl5LvPFVxv24LprENeWI4R8UApG006UQkF4SkmLygKq2BQXRad2/anQ13Te4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.3.15",
-        "@smithy/middleware-retry": "^4.4.15",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.14",
-        "@smithy/util-defaults-mode-node": "^4.2.17",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4235,9 +1927,9 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4247,15 +1939,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4263,12 +1955,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4276,13 +1968,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4290,9 +1982,9 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4302,12 +1994,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4315,12 +2007,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4328,9 +2020,9 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4340,12 +2032,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4353,38 +2045,25 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.953.0.tgz",
-      "integrity": "sha512-5MJgnsc+HLO+le0EK1cy92yrC7kyhGZSpaq8PcQvKs9qtXCXT5Tb6tMdkr5Y07JxYsYOV1omWBynvL6PWh08tQ==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4394,30 +2073,30 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.948.0.tgz",
-      "integrity": "sha512-KBW4dFcFvOOn4aWF7ACvTDtRtgoL3dQEki4QdxOqsb6F0YT8KRecjF5ZF+lpWbY9Mp/HyJ9Eg6WxTS7SiW3ZMA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.1003.0.tgz",
+      "integrity": "sha512-GCgfyMNcctUhsJ+buC2X7qzv9p9kCb1UH1RM2scJTyHR4Pp9dEZSRNRnMTD+S9eT1+uEpaA9KAK3MZiTQio/PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-format-url": "3.936.0",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/client-s3": "3.1003.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-format-url": "^3.972.7",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4428,9 +2107,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4441,13 +2120,13 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4455,9 +2134,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4468,13 +2147,13 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4482,31 +2161,31 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.948.0.tgz",
-      "integrity": "sha512-tlQhMDsDWwUDUzzlo8XYGpmMfjGDmXgbysv1+h1v2xJe0A+ogv/nJ6KFVP94uf1j4ePmCN/gDdxEp2PWZMBPOQ==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1003.0.tgz",
+      "integrity": "sha512-lEMaCGi5HmsXxxago5UCyDSroqX9rkgA1mFxmzld6XzoVozZCqGIr9CKUas0Vmvu60LXukF8MWUwCYdwVP2oCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-format-url": "3.936.0",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-format-url": "^3.972.7",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4514,9 +2193,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4526,29 +2205,29 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.947.0.tgz",
-      "integrity": "sha512-UaYmzoxf9q3mabIA2hc4T6x5YSFUG2BpNjAZ207EA1bnQMiK+d6vZvb83t7dIWL/U1de1sGV19c1C81Jf14rrA==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.6.tgz",
+      "integrity": "sha512-NnsOQsVmJXy4+IdPFUjRCWPn9qNH1TzS/f7MiWgXeoHs903tJpAWQWQtoFvLccyPoBgomKP9L89RRr2YsT/L0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4556,9 +2235,9 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4568,130 +2247,29 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.953.0.tgz",
-      "integrity": "sha512-4FWWR3lDDuIftmCEWpGejfkJu2J1VG2MUktChQshADXABfVfM0fsT7OYlO7Sy106nOe9upE4uQTWXg9YT/6ssw==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1003.0.tgz",
+      "integrity": "sha512-SOyyWNdT7njKRwtZ1JhwHlH1csv6Pkgf305X96/OIfnhq1pU/EjmT6W6por57rVrjrKuHBuEIXgpWv8OgoMHpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/core": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-      "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/xml-builder": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/signature-v4": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4699,22 +2277,22 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
-      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4724,50 +2302,37 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.953.0.tgz",
-      "integrity": "sha512-rjaS6jrFksopXvNg6YeN+D1lYwhcByORNlFuYesFvaQNtPOufbE5tJL4GJ3TMXyaY0uFR28N5BHHITPyWWfH/g==",
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-endpoints": "^3.2.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4777,28 +2342,28 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
-      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
+      "integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4806,9 +2371,9 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4818,9 +2383,9 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4841,34 +2406,21 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.953.0.tgz",
-      "integrity": "sha512-UF5NeqYesWuFao+u7LJvpV1SJCaLml5BtFZKUdTnNNMeN6jvV+dW/eQoFGpXF94RCqguX0XESmRuRRPQp+/rzQ==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4878,19 +2430,19 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.953.0.tgz",
-      "integrity": "sha512-HjJ0Nq/57kg0QCjt8mwBAK6C34njKezy9ItUNcrWITzrBZv7ikQtyqM1pindAIzgLaBb7ly/0kbJqMY+NPbcJA==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.3.tgz",
+      "integrity": "sha512-8s2cQmTUOwcBlIJyI9PAZNnnnF+cGtdhHc1yzMMsSD/GR/Hxj7m0IGUE92CslXXb8/p5Q76iqOCjN1GFwyf+1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -4901,23 +2453,10 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-      "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4927,23 +2466,23 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.953.0.tgz",
-      "integrity": "sha512-Zmrj21jQ2OeOJGr9spPiN00aQvXa/WUqRXcTVENhrMt+OFoSOfDFpYhUj9NQ09QmQ8KMWFoWuWW6iKurNqLvAA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4952,40 +2491,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder/node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
-      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -12467,9 +9976,9 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
-      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12479,12 +9988,12 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
-      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12492,16 +10001,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
-      "integrity": "sha512-s3U5ChS21DwU54kMmZ0UJumoS5cg0+rGVZvN6f5Lp6EbAVi0ZyP+qDSHdewfmXKUgNK1j3z45JyzulkDukrjAA==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12509,9 +10018,9 @@
       }
     },
     "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12521,12 +10030,12 @@
       }
     },
     "node_modules/@smithy/config-resolver/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12534,20 +10043,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
-      "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
+      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-stream": "^4.5.7",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12555,9 +10064,9 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12567,12 +10076,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12580,9 +10089,9 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12592,12 +10101,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12605,12 +10114,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12618,12 +10127,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12631,15 +10140,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
-      "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12647,9 +10156,9 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12659,14 +10168,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.6.tgz",
-      "integrity": "sha512-OZfsI+YRG26XZik/jKMMg37acnBSbUiK/8nETW3uM3mLj+0tMmFXdHQw1e5WEd/IHN8BGOh3te91SNDe2o4RHg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.11.tgz",
+      "integrity": "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12674,9 +10183,9 @@
       }
     },
     "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12686,9 +10195,9 @@
       }
     },
     "node_modules/@smithy/eventstream-codec/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12698,13 +10207,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.6.tgz",
-      "integrity": "sha512-6OiaAaEbLB6dEkRbQyNzFSJv5HDvly3Mc6q/qcPd2uS/g3szR8wAIkh7UndAFKfMypNSTuZ6eCBmgCLR5LacTg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.11.tgz",
+      "integrity": "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12712,9 +10221,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12724,12 +10233,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.6.tgz",
-      "integrity": "sha512-xP5YXbOVRVN8A4pDnSUkEUsL9fYFU6VNhxo8tgr13YnMbf3Pn4xVr+hSyLVjS1Frfi1Uk03ET5Bwml4+0CeYEw==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.11.tgz",
+      "integrity": "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12737,9 +10246,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12749,13 +10258,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.6.tgz",
-      "integrity": "sha512-jhH7nJuaOpnTFcuZpWK9dqb6Ge2yGi1okTo0W6wkJrfwAm2vwmO74tF1v07JmrSyHBcKLQATEexclJw9K1Vj7w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.11.tgz",
+      "integrity": "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12763,9 +10272,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12775,13 +10284,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.6.tgz",
-      "integrity": "sha512-olIfZ230B64TvPD6b0tPvrEp2eB0FkyL3KvDlqF4RVmIc/kn3orzXnV6DTQdOOW5UU+M5zKY3/BU47X420/oPw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.11.tgz",
+      "integrity": "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-codec": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12789,9 +10298,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12801,15 +10310,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
-      "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12817,12 +10326,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12830,13 +10339,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12844,9 +10353,9 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12856,9 +10365,9 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12868,14 +10377,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.7.tgz",
-      "integrity": "sha512-CIbCTGGX5CI7tfewBPSYD9ycp2Vb2GW5xnXD1n7GcO9mu37EN7A6DvCHM9MX7pOeS1adMn5D+1yRwI3eABVbcA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.12.tgz",
+      "integrity": "sha512-1wQE33DsxkM/waftAhCH9VtJbUGyt1PJ9YRDpOu+q9FUi73LLFUZ2fD8A61g2mT1UY9k7b99+V1xZ41Rz4SHRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.0",
-        "@smithy/chunked-blob-reader-native": "^4.2.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12883,9 +10392,9 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12895,14 +10404,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.6.tgz",
-      "integrity": "sha512-k3Dy9VNR37wfMh2/1RHkFf/e0rMyN0pjY0FdyY6ItJRjENYyVPRMwad6ZR1S9HFm6tTuIOd9pqKBmtJ4VHxvxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12910,9 +10419,9 @@
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12922,9 +10431,9 @@
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12934,12 +10443,12 @@
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12947,12 +10456,12 @@
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12960,13 +10469,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.6.tgz",
-      "integrity": "sha512-+3T8LkH39YIhYHsv/Ec8lF+92nykZpU+XMBvAyXF/uLcTp86pxa5oSJk1vzaRY9N++qgDLYjzJ6OVbtAgDGwfw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.11.tgz",
+      "integrity": "sha512-hQsTjwPCRY8w9GK07w1RqJi3e+myh0UaOWBBhZ1UMSDgofH/Q1fEYzU1teaX6HkpX/eWDdm7tAGR0jBPlz9QEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12974,9 +10483,9 @@
       }
     },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12986,9 +10495,9 @@
       }
     },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12998,12 +10507,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13011,12 +10520,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13024,12 +10533,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.6.tgz",
-      "integrity": "sha512-E4t/V/q2T46RY21fpfznd1iSLTvCXKNKo4zJ1QuEFN4SE9gKfu2vb6bgq35LpufkQ+SETWIC7ZAf2GGvTlBaMQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13037,9 +10546,9 @@
       }
     },
     "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13060,13 +10569,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.6.tgz",
-      "integrity": "sha512-ZXeh8UmH31JdcNsrQ1o9v1IVuva9JFwxIc6zTMxWX7wcmWvVR7Ai9aUEw5LraNKqdkAsb06clpM2sRH4Iy55Sg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.11.tgz",
+      "integrity": "sha512-350X4kGIrty0Snx2OWv7rPM6p6vM7RzryvFs6B/56Cux3w3sChOb3bymo5oidXJlPcP9fIRxGUCk7GqpiSOtng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13074,9 +10583,9 @@
       }
     },
     "node_modules/@smithy/md5-js/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13086,9 +10595,9 @@
       }
     },
     "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13098,12 +10607,12 @@
       }
     },
     "node_modules/@smithy/md5-js/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13111,12 +10620,12 @@
       }
     },
     "node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13124,13 +10633,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.6.tgz",
-      "integrity": "sha512-0cjqjyfj+Gls30ntq45SsBtqF3dfJQCeqQPyGz58Pk8OgrAr5YiB7ZvDzjCA94p4r6DCI4qLm7FKobqBjf515w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13138,12 +10647,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13151,9 +10660,9 @@
       }
     },
     "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13163,18 +10672,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.0.tgz",
-      "integrity": "sha512-M6qWfUNny6NFNy8amrCGIb9TfOMUkHVtg9bHtEFGRgfH7A7AtPpn/fcrToGPjVDK1ECuMVvqGQOXcZxmu9K+7A==",
+      "version": "4.4.22",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
+      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.19.0",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13182,9 +10691,9 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13194,12 +10703,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13207,19 +10716,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.16.tgz",
-      "integrity": "sha512-XPpNhNRzm3vhYm7YCsyw3AtmWggJbg1wNGAoqb7NBYr5XA5isMRv14jgbYyUV6IvbTBFZQdf2QpeW43LrRdStQ==",
+      "version": "4.4.39",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
+      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/service-error-classification": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13227,12 +10736,12 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13240,9 +10749,9 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13252,12 +10761,12 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13265,13 +10774,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.7.tgz",
-      "integrity": "sha512-PFMVHVPgtFECeu4iZ+4SX6VOQT0+dIpm4jSPLLL6JLSkp9RohGqKBKD0cbiXdeIFS08Forp0UHI6kc0gIHenSA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13279,12 +10788,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13292,9 +10801,9 @@
       }
     },
     "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13304,12 +10813,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.6.tgz",
-      "integrity": "sha512-JSbALU3G+JS4kyBZPqnJ3hxIYwOVRV7r9GNQMS6j5VsQDo5+Es5nddLfr9TQlxZLNHPvKSh+XSB0OuWGfSWFcA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13317,9 +10826,9 @@
       }
     },
     "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13329,14 +10838,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.6.tgz",
-      "integrity": "sha512-fYEyL59Qe82Ha1p97YQTMEQPJYmBS+ux76foqluaTVWoG9Px5J53w6NvXZNE3wP7lIicLDF7Vj1Em18XTX7fsA==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13344,9 +10853,9 @@
       }
     },
     "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13371,12 +10880,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.6.tgz",
-      "integrity": "sha512-a/tGSLPtaia2krbRdwR4xbZKO8lU67DjMk/jfY4QKt4PRlKML+2tL/gmAuhNdFDioO6wOq0sXkfnddNFH9mNUA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13384,9 +10893,9 @@
       }
     },
     "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13421,12 +10930,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.6.tgz",
-      "integrity": "sha512-YmWxl32SQRw/kIRccSOxzS/Ib8/b5/f9ex0r5PR40jRJg8X1wgM3KrR2In+8zvOGVhRSXgvyQpw9yOSlmfmSnA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13434,9 +10943,9 @@
       }
     },
     "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13446,21 +10955,21 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.6.tgz",
-      "integrity": "sha512-Q73XBrzJlGTut2nf5RglSntHKgAG0+KiTJdO5QQblLfr4TdliGwIAha1iZIjwisc3rA5ulzqwwsYC6xrclxVQg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0"
+        "@smithy/types": "^4.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13470,12 +10979,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.1.tgz",
-      "integrity": "sha512-tph+oQYPbpN6NamF030hx1gb5YN2Plog+GLaRHpoEDwp8+ZPG26rIJvStG9hkWzN2HBn3HcWg0sHeB0tmkYzqA==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13483,9 +10992,9 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13495,18 +11004,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
-      "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13514,9 +11023,9 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13526,12 +11035,12 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13539,9 +11048,9 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13551,12 +11060,12 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13564,9 +11073,9 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13576,12 +11085,12 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-middleware": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-      "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13589,9 +11098,9 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13601,12 +11110,12 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13614,17 +11123,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.1.tgz",
-      "integrity": "sha512-1ovWdxzYprhq+mWqiGZlt3kF69LJthuQcfY9BIyHx9MywTFKzFapluku1QXoaBB43GCsLDxNqS+1v30ure69AA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
+      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.19.0",
-        "@smithy/middleware-endpoint": "^4.4.0",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-stream": "^4.5.7",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13632,12 +11141,12 @@
       }
     },
     "node_modules/@smithy/smithy-client/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13645,9 +11154,9 @@
       }
     },
     "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13668,13 +11177,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.6.tgz",
-      "integrity": "sha512-tVoyzJ2vXp4R3/aeV4EQjBDmCuWxRa8eo3KybL7Xv4wEM16nObYh7H1sNfcuLWHAAAzb0RVyxUz1S3sGj4X+Tg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13682,9 +11191,9 @@
       }
     },
     "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13694,13 +11203,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13708,9 +11217,9 @@
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13720,12 +11229,12 @@
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13733,12 +11242,12 @@
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13746,9 +11255,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13758,9 +11267,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13782,9 +11291,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13794,14 +11303,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.15.tgz",
-      "integrity": "sha512-LiZQVAg/oO8kueX4c+oMls5njaD2cRLXRfcjlTYjhIqmwHnCwkQO5B3dMQH0c5PACILxGAQf6Mxsq7CjlDc76A==",
+      "version": "4.3.38",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
+      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13809,9 +11318,9 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13821,17 +11330,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.18.tgz",
-      "integrity": "sha512-Kw2J+KzYm9C9Z9nY6+W0tEnoZOofstVCMTshli9jhQbQCy64rueGfKzPfuFBnVUqZD9JobxTh2DzHmPkp/Va/Q==",
+      "version": "4.2.41",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
+      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13839,9 +11348,9 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13851,13 +11360,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.6.tgz",
-      "integrity": "sha512-v60VNM2+mPvgHCBXEfMCYrQ0RepP6u6xvbAkMenfe4Mi872CqNkJzgcnQL837e8NdeDxBgrWQRTluKq5Lqdhfg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13865,9 +11374,9 @@
       }
     },
     "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13913,13 +11422,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.6.tgz",
-      "integrity": "sha512-x7CeDQLPQ9cb6xN7fRJEjlP9NyGW/YeXWc4j/RUhg4I+H60F0PEeRc2c/z3rm9zmsdiMFzpV/rT+4UHW6KM1SA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13927,9 +11436,9 @@
       }
     },
     "node_modules/@smithy/util-retry/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13939,18 +11448,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.7.tgz",
-      "integrity": "sha512-Uuy4S5Aj4oF6k1z+i2OtIBJUns4mlg29Ph4S+CqjR+f4XXpSFVgTCYLzMszHJTicYDBxKFtwq2/QSEDSS5l02A==",
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13958,12 +11467,12 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13971,9 +11480,9 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -13983,15 +11492,15 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-      "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13999,12 +11508,12 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-      "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14012,13 +11521,13 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-      "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14026,9 +11535,9 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -14038,12 +11547,12 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14051,9 +11560,9 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -14063,9 +11572,9 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -14075,12 +11584,12 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14111,13 +11620,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.6.tgz",
-      "integrity": "sha512-xU9HwUSik9UUCJmm530yvBy0AwlQFICveKmqvaaTukKkXEAhyiBdHtSrhPrH3rH+uz0ykyaE3LdgsX86C6mDCQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.11.tgz",
+      "integrity": "sha512-x7Rh2azQPs3XxbvCzcttRErKKvLnbZfqRf/gOjw2pb+ZscX88e5UkRPCB67bVnsFHxayvMvmePfKTqsRb+is1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14125,12 +11634,12 @@
       }
     },
     "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-      "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14138,9 +11647,9 @@
       }
     },
     "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -14150,9 +11659,10 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -14583,14 +12093,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -14815,12 +12326,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -15130,9 +12642,10 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -15751,10 +13264,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -16208,10 +13722,41 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastify": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
-      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.1.tgz",
+      "integrity": "sha512-y0kicFvvn7CYWoPOVLOcvn4YyKQz03DIY7UxmyOy21/J8eXm09R+tmb+tVDBW5h+pja30cHI5dqUcSlvY86V2A==",
       "funding": [
         {
           "type": "github",
@@ -16233,7 +13778,7 @@
         "fast-json-stringify": "^6.0.0",
         "find-my-way": "^9.0.0",
         "light-my-request": "^6.0.0",
-        "pino": "^10.1.0",
+        "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
@@ -16317,9 +13862,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16378,15 +13923,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -16397,9 +13943,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -18440,10 +15986,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -19368,14 +16915,6 @@
         "pump": "^3.0.0"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -20190,6 +17729,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -20762,14 +18313,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -21207,2144 +18750,718 @@
       }
     },
     "@aws-sdk/client-ecs": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.948.0.tgz",
-      "integrity": "sha512-JzVENT/6gFL/gKkDQJ+YgyUMBr81zdPX0RUOmLPzujPWumcMo/GqeCA8xorfWW/EDG3CbgaBfDi2hLQO1TNrPg==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.1003.0.tgz",
+      "integrity": "sha512-K7vazGvj5P39g/6DgqB1IHAKM9s7Darm4qKtrGlH6u1FLPEQDRjgVi3mcuk8m6yHx1GtDuNlnS/lVzNcMLmeBA==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-          "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-          "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-          "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/util-stream": "^4.5.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-          "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-login": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-login": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-          "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-          "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-ini": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-          "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-          "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.948.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/token-providers": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-          "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-          "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-          "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-          "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-          "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@smithy/core": "^3.18.7",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-          "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-          "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-          "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-          "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-endpoints": "^3.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-          "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-          "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-          "requires": {
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.948.0.tgz",
-      "integrity": "sha512-uvEjds8aYA9SzhBS8RKDtsDUhNV9VhqKiHTcmvhM7gJO92q0WTn8/QeFTdNyLc6RxpiDyz+uBxS7PcdNiZzqfA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1003.0.tgz",
+      "integrity": "sha512-on8GvIWeH1pD0l53NuKbPO84bEC1mk/9zskgU+dVKcVoGxOZI94fVddCJb+IwIUN6rfBHCfXPCVbgVyzsHTAVg==",
       "peer": true,
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
-        "@aws-sdk/middleware-expect-continue": "3.936.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.947.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-location-constraint": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-sdk-s3": "3.947.0",
-        "@aws-sdk/middleware-ssec": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/signature-v4-multi-region": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/eventstream-serde-browser": "^4.2.5",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-        "@smithy/eventstream-serde-node": "^4.2.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-blob-browser": "^4.2.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/hash-stream-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/md5-js": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.7",
+        "@aws-sdk/middleware-expect-continue": "^3.972.7",
+        "@aws-sdk/middleware-flexible-checksums": "^3.973.4",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-location-constraint": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.18",
+        "@aws-sdk/middleware-ssec": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/eventstream-serde-browser": "^4.2.11",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.11",
+        "@smithy/eventstream-serde-node": "^4.2.11",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-blob-browser": "^4.2.12",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/hash-stream-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/md5-js": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-          "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-          "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-          "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/util-stream": "^4.5.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-          "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-login": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-login": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-          "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-          "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-ini": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-          "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-          "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.948.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/token-providers": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-          "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-          "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-          "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-          "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-          "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@smithy/core": "^3.18.7",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-          "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-          "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-          "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-          "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-endpoints": "^3.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-          "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-          "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-          "requires": {
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/client-s3vectors": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3vectors/-/client-s3vectors-3.948.0.tgz",
-      "integrity": "sha512-unMSPG+e4uJo72jyUa5bCAy4YWcCNfLS+QdmwVaLVtuU7YvOEH+BkQ70VEyRkhpUFx4e70gGdbZe3nbAy77ZKA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3vectors/-/client-s3vectors-3.1003.0.tgz",
+      "integrity": "sha512-tcmcFN5PjPOo9OeDWURByvd70eI/XgbJr7U8Kqm2rbYr3pIOGGdlUK6atnvihGnB3No4R3I4HPpG8RcxYVZ6Tw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/credential-provider-node": "3.948.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.948.0",
-        "@aws-sdk/middleware-user-agent": "3.947.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.947.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.7",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-retry": "^4.4.14",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.13",
-        "@smithy/util-defaults-mode-node": "^4.2.16",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-          "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-          "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-          "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/util-stream": "^4.5.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-          "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-login": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-login": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-          "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-          "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.947.0",
-            "@aws-sdk/credential-provider-http": "3.947.0",
-            "@aws-sdk/credential-provider-ini": "3.948.0",
-            "@aws-sdk/credential-provider-process": "3.947.0",
-            "@aws-sdk/credential-provider-sso": "3.948.0",
-            "@aws-sdk/credential-provider-web-identity": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/credential-provider-imds": "^4.2.5",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-          "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-          "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.948.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/token-providers": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-          "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-          "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-          "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-          "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-          "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@smithy/core": "^3.18.7",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-          "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/middleware-host-header": "3.936.0",
-            "@aws-sdk/middleware-logger": "3.936.0",
-            "@aws-sdk/middleware-recursion-detection": "3.948.0",
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/region-config-resolver": "3.936.0",
-            "@aws-sdk/types": "3.936.0",
-            "@aws-sdk/util-endpoints": "3.936.0",
-            "@aws-sdk/util-user-agent-browser": "3.936.0",
-            "@aws-sdk/util-user-agent-node": "3.947.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/core": "^3.18.7",
-            "@smithy/fetch-http-handler": "^5.3.6",
-            "@smithy/hash-node": "^4.2.5",
-            "@smithy/invalid-dependency": "^4.2.5",
-            "@smithy/middleware-content-length": "^4.2.5",
-            "@smithy/middleware-endpoint": "^4.3.14",
-            "@smithy/middleware-retry": "^4.4.14",
-            "@smithy/middleware-serde": "^4.2.6",
-            "@smithy/middleware-stack": "^4.2.5",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/node-http-handler": "^4.4.5",
-            "@smithy/protocol-http": "^5.3.5",
-            "@smithy/smithy-client": "^4.9.10",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-body-length-browser": "^4.2.0",
-            "@smithy/util-body-length-node": "^4.2.1",
-            "@smithy/util-defaults-mode-browser": "^4.3.13",
-            "@smithy/util-defaults-mode-node": "^4.2.16",
-            "@smithy/util-endpoints": "^3.2.5",
-            "@smithy/util-middleware": "^4.2.5",
-            "@smithy/util-retry": "^4.2.5",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-          "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/config-resolver": "^4.4.3",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.948.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-          "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
-          "requires": {
-            "@aws-sdk/core": "3.947.0",
-            "@aws-sdk/nested-clients": "3.948.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/property-provider": "^4.2.5",
-            "@smithy/shared-ini-file-loader": "^4.4.0",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-          "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "@smithy/url-parser": "^4.2.5",
-            "@smithy/util-endpoints": "^3.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.936.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-          "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/types": "^4.9.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.947.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-          "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-          "requires": {
-            "@aws-sdk/middleware-user-agent": "3.947.0",
-            "@aws-sdk/types": "3.936.0",
-            "@smithy/node-config-provider": "^4.3.5",
-            "@smithy/types": "^4.9.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
-      }
-    },
-    "@aws-sdk/client-sso": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.953.0.tgz",
-      "integrity": "sha512-WU8XtORGnhy1JjTLflcGcNGU329pmwl/2claTVGp7vrgUKyreQV9Ke3BkMuUPYLOGO/Znstzc1VbUT9ORH3+WQ==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.3.15",
-        "@smithy/middleware-retry": "^4.4.15",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.14",
-        "@smithy/util-defaults-mode-node": "^4.2.17",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
-          "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/core": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
-      "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
+      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/xml-builder": {
-          "version": "3.930.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-          "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
-          "requires": {
-            "@smithy/types": "^4.9.0",
-            "fast-xml-parser": "5.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
-        },
-        "fast-xml-parser": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+        }
+      }
+    },
+    "@aws-sdk/crc64-nvme": {
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.4.tgz",
+      "integrity": "sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==",
+      "requires": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "strnum": "^2.1.0"
+            "tslib": "^2.6.2"
           }
-        },
-        "strnum": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-          "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
         }
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.953.0.tgz",
-      "integrity": "sha512-ahOxDxvaKUf99LU9iRmRtPW2HLmsR+ix2WyzRGl1PpLltiRLMbKJHj5Tu2xyOsgLxs8tefK9D1j0SUgPk8GJ6g==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
+      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.953.0.tgz",
-      "integrity": "sha512-kYQEcJpJLiT+1ZdsQDMrIs2o3YydxdAIDdLUxbIwks1+WQz2sCr9b94ld19aMZ0rejosASO0J3dfY0lt3Tfl+Q==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
+      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-stream": "^4.5.7",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.953.0.tgz",
-      "integrity": "sha512-5cy6b3VntBvhRCanwohRtR0wbKKUd6JfIsnuXImB4JcZa2iMW5tDW0LhNangYZ9wrrM7sJol6cKHtUW9LNemFQ==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.16.tgz",
+      "integrity": "sha512-hzAnzNXKV0A4knFRWGu2NCt72P4WWxpEGnOc6H3DptUjC4oX3hGw846oN76M1rTHAOwDdbhjU0GAOWR4OUfTZg==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/credential-provider-env": "3.953.0",
-        "@aws-sdk/credential-provider-http": "3.953.0",
-        "@aws-sdk/credential-provider-login": "3.953.0",
-        "@aws-sdk/credential-provider-process": "3.953.0",
-        "@aws-sdk/credential-provider-sso": "3.953.0",
-        "@aws-sdk/credential-provider-web-identity": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-login": "^3.972.16",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.16",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-login": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.953.0.tgz",
-      "integrity": "sha512-Drf4v7uBKnU/nY/qgQD9ZA2zD5gjQEatxQajQHUN54erDSQ2rB5ApNuTnc2cyNwaxURnQvO1J72mwO6P5lIpsg==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.16.tgz",
+      "integrity": "sha512-VI0kXTlr0o1FTay+Jvx6AKqx5ECBgp7X4VevGBEbuXdCXnNp7SPU0KvjsOLVhIz3OoPK4/lTXphk43t0IVk65w==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.953.0.tgz",
-      "integrity": "sha512-/3gUap/QwAV/U3RPStcSjdiksDboTdcz82qajfhURhtAe9iEdoKJy7vTYqg75eX7IjpgBwLGajt0URasUofrPg==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.17.tgz",
+      "integrity": "sha512-98MAcQ2Dk7zkvgwZ5f6fLX2lTyptC3gTSDx4EpvTdJWET8qs9lBPYggoYx7GmKp/5uk0OwVl0hxIDZsDNS/Y9g==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.953.0",
-        "@aws-sdk/credential-provider-http": "3.953.0",
-        "@aws-sdk/credential-provider-ini": "3.953.0",
-        "@aws-sdk/credential-provider-process": "3.953.0",
-        "@aws-sdk/credential-provider-sso": "3.953.0",
-        "@aws-sdk/credential-provider-web-identity": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-ini": "^3.972.16",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.16",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.16",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23352,304 +19469,85 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.953.0.tgz",
-      "integrity": "sha512-YeqzqxzBzXnqdzn4pBuoXeCmWrXOLIu5owAowUc4dOvHmtlpXxB3beJdQ9g/Ky6fG6iaAPKO1vrCEoHNjM85Dw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
+      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.953.0.tgz",
-      "integrity": "sha512-Kp/49vAJweixMo3q85eVpq1JO9KgKc6A+f8/8WDkN5CkMsfKQcGJZbO5JtuJfzar4pPmRKbgOeOP1qQsOmfyfw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.16.tgz",
+      "integrity": "sha512-b9of7tQgERxgcEcwAFWvRe84ivw+Kw6b3jVuz/6LQzonkomiY5UoWfprkbjc8FSCQ2VjDqKTvIRA9F0KSQ025w==",
       "requires": {
-        "@aws-sdk/client-sso": "3.953.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/token-providers": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/token-providers": "3.1003.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.953.0.tgz",
-      "integrity": "sha512-V8SpGVtNjQZboHjb/GLM4L3/6O/AZJFtwJ8fiBaemKMTntl8haioZlQHDklWixR9s9zthOdFsCDs1+92ndUBRw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.16.tgz",
+      "integrity": "sha512-PaOH5jFoPQX4WkqpKzKh9cM7rieKtbgEGqrZ+ybGmotJhcvhI/xl69yCwMbHGnpQJJmHZIX9q2zaPB7HTBn/4w==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.948.0.tgz",
-      "integrity": "sha512-dY7wISfWgEqSHGps0DkQiDjHhCqR7bc0mMrBHZ810/j12uzhTakAcb9FlF7mFWkX6zEvz2kjxF4r91lBwNqt5w==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1003.0.tgz",
+      "integrity": "sha512-tyc2WazRhlBNdJu1Vpi7v9Oak8gl4zo0521MYOZustCmdSvGmV8kJdOEa4VK8pUPvm2D7mRgdiNRqesy87gcuQ==",
       "requires": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/smithy-client": "^4.12.2",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -23657,18 +19555,18 @@
       },
       "dependencies": {
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23676,32 +19574,32 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
-      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.7.tgz",
+      "integrity": "sha512-goX+axlJ6PQlRnzE2bQisZ8wVrlm6dXJfBzMJhd8LhAIBan/w1Kl73fJnalM/S+18VnpzIHumyV6DtgmvqG5IA==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23709,29 +19607,29 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
-      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.7.tgz",
+      "integrity": "sha512-mvWqvm61bmZUKmmrtl2uWbokqpenY3Mc3Jf4nXB/Hse6gWxLPaCQThmhPBDzsPSV8/Odn8V6ovWt3pZ7vy4BFQ==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23739,112 +19637,104 @@
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.947.0.tgz",
-      "integrity": "sha512-kXXxS2raNESNO+zR0L4YInVjhcGGNI2Mx0AE1ThRhDkAt2se3a+rGf9equ9YvOqA1m8Jl/GSI8cXYvSxXmS9Ag==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.4.tgz",
+      "integrity": "sha512-7CH2jcGmkvkHc5Buz9IGbdjq1729AAlgYJiAvGq7qhCHqYleCsriWdSnmsqWTwdAfXHMT+pkxX3w6v5tJNcSug==",
       "requires": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/crc64-nvme": "^3.972.4",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.953.0.tgz",
-      "integrity": "sha512-jTGhfkONav+r4E6HLOrl5SzBqDmPByUYCkyB/c/3TVb8jX3wAZx8/q9bphKpCh+G5ARi3IdbSisgkZrJYqQ19Q==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23852,19 +19742,19 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
-      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.7.tgz",
+      "integrity": "sha512-vdK1LJfffBp87Lj0Bw3WdK1rJk9OLDYdQpqoKgmpIZPe+4+HawZ6THTbvjhJt4C4MNnRrHTKHQjkwBiIpDBoig==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23872,28 +19762,19 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.953.0.tgz",
-      "integrity": "sha512-PlWdVYgcuptkIC0ZKqVUhWNtSHXJSx7U9V8J7dJjRmsXC40X7zpEycvrkzDMJjeTDGcCceYbyYAg/4X1lkcIMw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23901,39 +19782,30 @@
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.953.0.tgz",
-      "integrity": "sha512-cmIJx0gWeesUKK4YwgE+VQL3mpACr3/J24fbwnc1Z5tntC86b+HQFzU5vsBDw6lLwyD46dBgWdsXFh1jL+ZaFw==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
+        "@aws-sdk/types": "^3.973.5",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -23941,94 +19813,94 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.947.0.tgz",
-      "integrity": "sha512-DS2tm5YBKhPW2PthrRBDr6eufChbwXe0NjtTZcYDfUCXf0OR+W6cIqyKguwHMJ+IyYdey30AfVw9/Lb5KB8U8A==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.18.tgz",
+      "integrity": "sha512-5E3XxaElrdyk6ZJ0TjH7Qm6ios4b/qQCiLr6oQ8NK7e4Kn6JBTJCaYioQCQ65BpZ1+l1mK5wTAac2+pEz0Smpw==",
       "requires": {
-        "@aws-sdk/core": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/core": "^3.18.7",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
-      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.7.tgz",
+      "integrity": "sha512-G9clGVuAml7d8DYzY6DnRi7TIIDRvZ3YpqJPz/8wnWS5fYx/FNWNmkO6iJVlVkQg9BfeMzd+bVPtPJOvC4B+nQ==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24036,294 +19908,192 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.953.0.tgz",
-      "integrity": "sha512-xZSU54cEHlIvRTUewyTAajb4WJPdbBd1mIaDYOzac07+vsfMuCREQ5CheQ3inoBfqske7QOX+mIjLpVV4azAnw==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.18.tgz",
+      "integrity": "sha512-KcqQDs/7WtoEnp52+879f8/i1XAJkgka5i4arOtOCPR10o4wWo3VRecDI9Gxoh6oghmLCnIiOSKyRcXI/50E+w==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@smithy/core": "^3.19.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.8",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/nested-clients": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.953.0.tgz",
-      "integrity": "sha512-YEBI0b/4ezNkw5W4+RBRUoueFzqEPPrnkh/3LBqeJ7RWZTymBhxlpoLo6Gfxw9LxtDgv2vZ5K5rgC4/6Ly8ADg==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.6.tgz",
+      "integrity": "sha512-blNJ3ugn4gCQ9ZSZi/firzKCvVl5LvPFVxv24LprENeWI4R8UApG006UQkF4SkmLygKq2BQXRad2/anQ13Te4Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/middleware-host-header": "3.953.0",
-        "@aws-sdk/middleware-logger": "3.953.0",
-        "@aws-sdk/middleware-recursion-detection": "3.953.0",
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/region-config-resolver": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@aws-sdk/util-endpoints": "3.953.0",
-        "@aws-sdk/util-user-agent-browser": "3.953.0",
-        "@aws-sdk/util-user-agent-node": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/core": "^3.19.0",
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/hash-node": "^4.2.6",
-        "@smithy/invalid-dependency": "^4.2.6",
-        "@smithy/middleware-content-length": "^4.2.6",
-        "@smithy/middleware-endpoint": "^4.3.15",
-        "@smithy/middleware-retry": "^4.4.15",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/smithy-client": "^4.10.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.14",
-        "@smithy/util-defaults-mode-node": "^4.2.17",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/region-config-resolver": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.953.0.tgz",
-      "integrity": "sha512-5MJgnsc+HLO+le0EK1cy92yrC7kyhGZSpaq8PcQvKs9qtXCXT5Tb6tMdkr5Y07JxYsYOV1omWBynvL6PWh08tQ==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24331,99 +20101,99 @@
       }
     },
     "@aws-sdk/s3-presigned-post": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.948.0.tgz",
-      "integrity": "sha512-KBW4dFcFvOOn4aWF7ACvTDtRtgoL3dQEki4QdxOqsb6F0YT8KRecjF5ZF+lpWbY9Mp/HyJ9Eg6WxTS7SiW3ZMA==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.1003.0.tgz",
+      "integrity": "sha512-GCgfyMNcctUhsJ+buC2X7qzv9p9kCb1UH1RM2scJTyHR4Pp9dEZSRNRnMTD+S9eT1+uEpaA9KAK3MZiTQio/PA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-s3": "3.948.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-format-url": "3.936.0",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/client-s3": "3.1003.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-format-url": "^3.972.7",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "dev": true,
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "dev": true,
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "dev": true,
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-hex-encoding": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+          "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
           "dev": true,
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "dev": true,
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.948.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.948.0.tgz",
-      "integrity": "sha512-tlQhMDsDWwUDUzzlo8XYGpmMfjGDmXgbysv1+h1v2xJe0A+ogv/nJ6KFVP94uf1j4ePmCN/gDdxEp2PWZMBPOQ==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1003.0.tgz",
+      "integrity": "sha512-lEMaCGi5HmsXxxago5UCyDSroqX9rkgA1mFxmzld6XzoVozZCqGIr9CKUas0Vmvu60LXukF8MWUwCYdwVP2oCg==",
       "requires": {
-        "@aws-sdk/signature-v4-multi-region": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-format-url": "3.936.0",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-format-url": "^3.972.7",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24431,31 +20201,31 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.947.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.947.0.tgz",
-      "integrity": "sha512-UaYmzoxf9q3mabIA2hc4T6x5YSFUG2BpNjAZ207EA1bnQMiK+d6vZvb83t7dIWL/U1de1sGV19c1C81Jf14rrA==",
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.6.tgz",
+      "integrity": "sha512-NnsOQsVmJXy4+IdPFUjRCWPn9qNH1TzS/f7MiWgXeoHs903tJpAWQWQtoFvLccyPoBgomKP9L89RRr2YsT/L0g==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.947.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24463,115 +20233,42 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.953.0.tgz",
-      "integrity": "sha512-4FWWR3lDDuIftmCEWpGejfkJu2J1VG2MUktChQshADXABfVfM0fsT7OYlO7Sy106nOe9upE4uQTWXg9YT/6ssw==",
+      "version": "3.1003.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1003.0.tgz",
+      "integrity": "sha512-SOyyWNdT7njKRwtZ1JhwHlH1csv6Pkgf305X96/OIfnhq1pU/EjmT6W6por57rVrjrKuHBuEIXgpWv8OgoMHpg==",
       "requires": {
-        "@aws-sdk/core": "3.953.0",
-        "@aws-sdk/nested-clients": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.953.0.tgz",
-          "integrity": "sha512-hnz4ukn+XupuotZcFAyCIX41QqEWSHc8zf4gN4l5qVP2M8YCyZkLLZ5t5LaWLJkUFbOUU2w4SuGpUp+5ddtSkw==",
-          "requires": {
-            "@aws-sdk/types": "3.953.0",
-            "@aws-sdk/xml-builder": "3.953.0",
-            "@smithy/core": "^3.19.0",
-            "@smithy/node-config-provider": "^4.3.6",
-            "@smithy/property-provider": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/signature-v4": "^5.3.6",
-            "@smithy/smithy-client": "^4.10.0",
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-base64": "^4.3.0",
-            "@smithy/util-middleware": "^4.2.6",
-            "@smithy/util-utf8": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
-          "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-          "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
-      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
       "requires": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24579,38 +20276,29 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.953.0.tgz",
-      "integrity": "sha512-rjaS6jrFksopXvNg6YeN+D1lYwhcByORNlFuYesFvaQNtPOufbE5tJL4GJ3TMXyaY0uFR28N5BHHITPyWWfH/g==",
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-endpoints": "^3.2.6",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24618,38 +20306,38 @@
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
-      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
+      "integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
       "requires": {
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24665,29 +20353,20 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.953.0.tgz",
-      "integrity": "sha512-UF5NeqYesWuFao+u7LJvpV1SJCaLml5BtFZKUdTnNNMeN6jvV+dW/eQoFGpXF94RCqguX0XESmRuRRPQp+/rzQ==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
       "requires": {
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24695,30 +20374,21 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.953.0.tgz",
-      "integrity": "sha512-HjJ0Nq/57kg0QCjt8mwBAK6C34njKezy9ItUNcrWITzrBZv7ikQtyqM1pindAIzgLaBb7ly/0kbJqMY+NPbcJA==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.3.tgz",
+      "integrity": "sha512-8s2cQmTUOwcBlIJyI9PAZNnnnF+cGtdhHc1yzMMsSD/GR/Hxj7m0IGUE92CslXXb8/p5Q76iqOCjN1GFwyf+1A==",
       "requires": {
-        "@aws-sdk/middleware-user-agent": "3.953.0",
-        "@aws-sdk/types": "3.953.0",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.953.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.953.0.tgz",
-          "integrity": "sha512-M9Iwg9kTyqTErI0vOTVVpcnTHWzS3VplQppy8MuL02EE+mJ0BIwpWfsaAPQW+/XnVpdNpWZTsHcNE29f1+hR8g==",
-          "requires": {
-            "@smithy/types": "^4.10.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -24726,42 +20396,29 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.953.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.953.0.tgz",
-      "integrity": "sha512-Zmrj21jQ2OeOJGr9spPiN00aQvXa/WUqRXcTVENhrMt+OFoSOfDFpYhUj9NQ09QmQ8KMWFoWuWW6iKurNqLvAA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
       "requires": {
-        "@smithy/types": "^4.10.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
-        },
-        "fast-xml-parser": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-          "requires": {
-            "strnum": "^2.1.0"
-          }
-        },
-        "strnum": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-          "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
         }
       }
     },
     "@aws/lambda-invoke-store": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
-      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="
     },
     "@babel/code-frame": {
       "version": "7.26.2",
@@ -26542,7 +22199,7 @@
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
-        "glob": "^7.1.3",
+        "glob": "7",
         "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.0",
@@ -26567,7 +22224,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "^3.1.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -29863,141 +25520,141 @@
       }
     },
     "@smithy/chunked-blob-reader": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
-      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@smithy/chunked-blob-reader-native": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
-      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
       "requires": {
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/config-resolver": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
-      "integrity": "sha512-s3U5ChS21DwU54kMmZ0UJumoS5cg0+rGVZvN6f5Lp6EbAVi0ZyP+qDSHdewfmXKUgNK1j3z45JyzulkDukrjAA==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
       "requires": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.6",
-        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/core": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
-      "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
+      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
       "requires": {
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-stream": "^4.5.7",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
-      "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
       "requires": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30005,28 +25662,28 @@
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.6.tgz",
-      "integrity": "sha512-OZfsI+YRG26XZik/jKMMg37acnBSbUiK/8nETW3uM3mLj+0tMmFXdHQw1e5WEd/IHN8BGOh3te91SNDe2o4RHg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.11.tgz",
+      "integrity": "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==",
       "requires": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-hex-encoding": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+          "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30034,19 +25691,19 @@
       }
     },
     "@smithy/eventstream-serde-browser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.6.tgz",
-      "integrity": "sha512-6OiaAaEbLB6dEkRbQyNzFSJv5HDvly3Mc6q/qcPd2uS/g3szR8wAIkh7UndAFKfMypNSTuZ6eCBmgCLR5LacTg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.11.tgz",
+      "integrity": "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30054,18 +25711,18 @@
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.6.tgz",
-      "integrity": "sha512-xP5YXbOVRVN8A4pDnSUkEUsL9fYFU6VNhxo8tgr13YnMbf3Pn4xVr+hSyLVjS1Frfi1Uk03ET5Bwml4+0CeYEw==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.11.tgz",
+      "integrity": "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30073,19 +25730,19 @@
       }
     },
     "@smithy/eventstream-serde-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.6.tgz",
-      "integrity": "sha512-jhH7nJuaOpnTFcuZpWK9dqb6Ge2yGi1okTo0W6wkJrfwAm2vwmO74tF1v07JmrSyHBcKLQATEexclJw9K1Vj7w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.11.tgz",
+      "integrity": "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30093,19 +25750,19 @@
       }
     },
     "@smithy/eventstream-serde-universal": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.6.tgz",
-      "integrity": "sha512-olIfZ230B64TvPD6b0tPvrEp2eB0FkyL3KvDlqF4RVmIc/kn3orzXnV6DTQdOOW5UU+M5zKY3/BU47X420/oPw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.11.tgz",
+      "integrity": "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==",
       "requires": {
-        "@smithy/eventstream-codec": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/eventstream-codec": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30113,48 +25770,48 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
-      "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
       "requires": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/querystring-builder": "^4.2.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30162,20 +25819,20 @@
       }
     },
     "@smithy/hash-blob-browser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.7.tgz",
-      "integrity": "sha512-CIbCTGGX5CI7tfewBPSYD9ycp2Vb2GW5xnXD1n7GcO9mu37EN7A6DvCHM9MX7pOeS1adMn5D+1yRwI3eABVbcA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.12.tgz",
+      "integrity": "sha512-1wQE33DsxkM/waftAhCH9VtJbUGyt1PJ9YRDpOu+q9FUi73LLFUZ2fD8A61g2mT1UY9k7b99+V1xZ41Rz4SHRQ==",
       "requires": {
-        "@smithy/chunked-blob-reader": "^5.2.0",
-        "@smithy/chunked-blob-reader-native": "^4.2.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30183,111 +25840,111 @@
       }
     },
     "@smithy/hash-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.6.tgz",
-      "integrity": "sha512-k3Dy9VNR37wfMh2/1RHkFf/e0rMyN0pjY0FdyY6ItJRjENYyVPRMwad6ZR1S9HFm6tTuIOd9pqKBmtJ4VHxvxg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
       "requires": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/hash-stream-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.6.tgz",
-      "integrity": "sha512-+3T8LkH39YIhYHsv/Ec8lF+92nykZpU+XMBvAyXF/uLcTp86pxa5oSJk1vzaRY9N++qgDLYjzJ6OVbtAgDGwfw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.11.tgz",
+      "integrity": "sha512-hQsTjwPCRY8w9GK07w1RqJi3e+myh0UaOWBBhZ1UMSDgofH/Q1fEYzU1teaX6HkpX/eWDdm7tAGR0jBPlz9QEQ==",
       "requires": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.6.tgz",
-      "integrity": "sha512-E4t/V/q2T46RY21fpfznd1iSLTvCXKNKo4zJ1QuEFN4SE9gKfu2vb6bgq35LpufkQ+SETWIC7ZAf2GGvTlBaMQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30303,74 +25960,74 @@
       }
     },
     "@smithy/md5-js": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.6.tgz",
-      "integrity": "sha512-ZXeh8UmH31JdcNsrQ1o9v1IVuva9JFwxIc6zTMxWX7wcmWvVR7Ai9aUEw5LraNKqdkAsb06clpM2sRH4Iy55Sg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.11.tgz",
+      "integrity": "sha512-350X4kGIrty0Snx2OWv7rPM6p6vM7RzryvFs6B/56Cux3w3sChOb3bymo5oidXJlPcP9fIRxGUCk7GqpiSOtng==",
       "requires": {
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.6.tgz",
-      "integrity": "sha512-0cjqjyfj+Gls30ntq45SsBtqF3dfJQCeqQPyGz58Pk8OgrAr5YiB7ZvDzjCA94p4r6DCI4qLm7FKobqBjf515w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
       "requires": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30378,106 +26035,106 @@
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.0.tgz",
-      "integrity": "sha512-M6qWfUNny6NFNy8amrCGIb9TfOMUkHVtg9bHtEFGRgfH7A7AtPpn/fcrToGPjVDK1ECuMVvqGQOXcZxmu9K+7A==",
+      "version": "4.4.22",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
+      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
       "requires": {
-        "@smithy/core": "^3.19.0",
-        "@smithy/middleware-serde": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/url-parser": "^4.2.6",
-        "@smithy/util-middleware": "^4.2.6",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/middleware-retry": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.16.tgz",
-      "integrity": "sha512-XPpNhNRzm3vhYm7YCsyw3AtmWggJbg1wNGAoqb7NBYr5XA5isMRv14jgbYyUV6IvbTBFZQdf2QpeW43LrRdStQ==",
+      "version": "4.4.39",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
+      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
       "requires": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/service-error-classification": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-retry": "^4.2.6",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/middleware-serde": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.7.tgz",
-      "integrity": "sha512-PFMVHVPgtFECeu4iZ+4SX6VOQT0+dIpm4jSPLLL6JLSkp9RohGqKBKD0cbiXdeIFS08Forp0UHI6kc0gIHenSA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
       "requires": {
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30485,18 +26142,18 @@
       }
     },
     "@smithy/middleware-stack": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.6.tgz",
-      "integrity": "sha512-JSbALU3G+JS4kyBZPqnJ3hxIYwOVRV7r9GNQMS6j5VsQDo5+Es5nddLfr9TQlxZLNHPvKSh+XSB0OuWGfSWFcA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30504,20 +26161,20 @@
       }
     },
     "@smithy/node-config-provider": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.6.tgz",
-      "integrity": "sha512-fYEyL59Qe82Ha1p97YQTMEQPJYmBS+ux76foqluaTVWoG9Px5J53w6NvXZNE3wP7lIicLDF7Vj1Em18XTX7fsA==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
       "requires": {
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/shared-ini-file-loader": "^4.4.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30537,18 +26194,18 @@
       }
     },
     "@smithy/property-provider": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.6.tgz",
-      "integrity": "sha512-a/tGSLPtaia2krbRdwR4xbZKO8lU67DjMk/jfY4QKt4PRlKML+2tL/gmAuhNdFDioO6wOq0sXkfnddNFH9mNUA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30575,18 +26232,18 @@
       }
     },
     "@smithy/querystring-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.6.tgz",
-      "integrity": "sha512-YmWxl32SQRw/kIRccSOxzS/Ib8/b5/f9ex0r5PR40jRJg8X1wgM3KrR2In+8zvOGVhRSXgvyQpw9yOSlmfmSnA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30594,17 +26251,17 @@
       }
     },
     "@smithy/service-error-classification": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.6.tgz",
-      "integrity": "sha512-Q73XBrzJlGTut2nf5RglSntHKgAG0+KiTJdO5QQblLfr4TdliGwIAha1iZIjwisc3rA5ulzqwwsYC6xrclxVQg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
       "requires": {
-        "@smithy/types": "^4.10.0"
+        "@smithy/types": "^4.13.0"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30612,18 +26269,18 @@
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.1.tgz",
-      "integrity": "sha512-tph+oQYPbpN6NamF030hx1gb5YN2Plog+GLaRHpoEDwp8+ZPG26rIJvStG9hkWzN2HBn3HcWg0sHeB0tmkYzqA==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
       "requires": {
-        "@smithy/types": "^4.10.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30631,117 +26288,117 @@
       }
     },
     "@smithy/signature-v4": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
-      "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
       "requires": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.6",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-hex-encoding": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+          "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-middleware": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
-          "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+          "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/smithy-client": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.1.tgz",
-      "integrity": "sha512-1ovWdxzYprhq+mWqiGZlt3kF69LJthuQcfY9BIyHx9MywTFKzFapluku1QXoaBB43GCsLDxNqS+1v30ure69AA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
+      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
       "requires": {
-        "@smithy/core": "^3.19.0",
-        "@smithy/middleware-endpoint": "^4.4.0",
-        "@smithy/middleware-stack": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-stream": "^4.5.7",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30757,19 +26414,19 @@
       }
     },
     "@smithy/url-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.6.tgz",
-      "integrity": "sha512-tVoyzJ2vXp4R3/aeV4EQjBDmCuWxRa8eo3KybL7Xv4wEM16nObYh7H1sNfcuLWHAAAzb0RVyxUz1S3sGj4X+Tg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
       "requires": {
-        "@smithy/querystring-parser": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30777,55 +26434,55 @@
       }
     },
     "@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "requires": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "requires": {
         "tslib": "^2.6.2"
       }
@@ -30840,28 +26497,28 @@
       }
     },
     "@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "4.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.15.tgz",
-      "integrity": "sha512-LiZQVAg/oO8kueX4c+oMls5njaD2cRLXRfcjlTYjhIqmwHnCwkQO5B3dMQH0c5PACILxGAQf6Mxsq7CjlDc76A==",
+      "version": "4.3.38",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
+      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
       "requires": {
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30869,23 +26526,23 @@
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.18.tgz",
-      "integrity": "sha512-Kw2J+KzYm9C9Z9nY6+W0tEnoZOofstVCMTshli9jhQbQCy64rueGfKzPfuFBnVUqZD9JobxTh2DzHmPkp/Va/Q==",
+      "version": "4.2.41",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
+      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
       "requires": {
-        "@smithy/config-resolver": "^4.4.4",
-        "@smithy/credential-provider-imds": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/property-provider": "^4.2.6",
-        "@smithy/smithy-client": "^4.10.1",
-        "@smithy/types": "^4.10.0",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30893,19 +26550,19 @@
       }
     },
     "@smithy/util-endpoints": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.6.tgz",
-      "integrity": "sha512-v60VNM2+mPvgHCBXEfMCYrQ0RepP6u6xvbAkMenfe4Mi872CqNkJzgcnQL837e8NdeDxBgrWQRTluKq5Lqdhfg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
       "requires": {
-        "@smithy/node-config-provider": "^4.3.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30940,19 +26597,19 @@
       }
     },
     "@smithy/util-retry": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.6.tgz",
-      "integrity": "sha512-x7CeDQLPQ9cb6xN7fRJEjlP9NyGW/YeXWc4j/RUhg4I+H60F0PEeRc2c/z3rm9zmsdiMFzpV/rT+4UHW6KM1SA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
       "requires": {
-        "@smithy/service-error-classification": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -30960,107 +26617,107 @@
       }
     },
     "@smithy/util-stream": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.7.tgz",
-      "integrity": "sha512-Uuy4S5Aj4oF6k1z+i2OtIBJUns4mlg29Ph4S+CqjR+f4XXpSFVgTCYLzMszHJTicYDBxKFtwq2/QSEDSS5l02A==",
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
       "requires": {
-        "@smithy/fetch-http-handler": "^5.3.7",
-        "@smithy/node-http-handler": "^4.4.6",
-        "@smithy/types": "^4.10.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/is-array-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-          "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+          "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/node-http-handler": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-          "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+          "version": "4.4.14",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+          "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
           "requires": {
-            "@smithy/abort-controller": "^4.2.6",
-            "@smithy/protocol-http": "^5.3.6",
-            "@smithy/querystring-builder": "^4.2.6",
-            "@smithy/types": "^4.10.0",
+            "@smithy/abort-controller": "^4.2.11",
+            "@smithy/protocol-http": "^5.3.11",
+            "@smithy/querystring-builder": "^4.2.11",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/protocol-http": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
-          "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+          "version": "5.3.11",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+          "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/querystring-builder": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-          "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+          "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
           "requires": {
-            "@smithy/types": "^4.10.0",
-            "@smithy/util-uri-escape": "^4.2.0",
+            "@smithy/types": "^4.13.0",
+            "@smithy/util-uri-escape": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-buffer-from": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-          "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+          "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
           "requires": {
-            "@smithy/is-array-buffer": "^4.2.0",
+            "@smithy/is-array-buffer": "^4.2.2",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-hex-encoding": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-          "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+          "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-uri-escape": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-          "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+          "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
           "requires": {
             "tslib": "^2.6.2"
           }
         },
         "@smithy/util-utf8": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-          "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+          "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
           "requires": {
-            "@smithy/util-buffer-from": "^4.2.0",
+            "@smithy/util-buffer-from": "^4.2.2",
             "tslib": "^2.6.2"
           }
         }
@@ -31084,28 +26741,28 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.6.tgz",
-      "integrity": "sha512-xU9HwUSik9UUCJmm530yvBy0AwlQFICveKmqvaaTukKkXEAhyiBdHtSrhPrH3rH+uz0ykyaE3LdgsX86C6mDCQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.11.tgz",
+      "integrity": "sha512-x7Rh2azQPs3XxbvCzcttRErKKvLnbZfqRf/gOjw2pb+ZscX88e5UkRPCB67bVnsFHxayvMvmePfKTqsRb+is1A==",
       "requires": {
-        "@smithy/abort-controller": "^4.2.6",
-        "@smithy/types": "^4.10.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@smithy/abort-controller": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-          "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+          "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
           "requires": {
-            "@smithy/types": "^4.10.0",
+            "@smithy/types": "^4.13.0",
             "tslib": "^2.6.2"
           }
         },
         "@smithy/types": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-          "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+          "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -31113,9 +26770,9 @@
       }
     },
     "@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "requires": {
         "tslib": "^2.6.2"
       }
@@ -31502,14 +27159,14 @@
       }
     },
     "ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "requires": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       }
     },
     "ajv-formats": {
@@ -31666,12 +27323,12 @@
       }
     },
     "axios": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -31880,9 +27537,9 @@
       "dev": true
     },
     "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "brace-expansion": {
       "version": "1.1.12",
@@ -32293,9 +27950,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true
     },
     "diff-sequences": {
@@ -32622,10 +28279,24 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
+    "fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ=="
+    },
+    "fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "requires": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      }
+    },
     "fastify": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
-      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.1.tgz",
+      "integrity": "sha512-y0kicFvvn7CYWoPOVLOcvn4YyKQz03DIY7UxmyOy21/J8eXm09R+tmb+tVDBW5h+pja30cHI5dqUcSlvY86V2A==",
       "requires": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -32636,7 +28307,7 @@
         "fast-json-stringify": "^6.0.0",
         "find-my-way": "^9.0.0",
         "light-my-request": "^6.0.0",
-        "pino": "^10.1.0",
+        "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
@@ -32681,7 +28352,7 @@
       "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
       "requires": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^5.1.8"
       },
       "dependencies": {
         "brace-expansion": {
@@ -32694,9 +28365,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+          "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -32743,14 +28414,14 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
     "form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -33299,7 +28970,7 @@
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
+        "filelist": "1",
         "minimatch": "^3.1.2"
       }
     },
@@ -33387,7 +29058,7 @@
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
+        "glob": "7",
         "graceful-fs": "^4.2.9",
         "jest-circus": "^29.7.0",
         "jest-environment-node": "^29.7.0",
@@ -33413,7 +29084,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "^3.1.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -33642,7 +29313,7 @@
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
+        "glob": "7",
         "graceful-fs": "^4.2.9",
         "jest-haste-map": "^29.7.0",
         "jest-message-util": "^29.7.0",
@@ -33664,7 +29335,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "^3.1.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -34179,9 +29850,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -34837,11 +30508,6 @@
         "pump": "^3.0.0"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
     "pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -35391,6 +31057,11 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -35443,7 +31114,7 @@
       "dev": true,
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
+        "glob": "7",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -35456,7 +31127,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "^3.1.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -35581,7 +31252,7 @@
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "9",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -35594,7 +31265,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "^3.1.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -35605,7 +31276,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7"
           }
         },
         "ts-node": {
@@ -35616,7 +31287,7 @@
           "requires": {
             "arg": "^4.1.0",
             "create-require": "^1.1.0",
-            "diff": "^4.0.1",
+            "diff": "^4.0.4",
             "make-error": "^1.1.1",
             "source-map-support": "^0.5.17",
             "yn": "3.1.1"
@@ -35750,14 +31421,6 @@
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
-      }
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "url-parse": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "node": ">= 22.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-ecs": "^3.948.0",
-    "@aws-sdk/client-s3": "^3.948.0",
-    "@aws-sdk/client-s3vectors": "^3.948.0",
-    "@aws-sdk/lib-storage": "^3.948.0",
-    "@aws-sdk/s3-request-presigner": "^3.948.0",
+    "@aws-sdk/client-ecs": "^3.979.0",
+    "@aws-sdk/client-s3": "^3.979.0",
+    "@aws-sdk/client-s3vectors": "^3.979.0",
+    "@aws-sdk/lib-storage": "^3.979.0",
+    "@aws-sdk/s3-request-presigner": "^3.979.0",
     "@fastify/accepts": "^5.0.4",
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
@@ -61,14 +61,14 @@
     "@tus/s3-store": "2.0.0",
     "@tus/server": "2.2.1",
     "agentkeepalive": "^4.5.0",
-    "ajv": "^8.12.0",
+    "ajv": "^8.18.0",
     "async-retry": "^1.3.3",
     "aws-sigv4-sign": "^1.2.1",
-    "axios": "^1.12.0",
+    "axios": "^1.13.6",
     "axios-retry": "^3.9.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
-    "fastify": "^5.7.4",
+    "fastify": "^5.8.1",
     "fastify-plugin": "^5.1.0",
     "fs-extra": "^10.0.1",
     "fs-xattr": "0.3.1",
@@ -88,7 +88,7 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@aws-sdk/s3-presigned-post": "^3.948.0",
+    "@aws-sdk/s3-presigned-post": "^3.979.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
     "@biomejs/biome": "^2.4.4",
@@ -121,6 +121,17 @@
     "tsx": "^4.16.0",
     "tus-js-client": "^3.1.0",
     "typescript": "5.2.2"
+  },
+  "overrides": {
+    "filelist@1": {
+      "minimatch": "^5.1.8"
+    },
+    "glob@7": {
+      "minimatch": "^3.1.4"
+    },
+    "ts-node@9": {
+      "diff": "^4.0.4"
+    }
   },
   "bin": "./dist/server.js"
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Security issues in aws sdk/axios/minimatch/ajv

## What is the new behavior?

Bump to versions with fixes.

## Additional context

### Direct dependency bumps

| Package | From | To | Upstream changes |
| --- | --- | --- | --- |
| `@aws-sdk/client-ecs` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `@aws-sdk/client-s3` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `@aws-sdk/client-s3vectors` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `@aws-sdk/lib-storage` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `@aws-sdk/s3-request-presigner` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `@aws-sdk/s3-presigned-post` | `3.948.0` | `3.1003.0` | [Compare](https://github.com/aws/aws-sdk-js-v3/compare/v3.948.0...v3.1003.0) |
| `axios` | `1.12.0` | `1.13.6` | [Compare](https://github.com/axios/axios/compare/v1.12.0...v1.13.6), [Releases](https://github.com/axios/axios/releases) |
| `ajv` | `8.12.0` | `8.18.0` | [Compare](https://github.com/ajv-validator/ajv/compare/v8.12.0...v8.18.0), [Releases](https://github.com/ajv-validator/ajv/releases) |
| `fastify` | `5.7.4` | `5.8.1` | [Compare](https://github.com/fastify/fastify/compare/v5.7.4...v5.8.1), [Releases](https://github.com/fastify/fastify/releases) |

### Transitive fixes applied through `overrides`

| Package | From | To | Why it changed | Upstream changes |
| --- | --- | --- | --- | --- |
| `minimatch` | `3.1.2` | `3.1.5` | Forced via `glob@7` consumers | [Compare](https://github.com/isaacs/minimatch/compare/v3.1.2...v3.1.5), [Releases](https://github.com/isaacs/minimatch/releases) |
| `minimatch` | `5.1.6` | `5.1.9` | Forced via `filelist@1` | [Compare](https://github.com/isaacs/minimatch/compare/v5.1.6...v5.1.9), [Releases](https://github.com/isaacs/minimatch/releases) |
| `diff` | `4.0.2` | `4.0.4` | Forced via `ts-node@9` | [Compare](https://github.com/kpdecker/jsdiff/compare/v4.0.2...v4.0.4), [Releases](https://github.com/kpdecker/jsdiff/releases) |

### Notable transitive security-related movement from the AWS SDK bump

| Package | From | To | Upstream changes |
| --- | --- | --- | --- |
| `fast-xml-parser` | `5.2.5` | `5.4.1` | [Compare](https://github.com/NaturalIntelligence/fast-xml-parser/compare/v5.2.5...v5.4.1), [Releases](https://github.com/NaturalIntelligence/fast-xml-parser/releases) |
