### PR TITLE
fix: enable throw error and no common js rules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,9 +34,9 @@
         "noUnusedVariables": "error"
       },
       "style": {
-        "noCommonJs": "warn",
+        "noCommonJs": "error",
         "useConsistentObjectDefinitions": "error",
-        "useThrowOnlyError": "warn"
+        "useThrowOnlyError": "error"
       },
       "suspicious": {
         "noAssignInExpressions": "error",

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -32,6 +32,14 @@ export function escapeLike(str: string) {
   return str.replace(/([%_])/g, '\\$1')
 }
 
+class TestPermissionRollbackError extends Error {
+  constructor() {
+    super('Rollback test permission transaction')
+    this.name = 'TestPermissionRollbackError'
+    Object.setPrototypeOf(this, TestPermissionRollbackError.prototype)
+  }
+}
+
 /**
  * Database
  * the only source of truth for interacting with the storage database
@@ -99,10 +107,10 @@ export class StorageKnexDB implements Database {
     try {
       await this.withTransaction(async (db) => {
         result = await fn(db)
-        throw true
+        throw new TestPermissionRollbackError()
       })
     } catch (e) {
-      if (e === true) {
+      if (e instanceof TestPermissionRollbackError) {
         return result
       }
       throw e


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the new behavior?

Enable `noCommonJs` and `useThrowOnlyError` as error and fix their issues.

## Additional context

Part of better static analysis.