### PR TITLE
fix: include docs into release not to mutate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,10 @@ jobs:
           extra_plugins: |
             @semantic-release/commit-analyzer
             @semantic-release/release-notes-generator
+            @semantic-release/exec
             @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate API Specs for Release
-        if: steps.semantic.outputs.new_release_published == 'true'
-        run: |
-          npm run docs:export
-        env:
-          VERSION: ${{ steps.semantic.outputs.new_release_version }}
           ANON_KEY: ${{ secrets.ANON_KEY }}
           SERVICE_KEY: ${{ secrets.SERVICE_KEY }}
           TENANT_ID: ${{ secrets.TENANT_ID }}
@@ -58,17 +52,6 @@ jobs:
           FILE_SIZE_LIMIT: "52428800"
           STORAGE_BACKEND: s3
           ENABLE_IMAGE_TRANSFORMATION: true
-
-      - name: Attach API Specs to Release
-        if: steps.semantic.outputs.new_release_published == 'true'
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          tag_name: v${{ steps.semantic.outputs.new_release_version }}
-          files: |
-            static/api.json
-            static/api-admin.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     needs:

--- a/.releaserc
+++ b/.releaserc
@@ -3,10 +3,27 @@
     "master"
   ],
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
+    [
+      "@semantic-release/commit-analyzer",
+      {
         "preset": "conventionalcommits"
-    }],
+      }
+    ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "VERSION=${nextRelease.version} npm run docs:export"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          "static/api.json",
+          "static/api-admin.json"
+        ]
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Release was created and then docs artifacts were added but releases are marked immutable now.

## What is the new behavior?

Add docs into release creation step.

## Additional context

https://github.com/supabase/storage/actions/runs/23657173085/attempts/1