### PR TITLE
fix: manual admin tenant migration state recording

### DIFF
--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -5,7 +5,6 @@ import {
   getTenantConfig,
   jwksManager,
   multitenantKnex,
-  TenantMigrationStatus,
 } from '@internal/database'
 import {
   isDBMigrationName,
@@ -13,6 +12,7 @@ import {
   progressiveMigrations,
   resetMigration,
   runMigrationsOnTenant,
+  updateTenantMigrationsState,
 } from '@internal/database/migrations'
 import { StorageBackendError } from '@internal/errors'
 import { PG_BOSS_SCHEMA } from '@internal/queue'
@@ -344,12 +344,7 @@ export default async function routes(fastify: FastifyInstance) {
           tenantId,
           upToMigration: dbMigrationFreezeAt,
         })
-        await multitenantKnex('tenants')
-          .where('id', tenantId)
-          .update({
-            migrations_version: await lastLocalMigrationName(),
-            migrations_status: TenantMigrationStatus.COMPLETED,
-          })
+        await updateTenantMigrationsState(tenantId)
       } catch {
         progressiveMigrations.addTenant(tenantId)
       }
@@ -419,12 +414,7 @@ export default async function routes(fastify: FastifyInstance) {
             tenantId,
             upToMigration: dbMigrationFreezeAt,
           })
-          await multitenantKnex('tenants')
-            .where('id', tenantId)
-            .update({
-              migrations_version: await lastLocalMigrationName(),
-              migrations_status: TenantMigrationStatus.COMPLETED,
-            })
+          await updateTenantMigrationsState(tenantId)
         } catch (e) {
           if (e instanceof Error) {
             request.executionError = e
@@ -524,12 +514,7 @@ export default async function routes(fastify: FastifyInstance) {
           tenantId,
           upToMigration: dbMigrationFreezeAt,
         })
-        await multitenantKnex('tenants')
-          .where('id', tenantId)
-          .update({
-            migrations_version: await lastLocalMigrationName(),
-            migrations_status: TenantMigrationStatus.COMPLETED,
-          })
+        await updateTenantMigrationsState(tenantId)
       } catch (e) {
         request.executionError = e as Error
         progressiveMigrations.addTenant(tenantId)
@@ -600,6 +585,7 @@ export default async function routes(fastify: FastifyInstance) {
           tenantId,
           upToMigration: dbMigrationFreezeAt,
         })
+        await updateTenantMigrationsState(tenantId)
         return reply.send({
           migrated: true,
         })

