### PR TITLE
fix: report errors in orphan and test entity expansion

### DIFF
--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -1,3 +1,4 @@
+import { render } from '@internal/errors'
 import { ObjectScanner } from '@storage/scanner/scanner'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FastifyReply } from 'fastify/types/reply'
@@ -113,19 +114,22 @@ export default async function routes(fastify: FastifyInstance) {
         for await (const result of orphanObjects) {
           if (result.value.length > 0) {
             respPing.update()
-            reply.raw.write(
-              JSON.stringify({
-                ...result,
-                event: 'data',
-              }) + '\n'
-            )
+            writeNdjson(reply, {
+              ...result,
+              event: 'data',
+            })
           }
         }
       } catch (e) {
-        throw e
+        req.log.error({ err: e, bucket }, 'list orphaned objects stream failed')
+        writeNdjson(reply, {
+          event: 'error',
+          error: render(e),
+        })
+        return
       } finally {
         respPing.clear()
-        reply.raw.end()
+        endNdjson(reply)
       }
     }
   )
@@ -166,21 +170,51 @@ export default async function routes(fastify: FastifyInstance) {
 
         for await (const deleted of result) {
           respPing.update()
-          reply.raw.write(
-            JSON.stringify({
-              ...deleted,
-              event: 'data',
-            }) + '\n'
-          )
+          writeNdjson(reply, {
+            ...deleted,
+            event: 'data',
+          })
         }
       } catch (e) {
-        throw e
+        req.log.error({ err: e, bucket }, 'delete orphaned objects stream failed')
+        writeNdjson(reply, {
+          event: 'error',
+          error: render(e),
+        })
+        return
       } finally {
         respPing.clear()
-        reply.raw.end()
+        endNdjson(reply)
       }
     }
   )
