### PR TITLE
fix: harden jwk cache test wait

### DIFF
--- a/src/internal/auth/jwks/channels.ts
+++ b/src/internal/auth/jwks/channels.ts
@@ -1,0 +1,1 @@
+export const TENANTS_JWKS_UPDATE_CHANNEL = 'tenants_jwks_update'

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -9,9 +9,9 @@ import { PubSubAdapter } from '@internal/pubsub'
 import { Knex } from 'knex'
 import objectSizeOf from 'object-sizeof'
 import { JwksConfig, JwksConfigKeyOCT } from '../../../config'
+import { TENANTS_JWKS_UPDATE_CHANNEL } from './channels'
 import { JWKSManagerStore } from './store'
 
-const TENANTS_JWKS_UPDATE_CHANNEL = 'tenants_jwks_update'
 const JWK_KIND_STORAGE_URL_SIGNING = 'storage-url-signing-key'
 const JWK_KID_SEPARATOR = '_'
 

--- a/src/test/hash-stream.test.ts
+++ b/src/test/hash-stream.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { HashSpillWritable } from '@internal/streams/hash-stream'
+import { waitForEventually } from './utils/promise'
 
 function randBuf(size: number): Buffer {
   const b = Buffer.allocUnsafe(size)
@@ -43,6 +44,16 @@ async function findSpillFilePath(root: string): Promise<string | null> {
   } catch {
     return null
   }
+}
+
+async function waitForHashspillDirs(root: string, expected: number): Promise<number> {
+  return waitForEventually(
+    () => countHashspillDirs(root),
+    (count) => count === expected,
+    `${expected} hashspill dirs under ${root}`,
+    5000,
+    20
+  )
 }
 
 class SlowWritable extends Writable {
@@ -133,11 +144,8 @@ describe('HashSpillWritable', () => {
       })
     )
 
