### PR TITLE
feat: add tenant config per request hit ratio

### DIFF
--- a/monitoring/grafana/dashboards/storage-otel.json
+++ b/monitoring/grafana/dashboards/storage-otel.json
@@ -3168,7 +3168,7 @@
             "type": "prometheus",
             "uid": "local_prometheus"
           },
-          "description": "Derived cache hit ratio over time by cache. This treats misses and stale outcomes as non-hits so you can see whether each cache is actually avoiding backend lookups.",
+          "description": "Derived cache hit ratio over time by raw cache lookup. This treats misses and stale outcomes as non-hits. For tenant_config, repeated same-request lookups can make this look higher than request-level reuse.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3266,7 +3266,113 @@
               "refId": "A"
             }
           ],
-          "title": "Cache Hit Rate",
+          "title": "Cache Hit Rate (Lookup)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "local_prometheus"
+          },
+          "description": "Derived cache hit ratio over time using cache outcomes counted at most once per request. This is currently emitted for tenant_config so repeated tenant config lookups inside one request do not inflate the hit ratio.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line+area"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.95
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 120
+          },
+          "id": 231,
+          "options": {
+            "legend": {
+              "calcs": ["last", "min", "max"],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "local_prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(storage_api_otel_cache_requests_per_request_total{region=~\"$region\", instance=~\"$instance\", outcome=\"hit\"}[$__rate_interval])) by (cache) / clamp_min(sum(rate(storage_api_otel_cache_requests_per_request_total{region=~\"$region\", instance=~\"$instance\"}[$__rate_interval])) by (cache), 0.000001)",
+              "legendFormat": "{{ cache }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cache Hit Rate (Per Request)",
           "type": "timeseries"
         },
         {
@@ -3331,8 +3437,8 @@
           "gridPos": {
             "h": 8,
             "w": 8,
-            "x": 16,
-            "y": 120
+            "x": 0,
+            "y": 128
           },
           "id": 227,
           "options": {
@@ -3426,8 +3532,8 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 0,
+            "w": 8,
+            "x": 8,
             "y": 128
           },
           "id": 228,
@@ -3522,8 +3628,8 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
+            "w": 8,
+            "x": 16,
             "y": 128
           },
           "id": 229,

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -35,7 +35,7 @@ export const db = fastifyPlugin(
     fastify.decorateRequest('db')
 
     fastify.addHook('preHandler', async (request) => {
-      const adminUser = await getServiceKeyUser(request.tenantId)
+      const adminUser = await getServiceKeyUser(request.tenantId, { reqId: request.id })
       const userPayload = request.jwtPayload
 
       if (!userPayload) {
@@ -50,6 +50,7 @@ export const db = fastifyPlugin(
         superUser: adminUser,
         tenantId: request.tenantId,
         host: request.headers['x-forwarded-host'] as string,
+        reqId: request.id,
         headers: request.headers,
         path: request.url,
         method: request.method,
@@ -110,13 +111,14 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
     fastify.decorateRequest('db')
 
     fastify.addHook('preHandler', async (request) => {
-      const adminUser = await getServiceKeyUser(request.tenantId)
+      const adminUser = await getServiceKeyUser(request.tenantId, { reqId: request.id })
 
       request.db = await getPostgresConnection({
         user: adminUser,
         superUser: adminUser,
         tenantId: request.tenantId,
         host: request.headers['x-forwarded-host'] as string,
+        reqId: request.id,
         path: request.url,
         method: request.method,
         headers: request.headers,
@@ -176,7 +178,7 @@ export const migrations = fastifyPlugin(
   async function migrations(fastify) {
     fastify.addHook('preHandler', async (req) => {
       if (isMultitenant) {
-        const { migrationVersion } = await getTenantConfig(req.tenantId)
+        const { migrationVersion } = await getTenantConfig(req.tenantId, { reqId: req.id })
         req.latestMigration = migrationVersion
         return
       }
@@ -193,7 +195,7 @@ export const migrations = fastifyPlugin(
           return
         }
 
-        const tenant = await getTenantConfig(request.tenantId)
+        const tenant = await getTenantConfig(request.tenantId, { reqId: request.id })
         const migrationsUpToDate = await areMigrationsUpToDate(request.tenantId)
 
         if (tenant.syncMigrationsDone || migrationsUpToDate) {
@@ -201,7 +203,7 @@ export const migrations = fastifyPlugin(
         }
 
         await migrationsMutex(request.tenantId, async () => {
-          const tenant = await getTenantConfig(request.tenantId)
+          const tenant = await getTenantConfig(request.tenantId, { reqId: request.id })
 
           if (tenant.syncMigrationsDone) {
             return
@@ -224,7 +226,7 @@ export const migrations = fastifyPlugin(
           return
         }
 
-        const tenant = await getTenantConfig(request.tenantId)
+        const tenant = await getTenantConfig(request.tenantId, { reqId: request.id })
         const migrationsUpToDate = await areMigrationsUpToDate(request.tenantId)
 
         // migrations are up to date

--- a/src/http/plugins/iceberg.ts
+++ b/src/http/plugins/iceberg.ts
@@ -38,7 +38,7 @@ export const icebergRestCatalog = fastifyPlugin(async function (fastify: Fastify
     }
 
     if (isMultitenant) {
-      const { features } = await getTenantConfig(req.tenantId)
+      const { features } = await getTenantConfig(req.tenantId, { reqId: req.id })
 
       limits.maxTableCount = features.icebergCatalog.maxTables
       limits.maxNamespaceCount = features.icebergCatalog.maxNamespaces

--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -45,7 +45,7 @@ export const jwt = fastifyPlugin<JWTPluginOptions>(
         return
       }
 
-      const { secret, jwks } = await getJwtSecret(request.tenantId)
+      const { secret, jwks } = await getJwtSecret(request.tenantId, { reqId: request.id })
 
       try {
         const payload = await (jwtCachingEnabled

--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -113,7 +113,13 @@ async function authorizeRequestSignV4(
     signature: signatureV4,
     claims,
     token,
-  } = await createServerSignature(request.tenantId, clientSignature, service, allowBodyHash)
+  } = await createServerSignature(
+    request.tenantId,
+    request.id,
+    clientSignature,
+    service,
+    allowBodyHash
+  )
 
   let storagePrefix = s3ProtocolPrefix
   if (requestAllowXForwardedPrefix && typeof request.headers['x-forwarded-prefix'] === 'string') {
@@ -166,7 +172,7 @@ async function authorizeRequestSignV4(
     ? byteHasherStream!.toReadable({ autoCleanup: true })
     : (body as Readable)
 
-  const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId)
+  const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId, { reqId: request.id })
 
   if (!token) {
     if (!claims) {
@@ -241,6 +247,7 @@ async function extractSignature(req: AWSRequest) {
 
 async function createServerSignature(
   tenantId: string,
+  reqId: string,
   clientSignature: ClientSignature,
   awsService = SignatureV4Service.S3,
   allowBodyHash = false
@@ -249,7 +256,7 @@ async function createServerSignature(
 
   if (clientSignature?.sessionToken) {
     const tenantAnonKey = isMultitenant
-      ? (await getTenantConfig(tenantId)).anonKey
+      ? (await getTenantConfig(tenantId, { reqId })).anonKey
       : await anonKeyAsync
 
     if (!tenantAnonKey) {

--- a/src/http/plugins/tenant-feature.ts
+++ b/src/http/plugins/tenant-feature.ts
@@ -17,7 +17,7 @@ export const requireTenantFeature = (feature: keyof Features) =>
       fastify.addHook('onRequest', async (request, reply) => {
         if (!isMultitenant) return
 
-        const hasFeature = await tenantHasFeature(request.tenantId, feature)
+        const hasFeature = await tenantHasFeature(request.tenantId, feature, { reqId: request.id })
 
         if (!hasFeature) {
           return reply.status(403).send({

--- a/src/http/plugins/tracing.ts
+++ b/src/http/plugins/tracing.ts
@@ -21,7 +21,7 @@ export const tracing = fastifyPlugin(
     fastify.addHook('onRequest', async (request) => {
       try {
         if (isMultitenant && request.tenantId) {
-          const tenantConfig = await getTenantConfig(request.tenantId)
+          const tenantConfig = await getTenantConfig(request.tenantId, { reqId: request.id })
           request.tracingMode = tenantConfig.tracingMode
         } else {
           request.tracingMode = defaultTracingMode

--- a/src/http/plugins/vector.ts
+++ b/src/http/plugins/vector.ts
@@ -33,7 +33,7 @@ export const s3vector = fastifyPlugin(async function (fastify: FastifyInstance) 
     let maxIndexCount = vectorMaxIndexesCount
 
     if (isMultitenant) {
-      const { features } = await getTenantConfig(req.tenantId)
+      const { features } = await getTenantConfig(req.tenantId, { reqId: req.id })
       maxBucketCount = features?.vectorBuckets?.maxBuckets || vectorMaxBucketsCount
       maxIndexCount = features?.vectorBuckets?.maxIndexes || vectorMaxIndexesCount
     }

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -243,7 +243,9 @@ export default async function routes(fastify: FastifyInstance) {
         disable_events,
       } = tenant
 
-      const capabilities = await getTenantCapabilities(request.params.tenantId)
+      const capabilities = await getTenantCapabilities(request.params.tenantId, {
+        reqId: request.id,
+      })
 
       return {
         anonKey: decrypt(anon_key),
@@ -631,7 +633,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (req, reply) => {
       const { untilMigration, markCompletedTillMigration } = req.body as Record<string, unknown>
 
-      const { databaseUrl } = await getTenantConfig(req.params.tenantId)
+      const { databaseUrl } = await getTenantConfig(req.params.tenantId, { reqId: req.id })
 
       if (!isDBMigrationName(untilMigration)) {
         return reply.status(400).send({ message: 'Invalid migration' })

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -61,7 +61,9 @@ export default async function routes(fastify: FastifyInstance) {
       const { download } = request.query
 
       let payload: SignedToken
-      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId)
+      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId, {
+        reqId: request.id,
+      })
 
       try {
         payload = (await verifyJWT(token, jwtSecret, jwks)) as SignedToken

--- a/src/http/routes/object/getSignedURL.ts
+++ b/src/http/routes/object/getSignedURL.ts
@@ -68,7 +68,9 @@ export default async function routes(fastify: FastifyInstance) {
       const { expiresIn } = request.body
 
       const urlPath = request.url.split('?').shift()
-      const imageTransformationEnabled = await isImageTransformationEnabled(request.tenantId)
+      const imageTransformationEnabled = await isImageTransformationEnabled(request.tenantId, {
+        reqId: request.id,
+      })
 
       const transformationOptions = imageTransformationEnabled
         ? {

--- a/src/http/routes/object/listObjectsV2.ts
+++ b/src/http/routes/object/listObjectsV2.ts
@@ -63,7 +63,7 @@ export default async function routes(fastify: FastifyInstance) {
     },
     async (request, response) => {
       if (isMultitenant) {
-        const { migrationVersion } = await getTenantConfig(request.tenantId)
+        const { migrationVersion } = await getTenantConfig(request.tenantId, { reqId: request.id })
         if (migrationVersion && DBMigration[migrationVersion] < DBMigration['search-v2']) {
           return response.status(400).send({
             message: 'This feature is not available for your tenant',

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -64,7 +64,7 @@ export default async function routes(fastify: FastifyInstance) {
       const renderer = request.storage.renderer('image') as ImageRenderer
 
       if (isMultitenant) {
-        const tenantConfig = await getTenantConfig(request.tenantId)
+        const tenantConfig = await getTenantConfig(request.tenantId, { reqId: request.id })
         renderer.setLimits({
           maxResolution: tenantConfig.features.imageTransformation.maxResolution,
         })

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -64,7 +64,7 @@ export default async function routes(fastify: FastifyInstance) {
       const renderer = request.storage.renderer('image') as ImageRenderer
 
       if (isMultitenant) {
-        const tenantConfig = await getTenantConfig(request.tenantId)
+        const tenantConfig = await getTenantConfig(request.tenantId, { reqId: request.id })
         renderer.setLimits({
           maxResolution: tenantConfig.features.imageTransformation.maxResolution,
         })

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -58,7 +58,9 @@ export default async function routes(fastify: FastifyInstance) {
       const { download } = request.query
 
       let payload: SignedToken
-      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId)
+      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId, {
+        reqId: request.id,
+      })
 
       try {
         payload = (await verifyJWT(token, jwtSecret, jwks)) as SignedToken
@@ -86,7 +88,7 @@ export default async function routes(fastify: FastifyInstance) {
       const renderer = request.storage.renderer('image') as ImageRenderer
 
       if (isMultitenant) {
-        const tenantConfig = await getTenantConfig(request.tenantId)
+        const tenantConfig = await getTenantConfig(request.tenantId, { reqId: request.id })
         renderer.setLimits({
           maxResolution: tenantConfig.features.imageTransformation.maxResolution,
         })

--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -218,7 +218,9 @@ export default function PutObject(s3Router: S3Router) {
       const metadata = s3Protocol.parseMetadataHeaders(fieldsObject)
       const expiresField = fieldsObject.expires
 
-      const maxFileSize = await getStandardMaxFileSizeLimit(ctx.tenantId, bucket.file_size_limit)
+      const maxFileSize = await getStandardMaxFileSizeLimit(ctx.tenantId, bucket.file_size_limit, {
+        reqId: ctx.storage.db.reqId,
+      })
 
       return pipeline(file.file, new ByteLimitTransformStream(maxFileSize), async (fileStream) => {
         return s3Protocol.putObject(

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -151,7 +151,9 @@ function createTusServer(
       }
 
       if (!uploadId) {
-        return getFileSizeLimit(req.upload.tenantId)
+        return getFileSizeLimit(req.upload.tenantId, undefined, {
+          reqId: req.upload.storage.db.reqId,
+        })
       }
 
       const resourceId = UploadId.fromString(uploadId)
@@ -160,7 +162,9 @@ function createTusServer(
         .asSuperUser()
         .findBucket(resourceId.bucket, 'id,file_size_limit')
 
-      const globalFileLimit = await getFileSizeLimit(req.upload.tenantId)
+      const globalFileLimit = await getFileSizeLimit(req.upload.tenantId, undefined, {
+        reqId: req.upload.storage.db.reqId,
+      })
 
       const fileSizeLimit = bucket.file_size_limit || globalFileLimit
       if (fileSizeLimit > globalFileLimit) {

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -9,6 +9,7 @@ interface ConnectionOptions {
   host: string
   tenantId: string
   maxConnections?: number
+  reqId?: string
   headers?: Record<string, string | undefined | string[]>
   method?: string
   path?: string
@@ -25,6 +26,7 @@ interface ConnectionOptions {
 export async function getPostgresConnection(options: ConnectionOptions): Promise<TenantConnection> {
   const dbCredentials = await getDbSettings(options.tenantId, options.host, {
     disableHostCheck: options.disableHostCheck,
+    reqId: options.reqId,
   })
 
   return await TenantConnection.create({
@@ -37,7 +39,7 @@ export async function getPostgresConnection(options: ConnectionOptions): Promise
 async function getDbSettings(
   tenantId: string,
   host: string | undefined,
-  options?: { disableHostCheck?: boolean }
+  options?: { disableHostCheck?: boolean; reqId?: string }
 ) {
   const {
     isMultitenant,
@@ -71,7 +73,7 @@ async function getDbSettings(
       }
     }
 
-    const tenant = await getTenantConfig(tenantId)
+    const tenant = await getTenantConfig(tenantId, { reqId: options?.reqId })
     dbUrl = tenant.databasePoolUrl || tenant.databaseUrl
     isExternalPool = Boolean(tenant.databasePoolUrl)
     maxConnections = tenant.maxConnections ?? maxConnections

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -1,5 +1,6 @@
 import {
   createLruCache,
+  createTtlCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_CONFIG_CACHE_NAME,
 } from '@internal/cache'
@@ -7,6 +8,7 @@ import { TenantConnection } from '@internal/database/connection'
 import { lastLocalMigrationName } from '@internal/database/migrations/files'
 import { ERRORS } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
+import { cacheRequestsPerRequestTotal } from '@internal/monitoring/metrics'
 import {
   S3CredentialsManager,
   S3CredentialsManagerStoreKnex,
@@ -44,8 +46,9 @@ interface TenantConfig {
   disableEvents?: string[]
 }
 
-type GetTenantConfigOptions = {
+export type GetTenantConfigOptions = {
   recordMetrics?: boolean
+  reqId?: string
 }
 
 type LegacyJwksConfig = NonNullable<TenantConfig['jwks']>
@@ -92,6 +95,8 @@ const {
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
 export const TENANT_CONFIG_CACHE_MAX_SIZE_BYTES = 1024 * 1024 * 50 // 50 MiB
 export const TENANT_CONFIG_CACHE_TTL_MS = 1000 * 60 * 60 // 1h
+const TENANT_CONFIG_REQUEST_METRIC_TTL_MS = 5 * 60 * 1000
+const TENANT_CONFIG_REQUEST_METRIC_MAX_ITEMS = 100_000
 
 const tenantConfigCache = createLruCache<string, TenantConfig>(TENANT_CONFIG_CACHE_NAME, {
   max: TENANT_CONFIG_CACHE_MAX_ITEMS,
@@ -101,6 +106,10 @@ const tenantConfigCache = createLruCache<string, TenantConfig>(TENANT_CONFIG_CAC
   updateAgeOnGet: true,
   allowStale: false,
   purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
+})
+const tenantConfigRequestMetrics = createTtlCache<string, true>({
+  ttl: TENANT_CONFIG_REQUEST_METRIC_TTL_MS,
+  max: TENANT_CONFIG_REQUEST_METRIC_MAX_ITEMS,
 })
 
 const tenantMutex = createMutexByKey<TenantConfig>()
@@ -192,6 +201,8 @@ export async function getTenantConfig(
   const cachedConfig = tenantConfigCache.get(tenantId, {
     recordMetrics: options?.recordMetrics,
   })
+  recordTenantConfigRequestMetrics(tenantId, cachedConfig === undefined ? 'miss' : 'hit', options)
+
   if (cachedConfig !== undefined) {
     return cachedConfig
   }
@@ -287,9 +298,30 @@ export async function getTenantConfig(
   })
 }
 
-export async function getServiceKeyUser(tenantId: string) {
+function recordTenantConfigRequestMetrics(
+  tenantId: string,
+  outcome: 'hit' | 'miss',
+  options?: GetTenantConfigOptions
+): void {
+  if (options?.recordMetrics === false || !options?.reqId) {
+    return
+  }
+
+  const requestMetricKey = `${tenantId}:${options.reqId}`
+  if (tenantConfigRequestMetrics.get(requestMetricKey)) {
+    return
+  }
+
+  tenantConfigRequestMetrics.set(requestMetricKey, true)
+  cacheRequestsPerRequestTotal.add(1, {
+    cache: TENANT_CONFIG_CACHE_NAME,
+    outcome,
+  })
+}
+
+export async function getServiceKeyUser(tenantId: string, options?: GetTenantConfigOptions) {
   if (isMultitenant) {
-    const tenant = await getTenantConfig(tenantId)
+    const tenant = await getTenantConfig(tenantId, options)
 
     return {
       jwt: tenant.serviceKey,
@@ -318,7 +350,7 @@ enum Capability {
  * Get the capabilities for a specific tenant
  * @param tenantId
  */
-export async function getTenantCapabilities(tenantId: string) {
+export async function getTenantCapabilities(tenantId: string, options?: GetTenantConfigOptions) {
   const capabilities: Record<Capability, boolean> = {
     [Capability.LIST_V2]: false,
     [Capability.ICEBERG_CATALOG]: false,
@@ -327,7 +359,7 @@ export async function getTenantCapabilities(tenantId: string) {
   let latestMigrationName = dbMigrationFreezeAt || (await lastLocalMigrationName())
 
   if (isMultitenant) {
-    const { migrationVersion } = await getTenantConfig(tenantId)
+    const { migrationVersion } = await getTenantConfig(tenantId, options)
     latestMigrationName = migrationVersion || 'initialmigration'
   }
 
@@ -350,13 +382,14 @@ export async function getTenantCapabilities(tenantId: string) {
  */
 export async function tenantHasFeature(
   tenantId: string,
-  feature: keyof Features
+  feature: keyof Features,
+  options?: GetTenantConfigOptions
 ): Promise<boolean> {
   if (!isMultitenant) {
     return true // single tenant always has all features
   }
 
-  const { features } = await getTenantConfig(tenantId)
+  const { features } = await getTenantConfig(tenantId, options)
   return features ? features[feature].enabled : false
 }
 
@@ -364,7 +397,10 @@ export async function tenantHasFeature(
  * Get the jwt key from the tenant config
  * @param tenantId
  */
-export async function getJwtSecret(tenantId: string): Promise<{
+export async function getJwtSecret(
+  tenantId: string,
+  options?: GetTenantConfigOptions
+): Promise<{
   secret: string
   urlSigningKey: string | JwksConfigKeyOCT
   jwks: JwksConfig
@@ -372,7 +408,7 @@ export async function getJwtSecret(tenantId: string): Promise<{
   let { secret, jwks } = getSingleTenantJwtConfig()
 
   if (isMultitenant) {
-    const config = await getTenantConfig(tenantId)
+    const config = await getTenantConfig(tenantId, options)
     const tenantJwks = await jwksManager.getJwksTenantConfig(tenantId)
     secret = config.jwtSecret
     jwks = config.jwks?.keys ? mergeTenantJwksWithLegacyKeys(tenantJwks, config.jwks) : tenantJwks
@@ -386,8 +422,11 @@ export async function getJwtSecret(tenantId: string): Promise<{
  * Get the file size limit from the tenant config
  * @param tenantId
  */
-export async function getFileSizeLimit(tenantId: string): Promise<number> {
-  const { fileSizeLimit } = await getTenantConfig(tenantId)
+export async function getFileSizeLimit(
+  tenantId: string,
+  options?: GetTenantConfigOptions
+): Promise<number> {
+  const { fileSizeLimit } = await getTenantConfig(tenantId, options)
   return fileSizeLimit
 }
 
@@ -395,8 +434,11 @@ export async function getFileSizeLimit(tenantId: string): Promise<number> {
  * Get features flags config for a specific tenant
  * @param tenantId
  */
-export async function getFeatures(tenantId: string): Promise<Features> {
-  const { features } = await getTenantConfig(tenantId)
+export async function getFeatures(
+  tenantId: string,
+  options?: GetTenantConfigOptions
+): Promise<Features> {
+  const { features } = await getTenantConfig(tenantId, options)
   return features
 }
 

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -130,6 +130,15 @@ export const cacheRequestsTotal = registerMetric('cache_requests_total', 'counte
   })
 )
 
+export const cacheRequestsPerRequestTotal = registerMetric(
+  'cache_requests_per_request_total',
+  'counter',
+  () =>
+    meter.createCounter('cache_requests_per_request_total', {
+      description: 'Total cache lookup outcomes counted once per request by cache and outcome',
+    })
+)
+
 export const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
   meter.createCounter('cache_evictions_total', {
     description: 'Total cache evictions',

--- a/src/internal/queue/event.ts
+++ b/src/internal/queue/event.ts
@@ -167,7 +167,7 @@ export class Event<T extends Omit<BasePayload, '$version'>> {
   static async shouldSend(payload: any) {
     if (isMultitenant && payload?.tenant?.ref) {
       // Do not send an event if disabled for this specific tenant
-      const tenant = await getTenantConfig(payload.tenant.ref)
+      const tenant = await getTenantConfig(payload.tenant.ref, { reqId: payload.reqId })
       const disabledEvents = tenant.disableEvents || []
       if (disabledEvents.includes(this.eventName())) {
         return false

--- a/src/storage/events/base-event.ts
+++ b/src/storage/events/base-event.ts
@@ -62,19 +62,21 @@ export abstract class BaseEvent<T extends Omit<BasePayload, '$version'>> extends
   }
 
   protected static async createStorage(payload: BasePayload) {
-    const adminUser = await getServiceKeyUser(payload.tenant.ref)
+    const adminUser = await getServiceKeyUser(payload.tenant.ref, { reqId: payload.reqId })
 
     const client = await getPostgresConnection({
       user: adminUser,
       superUser: adminUser,
       host: payload.tenant.host,
       tenantId: payload.tenant.ref,
+      reqId: payload.reqId,
       disableHostCheck: true,
     })
 
     const db = new StorageKnexDB(client, {
       tenantId: payload.tenant.ref,
       host: payload.tenant.host,
+      reqId: payload.reqId,
     })
 
     return new Storage(this.getOrCreateStorageBackend(), db, new TenantLocation(storageS3Bucket))

--- a/src/storage/events/lifecycle/bucket-created.ts
+++ b/src/storage/events/lifecycle/bucket-created.ts
@@ -30,7 +30,7 @@ export class BucketCreatedEvent extends BaseEvent<ObjectCreatedEvent> {
       return
     }
 
-    const { features } = await getTenantConfig(job.data.tenant.ref)
+    const { features } = await getTenantConfig(job.data.tenant.ref, { reqId: job.data.reqId })
 
     const restCatalog = new TenantAwareRestCatalog({
       tenantId: job.data.tenant.ref,

--- a/src/storage/events/lifecycle/webhook.ts
+++ b/src/storage/events/lifecycle/webhook.ts
@@ -71,7 +71,9 @@ export class Webhook extends BaseEvent<WebhookEvent> {
   static async shouldSend(payload: WebhookEvent) {
     if (isMultitenant) {
       // Do not send an event if disabled for this specific tenant
-      const tenant = await getTenantConfig(payload.tenant.ref)
+      const tenant = await getTenantConfig(payload.tenant.ref, {
+        reqId: payload.event.payload.reqId,
+      })
       const disabledEvents = tenant.disableEvents || []
       if (
         disabledEvents.includes(`Webhook:${payload.event.type}`) ||

--- a/src/storage/events/migrations/reset-migrations.ts
+++ b/src/storage/events/migrations/reset-migrations.ts
@@ -40,7 +40,7 @@ export class ResetMigrationsOnTenant extends BaseEvent<ResetMigrationsPayload> {
 
   static async handle(job: JobWithMetadata<ResetMigrationsPayload>) {
     const tenantId = job.data.tenant.ref
-    const tenant = await getTenantConfig(tenantId)
+    const tenant = await getTenantConfig(tenantId, { reqId: job.data.reqId })
 
     logSchema.info(logger, `[Migrations] resetting migrations for ${tenantId}`, {
       type: 'migrations',

--- a/src/storage/events/migrations/run-migrations.ts
+++ b/src/storage/events/migrations/run-migrations.ts
@@ -47,7 +47,7 @@ export class RunMigrationsOnTenants extends BaseEvent<RunMigrationsPayload> {
   static async handle(job: JobWithMetadata<RunMigrationsPayload>) {
     const tenantId = job.data.tenant.ref
     deleteTenantConfig(tenantId)
-    const tenant = await getTenantConfig(tenantId)
+    const tenant = await getTenantConfig(tenantId, { reqId: job.data.reqId })
 
     const migrationsUpToDate = await areMigrationsUpToDate(tenantId)
 

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -19,11 +19,12 @@ export const RESERVED_BUCKET_SUFFIXES = [icebergBucketDetectionSuffix]
  */
 export async function getFileSizeLimit(
   tenantId: string,
-  maxUpperLimit?: number | null
+  maxUpperLimit?: number | null,
+  options?: { reqId?: string }
 ): Promise<number> {
   let { uploadFileSizeLimit } = getConfig()
   if (isMultitenant) {
-    uploadFileSizeLimit = await getFileSizeLimitForTenant(tenantId)
+    uploadFileSizeLimit = await getFileSizeLimitForTenant(tenantId, options)
   }
 
   if (maxUpperLimit) {
@@ -37,12 +38,12 @@ export async function getFileSizeLimit(
  * Determines if the image transformation feature is enabled.
  * @param tenantId
  */
-export async function isImageTransformationEnabled(tenantId: string) {
+export async function isImageTransformationEnabled(tenantId: string, options?: { reqId?: string }) {
   if (!isMultitenant) {
     return imageTransformationEnabled
   }
 
-  const { imageTransformation } = await getFeatures(tenantId)
+  const { imageTransformation } = await getFeatures(tenantId, options)
 
   return imageTransformation.enabled
 }

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -723,7 +723,7 @@ export class ObjectStorage {
 
     const urlParts = url.split('/')
     const urlToSign = decodeURI(urlParts.splice(3).join('/'))
-    const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
+    const { urlSigningKey } = await getJwtSecret(this.db.tenantId, { reqId: this.db.reqId })
     const token = await signJWT({ url: urlToSign, ...metadata }, urlSigningKey, expiresIn)
 
     let urlPath = 'object'
@@ -760,7 +760,7 @@ export class ObjectStorage {
 
     const nameSet = new Set(results.map(({ name }) => name))
 
-    const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
+    const { urlSigningKey } = await getJwtSecret(this.db.tenantId, { reqId: this.db.reqId })
 
     return Promise.all(
       paths.map(async (path) => {
@@ -811,7 +811,7 @@ export class ObjectStorage {
       metadata: options?.metadata,
     })
 
-    const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
+    const { urlSigningKey } = await getJwtSecret(this.db.tenantId, { reqId: this.db.reqId })
     const token = await signJWT(
       { owner, url, upsert: Boolean(options?.upsert) },
       urlSigningKey,
@@ -827,7 +827,9 @@ export class ObjectStorage {
    * @param objectName
    */
   async verifyObjectSignature(token: string, objectName: string) {
-    const { secret: jwtSecret, jwks } = await getJwtSecret(this.db.tenantId)
+    const { secret: jwtSecret, jwks } = await getJwtSecret(this.db.tenantId, {
+      reqId: this.db.reqId,
+    })
 
     let payload: SignedUploadToken
     try {

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -582,7 +582,9 @@ export class S3ProtocolHandler {
     }
 
     const bucket = await this.storage.asSuperUser().findBucket(Bucket, 'file_size_limit')
-    const maxFileSize = await getFileSizeLimit(this.storage.db.tenantId, bucket?.file_size_limit)
+    const maxFileSize = await getFileSizeLimit(this.storage.db.tenantId, bucket?.file_size_limit, {
+      reqId: this.storage.db.reqId,
+    })
 
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)
 
@@ -1271,7 +1273,10 @@ export class S3ProtocolHandler {
     })
     const maxFileSize = await getFileSizeLimit(
       this.storage.db.tenantId,
-      destinationBucket?.file_size_limit
+      destinationBucket?.file_size_limit,
+      {
+        reqId: this.storage.db.reqId,
+      }
     )
 
     const multipartData = await this.storage.db

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -114,7 +114,7 @@ export class Storage {
     if (data.type === 'ANALYTICS') {
       if (
         !(await tenantHasMigrations(this.db.tenantId, 'iceberg-catalog-flag-on-buckets')) ||
-        !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog'))
+        !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog', { reqId: this.db.reqId }))
       ) {
         throw ERRORS.FeatureNotEnabled(
           'iceberg_catalog',
@@ -242,7 +242,7 @@ export class Storage {
   async deleteIcebergBucket(name: string) {
     if (
       !(await tenantHasMigrations(this.db.tenantId, 'iceberg-catalog-flag-on-buckets')) ||
-      !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog'))
+      !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog', { reqId: this.db.reqId }))
     ) {
       throw ERRORS.FeatureNotEnabled(
         'iceberg_catalog',
@@ -326,7 +326,9 @@ export class Storage {
       maxFileLimit = parseFileSizeToBytes(maxFileLimit)
     }
 
-    const globalMaxLimit = await getFileSizeLimit(this.db.tenantId)
+    const globalMaxLimit = await getFileSizeLimit(this.db.tenantId, undefined, {
+      reqId: this.db.reqId,
+    })
 
     if (maxFileLimit > globalMaxLimit) {
       throw ERRORS.EntityTooLarge()

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -450,7 +450,9 @@ export async function fileUploadFromRequest(
 
   // When is an empty folder we restrict it to 0 bytes
   if (!isEmptyFolder(options.objectName)) {
-    maxFileSize = await getStandardMaxFileSizeLimit(request.tenantId, options?.fileSizeLimit)
+    maxFileSize = await getStandardMaxFileSizeLimit(request.tenantId, options?.fileSizeLimit, {
+      reqId: request.id,
+    })
   }
 
   let cacheControl: string
@@ -579,9 +581,10 @@ export function parseUserMetadata(metadata: string) {
 
 export async function getStandardMaxFileSizeLimit(
   tenantId: string,
-  bucketSizeLimit?: number | null
+  bucketSizeLimit?: number | null,
+  options?: { reqId?: string }
 ) {
-  let globalFileSizeLimit = await getFileSizeLimit(tenantId)
+  let globalFileSizeLimit = await getFileSizeLimit(tenantId, undefined, options)
 
   if (typeof bucketSizeLimit === 'number') {
     globalFileSizeLimit = Math.min(bucketSizeLimit, globalFileSizeLimit)

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -126,6 +126,32 @@ async function loadTenantModule(
   }
 }
 
+function mockTenantConfigMetrics() {
+  const cacheRequestsTotalAdd = jest.fn()
+  const cacheRequestsPerRequestTotalAdd = jest.fn()
+
+  jest.doMock('@internal/monitoring/metrics', () => {
+    const actual = jest.requireActual<typeof import('@internal/monitoring/metrics')>(
+      '@internal/monitoring/metrics'
+    )
+
+    return {
+      ...actual,
+      cacheRequestsPerRequestTotal: {
+        add: cacheRequestsPerRequestTotalAdd,
+      },
+      cacheRequestsTotal: {
+        add: cacheRequestsTotalAdd,
+      },
+    }
+  })
+
+  return {
+    cacheRequestsPerRequestTotalAdd,
+    cacheRequestsTotalAdd,
+  }
+}
+
 beforeAll(async () => {
   await migrate.runMultitenantMigrations()
   jest.spyOn(migrate, 'runMigrationsOnTenant').mockResolvedValue()
@@ -705,34 +731,35 @@ describe('Tenant configs', () => {
     }
   })
 
+  const encryptedTenant = {
+    anon_key: encrypt('anon'),
+    database_url: encrypt('postgres://tenant'),
+    database_pool_mode: null,
+    file_size_limit: 1,
+    jwt_secret: encrypt('jwt-secret'),
+    jwks: null,
+    service_key: encrypt('service-key'),
+    feature_purge_cache: false,
+    feature_image_transformation: false,
+    feature_s3_protocol: false,
+    feature_iceberg_catalog: false,
+    feature_iceberg_catalog_max_catalogs: 0,
+    feature_iceberg_catalog_max_namespaces: 0,
+    feature_iceberg_catalog_max_tables: 0,
+    feature_vector_buckets: false,
+    feature_vector_buckets_max_buckets: 0,
+    feature_vector_buckets_max_indexes: 0,
+    image_transformation_max_resolution: null,
+    database_pool_url: null,
+    max_connections: null,
+    migrations_version: migrationVersion,
+    migrations_status: 'COMPLETED',
+    tracing_mode: null,
+    disable_events: null,
+  }
+
   test('Get tenant config evicts cold tenants from cache', async () => {
     const tenantIds = ['cache-eviction-1', 'cache-eviction-2', 'cache-eviction-3']
-    const encryptedTenant = {
-      anon_key: encrypt('anon'),
-      database_url: encrypt('postgres://tenant'),
-      database_pool_mode: null,
-      file_size_limit: 1,
-      jwt_secret: encrypt('jwt-secret'),
-      jwks: null,
-      service_key: encrypt('service-key'),
-      feature_purge_cache: false,
-      feature_image_transformation: false,
-      feature_s3_protocol: false,
-      feature_iceberg_catalog: false,
-      feature_iceberg_catalog_max_catalogs: 0,
-      feature_iceberg_catalog_max_namespaces: 0,
-      feature_iceberg_catalog_max_tables: 0,
-      feature_vector_buckets: false,
-      feature_vector_buckets_max_buckets: 0,
-      feature_vector_buckets_max_indexes: 0,
-      image_transformation_max_resolution: null,
-      database_pool_url: null,
-      max_connections: null,
-      migrations_version: migrationVersion,
-      migrations_status: 'COMPLETED',
-      tracing_mode: null,
-      disable_events: null,
-    }
 
     const { tenantModule, multitenantDbModule } = await loadTenantModule(2)
     const knexTableSpy = jest.spyOn(multitenantDbModule.multitenantKnex, 'table')
@@ -768,32 +795,6 @@ describe('Tenant configs', () => {
     const knexTableSpy = jest.spyOn(multitenantKnex, 'table')
     const addSpy = jest.spyOn(cacheRequestsTotal, 'add')
     const tenantId = 'cache-metrics-lookup'
-    const encryptedTenant = {
-      anon_key: encrypt('anon'),
-      database_url: encrypt('postgres://tenant'),
-      database_pool_mode: null,
-      file_size_limit: 1,
-      jwt_secret: encrypt('jwt-secret'),
-      jwks: null,
-      service_key: encrypt('service-key'),
-      feature_purge_cache: false,
-      feature_image_transformation: false,
-      feature_s3_protocol: false,
-      feature_iceberg_catalog: false,
-      feature_iceberg_catalog_max_catalogs: 0,
-      feature_iceberg_catalog_max_namespaces: 0,
-      feature_iceberg_catalog_max_tables: 0,
-      feature_vector_buckets: false,
-      feature_vector_buckets_max_buckets: 0,
-      feature_vector_buckets_max_indexes: 0,
-      image_transformation_max_resolution: null,
-      database_pool_url: null,
-      max_connections: null,
-      migrations_version: migrationVersion,
-      migrations_status: 'COMPLETED',
-      tracing_mode: null,
-      disable_events: null,
-    }
 
     const tenantQuery = Promise.withResolvers<typeof encryptedTenant>()
     const queryBuilder = {
@@ -824,6 +825,55 @@ describe('Tenant configs', () => {
       deleteTenantConfig(tenantId)
       knexTableSpy.mockRestore()
       addSpy.mockRestore()
+    }
+  })
+
+  test('Get tenant config records one request-scoped cache outcome per request', async () => {
+    const metrics = mockTenantConfigMetrics()
+    const { tenantModule, multitenantDbModule } = await loadTenantModule(10)
+    const knexTableSpy = jest.spyOn(multitenantDbModule.multitenantKnex, 'table')
+    const tenantId = 'cache-request-metrics'
+    const noRequestTenantId = 'cache-request-metrics-no-req'
+    const queryBuilder = {
+      first: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      abortOnSignal: jest.fn().mockResolvedValue(encryptedTenant),
+    }
+
+    try {
+      knexTableSpy.mockReturnValue(queryBuilder as any)
+
+      await tenantModule.getTenantConfig(noRequestTenantId)
+
+      expect(metrics.cacheRequestsPerRequestTotalAdd).not.toHaveBeenCalled()
+
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-a' })
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-a' })
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-a' })
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-b' })
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-b' })
+      await tenantModule.getTenantConfig(tenantId, { reqId: 'request-b' })
+
+      expect(metrics.cacheRequestsTotalAdd.mock.calls).toEqual([
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'miss' }], // no req
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'miss' }], // first request-a
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }],
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }],
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }],
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }],
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }],
+      ])
+      expect(metrics.cacheRequestsPerRequestTotalAdd.mock.calls).toEqual([
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'miss' }], // first request-a
+        [1, { cache: TENANT_CONFIG_CACHE_NAME, outcome: 'hit' }], // first request-b
+      ])
+    } finally {
+      tenantModule.deleteTenantConfig(tenantId)
+      tenantModule.deleteTenantConfig(noRequestTenantId)
+      jest.dontMock('@internal/cache')
+      jest.dontMock('@internal/monitoring/metrics')
+      jest.resetModules()
+      knexTableSpy.mockRestore()
     }
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the current behavior?

Tenant config cache is used multiple times in a request so hit ratio is overcounting.

## What is the new behavior?

Add a separate metric to track hits per request.

## Additional context

Update dash to add it.