+}
+
+function canWriteNdjson(reply: FastifyReply) {
+  return !reply.raw.destroyed && !reply.raw.writableEnded
+}
+
+function writeNdjson(reply: FastifyReply, payload: unknown) {
+  if (!canWriteNdjson(reply)) {
+    return false
+  }
+
+  try {
+    reply.raw.write(JSON.stringify(payload) + '\n')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function endNdjson(reply: FastifyReply) {
+  if (!canWriteNdjson(reply)) {
+    return
+  }
+
+  try {
+    reply.raw.end()
+  } catch {}
 }
 
 // Occasionally write a ping message to the response stream
@@ -192,11 +226,9 @@ function ping(reply: FastifyReply) {
 
     if (!lastSend || (lastSend && lastSend < fiveSecondsEarly)) {
       lastSend = new Date()
-      reply.raw.write(
-        JSON.stringify({
-          event: 'ping',
-        }) + '\n'
-      )
+      writeNdjson(reply, {
+        event: 'ping',
+      })
     }
   }, 1000 * 10)
 

--- a/src/internal/errors/index.ts
+++ b/src/internal/errors/index.ts
@@ -1,3 +1,4 @@
 export * from './codes'
+export * from './render'
 export * from './renderable'
 export * from './storage-error'

--- a/src/internal/errors/render.ts
+++ b/src/internal/errors/render.ts
@@ -1,0 +1,9 @@
+import { isRenderableError, StorageBackendError } from './storage-error'
+
+export function render(error: unknown) {
+  if (isRenderableError(error)) {
+    return error.render()
+  }
+
+  return StorageBackendError.fromError(error).render()
+}

--- a/src/internal/errors/storage-error.ts
+++ b/src/internal/errors/storage-error.ts
@@ -106,7 +106,9 @@ export class StorageBackendError extends Error implements RenderableError {
  * @param error
  */
 export function isRenderableError(error: unknown): error is RenderableError {
-  return !!error && typeof error === 'object' && 'render' in error
+  return (
+    !!error && typeof error === 'object' && 'render' in error && typeof error.render === 'function'
+  )
 }
 
 /**

--- a/src/scripts/orphan-client-stream.ts
+++ b/src/scripts/orphan-client-stream.ts
@@ -1,0 +1,122 @@
+import fs from 'fs'
+import { mkdir } from 'fs/promises'
+import path from 'path'
+import { pipeline } from 'stream/promises'
+
+export interface OrphanObject {
+  event: 'data'
+  type: 'dbOrphans' | 's3Orphans'
+  value: {
+    name: string
+    version: string
+    size: number
+  }[]
+}
+
+export interface PingObject {
+  event: 'ping'
+}
+
+export interface StreamedErrorPayload {
+  statusCode: string
+  code: string
+  error: string
+  message: string
+}
+
+export interface ErrorObject {
+  event: 'error'
+  error: StreamedErrorPayload
+}
+
+export type OrphanStreamEvent = OrphanObject | PingObject | ErrorObject
+
+export function formatOrphanStreamError(error: StreamedErrorPayload) {
+  return `[${error.code}] ${error.message}`
+}
+
+export async function writeStreamToJsonArray(
+  stream: NodeJS.ReadableStream,
+  filePath: string
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true })
+
+  const localFile = fs.createWriteStream(filePath)
+  let isFirstItem = true
+  let receivedAnyData = false
+  let streamedError: Error | undefined
+  let deleteLimitReached = false
+  let inputStreamError: Error | undefined
+
+  const jsonArrayStream = (async function* () {
+    yield '[\n'
+
+    try {
+      for await (const data of stream as AsyncIterable<OrphanStreamEvent>) {
+        if (data.event === 'ping') {
+          console.log('Received ping event, ignoring')
+          continue
+        }
+
+        if (data.event === 'error') {
+          streamedError = new Error(formatOrphanStreamError(data.error))
+          console.error('Server error:', formatOrphanStreamError(data.error))
+          continue
+        }
+
+        if (data.event === 'data' && Array.isArray(data.value)) {
+          receivedAnyData = true
+          console.log(`Processing ${data.value.length} objects`)
+
+          for (const item of data.value) {
+            if (!isFirstItem) {
+              yield ',\n'
+            } else {
+              isFirstItem = false
+            }
+
+            yield JSON.stringify({ ...item, orphanType: data.type }, null, 2)
+          }
+          continue
+        }
+
+        console.warn(
+          'Received data with invalid format:',
+          JSON.stringify(data).substring(0, 100) + '...'
+        )
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === 'DELETE_LIMIT_REACHED') {
+        deleteLimitReached = true
+      } else {
+        inputStreamError =
+          err instanceof Error ? err : new Error('Unexpected stream failure', { cause: err })
+        console.error('Stream error:', inputStreamError)
+      }
+    }
+
+    yield '\n]'
+  })()
+
+  await pipeline(jsonArrayStream, localFile)
+
+  if (inputStreamError) {
+    throw inputStreamError
+  }
+
+  if (streamedError) {
+    throw streamedError
+  }
+
+  if (!receivedAnyData) {
+    console.warn(`No data was received! File might be empty: ${filePath}`)
+    return
+  }
+
+  if (deleteLimitReached) {
+    console.log(`Finished writing data to ${filePath}. Delete limit reached, data saved.`)
+    return
+  }
+
+  console.log(`Finished writing data to ${filePath}. Data was received and saved.`)
+}

--- a/src/scripts/orphan-client.ts
+++ b/src/scripts/orphan-client.ts
@@ -1,8 +1,8 @@
 import { NdJsonTransform } from '@internal/streams/ndjson'
 import axios from 'axios'
-import fs from 'fs'
 import path from 'path'
 import { Transform, TransformCallback } from 'stream'
+import { OrphanStreamEvent, writeStreamToJsonArray } from './orphan-client-stream'
 
 const ADMIN_URL = process.env.ADMIN_URL
 const ADMIN_API_KEY = process.env.ADMIN_API_KEY
@@ -24,20 +24,6 @@ const client = axios.create({
     ApiKey: ADMIN_API_KEY,
   },
 })
-
-interface OrphanObject {
-  event: 'data'
-  type: 's3Orphans'
-  value: {
-    name: string
-    version: string
-    size: number
-  }[]
-}
-
-interface PingObject {
-  event: 'ping'
-}
 
 async function main() {
   const action = process.argv[2]
@@ -90,7 +76,7 @@ async function listOrphans(tenantId: string, bucketId: string) {
 
   const jsonStream = request.data.pipe(transformStream)
 
-  await writeStreamToJsonArray(jsonStream, FILE_PATH('list', bucketId))
+  await writeStreamToJsonArray(jsonStream, path.resolve(__dirname, FILE_PATH('list', bucketId)))
 }
 
 /**
@@ -118,7 +104,7 @@ async function deleteS3Orphans(tenantId: string, bucketId: string) {
   let itemCount = 0
   const limitedStream = new Transform({
     objectMode: true,
-    transform(chunk: OrphanObject | PingObject, _encoding: string, callback: TransformCallback) {
+    transform(chunk: OrphanStreamEvent, _encoding: string, callback: TransformCallback) {
       if (chunk.event === 'data' && chunk.value && Array.isArray(chunk.value)) {
         itemCount += chunk.value.length
 
@@ -141,88 +127,10 @@ async function deleteS3Orphans(tenantId: string, bucketId: string) {
     },
   })
 
-  await writeStreamToJsonArray(jsonStream.pipe(limitedStream), FILE_PATH('delete', bucketId))
-}
-
-/**
- * Writes the output to a JSON array
- * @param stream
- * @param relativePath
- */
-async function writeStreamToJsonArray(
-  stream: NodeJS.ReadableStream,
-  relativePath: string
-): Promise<void> {
-  const filePath = path.resolve(__dirname, relativePath)
-  const localFile = fs.createWriteStream(filePath)
-
-  // Start with an empty array
-  localFile.write('[\n')
-  let isFirstItem = true
-
-  return new Promise((resolve, reject) => {
-    let receivedAnyData = false
-
-    stream.on('data', (data: OrphanObject | PingObject) => {
-      if (data.event === 'ping') {
-        console.log('Received ping event, ignoring')
-        return
-      }
-
-      if (data.event === 'data' && data.value && Array.isArray(data.value)) {
-        receivedAnyData = true
-        console.log(`Processing ${data.value.length} objects`)
-
-        for (const item of data.value) {
-          if (!isFirstItem) {
-            localFile.write(',\n')
-          } else {
-            isFirstItem = false
-          }
-
-          localFile.write(JSON.stringify({ ...item, orphanType: data.type }, null, 2))
-        }
-      } else {
-        console.warn(
-          'Received data with invalid format:',
-          JSON.stringify(data).substring(0, 100) + '...'
-        )
-      }
-    })
-
-    stream.on('error', (err) => {
-      // Handle DELETE_LIMIT_REACHED as a graceful stop, not an error
-      if (err.message === 'DELETE_LIMIT_REACHED') {
-        localFile.write('\n]')
-        localFile.end(() => {
-          if (receivedAnyData) {
-            console.log(`Finished writing data to ${filePath}. Delete limit reached, data saved.`)
-          }
-          resolve()
-        })
-        return
-      }
-
-      console.error('Stream error:', err)
-      localFile.end('\n]', () => {
-        reject(err)
-      })
-    })
-
-    stream.on('end', () => {
-      localFile.write('\n]')
-      localFile.end(() => {
-        resolve()
-      })
-
-      if (!receivedAnyData) {
-        console.warn(`No data was received! File might be empty: ${filePath}`)
-      } else {
-        // Check if the file exists and has content
-        console.log(`Finished writing data to ${filePath}. Data was received and saved.`)
-      }
-    })
-  })
+  await writeStreamToJsonArray(
+    jsonStream.pipe(limitedStream),
+    path.resolve(__dirname, FILE_PATH('delete', bucketId))
+  )
 }
 
 main()
@@ -230,5 +138,6 @@ main()
     console.log('Done')
   })
   .catch((e) => {
+    process.exitCode = 1
     console.error('Error:', e)
   })

