### PR TITLE
fix: preserve charset in content-type for non-zero byte files

### DIFF
--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -283,7 +283,7 @@ export class S3Backend implements StorageBackendAdapter {
         httpStatusCode: data.$metadata.httpStatusCode || metadata.httpStatusCode,
         cacheControl,
         eTag: metadata.eTag,
-        mimetype: metadata.mimetype,
+        mimetype: contentType || metadata.mimetype,
         contentLength: metadata.contentLength,
         lastModified: metadata.lastModified,
         size: metadata.size,

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -286,6 +286,35 @@ describe('testing GET object', () => {
  * multipart upload
  */
 describe('testing POST object via multipart upload', () => {
+  test('preserve charset in content-type for non-zero byte files', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`)) 
+    
+    const headers = Object.assign({}, form.getHeaders(), {
+      authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      'x-upsert': 'true',
+      'content-type': 'text/markdown; charset=UTF-8', 
+    })
+
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/bucket2/charset-test.md',
+      headers,
+      payload: form,
+    })
+  
+    expect(response.statusCode).toBe(200)
+    
+    const client = await getSuperuserPostgrestClient()
+    const object = await client
+      .table('objects')
+      .select('*')
+      .where('name', 'charset-test.md')
+      .first()
+
+    expect(object).not.toBeFalsy()
+    expect(object?.metadata?.mimetype).toBe('text/markdown; charset=UTF-8')
+  })
   test('check if RLS policies are respected: authenticated user is able to upload authenticated resource', async () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
@@ -807,7 +836,9 @@ describe('testing POST object via multipart upload', () => {
       .first()
 
     expect(objectResponse).toBe(undefined)
+    
   })
+  
 })
 
 /*


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix
## What is the current behavior?
When uploading a non-zero byte file with a Content-Type that includes a charset parameter (e.g. text/markdown; charset=UTF-8), the charset is silently dropped. This happens because bufferedMultipartUpload calls headObject after upload, and S3 normalizes the Content-Type by stripping the charset before returning it.
Fixes #816
## What is the new behavior?
The original contentType parameter (which contains the full Content-Type including charset) is now used directly in the return value, instead of relying on the normalized response from S3's headObject. Falls back to metadata.mimetype if contentType is empty.

// Before
mimetype: metadata.mimetype

// After
mimetype: contentType || metadata.mimetype

## Additional context
Zero-byte files were already handled correctly because they bypass headObject entirely. This fix brings non-zero byte files in line with the same behaviour.