### PR TITLE
fix: correct boolean check in doesSchemaExists

### DIFF
--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -806,7 +806,7 @@ async function doesSchemaExists(client: BasicPgClient, schemaName: string) {
       WHERE schema_name = ${schemaName}
   );`)
 
-  return result.rows.length > 0 && result.rows[0].exists === 'true'
+  return result.rows.length > 0 && result.rows[0].exists
 }
 
 /**


### PR DESCRIPTION
Fixes #928

`doesSchemaExists` compares the result of `SELECT EXISTS(...)` with the string `'true'`, but the `pg` driver returns a JavaScript boolean. So `true === 'true'` is always `false`, meaning the function always reports the schema doesn't exist.

This causes the migration to always run `CREATE SCHEMA IF NOT EXISTS storage`, which fails for self-hosted setups where the DB user has permissions within the storage schema but not `CREATE` on the database itself.

The fix aligns with how `doesTableExist` (same file, line 794) already handles the check -- just using the boolean value directly.