### PR TITLE
fix: admin handlers for migrations

### DIFF
--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -4,13 +4,14 @@ import {
   resetMigrationsOnTenants,
   runMigrationsOnAllTenants,
 } from '@internal/database/migrations'
-import { Queue } from '@internal/queue'
+import { PG_BOSS_SCHEMA, Queue } from '@internal/queue'
 import { RunMigrationsOnTenants } from '@storage/events'
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
 import apiKey from '../../plugins/apikey'
 
 const { pgQueueEnable } = getConfig()
+const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
@@ -59,9 +60,9 @@ export default async function routes(fastify: FastifyInstance) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
     const data = await multitenantKnex
-      .table('pgboss_v10.job')
+      .table(`${PG_BOSS_SCHEMA}.job`)
       .where('state', 'active')
-      .where('name', 'tenants-migrations')
+      .where('name', migrationQueueName)
       .orderBy('created_on', 'desc')
       .limit(2000)
 
@@ -73,9 +74,9 @@ export default async function routes(fastify: FastifyInstance) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
     const data = await multitenantKnex
-      .table('pgboss_v10.job')
+      .table(`${PG_BOSS_SCHEMA}.job`)
       .where('state', 'active')
-      .where('name', 'tenants-migrations')
+      .where('name', migrationQueueName)
       .orderBy('created_on', 'desc')
       .update({ state: 'completed' })
       .limit(2000)

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -15,6 +15,8 @@ import {
   runMigrationsOnTenant,
 } from '@internal/database/migrations'
 import { StorageBackendError } from '@internal/errors'
+import { PG_BOSS_SCHEMA } from '@internal/queue'
+import { RunMigrationsOnTenants } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig, JwksConfigKey } from '../../../config'
@@ -128,6 +130,7 @@ interface tenantDBInterface {
 }
 
 const { dbMigrationFreezeAt, icebergEnabled, vectorEnabled } = getConfig()
+const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
@@ -630,11 +633,11 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.get<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
     const data = await multitenantKnex
-      .table('pgboss.job')
+      .table(`${PG_BOSS_SCHEMA}.job`)
       .select('*')
       .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
-      .where('name', 'tenants-migrations')
-      .orderBy('createdon', 'desc')
+      .where('name', migrationQueueName)
+      .orderBy('created_on', 'desc')
       .limit(100)
 
     reply.send(data)
@@ -642,10 +645,10 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.delete<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
     const data = await multitenantKnex
-      .table('pgboss.job')
+      .table(`${PG_BOSS_SCHEMA}.job`)
       .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
-      .where('name', 'tenants-migrations')
-      .orderBy('createdon', 'desc')
+      .where('name', migrationQueueName)
+      .orderBy('created_on', 'desc')
       .limit(100)
       .delete()
 

--- a/src/internal/queue/event.ts
+++ b/src/internal/queue/event.ts
@@ -6,7 +6,7 @@ import { KnexQueueDB } from '@internal/queue/database'
 import { Knex } from 'knex'
 import PgBoss, { Job, Queue as PgBossQueue, SendOptions, WorkOptions } from 'pg-boss'
 import { getConfig } from '../../config'