--- a/src/test/error.test.ts
+++ b/src/test/error.test.ts
@@ -1,0 +1,39 @@
+import { ErrorCode, render } from '@internal/errors'
+
+describe('render', () => {
+  it('preserves message details for plain errors', () => {
+    expect(render(new Error('Entity expansion limit exceeded'))).toEqual({
+      statusCode: '500',
+      code: 'InternalError',
+      error: 'InternalError',
+      message: 'Entity expansion limit exceeded',
+    })
+  })
+
+  it('uses renderable error payloads as-is', () => {
+    const error = {
+      render: () => ({
+        statusCode: '499',
+        code: ErrorCode.AbortedTerminate,
+        error: ErrorCode.AbortedTerminate,
+        message: 'client disconnected',
+      }),
+    }
+
+    expect(render(error)).toEqual({
+      statusCode: '499',
+      code: ErrorCode.AbortedTerminate,
+      error: ErrorCode.AbortedTerminate,
+      message: 'client disconnected',
+    })
+  })
+
+  it('ignores non-callable render properties', () => {
+    expect(render({ render: 'not-a-function' })).toEqual({
+      statusCode: '500',
+      code: 'InternalError',
+      error: 'InternalError',
+      message: 'Internal server error',
+    })
+  })
+})

--- a/src/test/orphan-objects.test.ts
+++ b/src/test/orphan-objects.test.ts
@@ -1,0 +1,155 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { Readable } from 'stream'
+import { writeStreamToJsonArray } from '../scripts/orphan-client-stream'
+
+describe('writeStreamToJsonArray', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'orphan-client-stream-'))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('rejects when the server streams an error event', async () => {
+    const filePath = path.join(tempDir, 'orphan-objects.json')
+    const stream = Readable.from(
+      [
+        {
+          event: 'data',
+          type: 'dbOrphans',
+          value: [{ name: 'my-object', version: 'v1', size: 1 }],
+        },
+        {
+          event: 'error',
+          error: {
+            statusCode: '500',
+            code: 'InternalError',
+            error: 'InternalError',
+            message: 'Entity expansion limit exceeded',
+          },
+        },
+      ],
+      { objectMode: true }
+    )
+
+    await expect(writeStreamToJsonArray(stream, filePath)).rejects.toThrow(
+      '[InternalError] Entity expansion limit exceeded'
+    )
+    await expect(fs.readFile(filePath, 'utf8')).resolves.toContain('"my-object"')
+  })
+
+  it('creates parent directories for the output file', async () => {
+    const filePath = path.join(tempDir, 'nested', 'orphan-objects.json')
+    const stream = Readable.from(
+      [
+        {
+          event: 'data',
+          type: 's3Orphans',
+          value: [{ name: 'my-object', version: 'v1', size: 1 }],
+        },
+      ],
+      { objectMode: true }
+    )
+
+    await expect(writeStreamToJsonArray(stream, filePath)).resolves.toBeUndefined()
+    await expect(fs.readFile(filePath, 'utf8')).resolves.toContain('"my-object"')
+  })
+
+  it('resolves after writing partial data when the delete limit is reached', async () => {
+    const filePath = path.join(tempDir, 'delete-limit.json')
+    const stream = Readable.from(
+      (async function* () {
+        yield {
+          event: 'data' as const,
+          type: 's3Orphans' as const,
+          value: [{ name: 'my-object', version: 'v1', size: 1 }],
+        }
+
+        throw new Error('DELETE_LIMIT_REACHED')
+      })(),
+      { objectMode: true }
+    )
+
+    await expect(writeStreamToJsonArray(stream, filePath)).resolves.toBeUndefined()
+    await expect(fs.readFile(filePath, 'utf8')).resolves.toContain('"my-object"')
+  })
+
+  it('rejects after closing the JSON array on input stream errors', async () => {
+    const filePath = path.join(tempDir, 'stream-error.json')
+    const stream = Readable.from(
+      (async function* () {
+        yield {
+          event: 'data' as const,
+          type: 's3Orphans' as const,
+          value: [{ name: 'my-object', version: 'v1', size: 1 }],
+        }
+
+        throw new Error('upstream stream failed')
+      })(),
+      { objectMode: true }
+    )
+
+    await expect(writeStreamToJsonArray(stream, filePath)).rejects.toThrow('upstream stream failed')
+
+    const content = await fs.readFile(filePath, 'utf8')
+
+    expect(JSON.parse(content)).toEqual([
+      {
+        name: 'my-object',
+        version: 'v1',
+        size: 1,
+        orphanType: 's3Orphans',
+      },
+    ])
+  })
+
+  it('normalizes non-Error input stream failures', async () => {
+    const filePath = path.join(tempDir, 'non-error-stream-failure.json')
+    const stream = new Readable({
+      objectMode: true,
+      read() {
+        this.destroy('stream failed' as unknown as Error)
+      },
+    })
+
+    await expect(writeStreamToJsonArray(stream, filePath)).rejects.toThrow(
+      'Unexpected stream failure'
+    )
+  })
+
+  it('ignores malformed events that include a value field but are not data events', async () => {
+    const filePath = path.join(tempDir, 'invalid-event.json')
+    const stream = Readable.from(
+      [
+        {
+          event: 'unexpected',
+          type: 's3Orphans',
+          value: [{ name: 'my-object', version: 'v1', size: 1 }],
+        },
+      ] as Iterable<unknown>,
+      { objectMode: true }
+    )
+
+    await expect(writeStreamToJsonArray(stream, filePath)).resolves.toBeUndefined()
+
+    const content = await fs.readFile(filePath, 'utf8')
+
+    expect(JSON.parse(content)).toEqual([])
+    expect(console.warn).toHaveBeenCalled()
+  })
+
+  it('rejects when the local output stream cannot be opened', async () => {
+    const stream = Readable.from([], { objectMode: true })
+
+    await expect(writeStreamToJsonArray(stream, tempDir)).rejects.toThrow()
+  })
+})

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -711,6 +711,56 @@ describe('S3 Protocol', () => {
         expect(objectsPage3.Contents?.[0].Key).toBe('test-1.jpg')
         expect(objectsPage3.IsTruncated).toBe(false)
       })
