### PR TITLE
fix: flaky abort tests

### DIFF
--- a/src/test/query-abort-signal.test.ts
+++ b/src/test/query-abort-signal.test.ts
@@ -4,133 +4,181 @@ import { PoolManager } from '@internal/database/pool'
 import { getConfig } from '../config'
 
 const { databaseURL, databasePoolURL, tenantId } = getConfig()
+type TestPool = ReturnType<PoolManager['getPool']>
+type TestConnection = ReturnType<TestPool['acquire']>
 
 describe('Query Abort Signal', () => {
   let poolManager: PoolManager
-  let pool: ReturnType<PoolManager['getPool']>
+  let superUser: Awaited<ReturnType<typeof getServiceKeyUser>>
 
   beforeAll(async () => {
-    const superUser = await getServiceKeyUser(tenantId)
+    superUser = await getServiceKeyUser(tenantId)
     poolManager = new PoolManager()
-    pool = poolManager.getPool({
+  })
+
+  async function withIsolatedConnection<T>(run: (conn: TestConnection) => Promise<T>) {
+    // Force fresh, cache is checked before isSingleUse.
+    await poolManager.destroy(tenantId)
+
+    // Use an uncached single-use pool so aborted queries can't
+    // leak disposed connections into the next test case while Knex
+    // finishes tearing them down in the background.
+    const pool = poolManager.getPool({
       tenantId,
+      isSingleUse: true,
       isExternalPool: true,
-      maxConnections: 5,
+      maxConnections: 1,
       dbUrl: databasePoolURL || databaseURL,
       user: superUser,
       superUser,
     })
-  })
 
-  afterAll(async () => {
-    await pool.destroy()
-  })
+    const conn = pool.acquire()
+
+    try {
+      await conn.raw('SELECT 1')
+      return await run(conn)
+    } finally {
+      try {
+        await pool.destroy()
+      } finally {
+        await poolManager.destroy(tenantId)
+      }
+    }
+  }
 
   describe('abortOnSignal on Raw queries', () => {
     it('should execute query normally when signal is not aborted', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      const result = await conn.raw('SELECT 1 as test').abortOnSignal(controller.signal)
+        const result = await conn.raw('SELECT 1 as test').abortOnSignal(controller.signal)
 
-      expect(result.rows[0].test).toEqual(1)
+        expect(result.rows[0].test).toEqual(1)
+      })
     })
 
     it('should abort query when signal is aborted before execution', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      // Abort before creating the query
-      controller.abort()
+        // Abort before creating the query
+        controller.abort()
 
-      await expect(async () => {
-        conn.raw('SELECT 1 as test').abortOnSignal(controller.signal)
-      }).rejects.toThrow('Signal is already aborted')
+        await expect(
+          Promise.resolve().then(() =>
+            conn.raw('SELECT 1 as test').abortOnSignal(controller.signal)
+          )
+        ).rejects.toThrow('Signal is already aborted')
+      })
     })
 
     it('should abort a long-running query when signal is aborted', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      // Start a slow query (pg_sleep for 10 seconds)
-      const queryPromise = conn.raw('SELECT pg_sleep(10)').abortOnSignal(controller.signal)
+        // Start a slow query (pg_sleep for 10 seconds)
+        const queryPromise = conn.raw('SELECT pg_sleep(10)').abortOnSignal(controller.signal)
 
-      // Abort after a short delay
-      setTimeout(() => controller.abort(), 100)
+        // Abort after a short delay
+        const abortTimeout = setTimeout(() => controller.abort(), 100)
 
-      await expect(queryPromise).rejects.toMatchObject({
-        name: 'AbortError',
-        code: 'ABORT_ERR',
-        message: 'Query was aborted',
+        try {
+          await expect(queryPromise).rejects.toMatchObject({
+            name: 'AbortError',
+            code: 'ABORT_ERR',
+            message: 'Query was aborted',
+          })
+        } finally {
+          clearTimeout(abortTimeout)
+        }
       })
     })
 
     it('should reject with AbortError containing correct properties', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      const queryPromise = conn.raw('SELECT pg_sleep(5)').abortOnSignal(controller.signal)
+        const queryPromise = conn.raw('SELECT pg_sleep(5)').abortOnSignal(controller.signal)
 
-      setTimeout(() => controller.abort(), 50)
+        const abortTimeout = setTimeout(() => controller.abort(), 50)
 
-      try {
-        await queryPromise
-        fail('Expected query to be aborted')
-      } catch (error: any) {
-        expect(error.name).toBe('AbortError')
-        expect(error.code).toBe('ABORT_ERR')
-        expect(error.message).toBe('Query was aborted')
-      }
+        try {
+          await queryPromise
+          fail('Expected query to be aborted')
+        } catch (error: unknown) {
+          expect(error).toMatchObject({
+            name: 'AbortError',
+            code: 'ABORT_ERR',
+            message: 'Query was aborted',
+          })
+        } finally {
+          clearTimeout(abortTimeout)
+        }
+      })
     })
 
     it('should throw error for invalid signal parameter', async () => {
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const invalidSignal = 'not a signal' as unknown as AbortSignal
 
-      expect(() => {
-        conn.raw('SELECT 1').abortOnSignal('not a signal' as any)
-      }).toThrow('Expected signal to be an instance of AbortSignal')
+        expect(() => {
+          conn.raw('SELECT 1').abortOnSignal(invalidSignal)
+        }).toThrow('Expected signal to be an instance of AbortSignal')
+      })
     })
   })
 
   describe('abortOnSignal on Query Builder', () => {
     it('should execute query normally when signal is not aborted', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      const result = await conn.select(conn.raw('1 as test')).abortOnSignal(controller.signal)
+        const result = await conn.select(conn.raw('1 as test')).abortOnSignal(controller.signal)
 
-      expect(result[0].test).toEqual(1)
+        expect(result[0].test).toEqual(1)
+      })
     })
 
     it('should abort query builder query when signal is aborted', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      const queryPromise = conn.select(conn.raw('pg_sleep(10)')).abortOnSignal(controller.signal)
+        const queryPromise = conn.select(conn.raw('pg_sleep(10)')).abortOnSignal(controller.signal)
 
-      setTimeout(() => controller.abort(), 100)
+        const abortTimeout = setTimeout(() => controller.abort(), 100)
 
-      await expect(queryPromise).rejects.toMatchObject({
-        name: 'AbortError',
+        try {
+          await expect(queryPromise).rejects.toMatchObject({
+            name: 'AbortError',
+          })
+        } finally {
+          clearTimeout(abortTimeout)
+        }
       })
     })
   })
 
   describe('abortOnSignal with timeout', () => {
     it('should work with both timeout and abortSignal', async () => {
-      const controller = new AbortController()
-      const conn = pool.acquire()
+      await withIsolatedConnection(async (conn) => {
+        const controller = new AbortController()
 
-      const queryPromise = conn
-        .raw('SELECT pg_sleep(10)')
-        .timeout(5000, { cancel: true })
-        .abortOnSignal(controller.signal)
+        const queryPromise = conn
+          .raw('SELECT pg_sleep(10)')
+          .timeout(5000, { cancel: true })
+          .abortOnSignal(controller.signal)
 
-      // Abort should win over timeout since we abort immediately
-      setTimeout(() => controller.abort(), 50)
+        // Abort should win over timeout since we abort immediately
+        const abortTimeout = setTimeout(() => controller.abort(), 50)
 
-      await expect(queryPromise).rejects.toMatchObject({
-        name: 'AbortError',
+        try {
+          await expect(queryPromise).rejects.toMatchObject({
+            name: 'AbortError',
+          })
+        } finally {
+          clearTimeout(abortTimeout)
+        }
       })
     })
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Flaky test fix

## What is the current behavior?

Abort tests are cached pool and aborted connections are leaking between tests.

## What is the new behavior?

Mark the pool as single use to have test isolation.

## Additional context

Example [flaky failure](https://github.com/supabase/storage/actions/runs/23267483655/job/67651914128)
