### PR TITLE
fix: duplication in async abort controller

### DIFF
--- a/src/internal/concurrency/async-abort-controller.ts
+++ b/src/internal/concurrency/async-abort-controller.ts
@@ -3,8 +3,7 @@
  */
 export class AsyncAbortController extends AbortController {
   protected promises: Promise<any>[] = []
-  protected priority = 0
-  protected groups = new Map<number, AsyncAbortController[]>()
+  protected _nextGroup?: AsyncAbortController
 
   constructor() {
     super()
@@ -40,21 +39,12 @@ export class AsyncAbortController extends AbortController {
     }
   }
 
-  protected _nextGroup?: AsyncAbortController
-
   get nextGroup() {
-    if (!this._nextGroup) {
-      this._nextGroup = new AsyncAbortController()
-      this._nextGroup.priority = this.priority + 1
+    if (this._nextGroup) {
+      return this._nextGroup
     }
 
-    let existingGroups = this.groups.get(this._nextGroup.priority)
-    if (!existingGroups) {
-      existingGroups = []
-    }
-
-    existingGroups.push(this._nextGroup)
-    this.groups.set(this._nextGroup.priority, existingGroups)
+    this._nextGroup = new AsyncAbortController()
     return this._nextGroup
   }
 
@@ -64,12 +54,12 @@ export class AsyncAbortController extends AbortController {
       const promises = this.promises.splice(0, 100)
       await Promise.allSettled(promises)
     }
-    await this.abortGroups()
+    await this.abortNextGroup()
   }
 
-  protected async abortGroups() {
-    for (const [, group] of this.groups) {
-      await Promise.allSettled(group.map((g) => g.abortAsync()))
+  protected async abortNextGroup() {
+    if (this._nextGroup) {
+      await this._nextGroup.abortAsync()
     }
   }
 }

--- a/src/test/async-abort-controller.test.ts
+++ b/src/test/async-abort-controller.test.ts
@@ -1,0 +1,72 @@
+import { AsyncAbortController } from '@internal/concurrency'
+
+describe('AsyncAbortController', () => {
+  it('reuses nextGroup when accessed repeatedly', () => {
+    const controller = new AsyncAbortController()
+
+    const firstGroup = controller.nextGroup
+    const secondGroup = controller.nextGroup
+
+    expect(secondGroup).toBe(firstGroup)
+  })
+
+  it('reuses nested nextGroup access at each level', () => {
+    const controller = new AsyncAbortController()
+    const firstGroup = controller.nextGroup
+
+    const firstNestedGroup = controller.nextGroup.nextGroup
+    const secondNestedGroup = controller.nextGroup.nextGroup
+
+    expect(controller.nextGroup).toBe(firstGroup)
+    expect(secondNestedGroup).toBe(firstNestedGroup)
+    expect(firstNestedGroup).toBe(firstGroup.nextGroup)
+  })
+
+  it('aborts a nextGroup child only once even after repeated access', async () => {
+    const controller = new AsyncAbortController()
+    const childGroup = controller.nextGroup
+    const abortSpy = jest.spyOn(childGroup, 'abortAsync').mockResolvedValue(undefined)
+
+    void controller.nextGroup
+    void controller.nextGroup
+
+    await controller.abortAsync()
+
+    expect(abortSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for parent abort handlers before aborting nested groups', async () => {
+    const controller = new AsyncAbortController()
+    const childGroup = controller.nextGroup
+    const grandchildGroup = childGroup.nextGroup
+    const order: string[] = []
+    let releaseRootAbort!: () => void
+    const rootAbortDone = new Promise<void>((resolve) => {
+      releaseRootAbort = resolve
+    })
+
+    controller.signal.addEventListener('abort', async () => {
+      order.push('root:start')
+      await rootAbortDone
+      order.push('root:end')
+    })
+
+    childGroup.signal.addEventListener('abort', () => {
+      order.push('child')
+    })
+
+    grandchildGroup.signal.addEventListener('abort', () => {
+      order.push('grandchild')
+    })
+
+    const abortPromise = controller.abortAsync()
+
+    await Promise.resolve() // force microtask tick
+    expect(order).toEqual(['root:start'])
+
+    releaseRootAbort()
+    await abortPromise
+
+    expect(order).toEqual(['root:start', 'root:end', 'child', 'grandchild'])
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Every access pushes the controller even if cached and not created.

## What is the new behavior?

We could fix only add to groups when a new controller is created but instead simplified by dropping priority/groups because API doesn't use them. It's simpler linked list now. 