### PR TITLE
feat: add hit ratio tenant pool cache

### DIFF
--- a/src/internal/cache/names.ts
+++ b/src/internal/cache/names.ts
@@ -1,10 +1,12 @@
 export const JWT_CACHE_NAME = 'jwt' as const
 export const TENANT_CONFIG_CACHE_NAME = 'tenant_config' as const
 export const TENANT_JWKS_CACHE_NAME = 'tenant_jwks' as const
+export const TENANT_POOL_CACHE_NAME = 'tenant_pool' as const
 export const TENANT_S3_CREDENTIALS_CACHE_NAME = 'tenant_s3_credentials' as const
 
 export type CacheName =
   | typeof JWT_CACHE_NAME
   | typeof TENANT_CONFIG_CACHE_NAME
   | typeof TENANT_JWKS_CACHE_NAME
+  | typeof TENANT_POOL_CACHE_NAME
   | typeof TENANT_S3_CREDENTIALS_CACHE_NAME

--- a/src/internal/database/pool.ts
+++ b/src/internal/database/pool.ts
@@ -1,8 +1,9 @@
-import { createTtlCache } from '@internal/cache'
+import { createTtlCache, TENANT_POOL_CACHE_NAME } from '@internal/cache'
 import { wait } from '@internal/concurrency'
 import { getSslSettings } from '@internal/database/ssl'
 import { logger, logSchema } from '@internal/monitoring'
 import {
+  cacheRequestsTotal,
   dbActiveConnection,
   dbActivePool,
   dbInUseConnection,
@@ -207,16 +208,30 @@ export class PoolManager {
   }
 
   getPool(settings: TenantConnectionOptions) {
-    const existingPool = tenantPools.get(settings.tenantId)
+    const isCacheable = (settings.isSingleUse && !settings.isExternalPool) || !settings.isSingleUse
+    const { value: existingPool, outcome } = tenantPools.getWithOutcome(settings.tenantId)
+
     if (existingPool) {
+      cacheRequestsTotal.add(1, {
+        cache: TENANT_POOL_CACHE_NAME,
+        outcome,
+      })
+
       return existingPool
     }
 
+    if (!isCacheable) {
+      return this.newPool({ ...settings, numWorkers: this.numWorkers })
+    }
+
+    cacheRequestsTotal.add(1, {
+      cache: TENANT_POOL_CACHE_NAME,
+      outcome,
+    })
+
     const newPool = this.newPool({ ...settings, numWorkers: this.numWorkers })
 
-    if ((settings.isSingleUse && !settings.isExternalPool) || !settings.isSingleUse) {
-      tenantPools.set(settings.tenantId, newPool)
-    }
+    tenantPools.set(settings.tenantId, newPool)
     return newPool
   }
 

--- a/src/test/pool-cache.test.ts
+++ b/src/test/pool-cache.test.ts
@@ -1,5 +1,7 @@
 'use strict'
 
+import { TENANT_POOL_CACHE_NAME } from '@internal/cache'
+
 type TestPool = {
   acquire: jest.Mock
   rebalance: jest.Mock
@@ -148,6 +150,109 @@ describe('PoolManager cache lifecycle', () => {
     jest.advanceTimersByTime(20)
 
     expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
+
+    await poolManager.destroyAll()
+  })
+
+  test('records logical pool cache misses and hits', async () => {
+    const poolModule = await loadPoolModule(10_000)
+    const metricsModule = await import('../internal/monitoring/metrics')
+    const addSpy = jest.spyOn(metricsModule.cacheRequestsTotal, 'add')
+
+    class TestPoolManager extends poolModule.PoolManager {
+      created: TestPool[] = []
+
+      protected newPool(_settings: any): any {
+        const pool = createTestPool()
+        this.created.push(pool)
+        return pool
+      }
+    }
+
+    const poolManager = new TestPoolManager()
+    const settings = createPoolSettings('tenant-cache-metrics')
+
+    const first = poolManager.getPool(settings)
+    const second = poolManager.getPool(settings)
+
+    expect(second).toBe(first)
+    expect(poolManager.created).toHaveLength(1)
+    expect(addSpy.mock.calls).toEqual(
+      expect.arrayContaining([
+        [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'miss' }],
+        [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }],
+      ])
+    )
+
+    await poolManager.destroyAll()
+  })
+
+  test('does not record pool cache misses for single-use external pools without cached pools', async () => {
+    const poolModule = await loadPoolModule(10_000)
+    const metricsModule = await import('../internal/monitoring/metrics')
+    const addSpy = jest.spyOn(metricsModule.cacheRequestsTotal, 'add')
+
+    class TestPoolManager extends poolModule.PoolManager {
+      created: TestPool[] = []
+
+      protected newPool(_settings: any): any {
+        const pool = createTestPool()
+        this.created.push(pool)
+        return pool
+      }
+    }
+
+    const poolManager = new TestPoolManager()
+    const settings = {
+      ...createPoolSettings('tenant-single-use-external'),
+      isSingleUse: true,
+      isExternalPool: true,
+    }
+
+    const first = poolManager.getPool(settings)
+    const second = poolManager.getPool(settings)
+
+    expect(second).not.toBe(first)
+    expect(poolManager.created).toHaveLength(2)
+    expect(
+      addSpy.mock.calls.filter(([, attrs]) => {
+        return attrs && typeof attrs === 'object' && attrs.cache === TENANT_POOL_CACHE_NAME
+      })
+    ).toEqual([])
+
+    await Promise.all([first.destroy(), second.destroy()])
+    await poolManager.destroyAll()
+  })
+
+  test('reuses cached pools for single-use external requests and records a hit', async () => {
+    const poolModule = await loadPoolModule(10_000)
+    const metricsModule = await import('../internal/monitoring/metrics')
+    const addSpy = jest.spyOn(metricsModule.cacheRequestsTotal, 'add')
+
+    class TestPoolManager extends poolModule.PoolManager {
+      created: TestPool[] = []
+
+      protected newPool(_settings: any): any {
+        const pool = createTestPool()
+        this.created.push(pool)
+        return pool
+      }
+    }
+
+    const poolManager = new TestPoolManager()
+    const tenantId = 'tenant-single-use-external-reuses-cache'
+    const cachedPool = poolManager.getPool(createPoolSettings(tenantId))
+    addSpy.mockClear()
+
+    const reusedPool = poolManager.getPool({
+      ...createPoolSettings(tenantId),
+      isSingleUse: true,
+      isExternalPool: true,
+    })
+
+    expect(reusedPool).toBe(cachedPool)
+    expect(poolManager.created).toHaveLength(1)
+    expect(addSpy.mock.calls).toEqual([[1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }]])
 
     await poolManager.destroyAll()
   })

--- a/src/test/query-abort-signal.test.ts
+++ b/src/test/query-abort-signal.test.ts
@@ -17,7 +17,8 @@ describe('Query Abort Signal', () => {
   })
 
   async function withIsolatedConnection<T>(run: (conn: TestConnection) => Promise<T>) {
-    // Force fresh, cache is checked before isSingleUse.
+    // Force fresh because single-use external requests still reuse
+    // an already cached pool for the same tenant.
     await poolManager.destroy(tenantId)
 
     // Use an uncached single-use pool so aborted queries can't


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the current behavior?

We have lru and ttl caches decorated for metrics but ttl cache holds pools and does its own metric reporting so no name is passed and it doesn't report regulars (hits, evictions, size, etc.) 

## What is the new behavior?

Add hit ratio for ttl cache without changing existing metrics.

