### PR TITLE
fix: use parameters in pgboss jobs

### DIFF
--- a/src/storage/events/pgboss/move-jobs.ts
+++ b/src/storage/events/pgboss/move-jobs.ts
@@ -78,9 +78,9 @@ export class MoveJobs extends BaseEvent<MoveJobsPayload> {
                 policy,
                 state
             )
-            SELECT 
+            SELECT
                 id,
-                '${toQueue.name}' as name,
+                ? as name,
                 priority,
                 data,
                 retry_limit,
@@ -94,23 +94,23 @@ export class MoveJobs extends BaseEvent<MoveJobsPayload> {
                 created_on,
                 keep_until,
                 output,
-                '${toQueue.policy}' as policy,
+                ? as policy,
                 'created' as state
             FROM ${schema}.job
-            WHERE name = '${fromQueueName}'
+            WHERE name = ?
                 AND state IN ('created', 'active', 'retry')
             ON CONFLICT DO NOTHING
         `
 
-        await tnx.raw(sql)
+        await tnx.raw(sql, [toQueue.name, toQueue.policy, fromQueueName])
 
         if (job.data.deleteJobsFromOriginalQueue) {
           const deleteSql = `
                 DELETE FROM ${schema}.job
-                WHERE name = '${fromQueueName}'
+                WHERE name = ?
                     AND state IN ('created', 'active', 'retry')
             `
-          await tnx.raw(deleteSql)
+          await tnx.raw(deleteSql, [fromQueueName])
         }
       } catch (error) {
         logSchema.error(logger, '[PgBoss] Error while copying jobs', {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix - harden knex tnx calls

## What is the current behavior?

Uses template literals for pgboss sql construction

## What is the new behavior?

Uses bound parameters
