### PR TITLE
feat: add orioledb support for vector buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:export": "tsx ./src/scripts/export-docs.ts",
     "test:dummy-data": "tsx -r dotenv/config ./src/test/db/import-dummy-data.ts",
     "test": "npm run infra:restart && npm run test:dummy-data && jest --no-cache --runInBand",
-    "test:oriole": "npm run infra:restart:oriole && npm run test:dummy-data && jest --no-cache --runInBand --testPathIgnorePatterns=src/test/vectors.test.ts",
+    "test:oriole": "npm run infra:restart:oriole && npm run test:dummy-data && jest --no-cache --runInBand",
     "test:coverage": "npm run infra:restart && npm run test:dummy-data && jest --no-cache --runInBand --coverage",
     "infra:stop": "docker compose --project-directory . -f ./.docker/docker-compose-infra.yml down --remove-orphans",
     "infra:start": "docker compose --project-directory . -f ./.docker/docker-compose-infra.yml up -d && sleep 5 && npm run migration:run",

--- a/src/storage/protocols/vector/knex.ts
+++ b/src/storage/protocols/vector/knex.ts
@@ -9,6 +9,7 @@ import { Knex } from 'knex'
 import { DatabaseError } from 'pg'
 
 type DBVectorIndex = VectorIndex & { id: string; created_at: Date; updated_at: Date }
