### PR TITLE
fix: use parameterized queries in upgrade-v10.ts

### DIFF
--- a/src/storage/events/pgboss/upgrade-v10.ts
+++ b/src/storage/events/pgboss/upgrade-v10.ts
@@ -84,14 +84,14 @@ export class UpgradePgBossV10 extends BaseEvent<UpgradePgBossV10Payload> {
                 createdOn,
                 keepUntil,
                 output jsonb,
-                '${queue.policy}' as policy
+                ? as policy
             FROM ${sourceSchema}.job
-            WHERE name = '${queue.name}'
+            WHERE name = ?
                 AND state = 'created'
             ON CONFLICT DO NOTHING
         `
 
-          await multitenantKnex.raw(sql)
+          await tnx.raw(sql, [queue.policy, queue.name])
         } catch (error) {
           logSchema.error(logger, '[PgBoss] Error while copying jobs', {
             type: 'pgboss',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (follow-up to #940)

## What is the current behavior?

`upgrade-v10.ts` interpolates `queue.name` and `queue.policy` directly into raw SQL via template literals:

```ts
'${queue.policy}' as policy
...
WHERE name = '${queue.name}'
```

And executes the query with `multitenantKnex.raw(sql)` outside the transaction that holds the advisory lock.

#940 fixed this exact pattern in `move-jobs.ts` but this file was not included.

Resolves #945

## What is the new behavior?

Uses `?` placeholders with bound parameters and runs the query inside the transaction via `tnx.raw()`, matching the pattern applied in #940:

```ts
? as policy
...
WHERE name = ?

await tnx.raw(sql, [queue.policy, queue.name])
```