### PR TITLE
fix: prevent update bucket with missing payload

### DIFF
--- a/src/http/routes/bucket/updateBucket.ts
+++ b/src/http/routes/bucket/updateBucket.ts
@@ -6,6 +6,7 @@ import { ROUTE_OPERATIONS } from '../operations'
 
 const updateBucketBodySchema = {
   type: 'object',
+  minProperties: 1,
   properties: {
     public: { type: 'boolean', examples: [false] },
     file_size_limit: {
@@ -20,6 +21,11 @@ const updateBucketBodySchema = {
       items: { type: 'string', examples: [['image/png', 'image/jpg']] },
     },
   },
+  anyOf: [
+    { required: ['public'] },
+    { required: ['file_size_limit'] },
+    { required: ['allowed_mime_types'] },
+  ],
 } as const
 const updateBucketParamsSchema = {
   type: 'object',

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -194,6 +194,9 @@ export class Storage {
     }
   ) {
     mustBeValidBucketName(id)
+    if (!Object.values(data).some((v) => typeof v !== 'undefined')) {
+      throw ERRORS.NoContentProvided()
+    }
 
     const bucketData: Parameters<Database['updateBucket']>[1] = data
 

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -525,6 +525,19 @@ describe('testing public bucket functionality', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('user is not able to update a bucket with empty payload', async () => {
+    const bucketId = 'public-bucket'
+    const response = await appInstance.inject({
+      method: 'PUT',
+      url: `/bucket/${bucketId}`,
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {},
+    })
+    expect(response.statusCode).toBe(400)
+  })
 })
 
 describe('testing count objects in bucket', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an empty payload is passed to `storage.bucket.update` it results in an empty update resulting in a 500 error

```
Empty .update() call detected! Update data does not contain any values to update. This will result in a faulty query. Table: buckets. Columns: public,file_size_limit,allowed_mime_types.
```

## What is the new behavior?

Check that there is actually something to update and throw if there is not

