### PR TITLE
fix: handle empty authorization as invalid

### DIFF
--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -201,7 +201,7 @@ async function authorizeRequestSignV4(
 }
 
 async function extractSignature(req: AWSRequest) {
-  if (typeof req.headers.authorization === 'string') {
+  if (typeof req.headers.authorization === 'string' && req.headers.authorization !== '') {
     return SignatureV4.parseAuthorizationHeader(req.headers)
   }
 


### PR DESCRIPTION
Summary: treat empty Authorization header as absent in S3 signature extraction.
                                                                                                                                  
`extractSignature()` in `src/http/plugins/signature-v4.ts` determines where S3 credentials are located by checking three sources as follows:

1. `Authorization` header → parse as AWS Signature V4 (AWS4-HMAC-SHA256 Credential=...)
2. `X-Amz-Credential` query parameter → parse as presigned URL
3. Multipart form fields → parse as POST-based upload

The check for step 1 uses `typeof req.headers.authorization === 'string'`, which matches an empty string. An empty `Authorization` header enters `parseAuthorizationHeader`, which immediately fails with "Unsupported authorization type" because `"".split(' ')[0]` is not AWS4-HMAC-SHA256. Steps 2 and 3 are never reached.

This means any request that carries credentials in the query string (presigned URLs) or form fields (multipart POST) will fail if a reverse proxy or API gateway injects an empty `Authorization` header.

Empty string is never a valid AWS Signature V4 authorization value. The fix adds `&& req.headers.authorization !== ''` to the check, so empty headers fall through to query string and multipart parsing as intended.