+
+      it('lists an entity-heavy first page without XML expansion failure', async () => {
+        const bucket = await createBucket(client)
+        const minEntityExpansions = 2000
+        const pageSize = 10
+        const entityRefsPerKey = Math.ceil(minEntityExpansions / pageSize)
+        const entityRun = '&'.repeat(entityRefsPerKey)
+        const names = Array.from({ length: pageSize + 1 }, (_, i) => {
+          return `key-${String(i).padStart(2, '0')}-${entityRun}.txt`
+        })
+
+        for (let i = 0; i < names.length; i += pageSize) {
+          await Promise.all(
+            names.slice(i, i + pageSize).map((name) =>
+              client.send(
+                new PutObjectCommand({
+                  Bucket: bucket,
+                  Key: name,
+                  Body: Buffer.alloc(1),
+                  ContentType: 'text/plain',
+                })
+              )
+            )
+          )
+        }
+
+        const page1 = await client.send(
+          new ListObjectsV2Command({
+            Bucket: bucket,
+            MaxKeys: pageSize,
+          })
+        )
+
+        expect(page1.Contents).toHaveLength(pageSize)
+        expect(page1.IsTruncated).toBe(true)
+        expect(page1.NextContinuationToken).toBeTruthy()
+        expect(page1.Contents?.map((entry) => entry.Key)).toEqual(names.slice(0, pageSize))
+
+        const page2 = await client.send(
+          new ListObjectsV2Command({
+            Bucket: bucket,
+            ContinuationToken: page1.NextContinuationToken,
+            MaxKeys: pageSize,
+          })
+        )
+
+        expect(page2.Contents).toHaveLength(1)
+        expect(page2.IsTruncated).toBe(false)
+        expect(page2.Contents?.map((entry) => entry.Key)).toEqual(names.slice(pageSize))
+      }, 60000)
     })
 
     for (const urlEncode of [true, false]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
       "@internal/*": ["./src/internal/*"],
       "@storage/*": ["./src/storage/*"]
     },
+    "types": ["node", "jest"],
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix + refactor

## What is the current behavior?

https://github.com/supabase/storage/pull/905 caused entity expansion limit hit and failure isn't covered in tests and orphan objects script doesn't log errors. 

## What is the new behavior?

https://github.com/supabase/storage/pull/963 already addressed entity expansion limit but here we add test coverage specifically for it.

Create a render error utility for error details, pass it to orphan object streams and log it in the client. On error, exit script with code 1. Increase coverage as well.  

## Additional context

Related to https://github.com/supabase/storage/pull/961
