### PR TITLE
fix: use resilient multipart

### DIFF
--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -183,7 +183,11 @@ export default function PutObject(s3Router: S3Router) {
               ContentEncoding: req.Headers?.['content-encoding'],
               Metadata: metadata,
             },
-            { signal: ctx.signals.body, isTruncated: uploadRequest.isTruncated }
+            {
+              signal: ctx.signals.body,
+              isTruncated: uploadRequest.isTruncated,
+              declaredContentLength: uploadRequest.declaredContentLength,
+            }
           )
         }
       )

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -695,7 +695,11 @@ export class S3ProtocolHandler {
    */
   async putObject(
     command: PutObjectCommandInput,
-    options: { signal?: AbortSignal; isTruncated: () => boolean }
+    options: {
+      signal?: AbortSignal
+      isTruncated: () => boolean
+      declaredContentLength?: number
+    }
   ) {
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)
 
@@ -709,6 +713,7 @@ export class S3ProtocolHandler {
         cacheControl: command.CacheControl!,
         mimeType: command.ContentType!,
         contentLength: command.ContentLength,
+        declaredContentLength: options.declaredContentLength,
         isTruncated: options.isTruncated,
       },
       objectName: command.Key as string,

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -531,15 +531,18 @@ export async function fileUploadFromRequest(
     // Known-size binary uploads are rejected before
     // reaching the backend when they exceed the limit.
     // Unknown-size binary uploads do not have a later truncation signal.
+    //
+    // Keep the declared request size separate from the backend upload size:
+    // request-backed uploads should continue using multipart upstream writes
+    // instead of direct PutObject, even when the client sent Content-Length.
     isTruncated = () => false
     body = createUploadBodyProxy(request.raw)
+    fileContentLength = undefined
   }
 
   // Capture the declared content-length for RLS metadata purposes.
-  // For binary uploads fileContentLength is already set (with size enforcement applied above).
-  // For multipart, size enforcement is handled by the fileSize limit in form parsing, so we
-  // read the header separately and only use it for RLS — never for the actual S3 upload.
-  const declaredContentLength = fileContentLength ?? getKnownRequestContentLength(request)
+  // Request-backed uploads never forward this value to the backend upload path.
+  const declaredContentLength = getKnownRequestContentLength(request)
 
   // Detect if the request stream closed before we could pass it to the storage backend
   // Without this check, the storage backend (S3) would throw a 500 "Premature close" error

--- a/src/test/uploader.test.ts
+++ b/src/test/uploader.test.ts
@@ -39,6 +39,7 @@ describe('fileUploadFromRequest', () => {
     expect(requestFile).toHaveBeenCalledWith({ limits: { fileSize: 150 } })
     expect(upload.body).toBe(file)
     expect(upload.contentLength).toBeUndefined()
+    expect(upload.declaredContentLength).toBe(5 * 1024 * 1024 * 1024 + 512)
     expect(upload.mimeType).toBe('image/png')
     expect(upload.cacheControl).toBe('max-age=3600')
     expect(upload.userMetadata).toEqual({ source: 'multipart' })
@@ -66,6 +67,8 @@ describe('fileUploadFromRequest', () => {
       }
     )
 
+    expect(upload.contentLength).toBeUndefined()
+    expect(upload.declaredContentLength).toBe(123)
     expect(upload.isTruncated()).toBe(false)
   })
 
@@ -139,6 +142,8 @@ describe('fileUploadFromRequest', () => {
     )
 
     expect(upload.body).not.toBe(raw)
+    expect(upload.contentLength).toBeUndefined()
+    expect(upload.declaredContentLength).toBe(7)
 
     const proxyError = once(upload.body, 'error')
     upload.body.destroy(new Error('downstream failed'))
@@ -305,5 +310,63 @@ describe('fileUploadFromRequest', () => {
     } finally {
       objectAdminDeleteSendSpy.mockRestore()
     }
+  })
+
+  test('keeps declared request size for permission checks but omits backend size for request-backed uploads', async () => {
+    const capturedWrites: Array<{ metadata?: { contentLength?: number } }> = []
+    const backend = {
+      uploadObject: jest.fn().mockResolvedValue({
+        httpStatusCode: 200,
+        cacheControl: 'no-cache',
+        eTag: '"etag"',
+        mimetype: 'text/plain',
+        contentLength: 7,
+        lastModified: new Date(),
+        size: 7,
+        contentRange: undefined,
+      }),
+    }
+    const uploader = new Uploader(
+      backend as any,
+      {
+        tenantId: 'stub-tenant',
+        reqId: 'req-1',
+        tenant: () => ({ ref: 'stub-tenant' }),
+        testPermission: jest.fn(async (fn) =>
+          fn({
+            createObject: jest.fn(async (payload: { metadata?: { contentLength?: number } }) => {
+              capturedWrites.push(payload)
+            }),
+            upsertObject: jest.fn(async (payload: { metadata?: { contentLength?: number } }) => {
+              capturedWrites.push(payload)
+            }),
+          })
+        ),
+      } as any,
+      new TenantLocation('test-bucket')
+    )
+    const completeUploadSpy = jest.spyOn(uploader, 'completeUpload').mockResolvedValue({
+      metadata: { eTag: '"etag"' },
+      obj: { id: 'obj-id' },
+    } as any)
+
+    await uploader.upload({
+      bucketId: 'bucket',
+      objectName: 'test.txt',
+      uploadType: 'standard',
+      file: {
+        body: Readable.from(['payload']),
+        mimeType: 'text/plain',
+        cacheControl: 'no-cache',
+        declaredContentLength: 7,
+        isTruncated: () => false,
+      },
+    })
+
+    expect(capturedWrites[0]?.metadata?.contentLength).toBe(7)
+    expect(backend.uploadObject).toHaveBeenCalledTimes(1)
+    expect(backend.uploadObject.mock.calls[0][7]).toBeUndefined()
+
+    completeUploadSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

#905 started using streaming and #960 fixed using direct stream but still slow connections aren't resilient.

## What is the new behavior?

Keep the logic from #905 but clarify declared vs upstream content length. Clear content length to upstream so that it falls back to buffering multipart and it can retry. Request based upload is possible by providing content length if needed. 

## Additional context

This will revert memory savings from streaming.