-    // Allow event loop to process cleanup
-    await new Promise((r) => setTimeout(r, 100))
-
     // The hashspill dir should be gone
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('spill: multiple readers, autoCleanup waits for the last reader', async () => {
@@ -164,10 +172,7 @@ describe('HashSpillWritable', () => {
     const p2 = pipeline(r2, slowConsumer)
     await Promise.all([p1, p2])
 
-    // wait a tick for cleanup to run
-    await new Promise((r) => setTimeout(r, 10))
-
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('manual cleanup: delete after readers close (call cleanup after reading)', async () => {
@@ -236,9 +241,7 @@ describe('HashSpillWritable', () => {
 
     await Promise.all(jobs)
 
-    // Allow cleanup to finish
-    await new Promise((r) => setTimeout(r, 10))
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('size() tracks total bytes written', async () => {
@@ -323,9 +326,7 @@ describe('HashSpillWritable', () => {
       spy.mockRestore()
     }
 
-    // Ensure no lingering temp dirs/files (best-effort)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('spill: spilled file exists before read and is deleted after autoCleanup', async () => {
@@ -350,16 +351,21 @@ describe('HashSpillWritable', () => {
       })
     )
 
-    // Give the event loop a tick for cleanup
-    await new Promise((r) => setTimeout(r, 15))
+    const cleanupState = await waitForEventually(
+      async () => ({
+        postPath: await findSpillFilePath(tmpRoot),
+        prePathExists: fs.existsSync(prePath!),
+        dirCount: await countHashspillDirs(tmpRoot),
+      }),
+      (state) => state.postPath === null && !state.prePathExists && state.dirCount === 0,
+      `spill artifacts for ${prePath} to be removed`,
+      5000,
+      20
+    )
 
-    // The specific spilled file AND directory should be gone
-    const postPath = await findSpillFilePath(tmpRoot)
-    expect(postPath).toBeNull()
-    expect(fs.existsSync(prePath!)).toBe(false)
-
-    // And no hashspill dirs remain
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    expect(cleanupState.postPath).toBeNull()
+    expect(cleanupState.prePathExists).toBe(false)
+    expect(cleanupState.dirCount).toBe(0)
   })
   test('concurrent spill operations: no temp file name collisions with rapid creation', async () => {
     const limit = 4 * 1024
@@ -401,9 +407,8 @@ describe('HashSpillWritable', () => {
     )
 
     await Promise.all(readPromises)
-    await new Promise((r) => setTimeout(r, 20)) // Allow cleanup
 
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('concurrent spill with identical timestamps: UUID ensures uniqueness', async () => {
@@ -432,9 +437,7 @@ describe('HashSpillWritable', () => {
       const digests = await Promise.all(jobs)
       expect(digests).toHaveLength(N)
 
-      // All temp dirs should be cleaned up
-      await new Promise((r) => setTimeout(r, 10))
-      expect(await countHashspillDirs(tmpRoot)).toBe(0)
+      await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
     } finally {
       jest.restoreAllMocks()
     }
@@ -465,14 +468,11 @@ describe('HashSpillWritable', () => {
 
     await Promise.all(readPromises)
 
-    // Even though some had autoCleanup=true, cleanup should be deferred
-    // because other readers existed. Only manual cleanup should work now.
-    expect(await countHashspillDirs(tmpRoot)).toBe(1)
+    // Cleanup should happen once the final autoCleanup reader finishes,
+    // even if some concurrent readers did not request autoCleanup.
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
 
-    await new Promise((r) => setTimeout(r, 200))
-    // Manual cleanup should now succeed
-    await sink.cleanup()
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(sink.cleanup()).resolves.toBeUndefined()
   })
 
   test('rapid spill/cleanup cycles: no resource leaks or race conditions', async () => {
@@ -494,14 +494,9 @@ describe('HashSpillWritable', () => {
           },
         })
       )
-
-      // Brief pause to allow cleanup
-      await new Promise((r) => setTimeout(r, 2))
     }
 
-    // All temp artifacts should be cleaned up
-    await new Promise((r) => setTimeout(r, 20))
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('spill during concurrent writes to different tmp roots: isolation verified', async () => {
@@ -589,8 +584,6 @@ describe('HashSpillWritable', () => {
     expect(results1).toHaveLength(batchSize)
     expect(results2).toHaveLength(batchSize)
 
-    // Allow all cleanup to complete
-    await new Promise((r) => setTimeout(r, 50))
-    expect(await countHashspillDirs(tmpRoot)).toBe(0)
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 })

--- a/src/test/tenant-jwks.test.ts
+++ b/src/test/tenant-jwks.test.ts
@@ -8,6 +8,7 @@ mergeConfig({
 })
 
 import { encrypt, signJWT } from '@internal/auth'
+import { TENANTS_JWKS_UPDATE_CHANNEL } from '@internal/auth/jwks/channels'
 import { UrlSigningJwkGenerator } from '@internal/auth/jwks/generator'
 import { JWKSManagerStoreKnex } from '@internal/auth/jwks/store-knex'
 import { TENANT_JWKS_CACHE_NAME } from '@internal/cache'
@@ -26,10 +27,17 @@ import { adminApp, mockQueue } from './common'
 import { createMockKnexReturning } from './mocks/knex-mock'
 import { assertLogicalLookupMetrics } from './utils/cache-metrics'
 import { mockCreateLruCache } from './utils/cache-mock'
+import { waitForEventually } from './utils/promise'
 
 dotenv.config({ path: '.env.test' })
 
+const TENANT_JWKS_TEST_TIMEOUT_MS = 10000
+// Keep helper-level waits shorter than the per-test timeout
+// so helper errors surface first.
+const TENANT_JWKS_HELPER_TIMEOUT_MS = 4000
 const tenantId = 'abc123'
+
+jest.setTimeout(TENANT_JWKS_TEST_TIMEOUT_MS)
 
 const testJwks = {
   oct: {
@@ -83,18 +91,31 @@ async function loadJwksModules(
 }
 
 // returns a promise that resolves the next time the jwk cache is invalidated
-function createJwkConfigChangeAwaiter(expectedCacheKey = tenantId): Promise<string> {
-  return new Promise<string>((resolve) => {
+function createJwkConfigChangeAwaiter(
+  expectedCacheKey = tenantId,
+  timeoutMs = TENANT_JWKS_HELPER_TIMEOUT_MS
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pubSub.subscriber.notifications.removeListener(TENANTS_JWKS_UPDATE_CHANNEL, onNotification)
+      reject(
+        new Error(
+          `Timed out after ${timeoutMs}ms waiting for ${TENANTS_JWKS_UPDATE_CHANNEL}:${expectedCacheKey}`
+        )
+      )
+    }, timeoutMs)
+
     const onNotification = (cacheKey: string) => {
       if (cacheKey !== expectedCacheKey) {
         return
       }
 
-      pubSub.subscriber.notifications.removeListener('tenants_jwks_update', onNotification)
+      clearTimeout(timeout)
+      pubSub.subscriber.notifications.removeListener(TENANTS_JWKS_UPDATE_CHANNEL, onNotification)
       resolve(cacheKey)
     }
 
-    pubSub.subscriber.notifications.on('tenants_jwks_update', onNotification)
+    pubSub.subscriber.notifications.on(TENANTS_JWKS_UPDATE_CHANNEL, onNotification)
   })
 }
 
@@ -148,12 +169,12 @@ describe('Tenant jwks configs', () => {
       resolved = true
     })
 
-    pubSub.subscriber.notifications.emit('tenants_jwks_update', 'other-jwks-tenant')
+    pubSub.subscriber.notifications.emit(TENANTS_JWKS_UPDATE_CHANNEL, 'other-jwks-tenant')
     await new Promise((resolve) => setImmediate(resolve))
 
     expect(resolved).toBe(false)
 
-    pubSub.subscriber.notifications.emit('tenants_jwks_update', expectedTenantId)
+    pubSub.subscriber.notifications.emit(TENANTS_JWKS_UPDATE_CHANNEL, expectedTenantId)
 
     await expect(awaiter).resolves.toBe(expectedTenantId)
   })
@@ -225,10 +246,13 @@ describe('Tenant jwks configs', () => {
       expect(data.kid).toBeTruthy()
       expect(data.kid.startsWith(kind)).toBe(true)
 
-      const cacheKey = await configAwaiter
-      expect(cacheKey).toBe(tenantId)
+      await expect(configAwaiter).resolves.toBe(tenantId)
 
-      const config = await jwksManager.getJwksTenantConfig(tenantId)
+      const config = await waitForEventually(
+        () => jwksManager.getJwksTenantConfig(tenantId),
+        (value) => value.keys.some((key) => key.kid === data.kid),
+        `tenant ${tenantId} JWKS to include ${data.kid}`
+      )
       expect(config.keys.length - keysBefore.length).toBe(1)
       expect(config.keys.find((v) => v.kid === data.kid)).toBeTruthy()
     })
@@ -307,10 +331,13 @@ describe('Tenant jwks configs', () => {
     let data = response.json<{ result: boolean }>()
     expect(data.result).toBe(true)
 
-    let cacheKey = await configAwaiter
-    expect(cacheKey).toBe(tenantId)
+    await expect(configAwaiter).resolves.toBe(tenantId)
 
-    config = await jwksManager.getJwksTenantConfig(tenantId)
+    config = await waitForEventually(
+      () => jwksManager.getJwksTenantConfig(tenantId),
+      (value) => value.keys.length === 0,
+      `tenant ${tenantId} JWKS to clear after deactivation`
+    )
     expect(config.keys.length).toBe(0)
 
     configAwaiter = createJwkConfigChangeAwaiter()
@@ -326,10 +353,13 @@ describe('Tenant jwks configs', () => {
     data = response.json<{ result: boolean }>()
     expect(data.result).toBe(true)
 
-    cacheKey = await configAwaiter
-    expect(cacheKey).toBe(tenantId)
+    await expect(configAwaiter).resolves.toBe(tenantId)
 
-    const config2 = await jwksManager.getJwksTenantConfig(tenantId)
+    const config2 = await waitForEventually(
+      () => jwksManager.getJwksTenantConfig(tenantId),
+      (value) => value.keys.some((key) => key.kid === kid),
+      `tenant ${tenantId} JWKS to restore ${kid}`
+    )
     expect(config2.keys.length).toBe(1)
     expect(config2.keys[0]).toMatchObject({ kid })
   })
@@ -549,9 +579,15 @@ describe('Tenant jwks configs', () => {
       },
     })
 
-    await configAwaiter
+    await expect(configAwaiter).resolves.toBe(tenantId)
 
-    const secretWithoutJwk = await getJwtSecret(tenantId)
+    deleteTenantConfig(tenantId)
+
+    const secretWithoutJwk = await waitForEventually(
+      () => getJwtSecret(tenantId),
+      (value) => value.urlSigningKey === value.secret && value.jwks.keys.length === 0,
+      `tenant ${tenantId} url signing fallback to jwtSecret`
+    )
     expect(secretWithoutJwk.urlSigningKey).toBe(secretWithoutJwk.secret)
     expect(secretWithoutJwk.jwks.keys.length).toBe(0)
   })

--- a/src/test/utils/promise.ts
+++ b/src/test/utils/promise.ts
@@ -1,0 +1,24 @@
+export async function waitForEventually<T>(
+  getValue: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  description: string,
+  timeoutMs = 5000,
+  intervalMs = 25
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  let lastValue: T | undefined
+
+  while (Date.now() <= deadline) {
+    lastValue = await getValue()
+
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${description}. Last value: ${JSON.stringify(lastValue)}`
+  )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

JWK cache test was await so flaky.

## What is the new behavior?

Harden wait in test to reduce flakiness.

## Additional context

Also use the constant for the channel.
An [example flaky failure](https://app.blacksmith.sh/supabase/runs/23731388243/jobs/69125769150?attempt=1&autoLogin=true&tab=tests&status=failed&test_id=b5414a71-550e-43ff-9084-3c5907dfb3d7). 