### PR TITLE
fix: no tenant cache for run migrations event

### DIFF
--- a/src/storage/events/migrations/run-migrations.ts
+++ b/src/storage/events/migrations/run-migrations.ts
@@ -1,4 +1,4 @@
-import { getTenantConfig, TenantMigrationStatus } from '@internal/database'
+import { deleteTenantConfig, getTenantConfig, TenantMigrationStatus } from '@internal/database'
 import {
   areMigrationsUpToDate,
   DBMigration,
@@ -46,6 +46,7 @@ export class RunMigrationsOnTenants extends BaseEvent<RunMigrationsPayload> {
 
   static async handle(job: JobWithMetadata<RunMigrationsPayload>) {
     const tenantId = job.data.tenant.ref
+    deleteTenantConfig(tenantId)
     const tenant = await getTenantConfig(tenantId)
 
     const migrationsUpToDate = await areMigrationsUpToDate(tenantId)

--- a/src/test/run-migrations-event.test.ts
+++ b/src/test/run-migrations-event.test.ts
@@ -1,4 +1,5 @@
 const mockGetTenantConfig = jest.fn()
+const mockDeleteTenantConfig = jest.fn()
 const mockAreMigrationsUpToDate = jest.fn()
 const mockRunMigrationsOnTenant = jest.fn()
 const mockUpdateTenantMigrationsState = jest.fn()
@@ -7,6 +8,7 @@ const mockInfo = jest.fn()
 const mockError = jest.fn()
 
 jest.mock('@internal/database', () => ({
+  deleteTenantConfig: mockDeleteTenantConfig,
   getTenantConfig: mockGetTenantConfig,
   TenantMigrationStatus: {
     COMPLETED: 'COMPLETED',
@@ -79,6 +81,10 @@ describe('RunMigrationsOnTenants.handle', () => {
   it('runs migrations and marks the tenant completed on success', async () => {
     await expect(RunMigrationsOnTenants.handle(makeJob() as never)).resolves.toBeUndefined()
 
+    expect(mockDeleteTenantConfig).toHaveBeenCalledWith('tenant-a')
+    expect(mockDeleteTenantConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      mockGetTenantConfig.mock.invocationCallOrder[0]
+    )
     expect(mockRunMigrationsOnTenant).toHaveBeenCalledWith({
       databaseUrl: 'postgres://tenant-db',
       tenantId: 'tenant-a',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Run migrations event uses a cached config.

## What is the new behavior?

Event uses a fresh copy by loading from db.

## Additional context

Cached value could be with stale config.
