### PR TITLE
fix: use correct JSON Schema keyword in getSignedURLs response

### DIFF
--- a/src/http/routes/object/getSignedURLs.ts
+++ b/src/http/routes/object/getSignedURLs.ts
@@ -35,7 +35,7 @@ const successResponseSchema = {
     type: 'object',
     properties: {
       error: {
-        error: ['string', 'null'],
+        type: ['string', 'null'],
         examples: ['Either the object does not exist or you do not have access to it'],
       },
       path: {


### PR DESCRIPTION
Closes #1023

The `error` property in the `getSignedURLs` response schema uses `error:` as the JSON Schema keyword instead of `type:`. This isn't a valid JSON Schema keyword, so `@fastify/swagger` skips it when generating the OpenAPI spec -- the published API has no type info for this field.

The sibling `signedURL` property in the same object already uses `type: ['string', 'null']` correctly. One-word fix to match.