### PR TITLE
chore: add cool down for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -15,3 +17,5 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

dependabot updates weekly but still might get a release as recently available

## What is the new behavior?

ensure at least 3 days before proposing

