### PR TITLE
fix: drop ts-node-dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
         "resolve-tspaths": "^0.8.19",
         "stream-buffers": "^3.0.2",
         "ts-jest": "^29.4.6",
-        "ts-node-dev": "^1.1.8",
         "tsx": "^4.16.0",
         "tus-js-client": "^3.1.0",
         "typescript": "5.9.3"
@@ -18198,99 +18197,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
-        "tsconfig": "^7.0.0"
-      },
-      "bin": {
-        "ts-node-dev": "lib/bin.js",
-        "tsnd": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "*",
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
     "node_modules/tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -31288,63 +31194,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
           "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
           "dev": true
-        }
-      }
-    },
-    "ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "9",
-        "tsconfig": "^7.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "7"
-          }
-        },
-        "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-          "dev": true,
-          "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.4",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "resolve-tspaths": "^0.8.19",
     "stream-buffers": "^3.0.2",
     "ts-jest": "^29.4.6",
-    "ts-node-dev": "^1.1.8",
     "tsx": "^4.16.0",
     "tus-js-client": "^3.1.0",
     "typescript": "5.9.3"
@@ -129,9 +128,6 @@
     },
     "glob@7": {
       "minimatch": "^3.1.4"
-    },
-    "ts-node@9": {
-      "diff": "^4.0.4"
     }
   },
   "bin": "./dist/server.js"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dependency drop

## What is the current behavior?

ts-node-dev was used for `dev` script historically.

## What is the new behavior?

Now, `tsx` is used so drop unused dependency and cleanup override because of it.

## Additional context

Less deps is better for maintenance.