### PR TITLE
fix: tracing hidden metric pipeline

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -2,8 +2,9 @@ import { getConfig, setEnvPaths } from './src/config'
 
 setEnvPaths(['.env.test', '.env'])
 
-interface OTelMetricsGlobalState {
+interface OTelGlobalState {
   __otelMetricsShutdown?: () => Promise<void>
+  __otelTracingShutdown?: () => Promise<void>
 }
 
 beforeEach(() => {
@@ -11,8 +12,13 @@ beforeEach(() => {
 })
 
 afterAll(async () => {
-  const shutdownOtelMetrics = (globalThis as typeof globalThis & OTelMetricsGlobalState)
-    .__otelMetricsShutdown
+  const otelGlobalState = globalThis as typeof globalThis & OTelGlobalState
+  const shutdownOtelTracing = otelGlobalState.__otelTracingShutdown
+  const shutdownOtelMetrics = otelGlobalState.__otelMetricsShutdown
+
+  if (shutdownOtelTracing) {
+    await shutdownOtelTracing()
+  }
 
   if (shutdownOtelMetrics) {
     await shutdownOtelMetrics()

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@types/busboy": "^1.3.0",
         "@types/cloneable-readable": "^2.0.3",
         "@types/fs-extra": "^9.0.13",
-        "@types/jest": "^29.2.1",
+        "@types/jest": "^29.5.14",
         "@types/js-yaml": "^4.0.5",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^22.18.8",
@@ -11265,10 +11265,11 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.2.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.1.tgz",
-      "integrity": "sha512-nKixEdnGDqFOZkMTF74avFNr3yRqB1ZJ6sRZv5/28D5x2oLN14KApv7F9mfDT/vUic0L3tRCsh3XWpWjtJisUQ==",
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -25739,9 +25740,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.2.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.1.tgz",
-      "integrity": "sha512-nKixEdnGDqFOZkMTF74avFNr3yRqB1ZJ6sRZv5/28D5x2oLN14KApv7F9mfDT/vUic0L3tRCsh3XWpWjtJisUQ==",
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/busboy": "^1.3.0",
     "@types/cloneable-readable": "^2.0.3",
     "@types/fs-extra": "^9.0.13",
-    "@types/jest": "^29.2.1",
+    "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.5",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^22.18.8",

--- a/src/internal/monitoring/otel-class-instrumentations.ts
+++ b/src/internal/monitoring/otel-class-instrumentations.ts
@@ -193,3 +193,7 @@ export const classInstrumentations = [
     ],
   }),
 ]
+
+export async function loadClassInstrumentations() {
+  return classInstrumentations
+}

--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -26,9 +26,25 @@ const { version, otelMetricsExportIntervalMs, otelMetricsEnabled, otelMetricsTem
 let prometheusExporter: PrometheusExporter | undefined
 let meterProvider: MeterProvider | undefined
 let metricsShutdownPromise: Promise<void> | undefined
+let unregisterMetricInstrumentations: (() => void) | undefined
 
 interface OTelMetricsGlobalState {
   __otelMetricsShutdown?: () => Promise<void>
+}
+
+function unregisterMetricInstrumentation(unregister: (() => void) | undefined) {
+  if (!unregister) {
+    return
+  }
+
+  try {
+    unregister()
+  } catch (error) {
+    logSchema.error(logger, '[OTel Metrics] Failed to unregister metric instrumentations', {
+      type: 'otel-metrics',
+      error,
+    })
+  }
 }
 
 // =============================================================================
@@ -137,6 +153,10 @@ export async function shutdownOtelMetrics(): Promise<void> {
       type: 'otel-metrics',
     })
 
+    const unregister = unregisterMetricInstrumentations
+    unregisterMetricInstrumentations = undefined
+    unregisterMetricInstrumentation(unregister)
+
     try {
       await provider.shutdown()
       logSchema.info(logger, '[OTel Metrics] Shutdown complete', {
@@ -152,6 +172,7 @@ export async function shutdownOtelMetrics(): Promise<void> {
         meterProvider = undefined
       }
       prometheusExporter = undefined
+      metricsShutdownPromise = undefined
     }
   })()
 
@@ -244,7 +265,7 @@ if (otelMetricsEnabled) {
   hostMetrics.start()
 
   // Register Node.js runtime instrumentations
-  registerInstrumentations({
+  unregisterMetricInstrumentations = registerInstrumentations({
     meterProvider,
     instrumentations: [
       new RuntimeNodeInstrumentation(),

--- a/src/internal/monitoring/otel-tracing.ts
+++ b/src/internal/monitoring/otel-tracing.ts
@@ -46,6 +46,34 @@ Object.keys(exporterHeaders).forEach((key) => {
 
 const endpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 let traceExporter: SpanExporter | undefined = undefined
+let tracingSdk: NodeSDK | undefined
+let tracingShutdownPromise: Promise<void> | undefined
+let unregisterTracingInstrumentations: (() => void) | undefined
+let unregisterClassInstrumentations: (() => void) | undefined
+let classInstrumentationsImportPromise: Promise<void> | undefined
+let tracingShutdownRequested = false
+
+interface OTelTracingGlobalState {
+  __otelTracingShutdown?: () => Promise<void>
+}
+
+function unregisterTracingInstrumentation(
+  unregister: (() => void) | undefined,
+  name: 'class' | 'tracing'
+) {
+  if (!unregister) {
+    return
+  }
+
+  try {
+    unregister()
+  } catch (error) {
+    logSchema.error(logger, `[Otel] Failed to unregister ${name} instrumentations`, {
+      type: 'otel',
+      error,
+    })
+  }
+}
 
 if (tracingEnabled && endpoint) {
   // Create an OTLP trace exporter
@@ -73,114 +101,175 @@ if (tracingEnabled && traceExporter) {
 }
 
 if (tracingEnabled && traceExporter && spanProcessors.length > 0) {
-  const ignoreRoutes = ['/metrics', '/status', '/health', '/healthcheck']
-
   // Configure the OpenTelemetry Node SDK
-  const sdk = new NodeSDK({
+  tracingSdk = new NodeSDK({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: 'storage',
       [ATTR_SERVICE_VERSION]: version,
     }),
     spanProcessors,
-    traceExporter,
-    instrumentations: [
-      // @fastify/otel replaces @opentelemetry/instrumentation-fastify
-      // It auto-sets http.route, http.request.method, url.path on spans.
-      // Other attributes (tenant.ref, trace.mode, http.operation) are set
-      // in Fastify hooks via request.opentelemetry().span.
-      new FastifyOtelInstrumentation({
-        enabled: true,
-        registerOnInitialization: true,
-        ignorePaths: (routeOpts) => {
-          return ignoreRoutes.includes(routeOpts.url)
-        },
-      }),
-      getNodeAutoInstrumentations({
-        '@opentelemetry/instrumentation-http': {
-          enabled: true,
-          ignoreIncomingRequestHook: (req) => {
-            return ignoreRoutes.some((url) => req.url?.includes(url)) ?? false
-          },
-          ignoreOutgoingRequestHook: (req) => {
-            // Skip OTEL instrumentation for S3 Tables requests to avoid injecting
-            // unsupported headers (baggage, traceparent, tracestate)
-            const host = req.hostname || req.host || ''
-            return host.includes('.s3tables.') || host.includes('--table-s3')
-          },
-          startIncomingSpanHook: (req) => {
-            let tenantId = ''
-            if (isMultitenant) {
-              if (requestXForwardedHostRegExp) {
-                const serverRequest = req
-                const xForwardedHost = serverRequest.headers['x-forwarded-host']
-                if (typeof xForwardedHost !== 'string') return {}
-                const result = xForwardedHost.match(requestXForwardedHostRegExp)
-                if (!result) return {}
-                tenantId = result[1]
-              }
-            } else {
-              tenantId = defaultTenantId
-            }
-
-            return {
-              'tenant.ref': tenantId,
-              region,
-            }
-          },
-          headersToSpanAttributes: {
-            client: {
-              requestHeaders: requestTraceHeader ? [requestTraceHeader] : [],
-            },
-            server: {
-              requestHeaders: requestTraceHeader ? [requestTraceHeader] : [],
-            },
-          },
-        },
-        '@opentelemetry/instrumentation-fs': {
-          enabled: false,
-        },
-        '@opentelemetry/instrumentation-aws-sdk': {
-          enabled: storageS3InternalTracesEnabled,
-        },
-        '@opentelemetry/instrumentation-pg': {
-          enabled: true,
-          requireParentSpan: true,
-        },
-        '@opentelemetry/instrumentation-knex': {
-          enabled: true,
-        },
-      }),
-    ],
+    metricReaders: [],
   })
 
   // Initialize the OpenTelemetry Node SDK
-  sdk.start()
+  tracingSdk.start()
+  tracingShutdownRequested = false
 
-  // Load class instrumentations after SDK starts to avoid loading http/metrics.ts too early
-  void import('./otel-class-instrumentations').then(({ classInstrumentations }) => {
-    registerInstrumentations({
-      tracerProvider: trace.getTracerProvider(),
-      instrumentations: classInstrumentations,
-    })
+  const ignoreRoutes = ['/metrics', '/status', '/health', '/healthcheck']
+  const tracingInstrumentations = [
+    // @fastify/otel replaces @opentelemetry/instrumentation-fastify
+    // It auto-sets http.route, http.request.method, url.path on spans.
+    // Other attributes (tenant.ref, trace.mode, http.operation) are set
+    // in Fastify hooks via request.opentelemetry().span.
+    new FastifyOtelInstrumentation({
+      enabled: true,
+      registerOnInitialization: true,
+      ignorePaths: (routeOpts) => {
+        return ignoreRoutes.includes(routeOpts.url)
+      },
+    }),
+    getNodeAutoInstrumentations({
+      '@opentelemetry/instrumentation-http': {
+        enabled: true,
+        ignoreIncomingRequestHook: (req) => {
+          return ignoreRoutes.some((url) => req.url?.includes(url)) ?? false
+        },
+        ignoreOutgoingRequestHook: (req) => {
+          // Skip OTEL instrumentation for S3 Tables requests to avoid injecting
+          // unsupported headers (baggage, traceparent, tracestate)
+          const host = req.hostname || req.host || ''
+          return host.includes('.s3tables.') || host.includes('--table-s3')
+        },
+        startIncomingSpanHook: (req) => {
+          let tenantId = ''
+          if (isMultitenant) {
+            if (requestXForwardedHostRegExp) {
+              const serverRequest = req
+              const xForwardedHost = serverRequest.headers['x-forwarded-host']
+              if (typeof xForwardedHost !== 'string') return {}
+              const result = xForwardedHost.match(requestXForwardedHostRegExp)
+              if (!result) return {}
+              tenantId = result[1]
+            }
+          } else {
+            tenantId = defaultTenantId
+          }
+
+          return {
+            'tenant.ref': tenantId,
+            region,
+          }
+        },
+        headersToSpanAttributes: {
+          client: {
+            requestHeaders: requestTraceHeader ? [requestTraceHeader] : [],
+          },
+          server: {
+            requestHeaders: requestTraceHeader ? [requestTraceHeader] : [],
+          },
+        },
+      },
+      '@opentelemetry/instrumentation-fs': {
+        enabled: false,
+      },
+      '@opentelemetry/instrumentation-aws-sdk': {
+        enabled: storageS3InternalTracesEnabled,
+      },
+      '@opentelemetry/instrumentation-pg': {
+        enabled: true,
+        requireParentSpan: true,
+      },
+      '@opentelemetry/instrumentation-knex': {
+        enabled: true,
+      },
+      '@opentelemetry/instrumentation-runtime-node': {
+        enabled: false,
+      },
+    }),
+  ]
+
+  unregisterTracingInstrumentations = registerInstrumentations({
+    tracerProvider: trace.getTracerProvider(),
+    instrumentations: tracingInstrumentations,
   })
 
-  // Gracefully shutdown the SDK on process exit
-  process.once('SIGTERM', () => {
-    logSchema.info(logger, '[Otel] Stopping', {
-      type: 'otel',
+  const sdk = tracingSdk
+
+  // Load class instrumentations after SDK starts to avoid loading http/metrics.ts too early
+  classInstrumentationsImportPromise = import('./otel-class-instrumentations')
+    .then(({ loadClassInstrumentations }) => loadClassInstrumentations())
+    .then((classInstrumentations) => {
+      if (tracingShutdownRequested || tracingSdk !== sdk) {
+        return
+      }
+
+      unregisterClassInstrumentations = registerInstrumentations({
+        tracerProvider: trace.getTracerProvider(),
+        instrumentations: classInstrumentations,
+      })
     })
-    sdk
-      .shutdown()
-      .then(() => {
+    .catch((error) => {
+      logSchema.error(logger, '[Otel] Failed to load class instrumentations', {
+        type: 'otel',
+        error,
+      })
+    })
+
+  const shutdownOtelTracing = async () => {
+    if (tracingShutdownPromise) {
+      await tracingShutdownPromise
+      return
+    }
+
+    const sdk = tracingSdk
+    if (!sdk) {
+      return
+    }
+
+    tracingShutdownRequested = true
+
+    tracingShutdownPromise = (async () => {
+      logSchema.info(logger, '[Otel] Stopping', {
+        type: 'otel',
+      })
+
+      try {
+        await classInstrumentationsImportPromise
+        classInstrumentationsImportPromise = undefined
+
+        unregisterTracingInstrumentation(unregisterClassInstrumentations, 'class')
+        unregisterClassInstrumentations = undefined
+        unregisterTracingInstrumentation(unregisterTracingInstrumentations, 'tracing')
+        unregisterTracingInstrumentations = undefined
+
+        await sdk.shutdown()
+
         logSchema.info(logger, '[Otel] Exited', {
           type: 'otel',
         })
-      })
-      .catch((error) =>
+      } catch (error) {
         logSchema.error(logger, '[Otel] Shutdown error', {
           type: 'otel',
           error,
         })
-      )
+      } finally {
+        if (tracingSdk === sdk) {
+          tracingSdk = undefined
+        }
+        tracingShutdownRequested = false
+        classInstrumentationsImportPromise = undefined
+        tracingShutdownPromise = undefined
+      }
+    })()
+
+    await tracingShutdownPromise
+  }
+
+  ;(globalThis as typeof globalThis & OTelTracingGlobalState).__otelTracingShutdown =
+    shutdownOtelTracing
+
+  // Gracefully shutdown the SDK on process exit
+  process.once('SIGTERM', () => {
+    void shutdownOtelTracing()
   })
 }

--- a/src/internal/monitoring/system/base-collector.ts
+++ b/src/internal/monitoring/system/base-collector.ts
@@ -30,11 +30,19 @@ export abstract class BaseCollector<T extends CollectorConfig = CollectorConfig>
   }
 
   enable(): void {
+    if (this._enabled) {
+      return
+    }
+
     this._enabled = true
     this.internalEnable()
   }
 
   disable(): void {
+    if (!this._enabled) {
+      return
+    }
+
     this._enabled = false
     this.internalDisable()
   }

--- a/src/internal/monitoring/system/file-descriptor-collector.ts
+++ b/src/internal/monitoring/system/file-descriptor-collector.ts
@@ -114,6 +114,7 @@ export class FileDescriptorCollector extends BaseCollector {
       // Ignore errors
     })
     this._updateInterval = setInterval(() => this.updateMetrics().catch(() => {}), 5000)
+    this._updateInterval.unref()
   }
 
   protected internalDisable(): void {

--- a/src/test/otel-metrics.test.ts
+++ b/src/test/otel-metrics.test.ts
@@ -1,0 +1,138 @@
+interface OTelGlobalState {
+  __otelMetricsShutdown?: () => Promise<void>
+}
+
+describe('otel metrics shutdown', () => {
+  const originalOtelExporterEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+  const originalOtelMetricsEndpoint = process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+  const originalOtelMetricsHeaders = process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS
+
+  afterEach(async () => {
+    const otelGlobalState = globalThis as typeof globalThis & OTelGlobalState
+
+    if (otelGlobalState.__otelMetricsShutdown) {
+      await otelGlobalState.__otelMetricsShutdown()
+      delete otelGlobalState.__otelMetricsShutdown
+    }
+
+    if (originalOtelExporterEndpoint === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = originalOtelExporterEndpoint
+    }
+
+    if (originalOtelMetricsEndpoint === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = originalOtelMetricsEndpoint
+    }
+
+    if (originalOtelMetricsHeaders === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS = originalOtelMetricsHeaders
+    }
+
+    jest.restoreAllMocks()
+  })
+
+  test('still shuts down meter provider when unregister throws', async () => {
+    const shutdown = jest.fn().mockResolvedValue(undefined)
+    const unregisterError = new Error('metrics unregister failed')
+    const unregisterMetricInstrumentations = jest.fn(() => {
+      throw unregisterError
+    })
+    const registerInstrumentations = jest.fn(() => unregisterMetricInstrumentations)
+    const HostMetrics = jest.fn().mockImplementation(() => ({
+      start: jest.fn(),
+    }))
+    const MeterProvider = jest.fn().mockImplementation(() => ({
+      shutdown,
+    }))
+    const PrometheusExporter = jest.fn().mockImplementation(() => ({
+      getMetricsRequestHandler: jest.fn(),
+    }))
+    const RuntimeNodeInstrumentation = jest.fn().mockImplementation(() => ({}))
+    const StorageNodeInstrumentation = jest.fn().mockImplementation(() => ({}))
+    const logger = {
+      info: jest.fn(),
+    }
+    const logSchema = {
+      error: jest.fn(),
+      info: jest.fn(),
+    }
+
+    jest.doMock('../config', () => ({
+      getConfig: jest.fn(() => ({
+        version: 'test-version',
+        otelMetricsExportIntervalMs: 1000,
+        otelMetricsEnabled: true,
+        otelMetricsTemporality: 'CUMULATIVE',
+        region: 'local',
+      })),
+    }))
+    jest.doMock('@internal/monitoring/logger', () => ({
+      logger,
+      logSchema,
+    }))
+    jest.doMock('@internal/monitoring/system', () => ({
+      StorageNodeInstrumentation,
+    }))
+    jest.doMock('@opentelemetry/api', () => ({
+      metrics: {
+        setGlobalMeterProvider: jest.fn(),
+      },
+    }))
+    jest.doMock('@opentelemetry/exporter-metrics-otlp-grpc', () => ({
+      OTLPMetricExporter: jest.fn(),
+    }))
+    jest.doMock('@opentelemetry/exporter-prometheus', () => ({
+      PrometheusExporter,
+    }))
+    jest.doMock('@opentelemetry/host-metrics', () => ({
+      HostMetrics,
+    }))
+    jest.doMock('@opentelemetry/instrumentation', () => ({
+      registerInstrumentations,
+    }))
+    jest.doMock('@opentelemetry/instrumentation-runtime-node', () => ({
+      RuntimeNodeInstrumentation,
+    }))
+    jest.doMock('@opentelemetry/resources', () => ({
+      resourceFromAttributes: jest.fn(() => ({})),
+    }))
+    jest.doMock('@opentelemetry/sdk-metrics', () => ({
+      AggregationTemporality: {
+        CUMULATIVE: 'CUMULATIVE',
+        DELTA: 'DELTA',
+      },
+      AggregationType: {
+        DROP: 'DROP',
+        EXPLICIT_BUCKET_HISTOGRAM: 'EXPLICIT_BUCKET_HISTOGRAM',
+      },
+      MeterProvider,
+      PeriodicExportingMetricReader: jest.fn(),
+    }))
+
+    let shutdownOtelMetrics: (() => Promise<void>) | undefined
+
+    await jest.isolateModulesAsync(async () => {
+      await import('../internal/monitoring/otel-metrics')
+      shutdownOtelMetrics = (globalThis as typeof globalThis & OTelGlobalState)
+        .__otelMetricsShutdown
+    })
+
+    await expect(shutdownOtelMetrics?.()).resolves.toBeUndefined()
+
+    expect(unregisterMetricInstrumentations).toHaveBeenCalledTimes(1)
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(unregisterMetricInstrumentations.mock.invocationCallOrder[0]).toBeLessThan(
+      shutdown.mock.invocationCallOrder[0]
+    )
+    expect(logSchema.error).toHaveBeenCalledWith(
+      logger,
+      '[OTel Metrics] Failed to unregister metric instrumentations',
+      expect.objectContaining({ type: 'otel-metrics', error: unregisterError })
+    )
+  })
+})

--- a/src/test/otel-tracing.test.ts
+++ b/src/test/otel-tracing.test.ts
@@ -1,0 +1,244 @@
+interface OTelGlobalState {
+  __otelTracingShutdown?: () => Promise<void>
+}
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+describe('otel tracing bootstrap', () => {
+  const originalTracingEnabled = process.env.TRACING_ENABLED
+  const originalTraceEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    process.env.TRACING_ENABLED = 'true'
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'http://127.0.0.1:4317'
+  })
+
+  afterEach(async () => {
+    const otelGlobalState = globalThis as typeof globalThis & OTelGlobalState
+
+    if (otelGlobalState.__otelTracingShutdown) {
+      await otelGlobalState.__otelTracingShutdown()
+      delete otelGlobalState.__otelTracingShutdown
+    }
+
+    if (originalTracingEnabled === undefined) {
+      delete process.env.TRACING_ENABLED
+    } else {
+      process.env.TRACING_ENABLED = originalTracingEnabled
+    }
+
+    if (originalTraceEndpoint === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = originalTraceEndpoint
+    }
+
+    jest.restoreAllMocks()
+  })
+
+  test('does not let tracing sdk create a hidden metrics pipeline', async () => {
+    const start = jest.fn()
+    const shutdown = jest.fn().mockResolvedValue(undefined)
+    const NodeSDK = jest.fn().mockImplementation(() => ({
+      start,
+      shutdown,
+    }))
+    const registerInstrumentations = jest.fn(() => jest.fn())
+    const getNodeAutoInstrumentations = jest.fn().mockReturnValue([])
+    const FastifyOtelInstrumentation = jest.fn().mockImplementation((config) => ({
+      instrumentationName: '@fastify/otel',
+      config,
+    }))
+    const OTLPTraceExporter = jest.fn().mockImplementation(() => ({}))
+
+    jest.doMock('@opentelemetry/sdk-node', () => ({
+      NodeSDK,
+    }))
+    jest.doMock('@opentelemetry/instrumentation', () => ({
+      registerInstrumentations,
+    }))
+    jest.doMock('@opentelemetry/auto-instrumentations-node', () => ({
+      getNodeAutoInstrumentations,
+    }))
+    jest.doMock('@fastify/otel', () => ({
+      FastifyOtelInstrumentation,
+    }))
+    jest.doMock('@opentelemetry/exporter-trace-otlp-grpc', () => ({
+      OTLPTraceExporter,
+    }))
+
+    await jest.isolateModulesAsync(async () => {
+      await import('../internal/monitoring/otel-tracing')
+    })
+
+    expect(NodeSDK).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricReaders: [],
+      })
+    )
+
+    expect(getNodeAutoInstrumentations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        '@opentelemetry/instrumentation-runtime-node': expect.objectContaining({
+          enabled: false,
+        }),
+      })
+    )
+
+    expect(registerInstrumentations).toHaveBeenCalled()
+    expect(start).toHaveBeenCalled()
+  })
+
+  test('does not register class instrumentations after shutdown starts', async () => {
+    const start = jest.fn()
+    const shutdown = jest.fn().mockResolvedValue(undefined)
+    const unregisterTracingInstrumentations = jest.fn()
+    const unregisterClassInstrumentations = jest.fn()
+    const NodeSDK = jest.fn().mockImplementation(() => ({
+      start,
+      shutdown,
+    }))
+    const registerInstrumentations = jest
+      .fn()
+      .mockReturnValueOnce(unregisterTracingInstrumentations)
+      .mockReturnValueOnce(unregisterClassInstrumentations)
+    const getNodeAutoInstrumentations = jest.fn().mockReturnValue([])
+    const FastifyOtelInstrumentation = jest.fn().mockImplementation((config) => ({
+      instrumentationName: '@fastify/otel',
+      config,
+    }))
+    const OTLPTraceExporter = jest.fn().mockImplementation(() => ({}))
+    const classInstrumentationsDeferred = createDeferred<{ classInstrumentations: unknown[] }>()
+
+    jest.doMock('@opentelemetry/sdk-node', () => ({
+      NodeSDK,
+    }))
+    jest.doMock('@opentelemetry/instrumentation', () => ({
+      registerInstrumentations,
+    }))
+    jest.doMock('@opentelemetry/auto-instrumentations-node', () => ({
+      getNodeAutoInstrumentations,
+    }))
+    jest.doMock('@fastify/otel', () => ({
+      FastifyOtelInstrumentation,
+    }))
+    jest.doMock('@opentelemetry/exporter-trace-otlp-grpc', () => ({
+      OTLPTraceExporter,
+    }))
+    jest.doMock('../internal/monitoring/otel-class-instrumentations', () => ({
+      loadClassInstrumentations: jest.fn(() => classInstrumentationsDeferred.promise),
+    }))
+
+    let shutdownOtelTracing: (() => Promise<void>) | undefined
+
+    await jest.isolateModulesAsync(async () => {
+      await import('../internal/monitoring/otel-tracing')
+      shutdownOtelTracing = (globalThis as typeof globalThis & OTelGlobalState)
+        .__otelTracingShutdown
+    })
+
+    const shutdownPromise = shutdownOtelTracing?.()
+
+    classInstrumentationsDeferred.resolve({ classInstrumentations: [] })
+
+    await shutdownPromise
+
+    expect(registerInstrumentations).toHaveBeenCalledTimes(1)
+    expect(unregisterTracingInstrumentations).toHaveBeenCalledTimes(1)
+    expect(unregisterClassInstrumentations).not.toHaveBeenCalled()
+    expect(shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  test('still shuts down sdk when unregister callbacks throw', async () => {
+    const start = jest.fn()
+    const shutdown = jest.fn().mockResolvedValue(undefined)
+    const unregisterTracingError = new Error('tracing unregister failed')
+    const unregisterClassError = new Error('class unregister failed')
+    const unregisterTracingInstrumentations = jest.fn(() => {
+      throw unregisterTracingError
+    })
+    const unregisterClassInstrumentations = jest.fn(() => {
+      throw unregisterClassError
+    })
+    const NodeSDK = jest.fn().mockImplementation(() => ({
+      start,
+      shutdown,
+    }))
+    const registerInstrumentations = jest
+      .fn()
+      .mockReturnValueOnce(unregisterTracingInstrumentations)
+      .mockReturnValueOnce(unregisterClassInstrumentations)
+    const getNodeAutoInstrumentations = jest.fn().mockReturnValue([])
+    const FastifyOtelInstrumentation = jest.fn().mockImplementation((config) => ({
+      instrumentationName: '@fastify/otel',
+      config,
+    }))
+    const OTLPTraceExporter = jest.fn().mockImplementation(() => ({}))
+    const logSchema = {
+      error: jest.fn(),
+      info: jest.fn(),
+      warning: jest.fn(),
+    }
+
+    jest.doMock('@opentelemetry/sdk-node', () => ({
+      NodeSDK,
+    }))
+    jest.doMock('@opentelemetry/instrumentation', () => ({
+      registerInstrumentations,
+    }))
+    jest.doMock('@opentelemetry/auto-instrumentations-node', () => ({
+      getNodeAutoInstrumentations,
+    }))
+    jest.doMock('@fastify/otel', () => ({
+      FastifyOtelInstrumentation,
+    }))
+    jest.doMock('@opentelemetry/exporter-trace-otlp-grpc', () => ({
+      OTLPTraceExporter,
+    }))
+    jest.doMock('@internal/monitoring/logger', () => ({
+      logger: {},
+      logSchema,
+    }))
+    jest.doMock('../internal/monitoring/otel-class-instrumentations', () => ({
+      loadClassInstrumentations: jest.fn(async () => []),
+    }))
+
+    let shutdownOtelTracing: (() => Promise<void>) | undefined
+
+    await jest.isolateModulesAsync(async () => {
+      await import('../internal/monitoring/otel-tracing')
+      shutdownOtelTracing = (globalThis as typeof globalThis & OTelGlobalState)
+        .__otelTracingShutdown
+    })
+
+    await expect(shutdownOtelTracing?.()).resolves.toBeUndefined()
+
+    expect(unregisterClassInstrumentations).toHaveBeenCalledTimes(1)
+    expect(unregisterTracingInstrumentations).toHaveBeenCalledTimes(1)
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(logSchema.error).toHaveBeenCalledWith(
+      {},
+      '[Otel] Failed to unregister class instrumentations',
+      expect.objectContaining({ type: 'otel', error: unregisterClassError })
+    )
+    expect(logSchema.error).toHaveBeenCalledWith(
+      {},
+      '[Otel] Failed to unregister tracing instrumentations',
+      expect.objectContaining({ type: 'otel', error: unregisterTracingError })
+    )
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Tracing creates duplicate metrics.

## What is the new behavior?

SDK doesn't own instrumentations anymore, instead everything explicitly registered. 

## Additional context

Improve cleanup behavior.
Idempotent collector enable/disable.
Bump jest types.