-import { Queue } from './queue'
+import { PG_BOSS_SCHEMA, Queue } from './queue'
 
 export interface BasePayload {
   $version?: string
@@ -186,10 +186,10 @@ export class Event<T extends Omit<BasePayload, '$version'>> {
     }
 
     await Queue.getDb().executeSql(
-      `DELETE FROM pgboss_v10.job
+      `DELETE FROM ${PG_BOSS_SCHEMA}.job
        WHERE id = $1
        AND EXISTS(
-          SELECT 1 FROM pgboss_v10.job
+          SELECT 1 FROM ${PG_BOSS_SCHEMA}.job
              WHERE id != $2
              AND state < 'active'
              AND name = $3

--- a/src/internal/queue/queue.ts
+++ b/src/internal/queue/queue.ts
@@ -13,6 +13,8 @@ type SubclassOfBaseClass = (new (
   [K in keyof typeof Event]: (typeof Event)[K]
 }
 
+export const PG_BOSS_SCHEMA = 'pgboss_v10'
+
 export abstract class Queue {
   protected static events: SubclassOfBaseClass[] = []
   private static pgBoss?: PgBoss
@@ -51,7 +53,7 @@ export abstract class Queue {
       connectionString: url,
       migrate,
       db: opts.db,
-      schema: 'pgboss_v10',
+      schema: PG_BOSS_SCHEMA,
       ...(pgQueueDeleteAfterHours
         ? { deleteAfterHours: pgQueueDeleteAfterHours }
         : { deleteAfterDays: pgQueueDeleteAfterDays }),

--- a/src/storage/events/pgboss/move-jobs.ts
+++ b/src/storage/events/pgboss/move-jobs.ts
@@ -1,6 +1,6 @@
 import { multitenantKnex } from '@internal/database'
 import { logger, logSchema } from '@internal/monitoring'
-import { BasePayload, Queue } from '@internal/queue'
+import { BasePayload, PG_BOSS_SCHEMA, Queue } from '@internal/queue'
 import { Job, Queue as PgBossQueue, SendOptions, WorkOptions } from 'pg-boss'
 import { BaseEvent } from '../base-event'
 
@@ -46,7 +46,7 @@ export class MoveJobs extends BaseEvent<MoveJobsPayload> {
         return
       }
 
-      const schema = 'pgboss_v10'
+      const schema = PG_BOSS_SCHEMA
       const fromQueueName = job.data.fromQueue
       const toQueue = await Queue.getInstance().getQueue(job.data.toQueue)
 

--- a/src/storage/events/pgboss/upgrade-v10.ts
+++ b/src/storage/events/pgboss/upgrade-v10.ts
@@ -1,6 +1,6 @@
 import { multitenantKnex } from '@internal/database'
 import { logger, logSchema } from '@internal/monitoring'
-import { BasePayload, Queue } from '@internal/queue'
+import { BasePayload, PG_BOSS_SCHEMA, Queue } from '@internal/queue'
 import { Job, Queue as PgBossQueue, SendOptions, WorkOptions } from 'pg-boss'
 import { BaseEvent } from '../base-event'
 
@@ -42,7 +42,7 @@ export class UpgradePgBossV10 extends BaseEvent<UpgradePgBossV10Payload> {
         return
       }
 
-      const targetSchema = 'pgboss_v10'
+      const targetSchema = PG_BOSS_SCHEMA
       const sourceSchema = 'pgboss'
 
       const queues = await Queue.getInstance().getQueues()

--- a/src/test/admin-migrations-disabled.test.ts
+++ b/src/test/admin-migrations-disabled.test.ts
@@ -1,0 +1,47 @@
+import { getConfig, mergeConfig } from '../config'
+
+getConfig()
+mergeConfig({
+  pgQueueEnable: false,
+})
+
+import { adminApp } from './common'
+
+type DisabledRouteCase = {
+  method: 'DELETE' | 'GET' | 'POST'
+  url: string
+  payload?: Record<string, unknown>
+}
+
+const disabledRouteCases: DisabledRouteCase[] = [
+  { method: 'POST', url: '/migrations/migrate/fleet' },
+  {
+    method: 'POST',
+    url: '/migrations/reset/fleet',
+    payload: { untilMigration: 'storage-schema' },
+  },
+  { method: 'GET', url: '/migrations/active' },
+  { method: 'DELETE', url: '/migrations/active' },
+  { method: 'GET', url: '/migrations/progress' },
+  { method: 'GET', url: '/migrations/failed' },
+]
+
+describe('Admin migrations routes with queue disabled', () => {
+  afterAll(async () => {
+    await adminApp.close()
+  })
+
+  for (const { method, url, payload } of disabledRouteCases) {
+    test(`returns 400 for ${method} ${url} when queue is disabled`, async () => {
+      const response = await adminApp.inject({
+        method,
+        url,
+        payload,
+        headers: { apikey: process.env.ADMIN_API_KEYS },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({ message: 'Queue is not enabled' })
+    })
+  }
+})

--- a/src/test/admin-migrations.test.ts
+++ b/src/test/admin-migrations.test.ts
@@ -11,8 +11,11 @@ jest.mock('@internal/database/migrations', () => {
 
 import * as migrations from '@internal/database/migrations'
 import { DBMigration } from '@internal/database/migrations'
+import { randomUUID } from 'crypto'
 import { mergeConfig } from '../config'
 import { multitenantKnex } from '../internal/database/multitenant-db'
+import { PG_BOSS_SCHEMA, Queue } from '../internal/queue/queue'
+import { RunMigrationsOnTenants } from '../storage/events/migrations/run-migrations'
 
 mergeConfig({
   pgQueueEnable: true,
@@ -21,6 +24,12 @@ mergeConfig({
 import { adminApp } from './common'
 
 const tenantId = 'admin-migrations-test-tenant'
+const createdJobIds = new Set<string>()
+const createdTenantIds = new Set<string>()
+const pgBossJobTable = `${PG_BOSS_SCHEMA}.job`
+const headers = {
+  apikey: process.env.ADMIN_API_KEYS,
+}
 
 const tenantPayload = {
   anonKey: 'anon-key',
@@ -29,21 +38,57 @@ const tenantPayload = {
   serviceKey: 'service-key',
 }
 
+function trackJobId(jobId: string) {
+  createdJobIds.add(jobId)
+  return jobId
+}
+
+async function createTenant(currentTenantId: string) {
+  createdTenantIds.add(currentTenantId)
+  const response = await adminApp.inject({
+    method: 'POST',
+    url: `/tenants/${currentTenantId}`,
+    payload: tenantPayload,
+    headers,
+  })
+
+  expect(response.statusCode).toBe(201)
+}
+
 describe('Admin migrations routes', () => {
   beforeAll(async () => {
     await migrations.runMultitenantMigrations()
+    await multitenantKnex.raw(`CREATE SCHEMA IF NOT EXISTS ${PG_BOSS_SCHEMA}`)
+    await multitenantKnex.raw(`
+      CREATE TABLE IF NOT EXISTS ${pgBossJobTable} (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        state text NOT NULL,
+        created_on timestamptz NOT NULL DEFAULT now(),
+        data jsonb NOT NULL DEFAULT '{}'::jsonb
+      )
+    `)
   })
 
   afterEach(async () => {
+    jest.restoreAllMocks()
     jest.clearAllMocks()
 
-    await adminApp.inject({
-      method: 'DELETE',
-      url: `/tenants/${tenantId}`,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
+    if (createdJobIds.size > 0) {
+      await multitenantKnex(pgBossJobTable).whereIn('id', Array.from(createdJobIds)).delete()
+      createdJobIds.clear()
+    }
+
+    const tenantIdsToDelete = new Set([tenantId, ...createdTenantIds])
+    createdTenantIds.clear()
+
+    for (const currentTenantId of tenantIdsToDelete) {
+      await adminApp.inject({
+        method: 'DELETE',
+        url: `/tenants/${currentTenantId}`,
+        headers,
+      })
+    }
   })
 
   afterAll(async () => {
@@ -60,9 +105,7 @@ describe('Admin migrations routes', () => {
         untilMigration: 'storage-schema' satisfies keyof typeof DBMigration,
         markCompletedTillMigration: 'not-a-real-migration',
       },
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
+      headers,
     })
 
     expect(response.statusCode).toBe(400)
@@ -71,14 +114,7 @@ describe('Admin migrations routes', () => {
   })
 
   test('rejects invalid markCompletedTillMigration for tenant reset', async () => {
-    await adminApp.inject({
-      method: 'POST',
-      url: `/tenants/${tenantId}`,
-      payload: tenantPayload,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
+    await createTenant(tenantId)
 
     const resetSpy = jest.mocked(migrations.resetMigration).mockResolvedValue(false)
 
@@ -89,9 +125,7 @@ describe('Admin migrations routes', () => {
         untilMigration: 'storage-schema' satisfies keyof typeof DBMigration,
         markCompletedTillMigration: 'not-a-real-migration',
       },
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
+      headers,
     })
 
     expect(response.statusCode).toBe(400)
@@ -108,9 +142,7 @@ describe('Admin migrations routes', () => {
       payload: {
         untilMigration: 'create-migrations-table' satisfies keyof typeof DBMigration,
       },
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
+      headers,
     })
 
     expect(response.statusCode).toBe(200)
@@ -120,5 +152,331 @@ describe('Admin migrations routes', () => {
       markCompletedTillMigration: undefined,
       signal: expect.any(AbortSignal),
     })
+  })
+
+  test('lists active fleet migration jobs from the current pg-boss queue name', async () => {
+    const fleetTenantId = `admin-migrations-fleet-${randomUUID().slice(0, 8)}`
+    const jobId = trackJobId(randomUUID())
+    const wrongQueueJobId = trackJobId(randomUUID())
+    const wrongStateJobId = trackJobId(randomUUID())
+
+    await createTenant(fleetTenantId)
+
+    await multitenantKnex(pgBossJobTable).insert({
+      id: jobId,
+      name: RunMigrationsOnTenants.getQueueName(),
+      state: 'active',
+      data: {
+        tenantId: fleetTenantId,
+      },
+    })
+    await multitenantKnex(pgBossJobTable).insert({
+      id: wrongQueueJobId,
+      name: 'another-queue',
+      state: 'active',
+      data: {
+        tenantId: fleetTenantId,
+      },
+    })
+    await multitenantKnex(pgBossJobTable).insert({
+      id: wrongStateJobId,
+      name: RunMigrationsOnTenants.getQueueName(),
+      state: 'created',
+      data: {
+        tenantId: fleetTenantId,
+      },
+    })
+
+    const response = await adminApp.inject({
+      method: 'GET',
+      url: '/migrations/active',
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = JSON.parse(response.body)
+    expect(body).toHaveLength(1)
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: jobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'active',
+      }),
+    ])
+  })
+
+  test('lists tenant migration jobs from the current pg-boss schema and queue name', async () => {
+    const jobTenantId = `admin-migrations-tenant-${randomUUID().slice(0, 8)}`
+    const otherTenantId = `admin-migrations-other-${randomUUID().slice(0, 8)}`
+    const olderJobId = trackJobId(randomUUID())
+    const newerJobId = trackJobId(randomUUID())
+    const otherTenantJobId = trackJobId(randomUUID())
+    const wrongQueueJobId = trackJobId(randomUUID())
+
+    await createTenant(jobTenantId)
+    await createTenant(otherTenantId)
+
+    await multitenantKnex(pgBossJobTable).insert({
+      id: olderJobId,
+      name: RunMigrationsOnTenants.getQueueName(),
+      state: 'active',
+      created_on: new Date('2026-03-25T10:00:00.000Z'),
+      data: {
+        tenant: {
+          ref: jobTenantId,
+        },
+        tenantId: jobTenantId,
+      },
+    })
+    await multitenantKnex(pgBossJobTable).insert({
+      id: newerJobId,
+      name: RunMigrationsOnTenants.getQueueName(),
+      state: 'active',
+      created_on: new Date('2026-03-25T11:00:00.000Z'),
+      data: {
+        tenant: {
+          ref: jobTenantId,
+        },
+        tenantId: jobTenantId,
+      },
+    })
+    await multitenantKnex(pgBossJobTable).insert({
+      id: otherTenantJobId,
+      name: RunMigrationsOnTenants.getQueueName(),
+      state: 'active',
+      data: {
+        tenant: {
+          ref: otherTenantId,
+        },
+        tenantId: otherTenantId,
+      },
+    })
+    await multitenantKnex(pgBossJobTable).insert({
+      id: wrongQueueJobId,
+      name: 'another-queue',
+      state: 'active',
+      data: {
+        tenant: {
+          ref: jobTenantId,
+        },
+        tenantId: jobTenantId,
+      },
+    })
+
+    const response = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/${jobTenantId}/migrations/jobs`,
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = JSON.parse(response.body)
+    expect(body).toHaveLength(2)
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: newerJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+      }),
+      expect.objectContaining({
+        id: olderJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+      }),
+    ])
+  })
+
+  test('returns queue progress for the current migration queue', async () => {
+    const getQueueSize = jest.fn().mockResolvedValue(7)
+    jest.spyOn(Queue, 'getInstance').mockReturnValue({
+      getQueueSize,
+    } as never)
+
+    const response = await adminApp.inject({
+      method: 'GET',
+      url: '/migrations/progress',
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({ remaining: 7 })
+    expect(getQueueSize).toHaveBeenCalledWith(RunMigrationsOnTenants.getQueueName())
+  })
+
+  test('lists failed tenants and paginates by cursor', async () => {
+    const firstFailedTenantId = `admin-migrations-failed-${randomUUID().slice(0, 8)}`
+    const secondFailedTenantId = `admin-migrations-failed-${randomUUID().slice(0, 8)}`
+    const healthyTenantId = `admin-migrations-ok-${randomUUID().slice(0, 8)}`
+
+    await createTenant(firstFailedTenantId)
+    await createTenant(secondFailedTenantId)
+    await createTenant(healthyTenantId)
+
+    await multitenantKnex('tenants').where({ id: firstFailedTenantId }).update({
+      migrations_status: 'FAILED',
+    })
+    await multitenantKnex('tenants').where({ id: secondFailedTenantId }).update({
+      migrations_status: 'FAILED',
+    })
+    await multitenantKnex('tenants').where({ id: healthyTenantId }).update({
+      migrations_status: 'COMPLETED',
+    })
+
+    const firstPageResponse = await adminApp.inject({
+      method: 'GET',
+      url: '/migrations/failed',
+      headers,
+    })
+
+    expect(firstPageResponse.statusCode).toBe(200)
+    const firstPageBody = JSON.parse(firstPageResponse.body)
+    expect(firstPageBody.data).toHaveLength(2)
+    expect(firstPageBody.data.map((tenant: { id: string }) => tenant.id)).toEqual([
+      firstFailedTenantId,
+      secondFailedTenantId,
+    ])
+
+    const secondPageResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/migrations/failed?cursor=${firstPageBody.data[0].cursor_id}`,
+      headers,
+    })
+
+    expect(secondPageResponse.statusCode).toBe(200)
+    expect(JSON.parse(secondPageResponse.body)).toEqual({
+      next_cursor_id: firstPageBody.data[1].cursor_id,
+      data: [
+        expect.objectContaining({
+          id: secondFailedTenantId,
+          cursor_id: firstPageBody.data[1].cursor_id,
+        }),
+      ],
+    })
+  })
+
+  test('marks only active fleet migration jobs from the current queue as completed', async () => {
+    const matchingJobId = trackJobId(randomUUID())
+    const wrongQueueJobId = trackJobId(randomUUID())
+    const wrongStateJobId = trackJobId(randomUUID())
+
+    await multitenantKnex(pgBossJobTable).insert([
+      {
+        id: matchingJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'active',
+        data: {},
+      },
+      {
+        id: wrongQueueJobId,
+        name: 'another-queue',
+        state: 'active',
+        data: {},
+      },
+      {
+        id: wrongStateJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'created',
+        data: {},
+      },
+    ])
+
+    const response = await adminApp.inject({
+      method: 'DELETE',
+      url: '/migrations/active',
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toBe(1)
+
+    const rows = await multitenantKnex(pgBossJobTable)
+      .select('id', 'state')
+      .whereIn('id', [matchingJobId, wrongQueueJobId, wrongStateJobId])
+    const statesById = Object.fromEntries(rows.map((row) => [row.id, row.state]))
+
+    expect(statesById).toEqual({
+      [matchingJobId]: 'completed',
+      [wrongQueueJobId]: 'active',
+      [wrongStateJobId]: 'created',
+    })
+  })
+
+  test('deletes only tenant migration jobs from the current queue', async () => {
+    const tenantWithJobsId = `admin-migrations-delete-${randomUUID().slice(0, 8)}`
+    const otherTenantId = `admin-migrations-delete-other-${randomUUID().slice(0, 8)}`
+    const matchingJobId = trackJobId(randomUUID())
+    const otherTenantJobId = trackJobId(randomUUID())
+    const wrongQueueJobId = trackJobId(randomUUID())
+
+    await createTenant(tenantWithJobsId)
+    await createTenant(otherTenantId)
+
+    await multitenantKnex(pgBossJobTable).insert([
+      {
+        id: matchingJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'active',
+        data: {
+          tenant: {
+            ref: tenantWithJobsId,
+          },
+          tenantId: tenantWithJobsId,
+        },
+      },
+      {
+        id: otherTenantJobId,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'active',
+        data: {
+          tenant: {
+            ref: otherTenantId,
+          },
+          tenantId: otherTenantId,
+        },
+      },
+      {
+        id: wrongQueueJobId,
+        name: 'another-queue',
+        state: 'active',
+        data: {
+          tenant: {
+            ref: tenantWithJobsId,
+          },
+          tenantId: tenantWithJobsId,
+        },
+      },
+    ])
+
+    const response = await adminApp.inject({
+      method: 'DELETE',
+      url: `/tenants/${tenantWithJobsId}/migrations/jobs`,
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toBe(1)
+
+    const rows = await multitenantKnex(pgBossJobTable)
+      .select('id', 'name')
+      .whereIn('id', [matchingJobId, otherTenantJobId, wrongQueueJobId])
+    const namesById = Object.fromEntries(rows.map((row) => [row.id, row.name]))
+
+    expect(namesById).toEqual({
+      [otherTenantJobId]: RunMigrationsOnTenants.getQueueName(),
+      [wrongQueueJobId]: 'another-queue',
+    })
+  })
+
+  test('returns 0 when deleting tenant migration jobs for a tenant with no matching jobs', async () => {
+    const tenantWithoutJobsId = `admin-migrations-empty-${randomUUID().slice(0, 8)}`
+
+    await createTenant(tenantWithoutJobsId)
+
+    const response = await adminApp.inject({
+      method: 'DELETE',
+      url: `/tenants/${tenantWithoutJobsId}/migrations/jobs`,
+      headers,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toBe(0)
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Admin handlers are looking into wrong queue for migration ops.

## What is the new behavior?

Admin handlers are using event helpers to find the queue name so that it can't go out of sync.
Accordingly `createdOn` is updated to `created_on` in one query. Also, improve test coverage a bit.

## Additional context

https://github.com/supabase/storage/pull/755
