### PR TITLE
fix: drop content-type hook covered by fastify v5

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -59,15 +59,6 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.addSchema(schemas.authSchema)
   app.addSchema(schemas.errorSchema)
 
-  // Fixes security vulnerability:
-  // https://hackerone.com/reports/3464114
-  app.addHook('onRequest', async (request, reply) => {
-    const contentType = request.headers['content-type']
-    if (contentType && contentType.includes('\t')) {
-      return reply.code(400).send({ error: 'Invalid Content-Type header' })
-    }
-  })
-
   app.register(plugins.signals)
   app.register(plugins.tenantId)
   app.register(

--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -1,5 +1,5 @@
 import { FastifyError } from '@fastify/error'
-import { ERRORS, ErrorCode, isRenderableError, StorageError } from '@internal/errors'
+import { ErrorCode, isRenderableError, StorageError } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { DatabaseError } from 'pg'
 
@@ -80,16 +80,12 @@ export const setErrorHandler = (
       const err = error as FastifyError
 
       if (err.code === 'FST_ERR_CTP_INVALID_MEDIA_TYPE') {
-        const contentTypeHeader = request.headers['content-type']
-        const mimeType =
-          typeof contentTypeHeader === 'string' ? contentTypeHeader.split(';')[0].trim() : 'unknown'
-        const invalidMimeTypeError = ERRORS.InvalidMimeType(mimeType)
-        const renderableError = invalidMimeTypeError.render()
-
-        return reply.status(invalidMimeTypeError.userStatusCode).send(
+        return reply.status(400).send(
           formatter({
-            ...renderableError,
-            error: invalidMimeTypeError.error || renderableError.code,
+            statusCode: '415',
+            code: ErrorCode.InvalidMimeType,
+            error: 'invalid_mime_type',
+            message: 'Invalid Content-Type header',
           })
         )
       }

--- a/src/test/app.test.ts
+++ b/src/test/app.test.ts
@@ -1,0 +1,87 @@
+'use strict'
+
+import net, { AddressInfo } from 'node:net'
+import { FastifyInstance } from 'fastify'
+import app from '../app'
+import { getConfig } from '../config'
+
+const { serviceKeyAsync } = getConfig()
+
+type RawHttpResponse = {
+  body: string
+  statusLine: string
+}
+
+function sendRawRequest(port: number, rawRequest: string): Promise<RawHttpResponse> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+      socket.end(rawRequest)
+    })
+
+    let response = ''
+    socket.setEncoding('utf8')
+    socket.setTimeout(5000)
+    socket.on('data', (chunk) => {
+      response += chunk
+    })
+    socket.on('end', () => {
+      const splitIndex = response.indexOf('\r\n\r\n')
+      const rawHeaders = splitIndex === -1 ? response : response.slice(0, splitIndex)
+      const body = splitIndex === -1 ? '' : response.slice(splitIndex + 4)
+
+      resolve({
+        body,
+        statusLine: rawHeaders.split('\r\n')[0],
+      })
+    })
+    socket.on('error', reject)
+    socket.on('timeout', () => {
+      socket.destroy()
+      reject(new Error('Timed out waiting for raw HTTP response'))
+    })
+  })
+}
+
+describe('app request parsing', () => {
+  let appInstance: FastifyInstance
+  let port: number
+
+  beforeEach(async () => {
+    appInstance = app()
+    await appInstance.listen({ host: '127.0.0.1', port: 0 })
+
+    const address = appInstance.server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected Fastify to listen on a TCP port')
+    }
+
+    port = (address as AddressInfo).port
+  })
+
+  afterEach(async () => {
+    await appInstance.close()
+  })
+
+  test('returns invalid_mime_type for content-type headers with tabs on the wire', async () => {
+    const response = await sendRawRequest(
+      port,
+      [
+        'POST /bucket HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Connection: close',
+        `Authorization: Bearer ${await serviceKeyAsync}`,
+        'Content-Type: image/\tpng',
+        'Content-Length: 0',
+        '',
+        '',
+      ].join('\r\n')
+    )
+
+    expect(response.statusLine).toBe('HTTP/1.1 400 Bad Request')
+    expect(JSON.parse(response.body)).toEqual({
+      statusCode: '415',
+      error: 'invalid_mime_type',
+      message: 'Invalid Content-Type header',
+    })
+  })
+})

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -555,30 +555,6 @@ describe('testing POST object via multipart upload', () => {
     })
   })
 
-  test('return 422 when uploading an object with a not allowed mime-type', async () => {
-    const form = new FormData()
-    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
-    const headers = Object.assign({}, form.getHeaders(), {
-      authorization: `Bearer ${await serviceKeyAsync}`,
-      'x-upsert': 'true',
-      'content-type': 'image/png',
-    })
-
-    const response = await appInstance.inject({
-      method: 'POST',
-      url: '/object/public-limit-mime-types/sadcat-upload23.png',
-      headers,
-      payload: form,
-    })
-    expect(response.statusCode).toBe(400)
-    expect(await response.json()).toEqual({
-      error: 'invalid_mime_type',
-      message: `mime type image/png is not supported`,
-      statusCode: '415',
-    })
-    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
-  })
-
   test('can create an empty folder when mime-type is set', async () => {
     const form = new FormData()
     const headers = Object.assign({}, form.getHeaders(), {
@@ -616,7 +592,31 @@ describe('testing POST object via multipart upload', () => {
     expect(response.statusCode).toBe(400)
   })
 
-  test('return 422 when uploading an object with a malformed mime-type', async () => {
+  test('return 400 when uploading an object with a not allowed mime-type', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      authorization: `Bearer ${await serviceKeyAsync}`,
+      'x-upsert': 'true',
+      'content-type': 'image/png',
+    })
+
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/public-limit-mime-types/sadcat-upload23.png',
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'invalid_mime_type',
+      message: `mime type image/png is not supported`,
+      statusCode: '415',
+    })
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('return 400 when uploading an object with a malformed mime-type', async () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
     const headers = Object.assign({}, form.getHeaders(), {
@@ -634,7 +634,31 @@ describe('testing POST object via multipart upload', () => {
     expect(response.statusCode).toBe(400)
     expect(await response.json()).toEqual({
       error: 'invalid_mime_type',
-      message: `mime type thisisnotarealmimetype is not supported`,
+      message: 'Invalid Content-Type header',
+      statusCode: '415',
+    })
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('return 400 when uploading an object with a content-type header containing tabs', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      authorization: `Bearer ${await serviceKeyAsync}`,
+      'x-upsert': 'true',
+      'content-type': 'image/\tjpg',
+    })
+
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/public-limit-mime-types/sadcat-upload23.png',
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'invalid_mime_type',
+      message: 'Invalid Content-Type header',
       statusCode: '415',
     })
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

We had added a hook for content-type contains tabs in fastify v4.

## What is the new behavior?

Fastify v5 already does it so drop the hook. Add a regression test. 

## Additional context

Update two relevant test names to match what they expect/validate and reorder to have similar tests stay together. 