+export type VectorLockResourceType = 'bucket' | 'index' | 'global'
 
 interface CreateVectorIndexParams {
   dataType: string
@@ -44,7 +45,7 @@ export interface VectorMetadataDB {
     config?: Knex.TransactionConfig
   ): Promise<T>
 
-  lockResource(resourceType: 'bucket' | 'index', resourceId: string): Promise<void>
+  lockResource(resourceType: VectorLockResourceType, resourceId: string): Promise<void>
 
   findVectorBucket(vectorBucketName: string): Promise<VectorBucket>
   createVectorBucket(bucketName: string): Promise<void>
@@ -63,7 +64,7 @@ export interface VectorMetadataDB {
 export class KnexVectorMetadataDB implements VectorMetadataDB {
   constructor(protected readonly knex: Knex) {}
 
-  lockResource(resourceType: 'bucket' | 'index', resourceId: string): Promise<void> {
+  lockResource(resourceType: VectorLockResourceType, resourceId: string): Promise<void> {
     const lockId = hashStringToInt(`vector:${resourceType}:${resourceId}`)
     return this.knex.raw('SELECT pg_advisory_xact_lock(?::bigint)', [lockId])
   }

--- a/src/storage/protocols/vector/vector-store.ts
+++ b/src/storage/protocols/vector/vector-store.ts
@@ -16,6 +16,7 @@ import {
   QueryVectorsInput,
 } from '@aws-sdk/client-s3vectors'
 import { ERRORS } from '@internal/errors'
+import { ErrorCode } from '@internal/errors/codes'
 import { logger, logSchema } from '@internal/monitoring'
 import { Sharder } from '@internal/sharding/sharder'
 import { VectorStore } from './adapter/s3-vector'
@@ -26,6 +27,8 @@ interface VectorStoreConfig {
   maxBucketCount: number
   maxIndexCount: number
 }
+
+export const VECTOR_BUCKET_COUNT_LOCK = '__vector_bucket_count__'
 
 export class VectorStoreManager {
   constructor(
@@ -40,39 +43,47 @@ export class VectorStoreManager {
   }
 
   async createBucket(bucketName: string): Promise<void> {
-    await this.db.withTransaction(
-      async (tnx) => {
-        const bucketCount = await tnx.countBuckets()
-        if (bucketCount >= this.config.maxBucketCount) {
-          throw ERRORS.S3VectorMaxBucketsExceeded(this.config.maxBucketCount)
+    await this.db.withTransaction(async (tnx) => {
+      await tnx.lockResource('global', VECTOR_BUCKET_COUNT_LOCK)
+
+      const bucketCount = await tnx.countBuckets()
+      if (bucketCount >= this.config.maxBucketCount) {
+        try {
+          await tnx.findVectorBucket(bucketName)
+          return
+        } catch (e) {
+          if ((e as { code?: string }).code !== ErrorCode.S3VectorNotFoundException) {
+            throw e
+          }
         }
 
-        try {
-          await tnx.createVectorBucket(bucketName)
-        } catch (e) {
-          if (e instanceof ConflictException) {
-            return
-          }
-          throw e
+        throw ERRORS.S3VectorMaxBucketsExceeded(this.config.maxBucketCount)
+      }
+
+      try {
+        await tnx.createVectorBucket(bucketName)
+      } catch (e) {
+        if (e instanceof ConflictException) {
+          return
         }
-      },
-      { isolationLevel: 'serializable' }
-    )
+        throw e
+      }
+    })
   }
 
   async deleteBucket(bucketName: string): Promise<void> {
-    await this.db.withTransaction(
-      async (tx) => {
-        const indexes = await tx.listIndexes({ bucketId: bucketName, maxResults: 1 })
+    await this.db.withTransaction(async (tx) => {
+      await tx.lockResource('bucket', bucketName)
+      await tx.lockResource('global', VECTOR_BUCKET_COUNT_LOCK)
 
-        if (indexes.indexes.length > 0) {
-          throw ERRORS.S3VectorBucketNotEmpty(bucketName)
-        }
+      const indexes = await tx.listIndexes({ bucketId: bucketName, maxResults: 1 })
 
-        await tx.deleteVectorBucket(bucketName)
-      },
-      { isolationLevel: 'serializable' }
-    )
+      if (indexes.indexes.length > 0) {
+        throw ERRORS.S3VectorBucketNotEmpty(bucketName)
+      }
+
+      await tx.deleteVectorBucket(bucketName)
+    })
   }
 
   async getBucket(command: GetVectorBucketInput) {
@@ -134,6 +145,7 @@ export class VectorStoreManager {
     try {
       await this.db.withTransaction(async (tx) => {
         await tx.lockResource('bucket', command.vectorBucketName!)
+        await tx.findVectorBucket(command.vectorBucketName!)
 
         const indexCount = await tx.countIndexes(command.vectorBucketName!)
 

--- a/src/test/vector-store-manager.test.ts
+++ b/src/test/vector-store-manager.test.ts
@@ -1,0 +1,374 @@
+import {
+  ConflictException,
+  CreateIndexCommandOutput,
+  DeleteIndexCommandOutput,
+  DeleteVectorsOutput,
+  GetVectorsCommandOutput,
+  ListVectorsOutput,
+  PutVectorsOutput,
+  QueryVectorsOutput,
+} from '@aws-sdk/client-s3vectors'
+import { ERRORS } from '@internal/errors'
+import { Sharder } from '@internal/sharding'
+import {
+  KnexVectorMetadataDB,
+  VECTOR_BUCKET_COUNT_LOCK,
+  VectorLockResourceType,
+  VectorMetadataDB,
+  VectorStore,
+  VectorStoreManager,
+} from '@storage/protocols/vector'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function createMockVectorStore(): jest.Mocked<VectorStore> {
+  return {
+    createVectorIndex: jest.fn().mockResolvedValue({} as CreateIndexCommandOutput),
+    deleteVectorIndex: jest.fn().mockResolvedValue({} as DeleteIndexCommandOutput),
+    putVectors: jest.fn().mockResolvedValue({} as PutVectorsOutput),
+    listVectors: jest.fn().mockResolvedValue({} as ListVectorsOutput),
+    queryVectors: jest.fn().mockResolvedValue({} as QueryVectorsOutput),
+    deleteVectors: jest.fn().mockResolvedValue({} as DeleteVectorsOutput),
+    getVectors: jest.fn().mockResolvedValue({} as GetVectorsCommandOutput),
+  }
+}
+
+function createMockSharder(): jest.Mocked<Sharder> {
+  return {
+    createShard: jest.fn(),
+    setShardStatus: jest.fn(),
+    reserve: jest.fn(),
+    confirm: jest.fn(),
+    cancel: jest.fn(),
+    expireLeases: jest.fn(),
+    freeByLocation: jest.fn(),
+    freeByResource: jest.fn(),
+    shardStats: jest.fn(),
+    findShardByResourceId: jest.fn(),
+    listShardByKind: jest.fn(),
+    withTnx: jest.fn(),
+  } as unknown as jest.Mocked<Sharder>
+}
+
+function createMockVectorDb(): jest.Mocked<VectorMetadataDB> {
+  return {
+    withTransaction: jest.fn(),
+    lockResource: jest.fn(),
+    findVectorBucket: jest.fn(),
+    createVectorBucket: jest.fn(),
+    deleteVectorBucket: jest.fn(),
+    listBuckets: jest.fn(),
+    countBuckets: jest.fn(),
+    countIndexes: jest.fn(),
+    createVectorIndex: jest.fn(),
+    getIndex: jest.fn(),
+    listIndexes: jest.fn(),
+    deleteVectorIndex: jest.fn(),
+    findVectorIndexForBucket: jest.fn(),
+  } as unknown as jest.Mocked<VectorMetadataDB>
+}
+
+function createDeterministicVectorDb(options: {
+  bucketCount: number
+  existingBuckets?: string[]
+  onLockResource?: (
+    resourceType: VectorLockResourceType,
+    resourceId: string
+  ) => Promise<void> | void
+  onCreateVectorBucket?: (bucketName: string) => Promise<void> | void
+  onDeleteVectorBucket?: (bucketName: string) => Promise<void> | void
+}): VectorMetadataDB {
+  const state = {
+    bucketCount: options.bucketCount,
+    existingBuckets: new Set(options.existingBuckets ?? []),
+    countLockHeld: false,
+    countLockWaiters: [] as Array<() => void>,
+  }
+
+  async function acquireCountLock() {
+    if (!state.countLockHeld) {
+      state.countLockHeld = true
+      return
+    }
+
+    await new Promise<void>((resolve) => {
+      state.countLockWaiters.push(resolve)
+    })
+  }
+
+  function releaseCountLock() {
+    const next = state.countLockWaiters.shift()
+    if (next) {
+      next()
+      return
+    }
+
+    state.countLockHeld = false
+  }
+
+  return {
+    async withTransaction<T>(fn: (db: KnexVectorMetadataDB) => T): Promise<T> {
+      let holdsCountLock = false
+
+      const tx: Partial<VectorMetadataDB> = {
+        lockResource: async (resourceType: VectorLockResourceType, resourceId: string) => {
+          await options.onLockResource?.(resourceType, resourceId)
+
+          if (resourceType === 'global' && resourceId === VECTOR_BUCKET_COUNT_LOCK) {
+            await acquireCountLock()
+            holdsCountLock = true
+          }
+        },
+        findVectorBucket: async (bucketName: string) => {
+          if (state.existingBuckets.has(bucketName)) {
+            return {
+              id: bucketName,
+              created_at: new Date(),
+              updated_at: new Date().toISOString(),
+            } as any
+          }
+
+          throw ERRORS.S3VectorNotFoundException('vector bucket', bucketName)
+        },
+        countBuckets: async () => state.bucketCount,
+        createVectorBucket: async (bucketName: string) => {
+          await options.onCreateVectorBucket?.(bucketName)
+
+          if (state.existingBuckets.has(bucketName)) {
+            throw new ConflictException({
+              message: `vector bucket "${bucketName}" already exists`,
+              $metadata: {},
+            })
+          }
+
+          state.existingBuckets.add(bucketName)
+          state.bucketCount += 1
+        },
+        listIndexes: async () => ({ indexes: [] }),
+        deleteVectorBucket: async (bucketName: string) => {
+          await options.onDeleteVectorBucket?.(bucketName)
+
+          if (state.existingBuckets.delete(bucketName)) {
+            state.bucketCount -= 1
+          }
+        },
+      }
+
+      try {
+        return await fn(tx as KnexVectorMetadataDB)
+      } finally {
+        if (holdsCountLock) {
+          releaseCountLock()
+        }
+      }
+    },
+    lockResource: async () => undefined,
+    findVectorBucket: async () => {
+      throw new Error('not implemented')
+    },
+    createVectorBucket: async () => undefined,
+    deleteVectorBucket: async () => undefined,
+    listBuckets: async () => ({ vectorBuckets: [] }),
+    countBuckets: async () => state.bucketCount,
+    countIndexes: async () => 0,
+    createVectorIndex: async () => {
+      throw new Error('not implemented')
+    },
+    getIndex: async () => {
+      throw new Error('not implemented')
+    },
+    listIndexes: async () => ({ indexes: [] }),
+    deleteVectorIndex: async () => undefined,
+    findVectorIndexForBucket: async () => {
+      throw new Error('not implemented')
+    },
+  }
+}
+
+describe('VectorStoreManager bucket lifecycle', () => {
+  it('serializes concurrent creates for the final bucket slot', async () => {
+    const releaseFirstCreate = deferred()
+    const firstCreateStarted = deferred()
+
+    const db = createDeterministicVectorDb({
+      bucketCount: 1,
+      existingBuckets: ['existing-bucket'],
+      onCreateVectorBucket: async (bucketName) => {
+        if (bucketName === 'bucket-a') {
+          firstCreateStarted.resolve()
+          await releaseFirstCreate.promise
+        }
+      },
+    })
+
+    const manager = new VectorStoreManager(createMockVectorStore(), db, createMockSharder(), {
+      tenantId: 'test-tenant',
+      maxBucketCount: 2,
+      maxIndexCount: Infinity,
+    })
+
+    const createA = manager.createBucket('bucket-a')
+    await firstCreateStarted.promise
+
+    const createB = manager.createBucket('bucket-b')
+    releaseFirstCreate.resolve()
+
+    const results = await Promise.allSettled([createA, createB])
+
+    expect(results).toEqual([
+      { status: 'fulfilled', value: undefined },
+      {
+        status: 'rejected',
+        reason: expect.objectContaining({ code: 'S3VectorMaxBucketsExceeded' }),
+      },
+    ])
+  })
+
+  it('keeps createBucket idempotent for an existing bucket even when at capacity', async () => {
+    const db = createDeterministicVectorDb({
+      bucketCount: 1,
+      existingBuckets: ['bucket-a'],
+    })
+
+    const manager = new VectorStoreManager(createMockVectorStore(), db, createMockSharder(), {
+      tenantId: 'test-tenant',
+      maxBucketCount: 1,
+      maxIndexCount: Infinity,
+    })
+
+    await expect(manager.createBucket('bucket-a')).resolves.toBeUndefined()
+    await expect(manager.createBucket('bucket-b')).rejects.toMatchObject({
+      code: 'S3VectorMaxBucketsExceeded',
+    })
+  })
+
+  it('shares the bucket-count lock between delete and create so capacity is observed after delete commits', async () => {
+    const releaseDelete = deferred()
+    const deleteReachedRemoval = deferred()
+
+    const db = createDeterministicVectorDb({
+      bucketCount: 1,
+      existingBuckets: ['bucket-to-delete'],
+      onDeleteVectorBucket: async (bucketName) => {
+        if (bucketName === 'bucket-to-delete') {
+          deleteReachedRemoval.resolve()
+          await releaseDelete.promise
+        }
+      },
+    })
+
+    const manager = new VectorStoreManager(createMockVectorStore(), db, createMockSharder(), {
+      tenantId: 'test-tenant',
+      maxBucketCount: 1,
+      maxIndexCount: Infinity,
+    })
+
+    const deletePromise = manager.deleteBucket('bucket-to-delete')
+    await deleteReachedRemoval.promise
+
+    const createPromise = manager.createBucket('bucket-new')
+    releaseDelete.resolve()
+
+    await expect(deletePromise).resolves.toBeUndefined()
+    await expect(createPromise).resolves.toBeUndefined()
+  })
+
+  it('does not block unrelated creates while delete waits on the target bucket lock', async () => {
+    const releaseBucketLock = deferred()
+    const deleteWaitingOnBucketLock = deferred()
+
+    const db = createDeterministicVectorDb({
+      bucketCount: 1,
+      existingBuckets: ['bucket-a'],
+      onLockResource: async (resourceType, resourceId) => {
+        if (resourceType === 'bucket' && resourceId === 'bucket-a') {
+          deleteWaitingOnBucketLock.resolve()
+          await releaseBucketLock.promise
+        }
+      },
+    })
+
+    const manager = new VectorStoreManager(createMockVectorStore(), db, createMockSharder(), {
+      tenantId: 'test-tenant',
+      maxBucketCount: 2,
+      maxIndexCount: Infinity,
+    })
+
+    const deletePromise = manager.deleteBucket('bucket-a')
+    await deleteWaitingOnBucketLock.promise
+
+    await expect(manager.createBucket('bucket-b')).resolves.toBeUndefined()
+
+    releaseBucketLock.resolve()
+    await expect(deletePromise).resolves.toBeUndefined()
+  })
+
+  it('takes the per-bucket lock before the global count lock during bucket deletion', async () => {
+    const callOrder: string[] = []
+    const db = createDeterministicVectorDb({
+      bucketCount: 1,
+      existingBuckets: ['bucket-a'],
+      onLockResource: (resourceType, resourceId) => {
+        callOrder.push(`${resourceType}:${resourceId}`)
+      },
+      onDeleteVectorBucket: () => {
+        callOrder.push('delete')
+      },
+    })
+
+    const manager = new VectorStoreManager(createMockVectorStore(), db, createMockSharder(), {
+      tenantId: 'test-tenant',
+      maxBucketCount: Infinity,
+      maxIndexCount: Infinity,
+    })
+
+    await manager.deleteBucket('bucket-a')
+
+    expect(callOrder).toEqual(['bucket:bucket-a', `global:${VECTOR_BUCKET_COUNT_LOCK}`, 'delete'])
+  })
+
+  it('re-checks bucket existence after taking the bucket lock before creating an index', async () => {
+    const db = createMockVectorDb()
+    const sharder = createMockSharder()
+    const vectorStore = createMockVectorStore()
+
+    db.findVectorBucket
+      .mockResolvedValueOnce({
+        id: 'bucket-a',
+        created_at: new Date(),
+        updated_at: new Date().toISOString(),
+      } as any)
+      .mockRejectedValueOnce(ERRORS.S3VectorNotFoundException('vector bucket', 'bucket-a'))
+    db.withTransaction.mockImplementation(async (fn) => fn(db as unknown as KnexVectorMetadataDB))
+
+    const manager = new VectorStoreManager(vectorStore, db, sharder, {
+      tenantId: 'test-tenant',
+      maxBucketCount: Infinity,
+      maxIndexCount: Infinity,
+    })
+
+    await expect(
+      manager.createVectorIndex({
+        dataType: 'float32',
+        dimension: 4,
+        distanceMetric: 'cosine',
+        indexName: 'index-a',
+        vectorBucketName: 'bucket-a',
+      })
+    ).rejects.toMatchObject({ code: 'NotFoundException' })
+
+    expect(db.lockResource).toHaveBeenCalledWith('bucket', 'bucket-a')
+    expect(db.findVectorBucket).toHaveBeenCalledTimes(2)
+    expect(db.countIndexes).not.toHaveBeenCalled()
+    expect(db.createVectorIndex).not.toHaveBeenCalled()
+    expect(sharder.reserve).not.toHaveBeenCalled()
+    expect(vectorStore.createVectorIndex).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feat

## What is the current behavior?

Vector store uses serializable isolation level, which isn't supported by OrioleDB.

## What is the new behavior?

Switch into advisory row locks to drop serializable isolation level requirement and to support OrioleDB.

## Additional context

Improve test coverage for the possible races.