### PR TITLE
fix: handle json content type in delete tenant

### DIFF
--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -524,15 +524,33 @@ export default async function routes(fastify: FastifyInstance) {
     }
   )
 
-  fastify.delete<tenantRequestInterface>(
-    '/:tenantId',
-    { schema: { tags: ['tenant'] } },
-    async (request, reply) => {
-      await multitenantKnex('tenants').del().where('id', request.params.tenantId)
-      deleteTenantConfig(request.params.tenantId)
-      reply.code(204).send()
-    }
-  )
+  fastify.register(async (f) => {
+    const defaultJsonParser = f.getDefaultJsonParser(
+      f.initialConfig.onProtoPoisoning ?? 'error',
+      f.initialConfig.onConstructorPoisoning ?? 'error'
+    )
+
+    f.addContentTypeParser('application/json', { parseAs: 'string' }, (request, body, done) => {
+      if (!body) {
+        done(null, null)
+        return
+      }
+
+      const jsonBody = typeof body === 'string' ? body : body.toString('utf8')
+
+      defaultJsonParser(request, jsonBody, done)
+    })
+
+    f.delete<tenantRequestInterface>(
+      '/:tenantId',
+      { schema: { tags: ['tenant'] } },
+      async (request, reply) => {
+        await multitenantKnex('tenants').del().where('id', request.params.tenantId)
+        deleteTenantConfig(request.params.tenantId)
+        reply.code(204).send()
+      }
+    )
+  })
 
   fastify.get<tenantRequestInterface>(
     '/:tenantId/migrations',

--- a/src/test/admin-tenants.test.ts
+++ b/src/test/admin-tenants.test.ts
@@ -1,0 +1,28 @@
+import * as migrations from '@internal/database/migrations'
+import { multitenantKnex } from '@internal/database/multitenant-db'
+import { adminApp } from './common'
+
+describe('admin tenant delete route', () => {
+  beforeAll(async () => {
+    await migrations.runMultitenantMigrations()
+  })
+
+  afterAll(async () => {
+    await multitenantKnex.destroy()
+  })
+
+  it('accepts an empty json delete request', async () => {
+    const response = await adminApp.inject({
+      method: 'DELETE',
+      url: '/tenants/abc',
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS!,
+        'content-type': 'application/json',
+      },
+      payload: '',
+    })
+
+    expect(response.statusCode).toBe(204)
+    expect(response.body).toBe('')
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor, bug fix.

## What is the current behavior?

While deleting a tenant in admin app, if content-type is set to json, body is needed. 

## What is the new behavior?

Body isn't needed but also there is no need to fail the request. Make it permissive to accept empty json body.

## Additional context

Can be seen related to #953 partially due to implementation but the reason is completely different (client convenience here vs genuine bug).