--- a/src/test/admin-migrations.test.ts
+++ b/src/test/admin-migrations.test.ts
@@ -12,6 +12,7 @@ jest.mock('@internal/database/migrations', () => {
 import * as migrations from '@internal/database/migrations'
 import { DBMigration } from '@internal/database/migrations'
 import { randomUUID } from 'crypto'
+import type { FastifyInstance } from 'fastify'
 import { mergeConfig } from '../config'
 import { multitenantKnex } from '../internal/database/multitenant-db'
 import { PG_BOSS_SCHEMA, Queue } from '../internal/queue/queue'
@@ -152,6 +153,128 @@ describe('Admin migrations routes', () => {
       markCompletedTillMigration: undefined,
       signal: expect.any(AbortSignal),
     })
+  })
+
+  test('manual tenant migration updates the tenant migration state', async () => {
+    const migrationTenantId = `admin-migrations-state-${randomUUID().slice(0, 8)}`
+    const latestMigration = await migrations.lastLocalMigrationName()
+
+    await createTenant(migrationTenantId)
+
+    await multitenantKnex('tenants').where({ id: migrationTenantId }).update({
+      migrations_version: null,
+      migrations_status: null,
+    })
+
+    const migrateResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/${migrationTenantId}/migrations`,
+      headers,
+    })
+
+    expect(migrateResponse.statusCode).toBe(200)
+    expect(JSON.parse(migrateResponse.body)).toEqual({ migrated: true })
+
+    const getResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/${migrationTenantId}/migrations`,
+      headers,
+    })
+
+    expect(getResponse.statusCode).toBe(200)
+    expect(JSON.parse(getResponse.body)).toEqual({
+      isLatest: true,
+      migrationsVersion: latestMigration,
+      migrationsStatus: 'COMPLETED',
+    })
+
+    await expect(
+      multitenantKnex('tenants')
+        .select('migrations_version', 'migrations_status')
+        .where({ id: migrationTenantId })
+        .first()
+    ).resolves.toEqual({
+      migrations_version: latestMigration,
+      migrations_status: 'COMPLETED',
+    })
+  })
+
+  test('manual tenant migration records the frozen migration target', async () => {
+    const migrationTenantId = `admin-migrations-freeze-${randomUUID().slice(0, 8)}`
+    const frozenMigration = 'create-migrations-table' satisfies keyof typeof DBMigration
+    let isolatedAdminApp: FastifyInstance | undefined
+    let isolatedMultitenantKnex: typeof multitenantKnex | undefined
+
+    await createTenant(migrationTenantId)
+
+    await multitenantKnex('tenants').where({ id: migrationTenantId }).update({
+      migrations_version: null,
+      migrations_status: null,
+    })
+
+    jest.resetModules()
+
+    try {
+      await jest.isolateModulesAsync(async () => {
+        const config = await import('../config')
+        config.getConfig({ reload: true })
+        config.mergeConfig({
+          pgQueueEnable: true,
+          dbMigrationFreezeAt: frozenMigration,
+        })
+
+        const isolatedMigrations = await import('@internal/database/migrations')
+        jest.mocked(isolatedMigrations.runMigrationsOnTenant).mockResolvedValue(undefined)
+
+        const multitenantDb = await import('../internal/database/multitenant-db')
+        isolatedMultitenantKnex = multitenantDb.multitenantKnex
+
+        const adminAppModule = await import('../admin-app')
+        isolatedAdminApp = adminAppModule.default({})
+      })
+
+      if (!isolatedAdminApp) {
+        throw new Error('Failed to build isolated admin app')
+      }
+
+      const migrateResponse = await isolatedAdminApp.inject({
+        method: 'POST',
+        url: `/tenants/${migrationTenantId}/migrations`,
+        headers,
+      })
+
+      expect(migrateResponse.statusCode).toBe(200)
+      expect(JSON.parse(migrateResponse.body)).toEqual({ migrated: true })
+
+      const getResponse = await isolatedAdminApp.inject({
+        method: 'GET',
+        url: `/tenants/${migrationTenantId}/migrations`,
+        headers,
+      })
+
+      expect(getResponse.statusCode).toBe(200)
+      expect(JSON.parse(getResponse.body)).toEqual({
+        isLatest: true,
+        migrationsVersion: frozenMigration,
+        migrationsStatus: 'COMPLETED',
+      })
+
+      await expect(
+        multitenantKnex('tenants')
+          .select('migrations_version', 'migrations_status')
+          .where({ id: migrationTenantId })
+          .first()
+      ).resolves.toEqual({
+        migrations_version: frozenMigration,
+        migrations_status: 'COMPLETED',
+      })
+    } finally {
+      await isolatedAdminApp?.close()
+      if (isolatedMultitenantKnex && isolatedMultitenantKnex !== multitenantKnex) {
+        await isolatedMultitenantKnex.destroy()
+      }
+      jest.resetModules()
+    }
   })
 
   test('lists active fleet migration jobs from the current pg-boss queue name', async () => {

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -15,6 +15,7 @@ import { adminApp } from './common'
 dotenv.config({ path: '.env.test' })
 
 const serviceKeyPayload = { abc: 123 }
+const testTenantIds = ['abc', 'cache-test-abc'] as const
 
 const migrationVersion = Object.entries(DBMigration).sort(([_, a], [__, b]) => b - a)[0][0]
 
@@ -110,14 +111,24 @@ beforeAll(async () => {
   payload.serviceKey = await signJWT(serviceKeyPayload, payload.jwtSecret, 100)
 })
 
+async function cleanupTestTenants() {
+  for (const tenantId of testTenantIds) {
+    await adminApp.inject({
+      method: 'DELETE',
+      url: `/tenants/${tenantId}`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+  }
+}
+
+beforeEach(async () => {
+  await cleanupTestTenants()
+})
+
 afterEach(async () => {
-  await adminApp.inject({
-    method: 'DELETE',
-    url: '/tenants/abc',
-    headers: {
-      apikey: process.env.ADMIN_API_KEYS,
-    },
-  })
+  await cleanupTestTenants()
 })
 
 afterAll(async () => {
@@ -450,18 +461,18 @@ describe('Tenant configs', () => {
   })
 
   test('Get tenant config always retrieves concurrent requests from cache', async () => {
+    const tenantId = 'cache-test-abc'
+    await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/${tenantId}`,
+      payload,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+
     const knexTableSpy = jest.spyOn(multitenantKnex, 'table')
     try {
-      const tenantId = 'cache-test-abc'
-      await adminApp.inject({
-        method: 'POST',
-        url: `/tenants/${tenantId}`,
-        payload,
-        headers: {
-          apikey: process.env.ADMIN_API_KEYS,
-        },
-      })
-
       await getTenantConfig(tenantId)
       expect(knexTableSpy).toHaveBeenCalledTimes(1)
       expect(knexTableSpy).toHaveBeenCalledWith('tenants')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Manual migration run via admin doesn't update tenant migration status in multitenant database.

## What is the new behavior?

State is correctly updated.

## Additional context

Extracted a helper for the same state updating query.