### PR TITLE
fix: cap expires in and return bad request

### DIFF
--- a/src/http/routes/object/getSignedURL.ts
+++ b/src/http/routes/object/getSignedURL.ts
@@ -1,3 +1,4 @@
+import { assertValidNumericJWTExpiration } from '@internal/auth'
 import { isImageTransformationEnabled } from '@storage/limits'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
@@ -18,7 +19,11 @@ const getSignedURLParamsSchema = {
 const getSignedURLBodySchema = {
   type: 'object',
   properties: {
-    expiresIn: { type: 'integer', minimum: 1, examples: [60000] },
+    expiresIn: {
+      type: 'integer',
+      minimum: 1,
+      examples: [60000],
+    },
     transform: {
       type: 'object',
       properties: transformationOptionsSchema,
@@ -66,6 +71,7 @@ export default async function routes(fastify: FastifyInstance) {
       const { bucketName } = request.params
       const objectName = request.params['*']
       const { expiresIn } = request.body
+      assertValidNumericJWTExpiration(expiresIn)
 
       const urlPath = request.url.split('?').shift()
       const imageTransformationEnabled = await isImageTransformationEnabled(request.tenantId)

--- a/src/http/routes/object/getSignedURLs.ts
+++ b/src/http/routes/object/getSignedURLs.ts
@@ -1,3 +1,4 @@
+import { assertValidNumericJWTExpiration } from '@internal/auth'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema } from '../../routes-helper'
@@ -14,7 +15,11 @@ const getSignedURLsParamsSchema = {
 const getSignedURLsBodySchema = {
   type: 'object',
   properties: {
-    expiresIn: { type: 'integer', minimum: 1, examples: [60000] },
+    expiresIn: {
+      type: 'integer',
+      minimum: 1,
+      examples: [60000],
+    },
     paths: {
       type: 'array',
       items: { type: 'string' },
@@ -77,6 +82,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketName } = request.params
       const { expiresIn, paths } = request.body
+      assertValidNumericJWTExpiration(expiresIn)
 
       const signedURLs = await request.storage.from(bucketName).signObjectUrls(paths, expiresIn)
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -24,6 +24,7 @@ const JWT_HMAC_ALGOS = ['HS256', 'HS384', 'HS512']
 const JWT_RSA_ALGOS = ['RS256', 'RS384', 'RS512']
 const JWT_ECC_ALGOS = ['ES256', 'ES384', 'ES512']
 const JWT_ED_ALGOS = ['EdDSA']
+const MAX_ABSOLUTE_JWT_EXPIRATION_SECONDS = Math.floor(Number.MAX_SAFE_INTEGER / 1000)
 
 export type SignedToken = {
   url: string
@@ -230,9 +231,13 @@ export async function signJWT(
   expiresIn: string | number | undefined
 ): Promise<string> {
   const signer = new SignJWT(payload).setIssuedAt()
-  if (expiresIn) {
-    const expiresInStr = typeof expiresIn === 'string' ? expiresIn : Math.floor(expiresIn) + 's'
-    signer.setExpirationTime(expiresInStr)
+  if (expiresIn !== undefined) {
+    const expiresInStr = getJWTExpirationTime(expiresIn)
+    try {
+      signer.setExpirationTime(expiresInStr)
+    } catch (e) {
+      throw ERRORS.InvalidParameter('expiresIn', { error: e as Error })
+    }
   }
 
   if (typeof secret === 'string') {
@@ -243,6 +248,37 @@ export async function signJWT(
     return signer
       .setProtectedHeader({ kid: secret.kid, alg: secret.alg || jwtAlgorithm })
       .sign(signingSecret)
+  }
+}
+
+function getJWTExpirationTime(expiresIn: string | number) {
+  if (typeof expiresIn === 'string') {
+    return expiresIn
+  }
+
+  assertValidNumericJWTExpiration(expiresIn)
+  return `${Math.floor(expiresIn)}s`
+}
+
+export function getMaxNumericJWTExpiration(nowMs = Date.now()) {
+  const nowSeconds = Math.floor(nowMs / 1000)
+  return Math.max(0, MAX_ABSOLUTE_JWT_EXPIRATION_SECONDS - nowSeconds)
+}
+
+export function assertValidNumericJWTExpiration(expiresIn: number, nowMs = Date.now()) {
+  if (!Number.isFinite(expiresIn)) {
+    throw ERRORS.InvalidParameter('expiresIn')
+  }
+
+  const expiresInSeconds = Math.floor(expiresIn)
+  const maxRelativeExpirationSeconds = getMaxNumericJWTExpiration(nowMs)
+
+  if (
+    !Number.isSafeInteger(expiresInSeconds) ||
+    expiresInSeconds < 1 ||
+    expiresInSeconds > maxRelativeExpirationSeconds
+  ) {
+    throw ERRORS.InvalidParameter('expiresIn')
   }
 }
 

--- a/src/test/jwt.test.ts
+++ b/src/test/jwt.test.ts
@@ -1,9 +1,17 @@
 import { JWT_CACHE_NAME } from '@internal/cache'
+import { ErrorCode } from '@internal/errors'
 import { cacheRequestsTotal } from '@internal/monitoring/metrics'
 import * as crypto from 'crypto'
 import { SignJWT } from 'jose'
 import { JwksConfigKey } from '../config'
-import { generateHS512JWK, signJWT, verifyJWT, verifyJWTWithCache } from '../internal/auth'
+import {
+  assertValidNumericJWTExpiration,
+  generateHS512JWK,
+  getMaxNumericJWTExpiration,
+  signJWT,
+  verifyJWT,
+  verifyJWTWithCache,
+} from '../internal/auth'
 
 describe('JWT', () => {
   describe('verifyJWT with JWKS', () => {
@@ -146,6 +154,61 @@ describe('JWT', () => {
       await expect(signJWT({ sub: 'things' }, '', 100)).rejects.toThrow(
         'Zero-length key is not supported'
       )
+    })
+
+    test('it should allow the current maximum numeric expiration and keep exp millisecond-safe', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+      const maxNumericExpiration = getMaxNumericJWTExpiration()
+      const jwt = await signJWT({ sub: 'things' }, hmacPrivateKeyWithoutKid, maxNumericExpiration)
+      const result = await verifyJWT(jwt, hmacPrivateKeyWithoutKid)
+
+      expect(maxNumericExpiration).toBeGreaterThan(0)
+      expect(Number.isSafeInteger(result.exp)).toBe(true)
+      expect(Number.isSafeInteger(result.exp! * 1000)).toBe(true)
+    })
+
+    test('it should reject numeric expirations above the current maximum', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+      const maxNumericExpiration = getMaxNumericJWTExpiration()
+      await expect(
+        signJWT({ sub: 'things' }, hmacPrivateKeyWithoutKid, maxNumericExpiration + 1)
+      ).rejects.toMatchObject({
+        code: ErrorCode.InvalidParameter,
+        httpStatusCode: 400,
+        message: 'Invalid Parameter expiresIn',
+      })
+    })
+
+    test('it should reject numeric expirations above the current maximum in the shared validator', () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+      expect(() => assertValidNumericJWTExpiration(getMaxNumericJWTExpiration() + 1)).toThrow(
+        'Invalid Parameter expiresIn'
+      )
+    })
+
+    test('it should reject numeric expirations below one second', async () => {
+      await expect(signJWT({ sub: 'things' }, hmacPrivateKeyWithoutKid, 0)).rejects.toMatchObject({
+        code: ErrorCode.InvalidParameter,
+        httpStatusCode: 400,
+        message: 'Invalid Parameter expiresIn',
+      })
+
+      await expect(signJWT({ sub: 'things' }, hmacPrivateKeyWithoutKid, -1)).rejects.toMatchObject({
+        code: ErrorCode.InvalidParameter,
+        httpStatusCode: 400,
+        message: 'Invalid Parameter expiresIn',
+      })
+    })
+
+    test('it should reject numeric expirations below one second in the shared validator', () => {
+      expect(() => assertValidNumericJWTExpiration(0)).toThrow('Invalid Parameter expiresIn')
+      expect(() => assertValidNumericJWTExpiration(-1)).toThrow('Invalid Parameter expiresIn')
     })
 
     test('it should reject if jwt is malformed', async () => {

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1,6 +1,12 @@
 'use strict'
 
-import { generateHS512JWK, SignedToken, signJWT, verifyJWT } from '@internal/auth'
+import {
+  generateHS512JWK,
+  getMaxNumericJWTExpiration,
+  SignedToken,
+  signJWT,
+  verifyJWT,
+} from '@internal/auth'
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
 import { ErrorCode, StorageBackendError } from '@internal/errors'
 import { randomUUID } from 'crypto'
@@ -1830,6 +1836,38 @@ describe('testing generating signed URL', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('rejects oversized expiresIn values for signed URLs before jwt signing', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1e21,
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(JSON.parse(response.body).message).toContain('expiresIn')
+  })
+
+  test('rejects expiresIn values above the current runtime maximum for signed URLs', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: getMaxNumericJWTExpiration() + 10,
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(JSON.parse(response.body).message).toContain('expiresIn')
+  })
 })
 
 /**
@@ -2034,7 +2072,7 @@ describe('testing uploading with generated signed upload URL', () => {
     const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
     const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
 
-    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, -1)
+    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, '-1s')
     const response = await appInstance.inject({
       method: 'PUT',
       url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
@@ -2207,6 +2245,23 @@ describe('testing generating signed URLs', () => {
     const result = JSON.parse(response.body)
     expect(result[0].error).toBe('Either the object does not exist or you do not have access to it')
   })
+
+  test('rejects oversized expiresIn values for batch signed URLs before jwt signing', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1e21,
+        paths: ['authenticated/cat.jpg'],
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(JSON.parse(response.body).message).toContain('expiresIn')
+  })
 })
 
 /**
@@ -2300,7 +2355,7 @@ describe('testing retrieving signed URL', () => {
 
   test('get object with an expired JWT', async () => {
     const urlToSign = 'bucket2/public/sadcat-upload.png'
-    const expiredJWT = await signJWT({ url: urlToSign }, jwtSecret, -1)
+    const expiredJWT = await signJWT({ url: urlToSign }, jwtSecret, '-1s')
     const response = await appInstance.inject({
       method: 'GET',
       url: `/object/sign/${urlToSign}?token=${expiredJWT}`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

Schema only validates the type for expiresIn but doesn't cap the max value so invalid value can bubble as 500 while signing.

## What is the new behavior?

Cap the value by safe range and bubble it as 400 invalid parameter

