### PR TITLE
feat: return object id in TUS upload completion response header

### DIFF
--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -308,7 +308,7 @@ export async function onUploadFinish(rawReq: Request, upload: Upload) {
       }
     }
 
-    await uploader.completeUpload({
+    const result = await uploader.completeUpload({
       version: resourceId.version,
       bucketId: resourceId.bucket,
       objectName: resourceId.objectName,
@@ -322,6 +322,7 @@ export async function onUploadFinish(rawReq: Request, upload: Upload) {
     return {
       headers: {
         'Tus-Complete': '1',
+        'x-supabase-id': result.obj.id,
       },
     }
   } catch (e) {

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -322,7 +322,7 @@ export async function onUploadFinish(rawReq: Request, upload: Upload) {
     return {
       headers: {
         'Tus-Complete': '1',
-        'x-supabase-id': result.obj.id,
+        ...(result.obj.id ? { 'x-supabase-id': result.obj.id } : {}),
       },
     }
   } catch (e) {

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -146,6 +146,62 @@ describe('Tus multipart', () => {
     })
   })
 
+  it('Returns the object id in the x-supabase-id response header on upload completion', async () => {
+    const objectName = randomUUID() + '-cat.jpeg'
+
+    const bucket = await storage.createBucket({
+      id: bucketName,
+      name: bucketName,
+      public: true,
+    })
+
+    const authorization = `Bearer ${await serviceKeyAsync}`
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    let supabaseId: string | undefined
+
+    await new Promise((resolve, reject) => {
+      const upload = new tus.Upload(
+        fs.createReadStream(path.resolve(__dirname, 'assets', 'sadcat.jpg')),
+        {
+          endpoint: `${localServerAddress}/upload/resumable`,
+          onShouldRetry: () => false,
+          uploadDataDuringCreation: false,
+          headers: {
+            authorization,
+            'x-upsert': 'true',
+          },
+          metadata: {
+            bucketName,
+            objectName,
+            contentType: 'image/jpeg',
+            cacheControl: '3600',
+          },
+          onAfterResponse: (_req, res) => {
+            const id = res.getHeader('x-supabase-id')
+            if (id) {
+              supabaseId = id
+            }
+          },
+          onError(error) {
+            reject(error)
+          },
+          onSuccess: () => {
+            resolve(true)
+          },
+        }
+      )
+
+      upload.start()
+    })
+
+    expect(supabaseId).toBeDefined()
+    expect(supabaseId).toMatch(uuidRegex)
+
+    const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+    expect(supabaseId).toEqual(dbAsset.id)
+  })
+
   describe('TUS Validation', () => {
     it('Cannot upload to a non-existing bucket', async () => {
       const objectName = randomUUID() + '-cat.jpeg'


### PR DESCRIPTION
Closes #647

## Summary

After a TUS resumable upload completes, there's currently no way to get the `object_id` of the uploaded file without making a follow-up `.list()` call. The `onSuccess` callback from `tus-js-client` only gets the upload URL, not the object ID.

The standard `POST /object` endpoint already returns the ID in the JSON body (`{ Id, Key }`). For TUS, since the response format is governed by the protocol, a response header is the natural fit -- same approach @fenos suggested in #647.

This captures the return value of `completeUpload()` in the `onUploadFinish` lifecycle hook and includes the object's UUID in a new `x-supabase-id` response header. The `@tus/server` library already supports custom headers -- both `PatchHandler` and `PostHandler` merge them into the outgoing response.

## Changes

- `src/http/routes/tus/lifecycle.ts` -- capture `completeUpload()` result, add `x-supabase-id` header
- `src/test/tus.test.ts` -- new test verifying the header is present, is a valid UUID, and matches the database record

## Test plan

- [x] Added test: TUS upload completion returns `x-supabase-id` header with valid UUID matching DB record
- [ ] Existing TUS tests pass with no regressions