### PR TITLE
fix: update api spec, add admin api spec, add release action to publish versioned spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate API Specs for Release
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          npm run docs:export
+        env:
+          VERSION: ${{ steps.semantic.outputs.new_release_version }}
+          ANON_KEY: ${{ secrets.ANON_KEY }}
+          SERVICE_KEY: ${{ secrets.SERVICE_KEY }}
+          TENANT_ID: ${{ secrets.TENANT_ID }}
+          REGION: ${{ secrets.REGION }}
+          POSTGREST_URL: ${{ secrets.POSTGREST_URL }}
+          GLOBAL_S3_BUCKET: ${{ secrets.GLOBAL_S3_BUCKET }}
+          PGRST_JWT_SECRET: ${{ secrets.PGRST_JWT_SECRET }}
+          AUTHENTICATED_KEY: ${{ secrets.AUTHENTICATED_KEY }}
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1/postgres
+          PGOPTIONS: -c search_path=storage,public
+          FILE_SIZE_LIMIT: "52428800"
+          STORAGE_BACKEND: s3
+          ENABLE_IMAGE_TRANSFORMATION: true
+
+      - name: Attach API Specs to Release
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: v${{ steps.semantic.outputs.new_release_version }}
+          files: |
+            static/api.json
+            static/api-admin.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     needs:
       - release

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .env.*
 !.*.sample
 static/api.json
+static/api-admin.json
 data/
 bin/
 coverage/

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -1,12 +1,45 @@
+import fastifySwagger from '@fastify/swagger'
+import fastifySwaggerUi from '@fastify/swagger-ui'
 import { handleMetricsRequest } from '@internal/monitoring/otel-metrics'
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import { getConfig } from './config'
 import { plugins, routes, setErrorHandler } from './http'
 
+interface buildOpts extends FastifyServerOptions {
+  exposeDocs?: boolean
+}
+
 const { version, prometheusMetricsEnabled } = getConfig()
 
