### PR TITLE
fix: scanner pagination to follow token

### DIFF
--- a/src/storage/scanner/scanner.ts
+++ b/src/storage/scanner/scanner.ts
@@ -299,15 +299,15 @@ export class ObjectScanner {
         beforeDate: options.before,
       })
 
-      if (result.keys.length === 0) {
-        break
-      }
-
       nextToken = result.nextToken
 
-      yield result.keys.filter((k) => {
+      const keys = result.keys.filter((k) => {
         return k.name && !k.name.endsWith('.info')
       })
+
+      if (keys.length > 0) {
+        yield keys
+      }
 
       if (!nextToken) {
         break

--- a/src/test/scanner-pagination.test.ts
+++ b/src/test/scanner-pagination.test.ts
@@ -1,0 +1,81 @@
+jest.mock('@storage/events/objects/backup-object', () => ({
+  BackupObjectEvent: {
+    batchSend: jest.fn(),
+  },
+}))
+
+import { ObjectScanner } from '@storage/scanner/scanner'
+import type { Storage } from '@storage/storage'
+
+class TestObjectScanner extends ObjectScanner {
+  async collectAllS3Objects(prefix: string, before?: Date) {
+    const pages = []
+
+    for await (const page of this.listAllS3Objects(prefix, {
+      before,
+      signal: new AbortController().signal,
+    })) {
+      pages.push(...page)
+    }
+
+    return pages
+  }
+}
+
+function makeScanner(params: { listS3Objects?: jest.Mock }) {
+  const storage = {
+    backend: {
+      list: params.listS3Objects ?? jest.fn(),
+    },
+    db: {},
+  } as unknown as Storage
+
+  return new TestObjectScanner(storage)
+}
+
+describe('ObjectScanner pagination regressions', () => {
+  test('continues scanning S3 pages after an empty filtered page when a continuation token remains', async () => {
+    const listS3Objects = jest
+      .fn()
+      .mockResolvedValueOnce({
+        keys: [
+          { name: 'old-orphan-a/v0', size: 30 },
+          { name: 'old-orphan-a/v0.info', size: 1 },
+        ],
+        nextToken: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        keys: [],
+        nextToken: 'page-3',
+      })
+      .mockResolvedValueOnce({
+        keys: [
+          { name: 'old-orphan-b/v1', size: 10 },
+          { name: 'old-orphan-b/v1.info', size: 1 },
+          { name: 'old-orphan-c/v2', size: 20 },
+        ],
+        nextToken: undefined,
+      })
+
+    const scanner = makeScanner({ listS3Objects })
+
+    await expect(scanner.collectAllS3Objects('tenant/bucket')).resolves.toEqual([
+      { name: 'old-orphan-a/v0', size: 30 },
+      { name: 'old-orphan-b/v1', size: 10 },
+      { name: 'old-orphan-c/v2', size: 20 },
+    ])
+
+    expect(listS3Objects).toHaveBeenCalledTimes(3)
+    expect(listS3Objects.mock.calls[0][1]).toMatchObject({
+      prefix: 'tenant/bucket/',
+    })
+    expect(listS3Objects.mock.calls[1][1]).toMatchObject({
+      prefix: 'tenant/bucket/',
+      nextToken: 'page-2',
+    })
+    expect(listS3Objects.mock.calls[2][1]).toMatchObject({
+      prefix: 'tenant/bucket/',
+      nextToken: 'page-3',
+    })
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Object scanner stops when result set is empty.

## What is the new behavior?

Object scanner stop when next token doesn't exist. Empty page with next token is a valid case.

## Additional context

Orphan object script might not report even if there are orphans.