### PR TITLE
fix: allow webp as transformation option

### DIFF
--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -2,6 +2,6 @@ export const transformationOptionsSchema = {
   height: { type: 'integer', examples: [100], minimum: 0 },
   width: { type: 'integer', examples: [100], minimum: 0 },
   resize: { type: 'string', enum: ['cover', 'contain', 'fill'] },
-  format: { type: 'string', enum: ['origin', 'avif'] },
+  format: { type: 'string', enum: ['origin', 'avif', 'webp'] },
   quality: { type: 'integer', minimum: 20, maximum: 100 },
 } as const

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -15,7 +15,7 @@ export interface TransformOptions {
   width?: number
   height?: number
   resize?: 'cover' | 'contain' | 'fill'
-  format?: 'origin' | 'avif'
+  format?: 'origin' | 'avif' | 'webp'
   quality?: number
 }
 

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -76,6 +76,29 @@ describe('image rendering routes', () => {
     )
   })
 
+  it('will render a public image in all supported formats', async () => {
+    const formats = ['origin', 'webp', 'avif']
+    const testAxios = axios.create({ baseURL: imgProxyURL })
+    jest.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
+    const axiosSpy = jest.spyOn(testAxios, 'get')
+
+    for (let format of formats) {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/render/image/public/public-bucket-2/favicon.ico?format=${format}&width=100&height=100`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
+      const expectFormat = format === 'origin' ? '' : `/format:${format}`
+      expect(axiosSpy).toHaveBeenCalledWith(
+        `/public/height:100/width:100/resizing_type:fill${expectFormat}/plain/local:///${projectRoot}/data/sadcat.jpg`,
+        { responseType: 'stream', signal: expect.any(AbortSignal) }
+      )
+      jest.clearAllMocks()
+    }
+  })
+
   it('will render a transformed image providing a signed url', async () => {
     const assetUrl = 'bucket2/authenticated/casestudy.png'
     const signURLResponse = await appInstance.inject({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix,

## What is the current behavior?

- strict validation doesn't allow WebP

## What is the new behavior?

- Allow WebP in transformation options

Closes #1010 
