### PR TITLE
fix: bump tus s3-store version, fixes potential uncaught exception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@shopify/semaphore": "^3.0.2",
         "@smithy/node-http-handler": "^2.3.1",
         "@tus/file-store": "2.0.0",
-        "@tus/s3-store": "2.0.0",
+        "@tus/s3-store": "^2.0.2",
         "@tus/server": "2.2.1",
         "agentkeepalive": "^4.5.0",
         "ajv": "^8.18.0",
@@ -12668,9 +12668,10 @@
       }
     },
     "node_modules/@tus/s3-store": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.0.tgz",
-      "integrity": "sha512-hhaOGRgYzIVWqwsjsWoUPhzM5OsAS097mF8BYTDEuBnnQ2QjaJW0qPIPAESea4LLvfMlX/ujShNCx1SYHQLWGg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.2.tgz",
+      "integrity": "sha512-wXrlb8k0BikpSs5FuMSTjEOK0QrL+xBEqPrmROcLOWMAaximPHtzHjvG6QDc5UbjBaV8PTqMnWhtXj85vvn3tw==",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@shopify/semaphore": "^3.1.0",
@@ -13917,9 +13918,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15233,6 +15234,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
       "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -15514,6 +15516,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -17045,6 +17048,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -20046,6 +20050,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -29176,9 +29181,9 @@
       }
     },
     "@tus/s3-store": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.0.tgz",
-      "integrity": "sha512-hhaOGRgYzIVWqwsjsWoUPhzM5OsAS097mF8BYTDEuBnnQ2QjaJW0qPIPAESea4LLvfMlX/ujShNCx1SYHQLWGg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.2.tgz",
+      "integrity": "sha512-wXrlb8k0BikpSs5FuMSTjEOK0QrL+xBEqPrmROcLOWMAaximPHtzHjvG6QDc5UbjBaV8PTqMnWhtXj85vvn3tw==",
       "requires": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@shopify/semaphore": "^3.1.0",
@@ -30063,9 +30068,9 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -30947,6 +30952,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
       "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -31131,7 +31137,8 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "graphql": {
       "version": "16.13.2",
@@ -32185,6 +32192,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -34216,7 +34224,8 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@shopify/semaphore": "^3.0.2",
     "@smithy/node-http-handler": "^2.3.1",
     "@tus/file-store": "2.0.0",
-    "@tus/s3-store": "2.0.0",
+    "@tus/s3-store": "2.0.2",
     "@tus/server": "2.2.1",
     "agentkeepalive": "^4.5.0",
     "ajv": "^8.18.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Uses tus 2.0.0 which includes a bug that can cause uncaught database timeout errors

## What is the new behavior?

Use [@tus/s3-store v2.0.2](https://github.com/tus/tus-node-server/releases/tag/%40tus%2Fs3-store%402.0.2) which includes [a fix to ensure there are not uncaught exceptions](https://github.com/tus/tus-node-server/pull/812)