-const build = (opts: FastifyServerOptions = {}): FastifyInstance => {
+const build = (opts: buildOpts = {}): FastifyInstance => {
   const app = fastify(opts)
+
+  if (opts.exposeDocs) {
+    app.register(fastifySwagger, {
+      exposeHeadRoutes: true,
+      openapi: {
+        info: {
+          title: 'Supabase Storage Admin API',
+          description: 'Admin API documentation for Supabase Storage',
+          version,
+        },
+        tags: [
+          { name: 'tenant', description: 'Tenant management' },
+          { name: 'object', description: 'Object management' },
+          { name: 'jwks', description: 'JWKS configuration' },
+          { name: 'migration', description: 'Database migrations' },
+          { name: 's3-credentials', description: 'S3 credentials management' },
+          { name: 'queue', description: 'Queue management' },
+          { name: 'metrics', description: 'Metrics configuration' },
+        ],
+      },
+    })
+
+    app.register(fastifySwaggerUi, {
+      routePrefix: '/documentation',
+    })
+  }
+
   app.register(plugins.signals)
   app.register(plugins.adminTenantId)
   app.register(plugins.logRequest({ excludeUrls: ['/status', '/metrics', '/health', '/version'] }))

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
 
   if (opts.exposeDocs) {
     app.register(fastifySwagger, {
+      exposeHeadRoutes: true,
       openapi: {
         info: {
           title: 'Supabase Storage API',
@@ -37,6 +38,10 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
           { name: 's3', description: 'S3 end-points' },
           { name: 'transformation', description: 'Image transformation' },
           { name: 'resumable', description: 'Resumable Upload end-points' },
+          { name: 'cdn', description: 'CDN cache management' },
+          { name: 'health', description: 'Health check end-points' },
+          { name: 'iceberg', description: 'Apache Iceberg REST catalog' },
+          { name: 'vector', description: 'Vector storage and search' },
         ],
       },
     })

--- a/src/http/routes/admin/jwks.ts
+++ b/src/http/routes/admin/jwks.ts
@@ -102,7 +102,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.post<JwksAddRequestInterface>(
     '/:tenantId/jwks',
-    { schema: addSchema },
+    { schema: { ...addSchema, tags: ['jwks'] } },
     async ({ body, params }, reply) => {
       const validationResult = validateAddJwkRequest(body)
       if (validationResult?.message) {
@@ -116,7 +116,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.put<JwksUpdateRequestInterface>(
     '/:tenantId/jwks/:kid',
-    { schema: updateSchema },
+    { schema: { ...updateSchema, tags: ['jwks'] } },
     async (request, reply) => {
       const {
         params: { tenantId, kid },
@@ -127,26 +127,30 @@ export default async function routes(fastify: FastifyInstance) {
     }
   )
 
-  fastify.post('/jwks/generate-all-missing', async (request, reply) => {
-    const { running, sent } = UrlSigningJwkGenerator.getGenerationStatus()
-    if (running) {
-      return reply
-        .status(400)
-        .send(`Generate missing jwks is already running, and has sent ${sent} items so far`)
-    }
+  fastify.post(
+    '/jwks/generate-all-missing',
+    { schema: { tags: ['jwks'] } },
+    async (request, reply) => {
+      const { running, sent } = UrlSigningJwkGenerator.getGenerationStatus()
+      if (running) {
+        return reply
+          .status(400)
+          .send(`Generate missing jwks is already running, and has sent ${sent} items so far`)
+      }
 
-    UrlSigningJwkGenerator.generateUrlSigningJwksOnAllTenants(
-      request.signals.disconnect.signal
-    ).catch((e) => {
-      logSchema.error(request.log, 'Error generating url signing jwks for all tenants', {
-        type: 'jwk-generator',
-        error: e,
+      UrlSigningJwkGenerator.generateUrlSigningJwksOnAllTenants(
+        request.signals.disconnect.signal
+      ).catch((e) => {
+        logSchema.error(request.log, 'Error generating url signing jwks for all tenants', {
+          type: 'jwk-generator',
+          error: e,
+        })
       })
-    })
-    return reply.send({ started: true })
-  })
+      return reply.send({ started: true })
+    }
+  )
 
-  fastify.get('/jwks/generate-all-missing', (request, reply) => {
+  fastify.get('/jwks/generate-all-missing', { schema: { tags: ['jwks'] } }, (request, reply) => {
     return reply.send(UrlSigningJwkGenerator.getGenerationStatus())
   })
 }

--- a/src/http/routes/admin/metrics.ts
+++ b/src/http/routes/admin/metrics.ts
@@ -30,7 +30,7 @@ interface UpdateMetricsConfigRequest extends RequestGenericInterface {
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
 
-  fastify.get('/config', async (_request, reply) => {
+  fastify.get('/config', { schema: { tags: ['metrics'] } }, async (_request, reply) => {
     return reply.send({
       metrics: getMetricsConfig(),
     })
@@ -38,7 +38,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.put<UpdateMetricsConfigRequest>(
     '/config',
-    { schema: updateMetricsConfigSchema },
+    { schema: { ...updateMetricsConfigSchema, tags: ['metrics'] } },
     async (request, reply) => {
       setMetricsEnabled(request.body.metrics)
       return reply.code(200).send({

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -16,7 +16,7 @@ const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
 
-  fastify.post('/migrate/fleet', async (req, reply) => {
+  fastify.post('/migrate/fleet', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.status(400).send({ message: 'Queue is not enabled' })
     }
@@ -26,7 +26,7 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send({ message: 'Migrations scheduled' })
   })
 
-  fastify.post('/reset/fleet', async (req, reply) => {
+  fastify.post('/reset/fleet', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.status(400).send({ message: 'Queue is not enabled' })
     }
@@ -55,7 +55,7 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send({ message: 'Migrations scheduled' })
   })
 
-  fastify.get('/active', async (req, reply) => {
+  fastify.get('/active', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
@@ -69,7 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send(data)
   })
 
-  fastify.delete('/active', async (req, reply) => {
+  fastify.delete('/active', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
@@ -84,7 +84,7 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send(data)
   })
 
-  fastify.get('/progress', async (req, reply) => {
+  fastify.get('/progress', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
@@ -92,7 +92,7 @@ export default async function routes(fastify: FastifyInstance) {
     return { remaining: queueSize }
   })
 
-  fastify.get('/failed', async (req, reply) => {
+  fastify.get('/failed', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }

--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -80,7 +80,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.get<ListOrphanObjectsRequest>(
     '/:tenantId/buckets/:bucketId/orphan-objects',
     {
-      schema: listOrphanedObjects,
+      schema: { ...listOrphanedObjects, tags: ['object'] },
     },
     async (req, reply) => {
       const bucket = req.params.bucketId
@@ -133,7 +133,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.delete<SyncOrphanObjectsRequest>(
     '/:tenantId/buckets/:bucketId/orphan-objects',
     {
-      schema: syncOrphanedObjects,
+      schema: { ...syncOrphanedObjects, tags: ['object'] },
     },
     async (req, reply) => {
       if (!req.body.deleteDbKeys && !req.body.deleteS3Keys) {

--- a/src/http/routes/admin/queue.ts
+++ b/src/http/routes/admin/queue.ts
@@ -32,7 +32,7 @@ interface MoveJobsRequestInterface extends RequestGenericInterface {
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
 
-  fastify.post('/migrate/pgboss-v10', async (req, reply) => {
+  fastify.post('/migrate/pgboss-v10', { schema: { tags: ['queue'] } }, async (req, reply) => {
     if (!pgQueueEnable) {
       return reply.status(400).send({ message: 'Queue is not enabled' })
     }
@@ -42,21 +42,25 @@ export default async function routes(fastify: FastifyInstance) {
     return reply.send({ message: 'Migration scheduled' })
   })
 
-  fastify.post<MoveJobsRequestInterface>('/move', async (req, reply) => {
-    if (!pgQueueEnable) {
-      return reply.status(400).send({ message: 'Queue is not enabled' })
+  fastify.post<MoveJobsRequestInterface>(
+    '/move',
+    { schema: { tags: ['queue'] } },
+    async (req, reply) => {
+      if (!pgQueueEnable) {
+        return reply.status(400).send({ message: 'Queue is not enabled' })
+      }
+
+      const fromQueue = req.body.fromQueue
+      const toQueue = req.body.toQueue
+      const deleteJobsFromOriginalQueue = req.body.deleteJobsFromOriginalQueue || false
+
+      await MoveJobs.send({
+        fromQueue,
+        toQueue,
+        deleteJobsFromOriginalQueue,
+      })
+
+      return reply.send({ message: 'Move jobs scheduled' })
     }
-
-    const fromQueue = req.body.fromQueue
-    const toQueue = req.body.toQueue
-    const deleteJobsFromOriginalQueue = req.body.deleteJobsFromOriginalQueue || false
-
-    await MoveJobs.send({
-      fromQueue,
-      toQueue,
-      deleteJobsFromOriginalQueue,
-    })
-
-    return reply.send({ message: 'Move jobs scheduled' })
-  })
+  )
 }

--- a/src/http/routes/admin/s3.ts
+++ b/src/http/routes/admin/s3.ts
@@ -87,7 +87,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.post<CreateCredentialsRequest>(
     '/:tenantId/credentials',
     {
-      schema: createCredentialsSchema,
+      schema: { ...createCredentialsSchema, tags: ['s3-credentials'] },
     },
     async (req, reply) => {
       const credentials = await s3CredentialsManager.createS3Credentials(req.params.tenantId, {
@@ -106,7 +106,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.get<ListCredentialsRequest>(
     '/:tenantId/credentials',
-    { schema: listCredentialsSchema },
+    { schema: { ...listCredentialsSchema, tags: ['s3-credentials'] } },
     async (req, reply) => {
       const credentials = await s3CredentialsManager.listS3Credentials(req.params.tenantId)
       return reply.send(credentials)
@@ -115,7 +115,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.delete<DeleteCredentialsRequest>(
     '/:tenantId/credentials',
-    { schema: deleteCredentialsSchema },
+    { schema: { ...deleteCredentialsSchema, tags: ['s3-credentials'] } },
     async (req, reply) => {
       if (!isUuid(req.body.id)) {
         throw ERRORS.InvalidParameter('id not uuid')

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -135,7 +135,7 @@ const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(apiKey)
 
-  fastify.get('/', async () => {
+  fastify.get('/', { schema: { tags: ['tenant'] } }, async () => {
     const tenants = await multitenantKnex('tenants').select()
     return tenants.map(
       ({
@@ -206,153 +206,161 @@ export default async function routes(fastify: FastifyInstance) {
     )
   })
 
-  fastify.get<tenantRequestInterface>('/:tenantId', async (request, reply) => {
-    const tenant = await multitenantKnex('tenants').first().where('id', request.params.tenantId)
-    if (!tenant) {
-      return reply.code(404).send()
-    }
-    const {
-      anon_key,
-      database_url,
-      database_pool_url,
-      database_pool_mode,
-      max_connections,
-      file_size_limit,
-      jwt_secret,
-      jwks,
-      service_key,
-      feature_purge_cache,
-      feature_s3_protocol,
-      feature_image_transformation,
-      feature_iceberg_catalog,
-      feature_iceberg_catalog_max_catalogs,
-      feature_iceberg_catalog_max_namespaces,
-      feature_iceberg_catalog_max_tables,
-      feature_vector_buckets,
-      feature_vector_buckets_max_buckets,
-      feature_vector_buckets_max_indexes,
-      image_transformation_max_resolution,
-      migrations_version,
-      migrations_status,
-      tracing_mode,
-      disable_events,
-    } = tenant
-
-    const capabilities = await getTenantCapabilities(request.params.tenantId)
-
-    return {
-      anonKey: decrypt(anon_key),
-      databaseUrl: decrypt(database_url),
-      databasePoolUrl:
-        database_pool_url === null
-          ? null
-          : database_pool_url
-            ? decrypt(database_pool_url)
-            : undefined,
-      databasePoolMode: database_pool_mode,
-      maxConnections: max_connections ? Number(max_connections) : undefined,
-      fileSizeLimit: Number(file_size_limit),
-      jwtSecret: decrypt(jwt_secret),
-      jwks,
-      serviceKey: decrypt(service_key),
-      capabilities,
-      features: {
-        imageTransformation: {
-          enabled: feature_image_transformation,
-          maxResolution: image_transformation_max_resolution,
-        },
-        purgeCache: {
-          enabled: feature_purge_cache,
-        },
-        s3Protocol: {
-          enabled: feature_s3_protocol,
-        },
-        icebergCatalog: {
-          enabled: icebergEnabled || feature_iceberg_catalog,
-          maxNamespaces: feature_iceberg_catalog_max_namespaces,
-          maxTables: feature_iceberg_catalog_max_tables,
-          maxCatalogs: feature_iceberg_catalog_max_catalogs,
-        },
-        vectorBuckets: {
-          enabled: vectorEnabled || feature_vector_buckets,
-          maxBuckets: feature_vector_buckets_max_buckets,
-          maxIndexes: feature_vector_buckets_max_indexes,
-        },
-      },
-      migrationVersion: migrations_version,
-      migrationStatus: migrations_status,
-      tracingMode: tracing_mode,
-      disableEvents: disable_events,
-    }
-  })
-
-  fastify.post<tenantRequestInterface>('/:tenantId', { schema }, async (request, reply) => {
-    const { tenantId } = request.params
-    const {
-      anonKey,
-      databaseUrl,
-      databasePoolMode,
-      fileSizeLimit,
-      jwtSecret,
-      jwks,
-      serviceKey,
-      features,
-      databasePoolUrl,
-      maxConnections,
-      tracingMode,
-    } = request.body
-
-    await multitenantKnex.transaction(async (trx) => {
-      await multitenantKnex('tenants').insert({
-        id: tenantId,
-        anon_key: encrypt(anonKey),
-        database_url: encrypt(databaseUrl),
-        database_pool_url: databasePoolUrl ? encrypt(databasePoolUrl) : undefined,
-        database_pool_mode: databasePoolMode,
-        max_connections: maxConnections ? Number(maxConnections) : undefined,
-        file_size_limit: fileSizeLimit,
-        jwt_secret: encrypt(jwtSecret),
+  fastify.get<tenantRequestInterface>(
+    '/:tenantId',
+    { schema: { tags: ['tenant'] } },
+    async (request, reply) => {
+      const tenant = await multitenantKnex('tenants').first().where('id', request.params.tenantId)
+      if (!tenant) {
+        return reply.code(404).send()
+      }
+      const {
+        anon_key,
+        database_url,
+        database_pool_url,
+        database_pool_mode,
+        max_connections,
+        file_size_limit,
+        jwt_secret,
         jwks,
-        service_key: encrypt(serviceKey),
-        feature_image_transformation: features?.imageTransformation?.enabled ?? false,
-        feature_purge_cache: features?.purgeCache?.enabled ?? false,
-        feature_s3_protocol: features?.s3Protocol?.enabled ?? true,
-        feature_iceberg_catalog: features?.icebergCatalog?.enabled ?? false,
-        feature_iceberg_catalog_max_catalogs: features?.icebergCatalog?.maxCatalogs,
-        feature_iceberg_catalog_max_namespaces: features?.icebergCatalog?.maxNamespaces,
-        feature_iceberg_catalog_max_tables: features?.icebergCatalog?.maxTables,
-        feature_vector_buckets: features?.vectorBuckets?.enabled ?? false,
-        feature_vector_buckets_max_buckets: features?.vectorBuckets?.maxBuckets,
-        feature_vector_buckets_max_indexes: features?.vectorBuckets?.maxIndexes,
-        migrations_version: null,
-        migrations_status: null,
-        tracing_mode: tracingMode,
-      })
-      await jwksManager.generateUrlSigningJwk(tenantId, trx)
-    })
+        service_key,
+        feature_purge_cache,
+        feature_s3_protocol,
+        feature_image_transformation,
+        feature_iceberg_catalog,
+        feature_iceberg_catalog_max_catalogs,
+        feature_iceberg_catalog_max_namespaces,
+        feature_iceberg_catalog_max_tables,
+        feature_vector_buckets,
+        feature_vector_buckets_max_buckets,
+        feature_vector_buckets_max_indexes,
+        image_transformation_max_resolution,
+        migrations_version,
+        migrations_status,
+        tracing_mode,
+        disable_events,
+      } = tenant
 
-    try {
-      await runMigrationsOnTenant({
-        databaseUrl,
-        tenantId,
-        upToMigration: dbMigrationFreezeAt,
-      })
-      await multitenantKnex('tenants')
-        .where('id', tenantId)
-        .update({
-          migrations_version: await lastLocalMigrationName(),
-          migrations_status: TenantMigrationStatus.COMPLETED,
-        })
-    } catch {
-      progressiveMigrations.addTenant(tenantId)
+      const capabilities = await getTenantCapabilities(request.params.tenantId)
+
+      return {
+        anonKey: decrypt(anon_key),
+        databaseUrl: decrypt(database_url),
+        databasePoolUrl:
+          database_pool_url === null
+            ? null
+            : database_pool_url
+              ? decrypt(database_pool_url)
+              : undefined,
+        databasePoolMode: database_pool_mode,
+        maxConnections: max_connections ? Number(max_connections) : undefined,
+        fileSizeLimit: Number(file_size_limit),
+        jwtSecret: decrypt(jwt_secret),
+        jwks,
+        serviceKey: decrypt(service_key),
+        capabilities,
+        features: {
+          imageTransformation: {
+            enabled: feature_image_transformation,
+            maxResolution: image_transformation_max_resolution,
+          },
+          purgeCache: {
+            enabled: feature_purge_cache,
+          },
+          s3Protocol: {
+            enabled: feature_s3_protocol,
+          },
+          icebergCatalog: {
+            enabled: icebergEnabled || feature_iceberg_catalog,
+            maxNamespaces: feature_iceberg_catalog_max_namespaces,
+            maxTables: feature_iceberg_catalog_max_tables,
+            maxCatalogs: feature_iceberg_catalog_max_catalogs,
+          },
+          vectorBuckets: {
+            enabled: vectorEnabled || feature_vector_buckets,
+            maxBuckets: feature_vector_buckets_max_buckets,
+            maxIndexes: feature_vector_buckets_max_indexes,
+          },
+        },
+        migrationVersion: migrations_version,
+        migrationStatus: migrations_status,
+        tracingMode: tracing_mode,
+        disableEvents: disable_events,
+      }
     }
+  )
 
-    reply.code(201).send()
-  })
+  fastify.post<tenantRequestInterface>(
+    '/:tenantId',
+    { schema: { ...schema, tags: ['tenant'] } },
+    async (request, reply) => {
+      const { tenantId } = request.params
+      const {
+        anonKey,
+        databaseUrl,
+        databasePoolMode,
+        fileSizeLimit,
+        jwtSecret,
+        jwks,
+        serviceKey,
+        features,
+        databasePoolUrl,
+        maxConnections,
+        tracingMode,
+      } = request.body
+
+      await multitenantKnex.transaction(async (trx) => {
+        await multitenantKnex('tenants').insert({
+          id: tenantId,
+          anon_key: encrypt(anonKey),
+          database_url: encrypt(databaseUrl),
+          database_pool_url: databasePoolUrl ? encrypt(databasePoolUrl) : undefined,
+          database_pool_mode: databasePoolMode,
+          max_connections: maxConnections ? Number(maxConnections) : undefined,
+          file_size_limit: fileSizeLimit,
+          jwt_secret: encrypt(jwtSecret),
+          jwks,
+          service_key: encrypt(serviceKey),
+          feature_image_transformation: features?.imageTransformation?.enabled ?? false,
+          feature_purge_cache: features?.purgeCache?.enabled ?? false,
+          feature_s3_protocol: features?.s3Protocol?.enabled ?? true,
+          feature_iceberg_catalog: features?.icebergCatalog?.enabled ?? false,
+          feature_iceberg_catalog_max_catalogs: features?.icebergCatalog?.maxCatalogs,
+          feature_iceberg_catalog_max_namespaces: features?.icebergCatalog?.maxNamespaces,
+          feature_iceberg_catalog_max_tables: features?.icebergCatalog?.maxTables,
+          feature_vector_buckets: features?.vectorBuckets?.enabled ?? false,
+          feature_vector_buckets_max_buckets: features?.vectorBuckets?.maxBuckets,
+          feature_vector_buckets_max_indexes: features?.vectorBuckets?.maxIndexes,
+          migrations_version: null,
+          migrations_status: null,
+          tracing_mode: tracingMode,
+        })
+        await jwksManager.generateUrlSigningJwk(tenantId, trx)
+      })
+
+      try {
+        await runMigrationsOnTenant({
+          databaseUrl,
+          tenantId,
+          upToMigration: dbMigrationFreezeAt,
+        })
+        await multitenantKnex('tenants')
+          .where('id', tenantId)
+          .update({
+            migrations_version: await lastLocalMigrationName(),
+            migrations_status: TenantMigrationStatus.COMPLETED,
+          })
+      } catch {
+        progressiveMigrations.addTenant(tenantId)
+      }
+
+      reply.code(201).send()
+    }
+  )
 
   fastify.patch<tenantPatchRequestInterface>(
     '/:tenantId',
-    { schema: patchSchema },
+    { schema: { ...patchSchema, tags: ['tenant'] } },
     async (request, reply) => {
       const {
         anonKey,
@@ -429,231 +437,259 @@ export default async function routes(fastify: FastifyInstance) {
     }
   )
 
-  fastify.put<tenantRequestInterface>('/:tenantId', { schema }, async (request, reply) => {
-    const {
-      anonKey,
-      databaseUrl,
-      fileSizeLimit,
-      jwtSecret,
-      jwks,
-      serviceKey,
-      features,
-      databasePoolUrl,
-      databasePoolMode,
-      maxConnections,
-      tracingMode,
-    } = request.body
-    const { tenantId } = request.params
-
-    const tenantInfo: tenantDBInterface & {
-      tracing_mode?: string
-    } = {
-      id: tenantId,
-      anon_key: encrypt(anonKey),
-      database_url: encrypt(databaseUrl),
-      jwt_secret: encrypt(jwtSecret),
-      jwks: jwks || null,
-      service_key: encrypt(serviceKey),
-    }
-
-    if (fileSizeLimit) {
-      tenantInfo.file_size_limit = fileSizeLimit
-    }
-
-    if (typeof features?.imageTransformation?.enabled !== 'undefined') {
-      tenantInfo.feature_image_transformation = features?.imageTransformation?.enabled
-    }
-
-    if (typeof features?.purgeCache?.enabled !== 'undefined') {
-      tenantInfo.feature_purge_cache = features?.purgeCache?.enabled
-    }
-
-    if (typeof features?.imageTransformation?.maxResolution !== 'undefined') {
-      tenantInfo.image_transformation_max_resolution = features?.imageTransformation
-        ?.image_transformation_max_resolution as number | undefined
-    }
-
-    if (typeof features?.s3Protocol?.enabled !== 'undefined') {
-      tenantInfo.feature_s3_protocol = features?.s3Protocol?.enabled
-    }
-
-    if (databasePoolUrl) {
-      tenantInfo.database_pool_url = encrypt(databasePoolUrl)
-    }
-
-    if (maxConnections) {
-      tenantInfo.max_connections = Number(maxConnections)
-    }
-
-    if (databasePoolMode) {
-      tenantInfo.database_pool_mode = databasePoolMode
-    }
-
-    if (tracingMode) {
-      tenantInfo.tracing_mode = tracingMode
-    }
-
-    tenantInfo.feature_iceberg_catalog = features?.icebergCatalog?.enabled
-    tenantInfo.feature_iceberg_catalog_max_namespaces = features?.icebergCatalog?.maxNamespaces
-    tenantInfo.feature_iceberg_catalog_max_tables = features?.icebergCatalog?.maxTables
-    tenantInfo.feature_iceberg_catalog_max_catalogs = features?.icebergCatalog?.maxCatalogs
-
-    tenantInfo.feature_vector_buckets = features?.vectorBuckets?.enabled
-    tenantInfo.feature_vector_buckets_max_buckets = features?.vectorBuckets?.maxBuckets
-    tenantInfo.feature_vector_buckets_max_indexes = features?.vectorBuckets?.maxIndexes
-
-    await multitenantKnex.transaction(async (trx) => {
-      await trx('tenants').insert(tenantInfo).onConflict('id').merge()
-      await jwksManager.generateUrlSigningJwk(tenantId, trx)
-    })
-
-    try {
-      await runMigrationsOnTenant({
+  fastify.put<tenantRequestInterface>(
+    '/:tenantId',
+    { schema: { ...schema, tags: ['tenant'] } },
+    async (request, reply) => {
+      const {
+        anonKey,
         databaseUrl,
-        tenantId,
-        upToMigration: dbMigrationFreezeAt,
-      })
-      await multitenantKnex('tenants')
-        .where('id', tenantId)
-        .update({
-          migrations_version: await lastLocalMigrationName(),
-          migrations_status: TenantMigrationStatus.COMPLETED,
-        })
-    } catch (e) {
-      request.executionError = e as Error
-      progressiveMigrations.addTenant(tenantId)
-    }
+        fileSizeLimit,
+        jwtSecret,
+        jwks,
+        serviceKey,
+        features,
+        databasePoolUrl,
+        databasePoolMode,
+        maxConnections,
+        tracingMode,
+      } = request.body
+      const { tenantId } = request.params
 
-    reply.code(204).send()
-  })
-
-  fastify.delete<tenantRequestInterface>('/:tenantId', async (request, reply) => {
-    await multitenantKnex('tenants').del().where('id', request.params.tenantId)
-    deleteTenantConfig(request.params.tenantId)
-    reply.code(204).send()
-  })
-
-  fastify.get<tenantRequestInterface>('/:tenantId/migrations', async (req, reply) => {
-    const migrationsInfo = await multitenantKnex
-      .table<{ migrations_version?: string; migrations_status?: string }>('tenants')
-      .select('migrations_version', 'migrations_status')
-      .where('id', req.params.tenantId)
-      .first()
-
-    if (!migrationsInfo) {
-      reply.status(404).send({
-        error: 'Tenant not found',
-      })
-      return
-    }
-
-    reply.send({
-      isLatest: (await lastLocalMigrationName()) === migrationsInfo?.migrations_version,
-      migrationsVersion: migrationsInfo?.migrations_version,
-      migrationsStatus: migrationsInfo?.migrations_status,
-    })
-  })
-
-  fastify.post<tenantRequestInterface>('/:tenantId/migrations', async (req, reply) => {
-    const tenantId = req.params.tenantId
-    const migrationsInfo = await multitenantKnex
-      .table<{ databaseUrl: string }>('tenants')
-      .select('database_url')
-      .where('id', req.params.tenantId)
-      .first()
-
-    if (!migrationsInfo) {
-      reply.status(404).send({
-        error: 'Tenant not found',
-      })
-      return
-    }
-
-    const databaseUrl = decrypt(migrationsInfo.database_url)
-
-    try {
-      await runMigrationsOnTenant({
-        databaseUrl,
-        tenantId,
-        upToMigration: dbMigrationFreezeAt,
-      })
-      return reply.send({
-        migrated: true,
-      })
-    } catch (e) {
-      req.executionError = e as Error
-
-      if (e instanceof StorageBackendError) {
-        return reply.status(e.httpStatusCode || 400).send({
-          migrated: false,
-          metadata: e.metadata,
-          ...e.render(),
-        })
+      const tenantInfo: tenantDBInterface & {
+        tracing_mode?: string
+      } = {
+        id: tenantId,
+        anon_key: encrypt(anonKey),
+        database_url: encrypt(databaseUrl),
+        jwt_secret: encrypt(jwtSecret),
+        jwks: jwks || null,
+        service_key: encrypt(serviceKey),
       }
 
-      return reply.status(400).send({
-        migrated: false,
-        error: JSON.stringify(e),
+      if (fileSizeLimit) {
+        tenantInfo.file_size_limit = fileSizeLimit
+      }
+
+      if (typeof features?.imageTransformation?.enabled !== 'undefined') {
+        tenantInfo.feature_image_transformation = features?.imageTransformation?.enabled
+      }
+
+      if (typeof features?.purgeCache?.enabled !== 'undefined') {
+        tenantInfo.feature_purge_cache = features?.purgeCache?.enabled
+      }
+
+      if (typeof features?.imageTransformation?.maxResolution !== 'undefined') {
+        tenantInfo.image_transformation_max_resolution = features?.imageTransformation
+          ?.image_transformation_max_resolution as number | undefined
+      }
+
+      if (typeof features?.s3Protocol?.enabled !== 'undefined') {
+        tenantInfo.feature_s3_protocol = features?.s3Protocol?.enabled
+      }
+
+      if (databasePoolUrl) {
+        tenantInfo.database_pool_url = encrypt(databasePoolUrl)
+      }
+
+      if (maxConnections) {
+        tenantInfo.max_connections = Number(maxConnections)
+      }
+
+      if (databasePoolMode) {
+        tenantInfo.database_pool_mode = databasePoolMode
+      }
+
+      if (tracingMode) {
+        tenantInfo.tracing_mode = tracingMode
+      }
+
+      tenantInfo.feature_iceberg_catalog = features?.icebergCatalog?.enabled
+      tenantInfo.feature_iceberg_catalog_max_namespaces = features?.icebergCatalog?.maxNamespaces
+      tenantInfo.feature_iceberg_catalog_max_tables = features?.icebergCatalog?.maxTables
+      tenantInfo.feature_iceberg_catalog_max_catalogs = features?.icebergCatalog?.maxCatalogs
+
+      tenantInfo.feature_vector_buckets = features?.vectorBuckets?.enabled
+      tenantInfo.feature_vector_buckets_max_buckets = features?.vectorBuckets?.maxBuckets
+      tenantInfo.feature_vector_buckets_max_indexes = features?.vectorBuckets?.maxIndexes
+
+      await multitenantKnex.transaction(async (trx) => {
+        await trx('tenants').insert(tenantInfo).onConflict('id').merge()
+        await jwksManager.generateUrlSigningJwk(tenantId, trx)
+      })
+
+      try {
+        await runMigrationsOnTenant({
+          databaseUrl,
+          tenantId,
+          upToMigration: dbMigrationFreezeAt,
+        })
+        await multitenantKnex('tenants')
+          .where('id', tenantId)
+          .update({
+            migrations_version: await lastLocalMigrationName(),
+            migrations_status: TenantMigrationStatus.COMPLETED,
+          })
+      } catch (e) {
+        request.executionError = e as Error
+        progressiveMigrations.addTenant(tenantId)
+      }
+
+      reply.code(204).send()
+    }
+  )
+
+  fastify.delete<tenantRequestInterface>(
+    '/:tenantId',
+    { schema: { tags: ['tenant'] } },
+    async (request, reply) => {
+      await multitenantKnex('tenants').del().where('id', request.params.tenantId)
+      deleteTenantConfig(request.params.tenantId)
+      reply.code(204).send()
+    }
+  )
+
+  fastify.get<tenantRequestInterface>(
+    '/:tenantId/migrations',
+    { schema: { tags: ['tenant'] } },
+    async (req, reply) => {
+      const migrationsInfo = await multitenantKnex
+        .table<{ migrations_version?: string; migrations_status?: string }>('tenants')
+        .select('migrations_version', 'migrations_status')
+        .where('id', req.params.tenantId)
+        .first()
+
+      if (!migrationsInfo) {
+        reply.status(404).send({
+          error: 'Tenant not found',
+        })
+        return
+      }
+
+      reply.send({
+        isLatest: (await lastLocalMigrationName()) === migrationsInfo?.migrations_version,
+        migrationsVersion: migrationsInfo?.migrations_version,
+        migrationsStatus: migrationsInfo?.migrations_status,
       })
     }
-  })
+  )
 
-  fastify.post<tenantRequestInterface>('/:tenantId/migrations/reset', async (req, reply) => {
-    const { untilMigration, markCompletedTillMigration } = req.body as Record<string, unknown>
+  fastify.post<tenantRequestInterface>(
+    '/:tenantId/migrations',
+    { schema: { tags: ['tenant'] } },
+    async (req, reply) => {
+      const tenantId = req.params.tenantId
+      const migrationsInfo = await multitenantKnex
+        .table<{ databaseUrl: string }>('tenants')
+        .select('database_url')
+        .where('id', req.params.tenantId)
+        .first()
 
-    const { databaseUrl } = await getTenantConfig(req.params.tenantId)
+      if (!migrationsInfo) {
+        reply.status(404).send({
+          error: 'Tenant not found',
+        })
+        return
+      }
 
-    if (!isDBMigrationName(untilMigration)) {
-      return reply.status(400).send({ message: 'Invalid migration' })
+      const databaseUrl = decrypt(migrationsInfo.database_url)
+
+      try {
+        await runMigrationsOnTenant({
+          databaseUrl,
+          tenantId,
+          upToMigration: dbMigrationFreezeAt,
+        })
+        return reply.send({
+          migrated: true,
+        })
+      } catch (e) {
+        req.executionError = e as Error
+
+        if (e instanceof StorageBackendError) {
+          return reply.status(e.httpStatusCode || 400).send({
+            migrated: false,
+            metadata: e.metadata,
+            ...e.render(),
+          })
+        }
+
+        return reply.status(400).send({
+          migrated: false,
+          error: JSON.stringify(e),
+        })
+      }
     }
+  )
 
-    if (
-      typeof markCompletedTillMigration === 'string' &&
-      !isDBMigrationName(markCompletedTillMigration)
-    ) {
-      return reply.status(400).send({ message: 'Invalid migration' })
+  fastify.post<tenantRequestInterface>(
+    '/:tenantId/migrations/reset',
+    { schema: { tags: ['tenant'] } },
+    async (req, reply) => {
+      const { untilMigration, markCompletedTillMigration } = req.body as Record<string, unknown>
+
+      const { databaseUrl } = await getTenantConfig(req.params.tenantId)
+
+      if (!isDBMigrationName(untilMigration)) {
+        return reply.status(400).send({ message: 'Invalid migration' })
+      }
+
+      if (
+        typeof markCompletedTillMigration === 'string' &&
+        !isDBMigrationName(markCompletedTillMigration)
+      ) {
+        return reply.status(400).send({ message: 'Invalid migration' })
+      }
+
+      try {
+        await resetMigration({
+          tenantId: req.params.tenantId,
+          databaseUrl,
+          untilMigration,
+          markCompletedTillMigration: isDBMigrationName(markCompletedTillMigration)
+            ? markCompletedTillMigration
+            : undefined,
+        })
+
+        return reply.send({ message: 'Migrations reset' })
+      } catch (e) {
+        req.executionError = e as Error
+        return reply.status(400).send({ message: 'Failed to reset migration' })
+      }
     }
+  )
 
-    try {
-      await resetMigration({
-        tenantId: req.params.tenantId,
-        databaseUrl,
-        untilMigration,
-        markCompletedTillMigration: isDBMigrationName(markCompletedTillMigration)
-          ? markCompletedTillMigration
-          : undefined,
-      })
+  fastify.get<tenantRequestInterface>(
+    '/:tenantId/migrations/jobs',
+    { schema: { tags: ['tenant'] } },
+    async (req, reply) => {
+      const data = await multitenantKnex
+        .table(`${PG_BOSS_SCHEMA}.job`)
+        .select('*')
+        .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
+        .where('name', migrationQueueName)
+        .orderBy('created_on', 'desc')
+        .limit(100)
 
-      return reply.send({ message: 'Migrations reset' })
-    } catch (e) {
-      req.executionError = e as Error
-      return reply.status(400).send({ message: 'Failed to reset migration' })
+      reply.send(data)
     }
-  })
+  )
 
-  fastify.get<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
-    const data = await multitenantKnex
-      .table(`${PG_BOSS_SCHEMA}.job`)
-      .select('*')
-      .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
-      .where('name', migrationQueueName)
-      .orderBy('created_on', 'desc')
-      .limit(100)
+  fastify.delete<tenantRequestInterface>(
+    '/:tenantId/migrations/jobs',
+    { schema: { tags: ['tenant'] } },
+    async (req, reply) => {
+      const data = await multitenantKnex
+        .table(`${PG_BOSS_SCHEMA}.job`)
+        .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
+        .where('name', migrationQueueName)
+        .orderBy('created_on', 'desc')
+        .limit(100)
+        .delete()
 
-    reply.send(data)
-  })
-
-  fastify.delete<tenantRequestInterface>('/:tenantId/migrations/jobs', async (req, reply) => {
-    const data = await multitenantKnex
-      .table(`${PG_BOSS_SCHEMA}.job`)
-      .whereRaw("data->'tenant'->>'ref' = ?", [req.params.tenantId])
-      .where('name', migrationQueueName)
-      .orderBy('created_on', 'desc')
-      .limit(100)
-      .delete()
-
-    reply.send(data)
-  })
+      reply.send(data)
+    }
+  )
 
   fastify.register(async (fastify) => {
     fastify.register(dbSuperUser, {
@@ -661,16 +697,20 @@ export default async function routes(fastify: FastifyInstance) {
     })
     fastify.register(storage)
 
-    fastify.get<tenantRequestInterface>('/:tenantId/health', async (req, res) => {
-      try {
-        await req.storage.healthcheck()
-        return res.send({ healthy: true })
-      } catch (e) {
-        if (e instanceof Error) {
-          req.executionError = e
+    fastify.get<tenantRequestInterface>(
+      '/:tenantId/health',
+      { schema: { tags: ['tenant'] } },
+      async (req, res) => {
+        try {
+          await req.storage.healthcheck()
+          return res.send({ healthy: true })
+        } catch (e) {
+          if (e instanceof Error) {
+            req.executionError = e
+          }
+          return res.send({ healthy: false })
         }
-        return res.send({ healthy: false })
       }
-    })
+    )
   })
 }

--- a/src/http/routes/cdn/purgeCache.ts
+++ b/src/http/routes/cdn/purgeCache.ts
@@ -28,7 +28,7 @@ export default async function routes(fastify: FastifyInstance) {
   const schema = createDefaultSchema(successResponseSchema, {
     params: purgeObjectParamsSchema,
     summary,
-    tags: ['object'],
+    tags: ['cdn'],
   })
 
   fastify.delete<deleteObjectRequestInterface>(

--- a/src/http/routes/health/healthcheck.ts
+++ b/src/http/routes/health/healthcheck.ts
@@ -8,6 +8,7 @@ export default async function routes(fastify: FastifyInstance) {
     {
       schema: {
         summary,
+        tags: ['health'],
       },
     },
     async (req, res) => {

--- a/src/http/routes/operations.ts
+++ b/src/http/routes/operations.ts
@@ -25,7 +25,9 @@ export const ROUTE_OPERATIONS = {
   MOVE_OBJECT: 'storage.object.move',
   UPDATE_OBJECT: 'storage.object.upload_update',
   UPLOAD_SIGN_OBJECT: 'storage.object.upload_signed',
-  PURGE_OBJECT_CACHE: 'storage.object.purge_cache',
+
+  // CDN
+  PURGE_OBJECT_CACHE: 'storage.cdn.purge_object_cache',
 
   // Image Transformation
   RENDER_AUTH_IMAGE: 'storage.render.image_authenticated',

--- a/src/http/routes/s3/commands/head-bucket.ts
+++ b/src/http/routes/s3/commands/head-bucket.ts
@@ -3,6 +3,8 @@ import { ROUTE_OPERATIONS } from '../../operations'
 import { S3Router } from '../router'
 
 const HeadBucketInput = {
+  summary: 'Head Bucket',
+  tags: ['s3'],
   Params: {
     type: 'object',
     properties: {

--- a/src/http/routes/s3/commands/head-object.ts
+++ b/src/http/routes/s3/commands/head-object.ts
@@ -5,6 +5,7 @@ import { S3Router } from '../router'
 
 const HeadObjectInput = {
   summary: 'Head Object',
+  tags: ['s3'],
   Params: {
     type: 'object',
     properties: {

--- a/src/scripts/export-docs.ts
+++ b/src/scripts/export-docs.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from 'fs'
+import buildAdmin from '../admin-app'
 import app from '../app'
 ;(async () => {
+  // Export main API spec
   const storageApp = app({
     exposeDocs: true,
   })
@@ -13,4 +15,18 @@ import app from '../app'
   await fs.writeFile('static/api.json', response.body)
 
   await storageApp.close()
+
+  // Export admin API spec
+  const adminApp = buildAdmin({
+    exposeDocs: true,
+  })
+
+  const adminResponse = await adminApp.inject({
+    method: 'GET',
+    url: '/documentation/json',
+  })
+
+  await fs.writeFile('static/api-admin.json', adminResponse.body)
+
+  await adminApp.close()
 })().catch(console.error)

--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -202,11 +202,12 @@ async function httpAdminServer(
   app: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   signal: AbortSignal
 ) {
-  const { adminRequestIdHeader, adminPort, host } = getConfig()
+  const { exposeDocs, adminRequestIdHeader, adminPort, host } = getConfig()
 
   const adminApp = buildAdmin({
     loggerInstance: logger,
     disableRequestLogging: true,
+    exposeDocs,
     requestIdHeader: adminRequestIdHeader,
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

listed as `fix` so a semantic version bump will occur so we can test the updated release github action (and fix if needed)

## What is the current behavior?

Many missing storage api endpoints. No storage admin api spec.

## What is the new behavior?

- Add missing tags for storage api spec
- Change purge cache to `cdn` tag / operation
  - renamed to 'purge_object_cache' in anticipation of upcoming 'purge_bucket_cache', 'purge_tenant_cache', 'purge_transformation_cache'
- Add admin api spec and swagger ui
- Update github action to generate api specs with version specified on release and attach to the release


Adding tags to admin apis resulted in a lot of formatting changes so the PR looks a lot bigger than it is due to that
