### PR TITLE
fix: validate before date in DELETE orphan-objects

### DIFF
--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -149,6 +149,11 @@ export default async function routes(fastify: FastifyInstance) {
       const bucket = `${req.params.bucketId}`
       let before = req.body.before ? new Date(req.body.before as string) : undefined
 
+      if (before && isNaN(before.getTime())) {
+        return reply.status(400).send({
+          error: 'Invalid date format',
+        })
+      }
       if (!before) {
         before = new Date()
         before.setHours(before.getHours() - 1)

--- a/src/test/admin-orphan-objects.test.ts
+++ b/src/test/admin-orphan-objects.test.ts
@@ -47,7 +47,7 @@ describe('admin orphan-objects routes', () => {
       expect(JSON.parse(response.body).error).toBe('Invalid date format')
     })
 
-    it('returns 400 when neither deleteDbKeys nor deleteS3Keys is set (unchanged behavior)', async () => {
+    it('returns 400 when neither deleteDbKeys nor deleteS3Keys is set', async () => {
       const response = await adminApp.inject({
         method: 'DELETE',
         url: '/tenants/bjhaohmqunupljrqypxz/buckets/bucket2/orphan-objects',

--- a/src/test/admin-orphan-objects.test.ts
+++ b/src/test/admin-orphan-objects.test.ts
@@ -1,0 +1,70 @@
+import * as migrations from '@internal/database/migrations'
+import { multitenantKnex } from '@internal/database/multitenant-db'
+import { adminApp } from './common'
+
+describe('admin orphan-objects routes', () => {
+  beforeAll(async () => {
+    await migrations.runMultitenantMigrations()
+  })
+
+  afterAll(async () => {
+    await adminApp.close()
+    await multitenantKnex.destroy()
+  })
+
+  describe('GET /tenants/:tenantId/buckets/:bucketId/orphan-objects', () => {
+    it('returns 400 when the before query parameter is not a valid date', async () => {
+      const response = await adminApp.inject({
+        method: 'GET',
+        url: '/tenants/bjhaohmqunupljrqypxz/buckets/bucket2/orphan-objects?before=not-a-date',
+        headers: {
+          apikey: process.env.ADMIN_API_KEYS!,
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body).error).toBe('Invalid date format')
+    })
+  })
+
+  describe('DELETE /tenants/:tenantId/buckets/:bucketId/orphan-objects', () => {
+    it('returns 400 when the before body field is not a valid date', async () => {
+      const response = await adminApp.inject({
+        method: 'DELETE',
+        url: '/tenants/bjhaohmqunupljrqypxz/buckets/bucket2/orphan-objects',
+        headers: {
+          apikey: process.env.ADMIN_API_KEYS!,
+          'content-type': 'application/json',
+        },
+        payload: JSON.stringify({
+          deleteDbKeys: true,
+          deleteS3Keys: false,
+          before: 'not-a-date',
+        }),
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body).error).toBe('Invalid date format')
+    })
+
+    it('returns 400 when neither deleteDbKeys nor deleteS3Keys is set (unchanged behavior)', async () => {
+      const response = await adminApp.inject({
+        method: 'DELETE',
+        url: '/tenants/bjhaohmqunupljrqypxz/buckets/bucket2/orphan-objects',
+        headers: {
+          apikey: process.env.ADMIN_API_KEYS!,
+          'content-type': 'application/json',
+        },
+        payload: JSON.stringify({
+          deleteDbKeys: false,
+          deleteS3Keys: false,
+        }),
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body).error).toContain(
+        'At least one of deleteDbKeys or deleteS3Keys'
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #1031

The DELETE handler accepted any string as the `before` body field and passed it straight to `new Date()`. An invalid string becomes `Invalid Date`, which is truthy, so the `if (!before)` default-hour branch was skipped and the `Invalid Date` propagated into `scanner.deleteOrphans`. Comparisons against NaN are all false, so the scan quietly matched nothing.

The GET handler on the same route already validates this. Mirror the same `isNaN` check in DELETE, plus integration tests covering both handlers and the existing `deleteDbKeys`/`deleteS3Keys` guard.