### PR TITLE
fix: wrap passthrough proxy for binary

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -1,5 +1,5 @@
 import { FastifyError } from '@fastify/error'
-import { ErrorCode, isRenderableError, StorageError } from '@internal/errors'
+import { ErrorCode, isRenderableError, StorageBackendError, StorageError } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { DatabaseError } from 'pg'
 
@@ -55,7 +55,10 @@ export const setErrorHandler = (
             ? 500
             : 400
 
-      if (renderableError.code === ErrorCode.AbortedTerminate) {
+      if (
+        renderableError.code === ErrorCode.AbortedTerminate ||
+        (error instanceof StorageBackendError && error.shouldCloseConnection())
+      ) {
         reply.header('Connection', 'close')
 
         reply.raw.once('finish', () => {

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -491,7 +491,7 @@ export const ERRORS = {
       httpStatusCode: 500,
       message,
       originalError,
-    }),
+    }).withConnectionClose(),
   NoSuchCatalog: (name: string) => {
     return new StorageBackendError({
       code: ErrorCode.NoSuchCatalog,

--- a/src/internal/errors/storage-error.ts
+++ b/src/internal/errors/storage-error.ts
@@ -2,6 +2,8 @@ import type { S3ServiceException } from '@aws-sdk/client-s3'
 import { ErrorCode } from './codes'
 import { RenderableError, StorageErrorOptions } from './renderable'
 
+const CLOSE_CONNECTION_METADATA_KEY = 'closeConnection'
+
 /**
  * A generic error that should be always thrown for generic exceptions
  */
@@ -72,6 +74,17 @@ export class StorageBackendError extends Error implements RenderableError {
   withMetadata(metadata: Record<string, any>) {
     this.metadata = metadata
     return this
+  }
+
+  withConnectionClose() {
+    return this.withMetadata({
+      ...this.metadata,
+      [CLOSE_CONNECTION_METADATA_KEY]: true,
+    })
+  }
+
+  shouldCloseConnection() {
+    return Boolean(this.metadata?.[CLOSE_CONNECTION_METADATA_KEY])
   }
 
   render() {

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -1,10 +1,10 @@
-import { ERRORS } from '@internal/errors'
+import { ERRORS, StorageBackendError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import { fileUploadedSuccess, fileUploadStarted } from '@internal/monitoring/metrics'
 import { StorageObjectLocator } from '@storage/locator'
 import { randomUUID } from 'crypto'
 import { FastifyRequest } from 'fastify'
-import { Readable } from 'stream'
+import { PassThrough, Readable } from 'stream'
 import { getConfig } from '../config'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
 import { Database } from './database'
@@ -48,6 +48,13 @@ export interface CanUploadOptions {
 }
 
 const MAX_CUSTOM_METADATA_SIZE = 1024 * 1024
+const CLOSE_CONNECTION_ON_ERROR = Symbol('closeConnectionOnError')
+
+type UploadBodyProxy = PassThrough & {
+  [CLOSE_CONNECTION_ON_ERROR]?: boolean
+}
+
+type UploadBodySource = FastifyRequest['raw']
 
 /**
  * Uploader
@@ -110,6 +117,7 @@ export class Uploader {
    * @param options
    */
   async upload(request: UploadRequest) {
+    const file = request.file
     const version = await this.prepareUpload({
       bucketId: request.bucketId,
       objectName: request.objectName,
@@ -117,15 +125,13 @@ export class Uploader {
       isUpsert: request.isUpsert,
       userMetadata: request.userMetadata,
       metadata: {
-        mimetype: request.file.mimeType,
-        contentLength: request.file.declaredContentLength ?? request.file.contentLength,
+        mimetype: file.mimeType,
+        contentLength: file.declaredContentLength ?? file.contentLength,
       },
       uploadType: request.uploadType,
     })
 
     try {
-      const file = request.file
-
       const s3Key = this.location.getKeyLocation({
         tenantId: this.db.tenantId,
         bucketId: request.bucketId,
@@ -165,7 +171,7 @@ export class Uploader {
         version,
         reqId: this.db.reqId,
       })
-      throw e
+      throw shouldCloseConnectionAfterResponse(file.body) ? withConnectionClose(e) : e
     }
   }
 
@@ -341,6 +347,72 @@ function getKnownRequestContentLength(request: FastifyRequest): number | undefin
   return contentLength
 }
 
+function createUploadBodyProxy(body: UploadBodySource) {
+  const proxy = new PassThrough() as UploadBodyProxy
+  let bodyEnded = false
+  const destroy = proxy.destroy.bind(proxy)
+
+  proxy.destroy = ((error?: Error) => {
+    if (error) {
+      proxy[CLOSE_CONNECTION_ON_ERROR] = true
+    }
+
+    return destroy(error)
+  }) as typeof proxy.destroy
+
+  const onBodyError = (err: Error) => {
+    if (!proxy.destroyed) {
+      proxy.destroy(err)
+    }
+  }
+
+  const onBodyEnd = () => {
+    bodyEnded = true
+  }
+
+  const onBodyClose = () => {
+    if (!bodyEnded && !body.readableEnded && !proxy.destroyed) {
+      proxy.destroy(new Error('Request stream closed before upload could complete'))
+    }
+  }
+
+  const onProxyError = () => {
+    body.unpipe(proxy)
+  }
+
+  const cleanup = () => {
+    body.unpipe(proxy)
+    body.off('aborted', onBodyClose)
+    body.off('close', onBodyClose)
+    body.off('end', onBodyEnd)
+    body.off('error', onBodyError)
+    proxy.off('error', onProxyError)
+    proxy.off('close', cleanup)
+  }
+
+  body.on('aborted', onBodyClose)
+  body.on('close', onBodyClose)
+  body.on('end', onBodyEnd)
+  body.on('error', onBodyError)
+  proxy.on('error', onProxyError)
+  proxy.on('close', cleanup)
+  body.pipe(proxy)
+
+  return proxy
+}
+
+function shouldCloseConnectionAfterResponse(body: Readable) {
+  return Boolean((body as UploadBodyProxy)[CLOSE_CONNECTION_ON_ERROR])
+}
+
+function withConnectionClose(error: unknown) {
+  if (error instanceof StorageBackendError) {
+    return error.withConnectionClose()
+  }
+
+  return StorageBackendError.fromError(error).withConnectionClose()
+}
+
 /**
  * Extracts the file information from the request
  * @param request
@@ -430,7 +502,10 @@ export async function fileUploadFromRequest(
     }
   } else {
     // just assume it's a binary file
-    body = request.raw
+    if (!request.raw || request.raw.closed || request.raw.destroyed || request.raw.readableEnded) {
+      throw ERRORS.NoContentProvided(new Error('Request stream closed before upload could begin'))
+    }
+
     mimeType = request.headers['content-type'] || 'application/octet-stream'
     cacheControl = request.headers['cache-control'] ?? 'no-cache'
 
@@ -457,6 +532,7 @@ export async function fileUploadFromRequest(
     // reaching the backend when they exceed the limit.
     // Unknown-size binary uploads do not have a later truncation signal.
     isTruncated = () => false
+    body = createUploadBodyProxy(request.raw)
   }
 
   // Capture the declared content-length for RLS metadata purposes.

--- a/src/test/uploader.test.ts
+++ b/src/test/uploader.test.ts
@@ -1,7 +1,10 @@
+import { once } from 'events'
 import { FastifyRequest } from 'fastify'
-import { Readable } from 'stream'
-import { ErrorCode, isStorageError } from '../internal/errors'
-import { fileUploadFromRequest } from '../storage/uploader'
+import { PassThrough, Readable } from 'stream'
+import { ErrorCode, isStorageError, StorageBackendError } from '../internal/errors'
+import { ObjectAdminDelete } from '../storage/events'
+import { TenantLocation } from '../storage/locator'
+import { fileUploadFromRequest, Uploader } from '../storage/uploader'
 
 describe('fileUploadFromRequest', () => {
   test('keeps multipart/form-data file size undefined even when the request content-length exceeds 5GB', async () => {
@@ -90,6 +93,8 @@ describe('fileUploadFromRequest', () => {
   })
 
   test('rejects known-size binary uploads that already exceed the size limit', async () => {
+    const raw = new PassThrough()
+
     try {
       await fileUploadFromRequest(
         {
@@ -97,7 +102,7 @@ describe('fileUploadFromRequest', () => {
             'content-type': 'application/octet-stream',
             'content-length': '177',
           },
-          raw: Readable.from(['payload']),
+          raw,
           tenantId: 'stub-tenant',
         } as unknown as FastifyRequest,
         {
@@ -108,6 +113,197 @@ describe('fileUploadFromRequest', () => {
       throw new Error('Expected fileUploadFromRequest to throw')
     } catch (error) {
       expect(isStorageError(ErrorCode.EntityTooLarge, error)).toBe(true)
+      expect(raw.listenerCount('aborted')).toBe(0)
+      expect(raw.listenerCount('close')).toBe(0)
+      expect(raw.listenerCount('end')).toBe(0)
+      expect(raw.listenerCount('error')).toBe(0)
+      expect(raw.readableFlowing).not.toBe(true)
+    }
+  })
+
+  test('wraps binary request bodies so downstream stream failures do not destroy the raw request', async () => {
+    const raw = new PassThrough()
+    const upload = await fileUploadFromRequest(
+      {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-length': '7',
+        },
+        raw,
+        tenantId: 'stub-tenant',
+      } as unknown as FastifyRequest,
+      {
+        objectName: 'test.txt',
+        fileSizeLimit: 150,
+      }
+    )
+
+    expect(upload.body).not.toBe(raw)
+
+    const proxyError = once(upload.body, 'error')
+    upload.body.destroy(new Error('downstream failed'))
+
+    const [error] = await proxyError
+    expect((error as Error).message).toBe('downstream failed')
+    expect(raw.destroyed).toBe(false)
+  })
+
+  test('cleans up raw request listeners after a successful proxied upload stream completes', async () => {
+    const raw = new PassThrough()
+    const upload = await fileUploadFromRequest(
+      {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-length': '7',
+        },
+        raw,
+        tenantId: 'stub-tenant',
+      } as unknown as FastifyRequest,
+      {
+        objectName: 'test.txt',
+        fileSizeLimit: 150,
+      }
+    )
+
+    const proxyClosed = once(upload.body, 'close')
+    upload.body.resume()
+    raw.end('payload')
+    await proxyClosed
+
+    expect(raw.listenerCount('aborted')).toBe(0)
+    expect(raw.listenerCount('close')).toBe(0)
+    expect(raw.listenerCount('end')).toBe(0)
+    expect(raw.listenerCount('error')).toBe(0)
+  })
+
+  test('propagates raw request stream errors to the upload body proxy', async () => {
+    const raw = new PassThrough()
+    const upload = await fileUploadFromRequest(
+      {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-length': '7',
+        },
+        raw,
+        tenantId: 'stub-tenant',
+      } as unknown as FastifyRequest,
+      {
+        objectName: 'test.txt',
+        fileSizeLimit: 150,
+      }
+    )
+
+    const proxyError = once(upload.body, 'error')
+    const requestError = new Error('request stream failed')
+    raw.destroy(requestError)
+
+    const [error] = await proxyError
+    expect(error).toBe(requestError)
+    expect(upload.body.destroyed).toBe(true)
+  })
+
+  test('destroys the upload body proxy when the raw request closes without EOF', async () => {
+    const raw = new PassThrough()
+    const upload = await fileUploadFromRequest(
+      {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-length': '7',
+        },
+        raw,
+        tenantId: 'stub-tenant',
+      } as unknown as FastifyRequest,
+      {
+        objectName: 'test.txt',
+        fileSizeLimit: 150,
+      }
+    )
+
+    const proxyError = once(upload.body, 'error')
+    raw.destroy()
+
+    const [error] = await proxyError
+    expect((error as Error).message).toBe('Request stream closed before upload could complete')
+    expect(upload.body.destroyed).toBe(true)
+  })
+
+  test('rejects binary uploads when the raw request stream is already closed', async () => {
+    const raw = new PassThrough()
+    raw.destroy()
+
+    try {
+      await fileUploadFromRequest(
+        {
+          headers: {
+            'content-type': 'application/octet-stream',
+            'content-length': '7',
+          },
+          raw,
+          tenantId: 'stub-tenant',
+        } as unknown as FastifyRequest,
+        {
+          objectName: 'test.txt',
+          fileSizeLimit: 150,
+        }
+      )
+      throw new Error('Expected fileUploadFromRequest to throw')
+    } catch (error) {
+      expect(isStorageError(ErrorCode.InvalidRequest, error)).toBe(true)
+      expect((error as Error).message).toBe('Request stream closed before upload could begin')
+    }
+  })
+
+  test('marks proxied upload failures to close the client connection after the response', async () => {
+    const raw = new PassThrough()
+    const file = await fileUploadFromRequest(
+      {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-length': '7',
+        },
+        raw,
+        tenantId: 'stub-tenant',
+      } as unknown as FastifyRequest,
+      {
+        objectName: 'test.txt',
+        fileSizeLimit: 150,
+      }
+    )
+
+    const objectAdminDeleteSendSpy = jest
+      .spyOn(ObjectAdminDelete, 'send')
+      .mockResolvedValue(undefined)
+
+    const uploader = new Uploader(
+      {
+        uploadObject: jest.fn(async (_bucket, _key, _version, body: Readable) => {
+          body.destroy(new Error('stream pipeline failed'))
+          throw StorageBackendError.fromError(new Error('socket hang up'))
+        }),
+      } as any,
+      {
+        tenantId: 'stub-tenant',
+        reqId: 'req-1',
+        tenant: () => ({ ref: 'stub-tenant' }),
+        testPermission: jest.fn().mockResolvedValue(undefined),
+      } as any,
+      new TenantLocation('test-bucket')
+    )
+
+    try {
+      await uploader.upload({
+        bucketId: 'bucket',
+        objectName: 'test.txt',
+        file,
+        uploadType: 'standard',
+      })
+      throw new Error('Expected upload to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StorageBackendError)
+      expect((error as StorageBackendError).shouldCloseConnection()).toBe(true)
+      expect((error as StorageBackendError).message).toBe('socket hang up')
+    } finally {
+      objectAdminDeleteSendSpy.mockRestore()
     }
   })
 })

--- a/src/test/validators.test.ts
+++ b/src/test/validators.test.ts
@@ -1,6 +1,7 @@
 import Fastify, { FastifyInstance } from 'fastify'
 import { setErrorHandler } from '../http/error-handler'
 import { headerValidator } from '../http/plugins/header-validator'
+import { StorageBackendError } from '../internal/errors'
 import { validateXRobotsTag } from '../storage/validators/x-robots-tag'
 
 describe('header-validator plugin', () => {
@@ -96,6 +97,17 @@ describe('header-validator plugin', () => {
       'blah',
       'blah',
     ])
+  })
+
+  it('should close the connection when a renderable error requests it', async () => {
+    app.get('/test-close-connection', async () => {
+      throw StorageBackendError.fromError(new Error('socket hang up')).withConnectionClose()
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/test-close-connection' })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.headers.connection).toBe('close')
   })
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

We started passing raw stream in #905. Teardown on the stream works on the client socket.

## What is the new behavior?

Wrap stream into passthrough proxy so that request.raw isn't exposed directly anymore.

## Additional context

This helps performance by preventing buffering.