### PR TITLE
feat: create admin endpoint to roll tenant url signing jwk

### DIFF
--- a/src/http/routes/admin/jwks.ts
+++ b/src/http/routes/admin/jwks.ts
@@ -1,6 +1,7 @@
 import { UrlSigningJwkGenerator } from '@internal/auth/jwks/generator'
 import { jwksManager } from '@internal/database'
 import { logSchema } from '@internal/monitoring'
+import { JwksRollUrlSigningKey } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import apiKey from '../../plugins/apikey'
@@ -48,6 +49,12 @@ interface JwksUpdateRequestInterface extends RequestGenericInterface {
   Params: {
     tenantId: string
     kid: string
+  }
+}
+
+interface JwksRollRequestInterface extends RequestGenericInterface {
+  Params: {
+    tenantId: string
   }
 }
 
@@ -124,6 +131,23 @@ export default async function routes(fastify: FastifyInstance) {
       } = request
       const result = await jwksManager.toggleJwkActive(tenantId, kid, active)
       return reply.send({ result })
+    }
+  )
+
+  fastify.post<JwksRollRequestInterface>(
+    '/:tenantId/jwks/url-signing/roll',
+    { schema: { tags: ['jwks'] } },
+    async (request, reply) => {
+      const { tenantId } = request.params
+
+      await JwksRollUrlSigningKey.send({
+        tenantId,
+        tenant: {
+          ref: tenantId,
+        },
+      })
+
+      return reply.send({ started: true })
     }
   )
 

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -72,7 +72,7 @@ export class JWKSManager {
    */
   async rollUrlSigningJwk(tenantId: string): Promise<{ oldKid: string | null; newKid: string }> {
     return this.storage.transaction(async (trx) => {
-      const currentKeys = await this.storage.listActive(tenantId, JWK_KIND_STORAGE_URL_SIGNING)
+      const currentKeys = await this.storage.listActive(tenantId, JWK_KIND_STORAGE_URL_SIGNING, trx)
       const currentKey = currentKeys[0]
 
       if (currentKey) {

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -67,6 +67,30 @@ export class JWKSManager {
   }
 
   /**
+   * Atomically rolls the URL signing JWK by deactivating the current key and creating a new one
+   * @param tenantId
+   */
+  async rollUrlSigningJwk(tenantId: string): Promise<{ oldKid: string | null; newKid: string }> {
+    return this.storage.transaction(async (trx) => {
+      const currentKeys = await this.storage.listActive(tenantId, JWK_KIND_STORAGE_URL_SIGNING)
+      const currentKey = currentKeys[0]
+
+      if (currentKey) {
+        await this.storage.toggleActive(tenantId, currentKey.id, false, trx)
+      }
+
+      const { kid: newKid } = await this.generateUrlSigningJwk(tenantId, trx)
+
+      return {
+        oldKid: currentKey
+          ? createJwkKid({ kind: JWK_KIND_STORAGE_URL_SIGNING, id: currentKey.id })
+          : null,
+        newKid,
+      }
+    })
+  }
+
+  /**
    * Adds a new jwk that can be used for signing urls
    * @param tenantId
    * @param jwk jwk content

--- a/src/internal/auth/jwks/store-knex.ts
+++ b/src/internal/auth/jwks/store-knex.ts
@@ -7,6 +7,10 @@ const { multitenantDatabaseQueryTimeout } = getConfig()
 export class JWKSManagerStoreKnex implements JWKSManagerStore<Knex.Transaction> {
   constructor(private knex: Knex) {}
 
+  async transaction<T>(callback: (trx: Knex.Transaction) => Promise<T>): Promise<T> {
+    return this.knex.transaction(callback)
+  }
+
   async insert(
     tenant_id: string,
     content: string,
@@ -49,8 +53,14 @@ export class JWKSManagerStoreKnex implements JWKSManagerStore<Knex.Transaction> 
     }
   }
 
-  async toggleActive(tenantId: string, id: string, newState: boolean): Promise<boolean> {
-    const updated = await this.knex
+  async toggleActive(
+    tenantId: string,
+    id: string,
+    newState: boolean,
+    trx?: Knex.Transaction
+  ): Promise<boolean> {
+    const db = trx || this.knex
+    const updated = await db
       .table('tenants_jwks')
       .where('id', id)
       .where('tenant_id', tenantId)
@@ -60,13 +70,18 @@ export class JWKSManagerStoreKnex implements JWKSManagerStore<Knex.Transaction> 
     return updated > 0
   }
 
-  listActive(tenantId: string): Promise<JWKStoreItem[]> {
-    return this.knex
+  listActive(tenantId: string, kind?: string): Promise<JWKStoreItem[]> {
+    const query = this.knex
       .table<JWKStoreItem>('tenants_jwks')
       .select('id', 'kind', 'content')
       .where('tenant_id', tenantId)
       .where('active', true)
-      .abortOnSignal(AbortSignal.timeout(multitenantDatabaseQueryTimeout))
+
+    if (kind) {
+      query.where('kind', kind)
+    }
+
+    return query.abortOnSignal(AbortSignal.timeout(multitenantDatabaseQueryTimeout))
   }
 
   async listTenantsWithoutKindPaginated(

--- a/src/internal/auth/jwks/store-knex.ts
+++ b/src/internal/auth/jwks/store-knex.ts
@@ -70,8 +70,9 @@ export class JWKSManagerStoreKnex implements JWKSManagerStore<Knex.Transaction> 
     return updated > 0
   }
 
-  listActive(tenantId: string, kind?: string): Promise<JWKStoreItem[]> {
-    const query = this.knex
+  listActive(tenantId: string, kind?: string, trx?: Knex.Transaction): Promise<JWKStoreItem[]> {
+    const db = trx || this.knex
+    const query = db
       .table<JWKStoreItem>('tenants_jwks')
       .select('id', 'kind', 'content')
       .where('tenant_id', tenantId)

--- a/src/internal/auth/jwks/store.ts
+++ b/src/internal/auth/jwks/store.ts
@@ -11,6 +11,12 @@ export interface PaginatedTenantItem {
 
 export interface JWKSManagerStore<TRX> {
   /**
+   * Run operations in a transaction
+   * @param callback
+   */
+  transaction<T>(callback: (trx: TRX) => Promise<T>): Promise<T>
+
+  /**
    * Adds a jwk to the database
    * @param tenant_id owning tenant
    * @param content serialized and encrypted jwk content
@@ -31,14 +37,16 @@ export interface JWKSManagerStore<TRX> {
    * @param tenantId
    * @param id
    * @param newState
+   * @param trx optional transaction to use for this query
    */
-  toggleActive(tenantId: string, id: string, newState: boolean): Promise<boolean>
+  toggleActive(tenantId: string, id: string, newState: boolean, trx?: TRX): Promise<boolean>
 
   /**
    * Lists all active jwks for the specified tenant
    * @param tenantId
+   * @param kind optional filter by kind
    */
-  listActive(tenantId: string): Promise<JWKStoreItem[]>
+  listActive(tenantId: string, kind?: string): Promise<JWKStoreItem[]>
 
   /**
    * Lists tenants that do not have a jwk of the specified kind

--- a/src/internal/auth/jwks/store.ts
+++ b/src/internal/auth/jwks/store.ts
@@ -46,7 +46,7 @@ export interface JWKSManagerStore<TRX> {
    * @param tenantId
    * @param kind optional filter by kind
    */
-  listActive(tenantId: string, kind?: string): Promise<JWKStoreItem[]>
+  listActive(tenantId: string, kind?: string, trx?: TRX): Promise<JWKStoreItem[]>
 
   /**
    * Lists tenants that do not have a jwk of the specified kind

--- a/src/storage/events/index.ts
+++ b/src/storage/events/index.ts
@@ -1,5 +1,6 @@
 export * from './base-event'
 export * from './jwks/jwks-create-signing-secret'
+export * from './jwks/jwks-roll-url-signing-key'
 export * from './lifecycle/bucket-created'
 export * from './lifecycle/bucket-deleted'
 export * from './lifecycle/object-created'

--- a/src/storage/events/jwks/jwks-roll-url-signing-key.ts
+++ b/src/storage/events/jwks/jwks-roll-url-signing-key.ts
@@ -34,6 +34,10 @@ export class JwksRollUrlSigningKey extends BaseEvent<JwksRollUrlSigningKeyPayloa
     }
   }
 
+  static async shouldSend() {
+    return true
+  }
+
   static async handle(job: Job<JwksRollUrlSigningKeyPayload>) {
     const { tenantId } = job.data
 

--- a/src/storage/events/jwks/jwks-roll-url-signing-key.ts
+++ b/src/storage/events/jwks/jwks-roll-url-signing-key.ts
@@ -1,0 +1,60 @@
+import { jwksManager } from '@internal/database'
+import { logger, logSchema } from '@internal/monitoring'
+import { BasePayload } from '@internal/queue'
+import { Job, Queue, SendOptions, WorkOptions } from 'pg-boss'
+import { BaseEvent } from '../base-event'
+
+interface JwksRollUrlSigningKeyPayload extends BasePayload {
+  tenantId: string
+}
+
+export class JwksRollUrlSigningKey extends BaseEvent<JwksRollUrlSigningKeyPayload> {
+  static queueName = 'tenants-jwks-roll-url-signing-key-v1'
+
+  static getQueueOptions(): Queue {
+    return {
+      name: this.queueName,
+      policy: 'exactly_once',
+    } as const
+  }
+
+  static getWorkerOptions(): WorkOptions {
+    return {
+      includeMetadata: true,
+    }
+  }
+
+  static getSendOptions(payload: JwksRollUrlSigningKeyPayload): SendOptions {
+    return {
+      expireInHours: 2,
+      singletonKey: `jwks_roll_url_signing_key_${payload.tenantId}`,
+      retryLimit: 3,
+      retryDelay: 5,
+      priority: 10,
+    }
+  }
+
+  static async handle(job: Job<JwksRollUrlSigningKeyPayload>) {
+    const { tenantId } = job.data
+
+    try {
+      const { oldKid, newKid } = await jwksManager.rollUrlSigningJwk(tenantId)
+
+      logSchema.info(
+        logger,
+        `[Jwks] rolled url signing key for tenant ${tenantId} (old: ${oldKid}, new: ${newKid})`,
+        {
+          type: 'jwks',
+          project: tenantId,
+        }
+      )
+    } catch (e) {
+      logSchema.error(logger, `[Jwks] roll url signing key failed for tenant ${tenantId}`, {
+        type: 'jwks',
+        error: e,
+        project: tenantId,
+      })
+      throw e
+    }
+  }
+}

--- a/src/storage/events/workers.ts
+++ b/src/storage/events/workers.ts
@@ -2,6 +2,7 @@ import { Queue } from '@internal/queue'
 import { DeleteIcebergResources } from './iceberg/delete-iceberg-resources'
 import { ReconcileIcebergCatalog } from './iceberg/reconcile-catalog'
 import { JwksCreateSigningSecret } from './jwks/jwks-create-signing-secret'
+import { JwksRollUrlSigningKey } from './jwks/jwks-roll-url-signing-key'
 import { Webhook } from './lifecycle/webhook'
 import { ResetMigrationsOnTenant } from './migrations/reset-migrations'
 import { RunMigrationsOnTenants } from './migrations/run-migrations'
@@ -20,6 +21,7 @@ export function registerWorkers() {
   Queue.register(BackupObjectEvent)
   Queue.register(ResetMigrationsOnTenant)
   Queue.register(JwksCreateSigningSecret)
+  Queue.register(JwksRollUrlSigningKey)
   Queue.register(UpgradePgBossV10)
   Queue.register(MoveJobs)
   Queue.register(ReconcileIcebergCatalog)

--- a/src/test/tenant-jwks.test.ts
+++ b/src/test/tenant-jwks.test.ts
@@ -618,4 +618,104 @@ describe('Tenant jwks configs', () => {
     const insert = storage.insert('tenant-id', 'encrypted', 'kind', true)
     await expect(insert).rejects.toThrow('failed to find existing jwk on idempotent insert')
   })
+
+  test('Roll url signing key', async () => {
+    const queueSendSpy = mockQueue().sendSpy
+    const queueSpyAwaiter = new Promise((resolve) => {
+      queueSendSpy.mockImplementationOnce((...args) => {
+        resolve(args)
+      })
+    })
+    try {
+      const response = await adminApp.inject({
+        method: 'POST',
+        url: `/tenants/${tenantId}/jwks/url-signing/roll`,
+        headers: {
+          apikey: process.env.ADMIN_API_KEYS,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const data = response.json<{ started: boolean }>()
+      expect(data.started).toBe(true)
+
+      await queueSpyAwaiter
+      expect(queueSendSpy).toHaveBeenCalledTimes(1)
+      const [[callArg]] = queueSendSpy.mock.calls
+      expect(callArg).toMatchObject({
+        data: { tenantId },
+        name: 'tenants-jwks-roll-url-signing-key-v1',
+      })
+    } finally {
+      queueSendSpy.mockRestore()
+    }
+  })
+
+  test('Roll url signing key when no key exists', async () => {
+    let configAwaiter = createJwkConfigChangeAwaiter()
+
+    const config = await jwksManager.getJwksTenantConfig(tenantId)
+    expect(config.keys.length).toBe(1)
+    const { kid } = config.keys[0]
+
+    await adminApp.inject({
+      method: 'PUT',
+      url: `/tenants/${tenantId}/jwks/${kid}`,
+      payload: { active: false },
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+
+    await expect(configAwaiter).resolves.toBe(tenantId)
+
+    const configBeforeRoll = await waitForEventually(
+      () => jwksManager.getJwksTenantConfig(tenantId),
+      (value) => value.keys.length === 0,
+      `tenant ${tenantId} JWKS to clear after deactivation`
+    )
+    expect(configBeforeRoll.keys.length).toBe(0)
+
+    configAwaiter = createJwkConfigChangeAwaiter()
+    const { oldKid, newKid } = await jwksManager.rollUrlSigningJwk(tenantId)
+
+    expect(oldKid).toBeNull()
+    expect(newKid).toContain('storage-url-signing-key')
+
+    await expect(configAwaiter).resolves.toBe(tenantId)
+    const configAfterRoll = await waitForEventually(
+      () => jwksManager.getJwksTenantConfig(tenantId),
+      (value) => value.keys.length === 1,
+      `tenant ${tenantId} JWKS to clear after deactivation`
+    )
+    expect(configAfterRoll.keys.length).toBe(1)
+    expect(configAfterRoll.keys[0].kid).toBe(newKid)
+  })
+
+  test('Roll url signing key atomically replaces existing key', async () => {
+    const configBefore = await jwksManager.getJwksTenantConfig(tenantId)
+    expect(configBefore.keys.length).toBe(1)
+    const oldKid = configBefore.keys[0].kid
+
+    const configAwaiter = createJwkConfigChangeAwaiter()
+    const { oldKid: returnedOldKid, newKid } = await jwksManager.rollUrlSigningJwk(tenantId)
+
+    expect(returnedOldKid).toBe(oldKid)
+    expect(newKid).not.toBe(oldKid)
+    expect(newKid).toContain('storage-url-signing-key')
+
+    await expect(configAwaiter).resolves.toBe(tenantId)
+    const configAfter = await waitForEventually(
+      () => jwksManager.getJwksTenantConfig(tenantId),
+      (value) => value.keys[0].kid !== oldKid,
+      `tenant ${tenantId} JWKS to clear after deactivation`
+    )
+
+    await jwksManager.getJwksTenantConfig(tenantId)
+    expect(configAfter.keys.length).toBe(1)
+    expect(configAfter.keys[0].kid).toBe(newKid)
+
+    const activeKeys = await jwksManager['storage'].listActive(tenantId, 'storage-url-signing-key')
+    expect(activeKeys.length).toBe(1)
+    expect(activeKeys[0].id).toBe(newKid.split('_')[1])
+  })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

There is no admin api endpoint to roll the tenant url signing jwk. This means that rolling the url signing jwk for a tenant is possible but a clunky manual process.

## What is the new behavior?

Add admin api endpoint that rolls the url signing jwk

