### PR TITLE
refactor: drop axios from iceberg rest catalog client

### DIFF
--- a/acceptance/specs/iceberg.test.ts
+++ b/acceptance/specs/iceberg.test.ts
@@ -38,6 +38,14 @@ interface IcebergTableResponse {
   'metadata-location'?: string
 }
 
+interface IcebergErrorResponse {
+  error?: {
+    code?: number
+    message?: string
+    type?: string
+  }
+}
+
 describeAcceptance(
   'Iceberg catalog contract',
   {
@@ -87,6 +95,21 @@ describeAcceptance(
         expect(catalogConfig.json?.defaults?.prefix).toBe(bucketName)
         expect(catalogConfig.json?.overrides?.prefix).toBe(bucketName)
 
+        const missingWarehouse = await client.request<IcebergErrorResponse>(
+          'GET',
+          `/iceberg/v1/${bucketName}-missing/namespaces/${namespaceName}/tables/${tableName}`,
+          {
+            expectedStatus: 404,
+            token,
+          }
+        )
+        expect(missingWarehouse.json).toMatchObject({
+          error: {
+            code: 404,
+            type: 'NoSuchCatalog',
+          },
+        })
+
         const createdNamespace = await client.request<IcebergNamespaceResponse>(
           'POST',
           `/iceberg/v1/${bucketName}/namespaces`,
@@ -104,10 +127,15 @@ describeAcceptance(
         namespaceCreated = true
         expect(createdNamespace.json?.namespace).toEqual([namespaceName])
 
-        await client.request('HEAD', `/iceberg/v1/${bucketName}/namespaces/${namespaceName}`, {
-          expectedStatus: 204,
-          token,
-        })
+        const headNamespace = await client.request(
+          'HEAD',
+          `/iceberg/v1/${bucketName}/namespaces/${namespaceName}`,
+          {
+            expectedStatus: 204,
+            token,
+          }
+        )
+        expect(headNamespace.body).toBe('')
 
         const namespace = await client.request<IcebergNamespaceResponse>(
           'GET',
@@ -196,7 +224,7 @@ describeAcceptance(
         expect(table.json?.metadata).toBeTruthy()
         expect(table.json?.['metadata-location']).toBeTruthy()
 
-        await client.request(
+        const headTable = await client.request(
           'HEAD',
           `/iceberg/v1/${bucketName}/namespaces/${namespaceName}/tables/${tableName}`,
           {
@@ -204,6 +232,7 @@ describeAcceptance(
             token,
           }
         )
+        expect(headTable.body).toBe('')
 
         const committed = await client.request<IcebergTableResponse>(
           'POST',
@@ -224,12 +253,23 @@ describeAcceptance(
         )
         expect(committed.json?.metadata).toBeTruthy()
 
-        await client.request('GET', `/iceberg/v1/${bucketName}/namespaces/missing${suffix}`, {
-          expectedStatus: 404,
-          token,
+        const missingNamespace = await client.request<IcebergErrorResponse>(
+          'GET',
+          `/iceberg/v1/${bucketName}/namespaces/missing${suffix}`,
+          {
+            expectedStatus: 404,
+            token,
+          }
+        )
+        expect(missingNamespace.json).toMatchObject({
+          error: {
+            code: 404,
+            message: 'Namespace not found',
+            type: 'NoSuchNamespaceException',
+          },
         })
 
-        await client.request(
+        const missingTable = await client.request<IcebergErrorResponse>(
           'GET',
           `/iceberg/v1/${bucketName}/namespaces/${namespaceName}/tables/missing${suffix}`,
           {
@@ -237,8 +277,15 @@ describeAcceptance(
             token,
           }
         )
+        expect(missingTable.json).toMatchObject({
+          error: {
+            code: 404,
+            message: 'Table not found',
+            type: 'NoSuchTableException',
+          },
+        })
 
-        await client.request(
+        const duplicateTable = await client.request<IcebergErrorResponse>(
           'POST',
           `/iceberg/v1/${bucketName}/namespaces/${namespaceName}/tables`,
           {
@@ -260,6 +307,13 @@ describeAcceptance(
             token,
           }
         )
+        expect(duplicateTable.json).toMatchObject({
+          error: {
+            code: 409,
+            message: 'Table already exists',
+            type: 'AlreadyExistsException',
+          },
+        })
       } finally {
         if (tableCreated) {
           await client

--- a/src/storage/protocols/iceberg/catalog/errors.ts
+++ b/src/storage/protocols/iceberg/catalog/errors.ts
@@ -114,7 +114,17 @@ export class IcebergError extends Error {
 
     const message = String(errorObj.message || 'Unknown error')
     const type = (errorObj.type as IcebergErrorType) || IcebergErrorType.InternalServerError
-    const code = (errorObj.code as number) || IcebergHttpStatusCode.InternalServerError
+    const rawCode = errorObj.code
+    const parsedCode =
+      typeof rawCode === 'number'
+        ? rawCode
+        : typeof rawCode === 'string'
+          ? Number(rawCode)
+          : IcebergHttpStatusCode.InternalServerError
+    const code =
+      Number.isInteger(parsedCode) && parsedCode > 0
+        ? parsedCode
+        : IcebergHttpStatusCode.InternalServerError
 
     return new IcebergError(message, type, code)
   }

--- a/src/storage/protocols/iceberg/catalog/rest-catalog-client.contract.test.ts
+++ b/src/storage/protocols/iceberg/catalog/rest-catalog-client.contract.test.ts
@@ -1,0 +1,203 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { AddressInfo, Socket } from 'node:net'
+import { ErrorCode, type StorageBackendError } from '@internal/errors'
+import JSONBigint from 'json-bigint'
+import { afterEach, describe, expect, it } from 'vitest'
+import { BearerTokenAuth, RestCatalogClient, SignV4Auth } from './rest-catalog-client'
+
+interface TestServer {
+  close(): Promise<void>
+  url: string
+}
+
+type RequestRecord = {
+  body: string
+  headers: IncomingMessage['headers']
+  method?: string
+  rawHeaders: string[]
+  url?: string
+}
+
+const servers: TestServer[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()))
+})
+
+describe('RestCatalogClient HTTP contract', () => {
+  it('preserves large integers when sending and parsing JSON bodies', async () => {
+    const largeFieldId = JSONBigint.parse('9223372036854775807') as number
+    let requestBody = ''
+    const server = await startServer(async (req, res) => {
+      requestBody = await readRequestBody(req)
+      sendJson(res, {
+        'metadata-location': 's3://warehouse/ns/table/metadata.json',
+        metadata: {
+          'current-snapshot-id': JSONBigint.parse('9223372036854775807'),
+          'format-version': 2,
+          'table-uuid': 'table-id',
+        },
+      })
+    })
+
+    const client = new RestCatalogClient({
+      auth: new BearerTokenAuth({ token: 'token' }),
+      catalogUrl: `${server.url}/v1`,
+    })
+
+    const response = await client.createTable({
+      name: 'tbl',
+      namespace: 'ns',
+      schema: {
+        fields: [
+          {
+            id: largeFieldId,
+            name: 'id',
+            required: true,
+            type: 'long',
+          },
+        ],
+        type: 'struct',
+      },
+      spec: { fields: [] },
+      warehouse: 'wh',
+    })
+
+    expect(requestBody).toContain('"id":9223372036854775807')
+    expect(String(response.metadata['current-snapshot-id'])).toBe('9223372036854775807')
+  })
+
+  it('reports timed out requests as timed out rather than aborted', async () => {
+    const server = await startServer(() => {
+      // Intentionally leave the response open until the client-side timeout aborts it.
+    })
+    const client = new RestCatalogClient({
+      auth: new BearerTokenAuth({ token: 'token' }),
+      catalogUrl: `${server.url}/v1`,
+      timeoutMs: 100,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog request timed out',
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('rejects successful non-JSON responses', async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('ok')
+    })
+    const client = new RestCatalogClient({
+      auth: new BearerTokenAuth({ token: 'token' }),
+      catalogUrl: `${server.url}/v1`,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Unexpected non-JSON response from Iceberg catalog',
+      originalError: expect.objectContaining({
+        message: 'Unexpected Content-Type: text/plain',
+      }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('sends one real SigV4 authorization header through fetch', async () => {
+    const requests: RequestRecord[] = []
+    const server = await startServer(async (req, res) => {
+      requests.push({
+        body: await readRequestBody(req),
+        headers: req.headers,
+        method: req.method,
+        rawHeaders: req.rawHeaders,
+        url: req.url,
+      })
+      sendJson(res, { defaults: {} })
+    })
+    const client = new RestCatalogClient({
+      auth: new SignV4Auth({
+        credentials: {
+          accessKeyId: 'AKIDEXAMPLE',
+          secretAccessKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        region: 'us-east-1',
+      }),
+      catalogUrl: `${server.url}/v1`,
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    expect(requests).toHaveLength(1)
+    const request = requests[0]
+    expect(request.headers.authorization).toContain('AWS4-HMAC-SHA256')
+    expect(request.headers['x-amz-date']).toMatch(/^\d{8}T\d{6}Z$/)
+    expect(countRawHeader(request.rawHeaders, 'authorization')).toBe(1)
+    expect(countRawHeader(request.rawHeaders, 'x-amz-date')).toBe(1)
+    expect(countRawHeader(request.rawHeaders, 'host')).toBe(1)
+  })
+})
+
+async function startServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>
+): Promise<TestServer> {
+  const sockets = new Set<Socket>()
+  const server = createServer((req, res) => {
+    void Promise.resolve(handler(req, res)).catch((error) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: String(error) }))
+    })
+  })
+
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    socket.once('close', () => sockets.delete(socket))
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address() as AddressInfo
+  const testServer = {
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy()
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    },
+    url: `http://127.0.0.1:${address.port}`,
+  }
+  servers.push(testServer)
+  return testServer
+}
+
+async function readRequestBody(req: IncomingMessage) {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function sendJson(res: ServerResponse, body: unknown) {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSONBigint.stringify(body))
+}
+
+function countRawHeader(rawHeaders: string[], header: string) {
+  let count = 0
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index].toLowerCase() === header) {
+      count++
+    }
+  }
+  return count
+}

--- a/src/storage/protocols/iceberg/catalog/rest-catalog-client.test.ts
+++ b/src/storage/protocols/iceberg/catalog/rest-catalog-client.test.ts
@@ -1,0 +1,987 @@
+import { ErrorCode, type StorageBackendError } from '@internal/errors'
+import type { SignRequestOptions } from 'aws-sigv4-sign'
+import JSONBigint from 'json-bigint'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSignRequest = vi.fn()
+vi.mock('aws-sigv4-sign', () => ({
+  signRequest: (...args: unknown[]) => mockSignRequest(...args),
+}))
+
+import { type IcebergError, IcebergErrorType } from './errors'
+import { BearerTokenAuth, RestCatalogClient, SignV4Auth } from './rest-catalog-client'
+
+type TestableRestCatalogClient = {
+  request<T>(input: {
+    method?: string
+    url: string
+    params?: Record<
+      string,
+      string | number | boolean | readonly (string | number | boolean)[] | null | undefined
+    >
+    data?: unknown
+    headers?: Record<string, string>
+  }): Promise<T>
+}
+
+function spyOnAbortSignalTimeout() {
+  const timeoutSignal = new AbortController().signal
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+  return { timeoutSignal, timeoutSpy }
+}
+
+describe('RestCatalogClient request pipeline', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ defaults: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    mockSignRequest.mockReset()
+    mockSignRequest.mockImplementation(
+      async () =>
+        new Request('https://signed.example.com/', {
+          headers: { 'x-amz-date': '20200101T000000Z', authorization: 'AWS4-HMAC-SHA256 ...' },
+        })
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves the catalogUrl path segment in the fetched URL', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://s3tables.ap-southeast-1.amazonaws.com/iceberg/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('/iceberg/v1/config')
+  })
+
+  it('preserves query and configured fragment in the request URL string', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1?token=abc#frag',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.listNamespaces({ warehouse: 'wh' })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.pathname).toBe('/v1/wh/namespaces')
+    expect(url.searchParams.get('token')).toBe('abc')
+    expect(fetchMock.mock.calls[0][0]).toContain('#frag')
+    expect(url.hash).toBe('#frag')
+  })
+
+  it('preserves the catalogUrl path segment for nested resources', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/some/prefix',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('/some/prefix/')
+    expect(url).toMatch(/\/wh\/namespaces\/ns\/tables\/tbl/)
+  })
+
+  it('signs the exact URL that fetch is called with (SigV4)', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://s3tables.ap-southeast-1.amazonaws.com/iceberg/v1',
+      auth: new SignV4Auth({ region: 'us-east-1' }),
+    })
+
+    await client.getConfig({ warehouse: 'my-warehouse' })
+
+    expect(mockSignRequest).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const signedUrl = mockSignRequest.mock.calls[0][0] as string
+    const fetchedUrl = fetchMock.mock.calls[0][0] as string
+
+    expect(fetchedUrl).toBe(signedUrl)
+  })
+
+  it('produces identical signed and fetched params even when params include empty strings', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new SignV4Auth({ region: 'us-east-1' }),
+    })
+
+    await client.listNamespaces({ warehouse: 'wh', pageToken: '', parent: 'p' })
+
+    const signedUrl = mockSignRequest.mock.calls[0][0] as string
+    const fetchedUrl = fetchMock.mock.calls[0][0] as string
+
+    const signed = new URL(signedUrl)
+    const fetched = new URL(fetchedUrl)
+
+    expect(fetched.pathname).toBe(signed.pathname)
+    expect(fetched.searchParams.toString()).toBe(signed.searchParams.toString())
+    expect(fetched.searchParams.has('pageToken')).toBe(true)
+    expect(fetched.searchParams.get('pageToken')).toBe('')
+    expect(fetched.searchParams.get('parent')).toBe('p')
+  })
+
+  it('treats null data the same as undefined: no body, no Content-Type', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    }) as unknown as TestableRestCatalogClient
+
+    await client.request<unknown>({
+      url: '/wh/namespaces',
+      method: 'POST',
+      data: null,
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.body).toBeUndefined()
+    expect(new Headers(init.headers).has('content-type')).toBe(false)
+  })
+
+  it('serializes scalar query params and skips nullish values', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    }) as unknown as TestableRestCatalogClient
+
+    await client.request<unknown>({
+      url: '/wh/namespaces',
+      params: {
+        empty: '',
+        zero: 0,
+        enabled: false,
+        missing: undefined,
+        nil: null,
+      },
+    })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.searchParams.get('empty')).toBe('')
+    expect(url.searchParams.get('zero')).toBe('0')
+    expect(url.searchParams.get('enabled')).toBe('false')
+    expect(url.searchParams.has('missing')).toBe(false)
+    expect(url.searchParams.has('nil')).toBe(false)
+  })
+
+  it('serializes array query params using OpenAPI form explode syntax', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    }) as unknown as TestableRestCatalogClient
+
+    await client.request<unknown>({
+      url: '/wh/namespaces',
+      params: {
+        namespace: ['a', 'b'],
+        mixed: ['x', 1, false],
+      },
+    })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.searchParams.getAll('namespace')).toEqual(['a', 'b'])
+    expect(url.searchParams.getAll('mixed')).toEqual(['x', '1', 'false'])
+    expect(url.search).toContain('namespace=a&namespace=b')
+    expect(url.search).not.toContain('namespace%5B%5D=')
+    expect(url.search).not.toContain('namespace=a%2Cb')
+  })
+
+  it('rejects unsupported query param objects instead of stringifying them', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    }) as unknown as TestableRestCatalogClient
+
+    await expect(
+      client.request<unknown>({
+        url: '/wh/namespaces',
+        params: { filter: { name: 'ns' } } as unknown as Record<string, string>,
+      })
+    ).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Unsupported Iceberg catalog query parameter',
+      originalError: expect.objectContaining({
+        message: 'Unsupported query parameter "filter" type: object',
+      }),
+    } satisfies Partial<StorageBackendError>)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('encodes namespace and table path segments', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.loadTable({
+      warehouse: 'wh',
+      namespace: 'ns/a b?#æ',
+      table: 'tbl/a b?#æ',
+    })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.pathname).toBe(
+      '/v1/wh/namespaces/ns%2Fa%20b%3F%23%C3%A6/tables/tbl%2Fa%20b%3F%23%C3%A6'
+    )
+  })
+
+  it('signs the same URL for POST requests with a body', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new SignV4Auth({ region: 'us-east-1' }),
+    })
+
+    await client.createNamespace({
+      warehouse: 'wh',
+      namespace: ['a', 'b'],
+      properties: { k: 'v' },
+    })
+
+    const signedUrl = mockSignRequest.mock.calls[0][0] as string
+    const fetchedUrl = fetchMock.mock.calls[0][0] as string
+    expect(fetchedUrl).toBe(signedUrl)
+  })
+
+  it('sends Accept: application/json on every request', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(new Headers(init.headers).get('accept')).toBe('application/json')
+  })
+
+  it('preserves an explicitly provided Accept header', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    }) as unknown as TestableRestCatalogClient
+
+    await client.request<unknown>({
+      url: '/wh/namespaces',
+      headers: { Accept: 'application/vnd.iceberg.table.v1+json' },
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(new Headers(init.headers).get('accept')).toBe('application/vnd.iceberg.table.v1+json')
+  })
+
+  it('sends bearer auth headers to fetch', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 'catalog-token' }),
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer catalog-token')
+  })
+
+  it('sends SigV4 headers to fetch', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new SignV4Auth({ region: 'us-east-1' }),
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('x-amz-date')).toBe('20200101T000000Z')
+    expect(headers.get('authorization')).toBe('AWS4-HMAC-SHA256 ...')
+  })
+
+  it('can sign Headers-based URL-encoded catalog requests with the real SigV4 signer', async () => {
+    const actual = await vi.importActual<typeof import('aws-sigv4-sign')>('aws-sigv4-sign')
+    mockSignRequest.mockImplementationOnce(
+      (input: string | Request | URL, init: RequestInit, options: SignRequestOptions) =>
+        actual.signRequest(input, init, options)
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new SignV4Auth({
+        region: 'us-east-1',
+        credentials: {
+          accessKeyId: 'AKIDEXAMPLE',
+          secretAccessKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+      }),
+    })
+
+    await client.loadTable({
+      warehouse: 'warehouse with space',
+      namespace: 'ns/a b?#æ',
+      table: 'tbl/a b?#æ',
+    })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string)
+    expect(url.pathname).toBe(
+      '/v1/warehouse%20with%20space/namespaces/ns%2Fa%20b%3F%23%C3%A6/tables/tbl%2Fa%20b%3F%23%C3%A6'
+    )
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('x-amz-date')).toMatch(/^\d{8}T\d{6}Z$/)
+    expect(headers.get('authorization')).toContain('AWS4-HMAC-SHA256')
+    expect(headers.get('authorization')).toContain('SignedHeaders=')
+
+    const signedInit = mockSignRequest.mock.calls[0][1] as RequestInit
+    expect(signedInit.headers).toBeInstanceOf(Headers)
+  })
+
+  it('passes a timeout signal to fetch', async () => {
+    const timeout = spyOnAbortSignalTimeout()
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 1234,
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    expect(timeout.timeoutSpy).toHaveBeenCalledWith(1234)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBe(timeout.timeoutSignal)
+  })
+
+  it('uses a 60 second timeout by default', async () => {
+    const timeout = spyOnAbortSignalTimeout()
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    expect(timeout.timeoutSpy).toHaveBeenCalledWith(60_000)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBe(timeout.timeoutSignal)
+  })
+
+  it('omits the timeout signal when timeoutMs is 0', async () => {
+    const timeout = spyOnAbortSignalTimeout()
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 0,
+    })
+
+    await client.getConfig({ warehouse: 'wh' })
+
+    expect(timeout.timeoutSpy).not.toHaveBeenCalled()
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBeUndefined()
+  })
+
+  it('serializes request bodies with JSONBigint', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+    const largeFieldId = JSONBigint.parse('9223372036854775807')
+
+    await client.createTable({
+      warehouse: 'wh',
+      namespace: 'ns',
+      name: 'tbl',
+      schema: {
+        type: 'struct',
+        fields: [
+          {
+            id: largeFieldId as number,
+            name: 'id',
+            type: 'long',
+            required: true,
+          },
+        ],
+      },
+      spec: { fields: [] },
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.body).toContain('"id":9223372036854775807')
+    expect(new Headers(init.headers).get('content-type')).toBe('application/json')
+  })
+
+  it('omits path-only parameters from table request bodies', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+    const schema = { type: 'struct' as const, fields: [] }
+    const spec = { fields: [] }
+
+    await client.createTable({
+      warehouse: 'wh',
+      namespace: 'ns',
+      name: 'tbl',
+      schema,
+      spec,
+    })
+    await client.updateTable({
+      warehouse: 'wh',
+      namespace: 'ns',
+      table: 'tbl',
+      requirements: [],
+      updates: [],
+    })
+
+    const createInit = fetchMock.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(String(createInit.body))).toEqual({
+      name: 'tbl',
+      schema,
+      spec,
+    })
+
+    const updateInit = fetchMock.mock.calls[1][1] as RequestInit
+    expect(JSON.parse(String(updateInit.body))).toEqual({
+      requirements: [],
+      updates: [],
+    })
+  })
+
+  it('parses response bodies with JSONBigint', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        '{"metadata-location":"s3://bucket/metadata.json","metadata":{"format-version":2,"table-uuid":"table-id","last-updated-ms":9223372036854775807}}',
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    const result = await client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+
+    expect(String(result.metadata['last-updated-ms'])).toBe('9223372036854775807')
+  })
+
+  it.each([
+    'application/json',
+    ' application/json ; charset=utf-8',
+    'application/problem+json',
+    'application/vnd.iceberg+json; charset=utf-8',
+  ])('accepts JSON content type %s', async (contentType) => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"defaults":{"clients":"4"}}', {
+        status: 200,
+        headers: { 'Content-Type': contentType },
+      })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).resolves.toMatchObject({
+      defaults: { clients: '4' },
+    })
+  })
+
+  it('rejects non-JSON successful responses with a specific internal error', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('not json', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Unexpected non-JSON response from Iceberg catalog',
+      originalError: expect.objectContaining({
+        message: 'Unexpected Content-Type: text/plain',
+      }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('throws a structured error for empty successful responses on JSON-returning endpoints', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog returned an empty response body',
+      originalError: expect.objectContaining({
+        message: 'Empty Iceberg loadTable response body',
+      }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('throws a structured error when getConfig response body is empty', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog returned an empty response body',
+      originalError: expect.objectContaining({
+        message: 'Empty Iceberg getConfig response body',
+      }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('throws a structured error when a required response body is JSON null', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('null', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog returned an empty response body',
+      originalError: expect.objectContaining({
+        message: 'Empty Iceberg loadTable response body',
+      }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('rejects malformed JSON successful responses with a specific internal error', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Invalid JSON response from Iceberg catalog',
+      originalError: expect.any(SyntaxError),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('translates Iceberg JSON errors from non-2xx responses', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: 'table already exists',
+            type: IcebergErrorType.AlreadyExistsException,
+            code: 409,
+          },
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.createNamespace({ warehouse: 'wh', namespace: ['ns'] })
+    ).rejects.toMatchObject({
+      code: 409,
+      message: 'table already exists',
+      type: IcebergErrorType.AlreadyExistsException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('uses resource-specific messages for status-only conflict responses', async () => {
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    fetchMock.mockResolvedValueOnce(new Response('conflict', { status: 409 }))
+    await expect(
+      client.createNamespace({ warehouse: 'wh', namespace: ['ns'] })
+    ).rejects.toMatchObject({
+      code: 409,
+      message: 'Namespace already exists',
+      type: IcebergErrorType.AlreadyExistsException,
+    } satisfies Partial<IcebergError>)
+
+    fetchMock.mockResolvedValueOnce(new Response('conflict', { status: 409 }))
+    await expect(
+      client.createTable({
+        warehouse: 'wh',
+        namespace: 'ns',
+        name: 'tbl',
+        schema: { type: 'struct', fields: [] },
+        spec: { fields: [] },
+      })
+    ).rejects.toMatchObject({
+      code: 409,
+      message: 'Table already exists',
+      type: IcebergErrorType.AlreadyExistsException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('maps non-JSON error responses by HTTP status', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('missing', { status: 404 }))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadNamespaceMetadata({ warehouse: 'wh', namespace: 'ns' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('maps empty 404 table responses to NoSuchTableException', async () => {
+    const response = new Response(null, { status: 404 })
+    const textSpy = vi.spyOn(response, 'text')
+    fetchMock.mockResolvedValueOnce(response)
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.tableExists({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Table not found',
+      type: IcebergErrorType.NoSuchTableException,
+    } satisfies Partial<IcebergError>)
+    expect(textSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not read successful HEAD response bodies', async () => {
+    const response = new Response(null, { status: 204 })
+    const textSpy = vi.spyOn(response, 'text')
+    fetchMock.mockResolvedValueOnce(response)
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.tableExists({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).resolves.toBeUndefined()
+    expect(textSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to status code mapping for 404 with empty JSON object body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('{}', { status: 404, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.tableExists({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Table not found',
+      type: IcebergErrorType.NoSuchTableException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('falls back to status code mapping for non-spec error envelopes', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'not found', detail: 'whatever' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadNamespaceMetadata({ warehouse: 'wh', namespace: 'ns' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('honors valid Iceberg error envelopes over the HTTP status', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: 'specific message from server',
+            type: IcebergErrorType.NoSuchTableException,
+            code: 404,
+          },
+        }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'specific message from server',
+      type: IcebergErrorType.NoSuchTableException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('accepts stringified numeric codes in Iceberg error envelopes', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: 'string-coded table miss',
+            type: IcebergErrorType.NoSuchTableException,
+            code: '404',
+          },
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.loadTable({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'string-coded table miss',
+      type: IcebergErrorType.NoSuchTableException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('falls back to 500 for empty string codes in Iceberg error envelopes', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: 'empty-coded server error',
+            type: IcebergErrorType.InternalServerError,
+            code: '',
+          },
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: 500,
+      message: 'empty-coded server error',
+      type: IcebergErrorType.InternalServerError,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('maps 500 responses without spec error envelopes to InternalServerError', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('upstream exploded', { status: 500 }))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: 500,
+      message: 'Internal server error',
+      type: IcebergErrorType.InternalServerError,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('maps 503 responses without spec error envelopes to SlowDownException', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('busy', { status: 503 }))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: 503,
+      message: 'Service unavailable',
+      type: IcebergErrorType.SlowDownException,
+    } satisfies Partial<IcebergError>)
+  })
+
+  it('wraps auth strategy failures as internal storage errors', async () => {
+    const failingAuth = {
+      authorize: () => {
+        throw new Error('credential provider failed')
+      },
+    }
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: failingAuth,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Failed to authorize Iceberg catalog request',
+      originalError: expect.objectContaining({ message: 'credential provider failed' }),
+    } satisfies Partial<StorageBackendError>)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('wraps network failures as internal storage errors', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Network error reaching Iceberg catalog',
+      originalError: expect.any(TypeError),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('reports timeouts with a dedicated message while preserving the original error', async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation timed out', 'TimeoutError'))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 1,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog request timed out',
+      originalError: expect.objectContaining({ name: 'TimeoutError' }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('reports a fired client timeout as timed out even when fetch rejects AbortError', async () => {
+    const controller = new AbortController()
+    controller.abort(new DOMException('The operation timed out', 'TimeoutError'))
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 1,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog request timed out',
+      originalError: expect.objectContaining({ name: 'AbortError' }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('reports user-aborted requests with an aborted message', async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 1,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog request aborted',
+      originalError: expect.objectContaining({ name: 'AbortError' }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('reports timed out response body reads as timed out', async () => {
+    const controller = new AbortController()
+    controller.abort(new DOMException('The operation timed out', 'TimeoutError'))
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => {
+        throw new DOMException('The operation was aborted', 'AbortError')
+      },
+    } as unknown as Response)
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+      timeoutMs: 1,
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Iceberg catalog request timed out',
+      originalError: expect.objectContaining({ name: 'AbortError' }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('wraps response body read failures as internal storage errors', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('body stream broken'))
+      },
+    })
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(client.getConfig({ warehouse: 'wh' })).rejects.toMatchObject({
+      code: ErrorCode.InternalError,
+      message: 'Failed to read Iceberg catalog response',
+      originalError: expect.objectContaining({ message: expect.stringContaining('body stream') }),
+    } satisfies Partial<StorageBackendError>)
+  })
+
+  it('allows empty successful HEAD responses', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const client = new RestCatalogClient({
+      catalogUrl: 'https://host.example.com/v1',
+      auth: new BearerTokenAuth({ token: 't' }),
+    })
+
+    await expect(
+      client.tableExists({ warehouse: 'wh', namespace: 'ns', table: 'tbl' })
+    ).resolves.toBeUndefined()
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.method).toBe('HEAD')
+  })
+})

--- a/src/storage/protocols/iceberg/catalog/rest-catalog-client.ts
+++ b/src/storage/protocols/iceberg/catalog/rest-catalog-client.ts
@@ -1,6 +1,5 @@
-import { ERRORS } from '@internal/errors'
-import { signRequest } from 'aws-sigv4-sign'
-import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import { ERRORS, StorageBackendError } from '@internal/errors'
+import { type SignRequestOptions, signRequest } from 'aws-sigv4-sign'
 import JSONBigint from 'json-bigint'
 import {
   createAlreadyExistsError,
@@ -9,6 +8,7 @@ import {
   createForbiddenError,
   createInternalServerError,
   createNoSuchNamespaceError,
+  createNoSuchTableError,
   createSlowDownError,
   createUnauthorizedError,
   createUnprocessableEntityError,
@@ -16,6 +16,13 @@ import {
   IcebergError,
   IcebergHttpStatusCode,
 } from './errors'
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000
+
+type QueryParamPrimitive = string | number | boolean
+type QueryParamValue = QueryParamPrimitive | readonly QueryParamPrimitive[] | null | undefined
+type CatalogResource = 'namespace' | 'table'
+type NotFoundResource = CatalogResource
 
 export interface GetConfigRequest {
   tenantId?: string
@@ -45,10 +52,161 @@ export interface ListNamespacesResponse {
   'next-page-token'?: string
 }
 
+export interface FetchRequestConfig {
+  method: string
+  url: string
+  headers: Headers
+  body?: string
+}
+
+type FetchRequestInput = {
+  method?: string
+  url: string
+  params?: Record<string, QueryParamValue>
+  data?: unknown
+  headers?: Record<string, string>
+  notFoundResource?: NotFoundResource
+  conflictResource?: CatalogResource
+}
+
 interface CatalogAuth {
-  authorize(
-    req: InternalAxiosRequestConfig<string>
-  ): InternalAxiosRequestConfig<string> | Promise<InternalAxiosRequestConfig<string>>
+  authorize(req: FetchRequestConfig): FetchRequestConfig | Promise<FetchRequestConfig>
+}
+
+function appendSearchParam(url: URL, name: string, value: unknown) {
+  if (value === undefined || value === null) return
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      appendSearchParam(url, name, item)
+    }
+    return
+  }
+
+  const valueType = typeof value
+  if (valueType !== 'string' && valueType !== 'number' && valueType !== 'boolean') {
+    throw ERRORS.InternalError(
+      new TypeError(`Unsupported query parameter "${name}" type: ${valueType}`),
+      'Unsupported Iceberg catalog query parameter'
+    )
+  }
+
+  url.searchParams.append(name, String(value))
+}
+
+function buildCatalogRequestUrl(
+  catalogUrl: string,
+  path: string,
+  params?: Record<string, QueryParamValue>
+) {
+  const url = new URL(catalogUrl)
+  if (path) {
+    const basePath = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname
+    const suffix = path.startsWith('/') ? path : '/' + path
+    url.pathname = basePath + suffix
+  }
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      appendSearchParam(url, k, v)
+    }
+  }
+  return url
+}
+
+function isJsonContentType(contentType: string) {
+  return /^\s*application\/(?:json|[^;\s]+\+json)\s*(?:;|$)/i.test(contentType)
+}
+
+function isIcebergErrorEnvelope(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false
+  const error = (data as Record<string, unknown>).error
+  if (!error || typeof error !== 'object') return false
+  const e = error as Record<string, unknown>
+  return (
+    typeof e.message === 'string' &&
+    typeof e.type === 'string' &&
+    (typeof e.code === 'number' || typeof e.code === 'string')
+  )
+}
+
+function toError(error: unknown) {
+  if (error instanceof Error) return error
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = String((error as { message: unknown }).message)
+    if ('name' in error && error.name === 'SyntaxError') {
+      return new SyntaxError(message)
+    }
+    return new Error(message)
+  }
+
+  return new Error(String(error))
+}
+
+function parseSuccessfulResponse<T>(response: Response, text: string): T | undefined {
+  // Keep empty responses explicit in the type system. Void endpoints accept
+  // this, while JSON-returning public methods narrow through requestRequired().
+  if (!text.trim()) return undefined
+
+  const contentType = response.headers.get('content-type')
+  if (contentType && !isJsonContentType(contentType)) {
+    throw ERRORS.InternalError(
+      new Error(`Unexpected Content-Type: ${contentType}`),
+      'Unexpected non-JSON response from Iceberg catalog'
+    )
+  }
+
+  try {
+    return JSONBigint.parse(text) as T
+  } catch (error) {
+    throw ERRORS.InternalError(toError(error), 'Invalid JSON response from Iceberg catalog')
+  }
+}
+
+function getAbortErrorMessage(signal: AbortSignal | undefined, error: Error) {
+  if (error.name === 'TimeoutError' || getAbortReasonName(signal) === 'TimeoutError') {
+    return 'Iceberg catalog request timed out'
+  }
+
+  if (error.name === 'AbortError') {
+    return 'Iceberg catalog request aborted'
+  }
+
+  return undefined
+}
+
+function getAbortReasonName(signal: AbortSignal | undefined) {
+  if (!signal?.aborted) return undefined
+
+  const reason = signal.reason
+  if (reason instanceof Error) return reason.name
+  if (reason && typeof reason === 'object' && 'name' in reason) {
+    return String((reason as { name: unknown }).name)
+  }
+
+  return undefined
+}
+
+function getNotFoundMessage(resource?: NotFoundResource) {
+  switch (resource) {
+    case 'table':
+      return 'Table not found'
+    case 'namespace':
+      return 'Namespace not found'
+    default:
+      return 'Resource not found'
+  }
+}
+
+function getAlreadyExistsMessage(resource?: CatalogResource) {
+  switch (resource) {
+    case 'table':
+      return 'Table already exists'
+    case 'namespace':
+      return 'Namespace already exists'
+    default:
+      return 'Resource already exists'
+  }
 }
 
 export type CatalogAuthType = CatalogAuth
@@ -56,6 +214,7 @@ export type CatalogAuthType = CatalogAuth
 export interface RestCatalogClientOptions {
   catalogUrl: string
   auth: CatalogAuthType
+  timeoutMs?: number
 }
 
 export interface CreateNamespaceRequest {
@@ -346,86 +505,148 @@ export interface DropTableRequest {
 export type CreateTableResponse = LoadTableResult
 
 export class RestCatalogClient {
-  httpClient: AxiosInstance
+  catalogUrl: string
   auth: CatalogAuthType
+  timeoutMs: number
 
   constructor(options: RestCatalogClientOptions) {
-    this.httpClient = axios.create({
-      baseURL: options.catalogUrl,
-    })
-
+    this.catalogUrl = options.catalogUrl
     this.auth = options.auth
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  }
 
-    this.httpClient.interceptors.request.use((req) => {
-      return this.auth.authorize(req)
-    })
+  private async request<T>(input: FetchRequestInput): Promise<T | undefined> {
+    const method = (input.method || 'GET').toUpperCase()
+    const url = buildCatalogRequestUrl(this.catalogUrl, input.url, input.params)
+    const headers = new Headers(input.headers || {})
+    if (!headers.has('Accept')) {
+      headers.set('Accept', 'application/json')
+    }
+    const hasBody = input.data !== undefined && input.data !== null
+    const body = hasBody ? JSONBigint.stringify(input.data) : undefined
+    if (hasBody) {
+      headers.set('Content-Type', 'application/json')
+    }
 
-    // request interceptor, preventing the response the default behaviour of parsing the response with JSON.parse
-    this.httpClient.interceptors.request.use((request) => {
-      request.transformRequest = [
-        (data) => {
-          return data ? JSONBigint.stringify(data) : data
-        },
-      ]
-      request.transformResponse = [(data) => data]
-      return request
-    })
-
-    // response interceptor parsing the response data with JSONbigint, and returning the response
-    this.httpClient.interceptors.response.use((response) => {
-      if (response.data) {
-        response.data = JSONBigint.parse(response.data)
+    let authorized: FetchRequestConfig
+    try {
+      authorized = await this.auth.authorize({
+        method,
+        url: url.toString(),
+        headers,
+        body,
+      })
+    } catch (error) {
+      if (error instanceof IcebergError || error instanceof StorageBackendError) {
+        throw error
       }
-      return response
-    })
+      throw ERRORS.InternalError(toError(error), 'Failed to authorize Iceberg catalog request')
+    }
 
-    this.httpClient.interceptors.response.use(
-      // On 2xx responses, just pass through
-      (response) => response,
+    const signal = this.timeoutMs > 0 ? AbortSignal.timeout(this.timeoutMs) : undefined
+    let response: Response
+    try {
+      response = await fetch(authorized.url, {
+        method: authorized.method,
+        headers: authorized.headers,
+        body: authorized.body,
+        signal,
+      })
+    } catch (error) {
+      const err = toError(error)
+      throw ERRORS.InternalError(
+        err,
+        getAbortErrorMessage(signal, err) ?? 'Network error reaching Iceberg catalog'
+      )
+    }
 
-      // On errors…
-      (error) => {
-        // If there's no response, it's a network / CORS / timeout error
-        if (!error.response) {
-          throw ERRORS.InternalError(error, 'Network error')
+    try {
+      const isHead = authorized.method.toUpperCase() === 'HEAD'
+      if (!response.ok) {
+        let jsonResponse: unknown
+
+        if (isHead) {
+          jsonResponse = undefined
+        } else {
+          const text = await response.text()
+          const contentType = response.headers.get('content-type')
+          if (contentType && isJsonContentType(contentType)) {
+            try {
+              jsonResponse = JSONBigint.parse(text)
+            } catch {
+              jsonResponse = text
+            }
+          } else {
+            jsonResponse = text
+          }
         }
 
-        if (error instanceof AxiosError) {
-          const body = error.response?.data
-          const jsonResponse = typeof body === 'string' ? JSONBigint.parse(body) : body
-
-          // Parse Iceberg error response and throw appropriate error
-          throw this.parseIcebergError(error.response.status, jsonResponse)
-        }
-
-        throw ERRORS.InternalError(error, 'Iceberg request failed')
+        throw this.parseIcebergError(
+          response.status,
+          jsonResponse,
+          input.notFoundResource,
+          input.conflictResource
+        )
       }
-    )
+
+      if (isHead) {
+        return undefined
+      }
+
+      const resText = await response.text()
+      return parseSuccessfulResponse<T>(response, resText)
+    } catch (error) {
+      if (error instanceof IcebergError || error instanceof StorageBackendError) {
+        throw error
+      }
+      const err = toError(error)
+      throw ERRORS.InternalError(
+        err,
+        getAbortErrorMessage(signal, err) ?? 'Failed to read Iceberg catalog response'
+      )
+    }
+  }
+
+  private async requestRequired<T>(input: FetchRequestInput, emptyMessage: string) {
+    const data = await this.request<T>(input)
+    if (data === undefined || data === null) {
+      throw ERRORS.InternalError(
+        new Error(emptyMessage),
+        'Iceberg catalog returned an empty response body'
+      )
+    }
+
+    return data
   }
 
   /**
    * Parse HTTP response status and body to create appropriate Iceberg error
    * Handles all HTTP error codes from the Iceberg REST specification
    */
-  private parseIcebergError(status: number, data: unknown): IcebergError {
-    // Try to extract error details from response body
-    if (data && typeof data === 'object') {
-      try {
-        // Map error types to specific error creators
-        return IcebergError.fromResponse(data)
-      } catch {
-        // Fall through to status code handling
-      }
+  private parseIcebergError(
+    status: number,
+    data: unknown,
+    notFoundResource?: NotFoundResource,
+    conflictResource?: CatalogResource
+  ): IcebergError {
+    // Only trust the response body when it matches the spec envelope
+    // ({ error: { message, type, code } }). Otherwise the body is opaque
+    // and the HTTP status is the only signal we have.
+    if (isIcebergErrorEnvelope(data)) {
+      return IcebergError.fromResponse(data)
     }
 
-    // Handle specific status codes as per Iceberg spec
-    return this.createErrorByStatusCode(status)
+    return this.createErrorByStatusCode(status, notFoundResource, conflictResource)
   }
 
   /**
    * Create appropriate error based on HTTP status code
    */
-  private createErrorByStatusCode(status: number): IcebergError {
+  private createErrorByStatusCode(
+    status: number,
+    notFoundResource?: NotFoundResource,
+    conflictResource?: CatalogResource
+  ): IcebergError {
     switch (status) {
       case IcebergHttpStatusCode.BadRequest:
         return createBadRequestError('Bad request')
@@ -434,11 +655,14 @@ export class RestCatalogClient {
       case IcebergHttpStatusCode.Forbidden:
         return createForbiddenError('Forbidden')
       case IcebergHttpStatusCode.NotFound:
-        return createNoSuchNamespaceError('Not found')
+        if (notFoundResource === 'table') {
+          return createNoSuchTableError(getNotFoundMessage(notFoundResource))
+        }
+        return createNoSuchNamespaceError(getNotFoundMessage(notFoundResource))
       case IcebergHttpStatusCode.NotAcceptable:
         return createUnsupportedOperationError('Unsupported operation')
       case IcebergHttpStatusCode.Conflict:
-        return createAlreadyExistsError('Conflict')
+        return createAlreadyExistsError(getAlreadyExistsMessage(conflictResource))
       case IcebergHttpStatusCode.UnprocessableEntity:
         return createUnprocessableEntityError('Unprocessable entity')
       case IcebergHttpStatusCode.AuthenticationTimeout:
@@ -461,33 +685,26 @@ export class RestCatalogClient {
    * @returns The catalog configuration response
    */
   async getConfig(params: GetConfigRequest) {
-    return this.httpClient
-      .get<GetConfigResponse>('/config', {
-        params: {
-          warehouse: params.warehouse,
-        },
-      })
-      .then((response) => {
-        const data = response.data
+    const data = await this.requestRequired<GetConfigResponse>(
+      {
+        url: '/config',
+        method: 'GET',
+        params: { warehouse: params.warehouse },
+      },
+      'Empty Iceberg getConfig response body'
+    )
 
-        const overrides: Record<string, any> = {
-          prefix: params.warehouse,
-        }
+    const overrides: NonNullable<GetConfigResponse['overrides']> = {
+      prefix: params.warehouse,
+    }
 
-        return {
-          defaults: {
-            ...data.defaults,
-            prefix: params.warehouse,
-          },
-          overrides,
-        }
-      })
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return {
+      defaults: {
+        ...data.defaults,
+        prefix: params.warehouse,
+      },
+      overrides,
+    }
   }
 
   /**
@@ -497,17 +714,16 @@ export class RestCatalogClient {
    * @param params Request parameters for listing namespaces
    * @returns List of namespace identifiers
    */
-  listNamespaces(params: ListNamespacesRequest) {
+  async listNamespaces(params: ListNamespacesRequest) {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .get<ListNamespacesResponse>(`${warehouse}/namespaces`, { params })
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.requestRequired<ListNamespacesResponse>(
+      {
+        url: `${warehouse}/namespaces`,
+        method: 'GET',
+        params: { pageToken: params.pageToken, pageSize: params.pageSize, parent: params.parent },
+      },
+      'Empty Iceberg listNamespaces response body'
+    )
   }
 
   /**
@@ -517,20 +733,20 @@ export class RestCatalogClient {
    * @param params Request parameters for namespace creation
    * @returns The created namespace response
    */
-  createNamespace(params: CreateNamespaceRequest) {
+  async createNamespace(params: CreateNamespaceRequest) {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .post<CreateNamespaceResponse>(`${warehouse}/namespaces`, {
-        namespace: params.namespace,
-        properties: params.properties || {},
-      })
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.requestRequired<CreateNamespaceResponse>(
+      {
+        url: `${warehouse}/namespaces`,
+        method: 'POST',
+        data: {
+          namespace: params.namespace,
+          properties: params.properties || {},
+        },
+        conflictResource: 'namespace',
+      },
+      'Empty Iceberg createNamespace response body'
+    )
   }
 
   /**
@@ -540,17 +756,16 @@ export class RestCatalogClient {
    * @param params Request parameters including the namespace name
    * @returns The namespace metadata
    */
-  loadNamespaceMetadata(params: LoadNamespaceMetadataRequest) {
+  async loadNamespaceMetadata(params: LoadNamespaceMetadataRequest) {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .get<LoadNamespaceMetadataResponse>(`${warehouse}/namespaces/${params.namespace}`)
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.requestRequired<LoadNamespaceMetadataResponse>(
+      {
+        url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}`,
+        method: 'GET',
+        notFoundResource: 'namespace',
+      },
+      'Empty Iceberg loadNamespaceMetadata response body'
+    )
   }
 
   getEncodedWarehouse(warehouse: string) {
@@ -564,17 +779,13 @@ export class RestCatalogClient {
    * @param params Request parameters for namespace deletion
    * @returns Void response after successful deletion
    */
-  dropNamespace(params: DeleteNamespaceRequest) {
+  async dropNamespace(params: DeleteNamespaceRequest): Promise<void> {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .delete<void>(`${warehouse}/namespaces/${params.namespace}`)
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.request({
+      url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}`,
+      method: 'DELETE',
+      notFoundResource: 'namespace',
+    })
   }
 
   /**
@@ -584,20 +795,17 @@ export class RestCatalogClient {
    * @param params Request parameters including namespace and pagination options
    * @returns List of table identifiers
    */
-  listTables({ namespace, ...rest }: ListTableRequest) {
+  async listTables({ namespace, ...rest }: ListTableRequest) {
     const warehouse = this.getEncodedWarehouse(rest.warehouse)
-
-    return this.httpClient
-      .get<ListTableResponse>(`${warehouse}/namespaces/${namespace}/tables`, {
-        params: rest,
-      })
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.requestRequired<ListTableResponse>(
+      {
+        url: `${warehouse}/namespaces/${encodeURIComponent(namespace)}/tables`,
+        method: 'GET',
+        params: { pageToken: rest.pageToken, pageSize: rest.pageSize },
+        notFoundResource: 'namespace',
+      },
+      'Empty Iceberg listTables response body'
+    )
   }
 
   /**
@@ -607,17 +815,18 @@ export class RestCatalogClient {
    * @param params Request parameters for table creation including schema and partition spec
    * @returns The created table metadata
    */
-  createTable({ namespace, ...rest }: CreateTableRequest) {
-    const warehouse = this.getEncodedWarehouse(rest.warehouse)
-    return this.httpClient
-      .post<CreateTableResponse>(`${warehouse}/namespaces/${namespace}/tables`, rest)
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+  async createTable({ namespace, warehouse: warehouseName, ...table }: CreateTableRequest) {
+    const warehouse = this.getEncodedWarehouse(warehouseName)
+    return this.requestRequired<CreateTableResponse>(
+      {
+        url: `${warehouse}/namespaces/${encodeURIComponent(namespace)}/tables`,
+        method: 'POST',
+        data: table,
+        notFoundResource: 'namespace',
+        conflictResource: 'table',
+      },
+      'Empty Iceberg createTable response body'
+    )
   }
 
   /**
@@ -627,27 +836,17 @@ export class RestCatalogClient {
    * @param params Request parameters identifying the table to load
    * @returns The table metadata and location
    */
-  loadTable(params: LoadTableRequest) {
+  async loadTable(params: LoadTableRequest) {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .get<LoadTableResult>(`${warehouse}/namespaces/${params.namespace}/tables/${params.table}`, {
-        params: {
-          snapshots: params.snapshots,
-        },
-      })
-      .then((response) => {
-        // console.log({
-        //   url: response.request.,
-        //   headers: response.request.headers,
-        // })
-        return response.data
-      })
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.requestRequired<LoadTableResult>(
+      {
+        url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}/tables/${encodeURIComponent(params.table)}`,
+        method: 'GET',
+        params: { snapshots: params.snapshots },
+        notFoundResource: 'table',
+      },
+      'Empty Iceberg loadTable response body'
+    )
   }
 
   /**
@@ -657,20 +856,17 @@ export class RestCatalogClient {
    * @param params Request parameters with table changes to apply
    * @returns The updated table metadata
    */
-  updateTable(params: CommitTableRequest) {
-    const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .post<LoadTableResult>(
-        `${warehouse}/namespaces/${params.namespace}/tables/${params.table}`,
-        params
-      )
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+  async updateTable({ warehouse: warehouseName, namespace, table, ...commit }: CommitTableRequest) {
+    const warehouse = this.getEncodedWarehouse(warehouseName)
+    return this.requestRequired<LoadTableResult>(
+      {
+        url: `${warehouse}/namespaces/${encodeURIComponent(namespace)}/tables/${encodeURIComponent(table)}`,
+        method: 'POST',
+        data: commit,
+        notFoundResource: 'table',
+      },
+      'Empty Iceberg updateTable response body'
+    )
   }
 
   /**
@@ -680,7 +876,7 @@ export class RestCatalogClient {
    * @param params Request parameters identifying the table to drop
    * @returns Void response after successful deletion
    */
-  dropTable(params: DropTableRequest) {
+  async dropTable(params: DropTableRequest): Promise<void> {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
     const query: Record<string, string> = {}
 
@@ -688,17 +884,12 @@ export class RestCatalogClient {
       query.purgeRequested = 'true'
     }
 
-    return this.httpClient
-      .delete<void>(`${warehouse}/namespaces/${params.namespace}/tables/${params.table}`, {
-        params: query,
-      })
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.request({
+      url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}/tables/${encodeURIComponent(params.table)}`,
+      method: 'DELETE',
+      params: query,
+      notFoundResource: 'table',
+    })
   }
 
   /**
@@ -711,43 +902,37 @@ export class RestCatalogClient {
   renameTable() {}
 
   /**
-   * Checks if a specific table exists in the catalog
+   * Asserts that a specific table exists in the catalog
    *
    * @see https://iceberg.apache.org/spec/api/#check-table-exists
    * @param params Request parameters identifying the table to check
-   * @returns Boolean indicating if the table exists
+   * @returns Resolves with no body when the table exists
+   * @throws NoSuchTableException when the table is missing
    */
-  tableExists(params: TableExistsRequest) {
+  async tableExists(params: TableExistsRequest): Promise<void> {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .head<void>(`${warehouse}/namespaces/${params.namespace}/tables/${params.table}`)
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.request({
+      url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}/tables/${encodeURIComponent(params.table)}`,
+      method: 'HEAD',
+      notFoundResource: 'table',
+    })
   }
 
   /**
-   * Checks if a specific namespace exists in the catalog
+   * Asserts that a specific namespace exists in the catalog
    *
    * @see https://iceberg.apache.org/spec/api/#check-namespace-exists
    * @param params Request parameters identifying the namespace to check
-   * @returns Boolean indicating if the namespace exists
+   * @returns Resolves with no body when the namespace exists
+   * @throws NoSuchNamespaceException when the namespace is missing
    */
-  namespaceExists(params: NamespaceExistsRequest) {
+  async namespaceExists(params: NamespaceExistsRequest): Promise<void> {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
-    return this.httpClient
-      .head<void>(`${warehouse}/namespaces/${params.namespace}`)
-      .then((response) => response.data)
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          console.error('Error fetching configuration:', error.response?.data)
-        }
-        throw error
-      })
+    return this.request({
+      url: `${warehouse}/namespaces/${encodeURIComponent(params.namespace)}`,
+      method: 'HEAD',
+      notFoundResource: 'namespace',
+    })
   }
 }
 
@@ -757,38 +942,30 @@ export class RestCatalogClient {
  * to sign requests to the S3Tables service.
  */
 export class SignV4Auth {
-  constructor(private readonly opts: { region: string }) {}
+  constructor(
+    private readonly opts: {
+      region: string
+      credentials?: SignRequestOptions['credentials']
+    }
+  ) {}
 
-  async authorize(req: InternalAxiosRequestConfig<string>) {
-    const queryParams = Object.keys(req.params || {}).reduce(
-      (acc, name) => {
-        if (req.params[name]) {
-          acc[name] = req.params[name]
-        }
-
-        return acc
-      },
-      {} as Record<string, string>
-    )
-
-    const queryString = new URLSearchParams(queryParams).toString()
-
+  async authorize(req: FetchRequestConfig) {
     const signedReq = await signRequest(
-      ((req.baseURL || '') + req.url + (queryString ? `?${queryString}` : '')) as string,
+      req.url,
       {
-        method: req.method?.toUpperCase(),
+        method: req.method,
         headers: req.headers,
-        body: req.data ? JSONBigint.stringify(req.data) : undefined,
+        body: req.body,
       },
       {
         service: 's3tables',
         region: this.opts.region,
+        credentials: this.opts.credentials,
       }
     )
 
-    // Keep the original code for setting headers
     signedReq.headers.forEach((headerValue, headerName) => {
-      req.headers.set(headerName, headerValue as string, true)
+      req.headers.set(headerName, headerValue)
     })
 
     return req
@@ -803,9 +980,8 @@ export class SignV4Auth {
 export class BearerTokenAuth {
   constructor(private readonly opts: { token: string }) {}
 
-  async authorize(req: InternalAxiosRequestConfig<string>) {
-    req.headers.set('Authorization', `Bearer ${this.opts.token}`, true)
-
+  async authorize(req: FetchRequestConfig) {
+    req.headers.set('Authorization', `Bearer ${this.opts.token}`)
     return req
   }
 }

--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.test.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.test.ts
@@ -1,0 +1,396 @@
+import { ERRORS, ErrorCode } from '@internal/errors'
+import type { Sharder } from '@internal/sharding'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Metastore } from '../knex'
+import { IcebergErrorType } from './errors'
+import type { CatalogAuthType } from './rest-catalog-client'
+import { TenantAwareRestCatalog } from './tenant-catalog'
+
+function createCatalog(metastore: Partial<Metastore>) {
+  const auth: CatalogAuthType = {
+    authorize: (req) => req,
+  }
+
+  return new TenantAwareRestCatalog({
+    tenantId: 'tenant-id',
+    restCatalogUrl: 'https://catalog.example.com/v1',
+    metastore: metastore as unknown as Metastore,
+    auth,
+    sharding: {} as Sharder,
+    limits: {
+      maxCatalogsCount: 10,
+      maxNamespaceCount: 10,
+      maxTableCount: 10,
+    },
+  })
+}
+
+function expectNoSuchCatalog(error: Promise<unknown>) {
+  return expect(error).rejects.toMatchObject({
+    code: ErrorCode.NoSuchCatalog,
+    message: 'Catalog name "warehouse" not found',
+  })
+}
+
+describe('TenantAwareRestCatalog exists checks', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('maps a local missing table row to NoSuchTableException', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('table')),
+    })
+
+    await expect(
+      catalog.tableExists({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Table not found',
+      type: IcebergErrorType.NoSuchTableException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a missing warehouse distinct for tableExists', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockRejectedValue(ERRORS.NoSuchCatalog('warehouse')),
+    })
+
+    await expectNoSuchCatalog(
+      catalog.tableExists({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException for tableExists', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+    })
+
+    await expect(
+      catalog.tableExists({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a missing warehouse distinct for namespaceExists', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockRejectedValue(ERRORS.NoSuchCatalog('warehouse')),
+    })
+
+    await expectNoSuchCatalog(
+      catalog.namespaceExists({ warehouse: 'warehouse', namespace: 'namespace' })
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards tableExists to the upstream catalog with shard_key as warehouse and tenant-prefixed namespace', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'abc-def-ghi', name: 'namespace' }),
+      findTableByName: vi
+        .fn()
+        .mockResolvedValue({ id: 'table-id', name: 'table', shard_key: 'shard-1' }),
+    })
+
+    await expect(
+      catalog.tableExists({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).resolves.toBeUndefined()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [fetchedInput, init] = fetchMock.mock.calls[0]
+    const url = new URL(String(fetchedInput))
+    expect(init?.method).toBe('HEAD')
+    expect(url.pathname).toBe('/v1/shard-1/namespaces/tenant-id_abc_def_ghi/tables/table')
+  })
+
+  it('throws ShardNotFound when the local table row has no shard_key', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi.fn().mockResolvedValue({ id: 'table-id', name: 'table' }),
+    })
+
+    await expect(
+      catalog.tableExists({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: ErrorCode.ShardNotFound,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves namespaceExists from the local metastore without an HTTP call', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const findNamespaceByName = vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' })
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName,
+    })
+
+    await expect(
+      catalog.namespaceExists({ warehouse: 'warehouse', namespace: 'namespace' })
+    ).resolves.toBeUndefined()
+
+    expect(findNamespaceByName).toHaveBeenCalledWith({
+      tenantId: 'tenant-id',
+      name: 'namespace',
+      catalogId: 'catalog-id',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+    })
+
+    await expect(
+      catalog.namespaceExists({ warehouse: 'warehouse', namespace: 'namespace' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('TenantAwareRestCatalog metadata loads', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps a missing warehouse distinct for loadTable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockRejectedValue(ERRORS.NoSuchCatalog('warehouse')),
+    })
+
+    await expectNoSuchCatalog(
+      catalog.loadTable({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException for loadTable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+    })
+
+    await expect(
+      catalog.loadTable({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing table row to NoSuchTableException for loadTable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('table')),
+    })
+
+    await expect(
+      catalog.loadTable({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Table not found',
+      type: IcebergErrorType.NoSuchTableException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('throws ShardNotFound when the loadTable row has no shard_key', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi.fn().mockResolvedValue({ id: 'table-id', name: 'table' }),
+    })
+
+    await expect(
+      catalog.loadTable({ warehouse: 'warehouse', namespace: 'namespace', table: 'table' })
+    ).rejects.toMatchObject({
+      code: ErrorCode.ShardNotFound,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a missing warehouse distinct for loadNamespaceMetadata', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockRejectedValue(ERRORS.NoSuchCatalog('warehouse')),
+    })
+
+    await expectNoSuchCatalog(
+      catalog.loadNamespaceMetadata({ warehouse: 'warehouse', namespace: 'namespace' })
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException for loadNamespaceMetadata', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+    })
+
+    await expect(
+      catalog.loadNamespaceMetadata({ warehouse: 'warehouse', namespace: 'namespace' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException for listTables', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const listTables = vi.fn()
+
+    const catalog = createCatalog({
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+      listTables,
+    })
+
+    await expect(
+      catalog.listTables({ warehouse: 'warehouse', namespace: 'namespace' })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(listTables).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('TenantAwareRestCatalog resource mutations', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('maps a local missing namespace row to NoSuchNamespaceException for createTable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const store = {
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('namespace')),
+    }
+    const transaction = vi.fn(async (callback) => callback(store))
+    const catalog = createCatalog({ transaction })
+
+    await expect(
+      catalog.createTable({
+        warehouse: 'warehouse',
+        namespace: 'namespace',
+        name: 'table',
+        schema: { type: 'struct', fields: [] },
+        spec: { fields: [] },
+      })
+    ).rejects.toMatchObject({
+      code: 404,
+      message: 'Namespace not found',
+      type: IcebergErrorType.NoSuchNamespaceException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a local duplicate table row to AlreadyExistsException for createTable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const store = {
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi.fn().mockResolvedValue({ id: 'table-id', name: 'table' }),
+    }
+    const transaction = vi.fn(async (callback) => callback(store))
+    const catalog = createCatalog({ transaction })
+
+    await expect(
+      catalog.createTable({
+        warehouse: 'warehouse',
+        namespace: 'namespace',
+        name: 'table',
+        schema: { type: 'struct', fields: [] },
+        spec: { fields: [] },
+      })
+    ).rejects.toMatchObject({
+      code: 409,
+      message: 'Table already exists',
+      type: IcebergErrorType.AlreadyExistsException,
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
@@ -1,7 +1,13 @@
 import { ERRORS, ErrorCode, StorageBackendError } from '@internal/errors'
 import { Sharder } from '@internal/sharding'
 import { ICEBERG_BUCKET_RESERVED_SUFFIX } from '@storage/limits'
-import { IcebergError } from '@storage/protocols/iceberg/catalog/errors'
+import {
+  createAlreadyExistsError,
+  createNoSuchNamespaceError,
+  createNoSuchTableError,
+  IcebergError,
+  IcebergHttpStatusCode,
+} from '@storage/protocols/iceberg/catalog/errors'
 import { Metastore } from '../knex'
 import {
   CatalogAuthType,
@@ -44,6 +50,40 @@ interface FindTableByIdParams {
   id: string
   tenantId: string
   namespaceId: string
+}
+
+function isMetastoreNoSuchKeyError(error: unknown) {
+  return error instanceof StorageBackendError && error.code === ErrorCode.NoSuchKey
+}
+
+async function findNamespaceByNameOrThrow(
+  metastore: Pick<Metastore, 'findNamespaceByName'>,
+  params: Parameters<Metastore['findNamespaceByName']>[0]
+) {
+  try {
+    return await metastore.findNamespaceByName(params)
+  } catch (error) {
+    if (isMetastoreNoSuchKeyError(error)) {
+      throw createNoSuchNamespaceError('Namespace not found')
+    }
+
+    throw error
+  }
+}
+
+async function findTableByNameOrThrow(
+  metastore: Pick<Metastore, 'findTableByName'>,
+  params: Parameters<Metastore['findTableByName']>[0]
+) {
+  try {
+    return await metastore.findTableByName(params)
+  } catch (error) {
+    if (isMetastoreNoSuchKeyError(error)) {
+      throw createNoSuchTableError('Table not found')
+    }
+
+    throw error
+  }
 }
 
 /**
@@ -144,7 +184,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
         name: table.warehouse,
       })
 
-      const dbNamespace = await store.findNamespaceByName({
+      const dbNamespace = await findNamespaceByNameOrThrow(store, {
         name: namespace,
         tenantId: this.tenantId,
         catalogId: catalog.id,
@@ -157,7 +197,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
           tenantId: this.tenantId,
         })
 
-        throw ERRORS.ResourceAlreadyExists()
+        throw createAlreadyExistsError('Table already exists')
       } catch (e) {
         if (!(e instanceof StorageBackendError && e.code === ErrorCode.NoSuchKey)) {
           throw e
@@ -200,7 +240,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
             // },
           })
         } catch (e) {
-          if (e instanceof IcebergError && e.code === 409) {
+          if (e instanceof IcebergError && e.code === IcebergHttpStatusCode.Conflict) {
             // Namespace already exists, ignore
           } else {
             throw e
@@ -254,7 +294,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       name: params.warehouse,
     })
 
-    const dbNamespace = await this.findNamespaceByName({
+    const dbNamespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       name: params.namespace,
       tenantId: this.tenantId,
       catalogId: catalog.id,
@@ -294,13 +334,13 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       name: params.warehouse,
     })
 
-    const namespace = await this.options.metastore.findNamespaceByName({
+    const namespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.namespace,
       catalogId: catalog.id,
     })
 
-    const dbTable = await this.options.metastore.findTableByName({
+    const dbTable = await findTableByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.table,
       namespaceId: namespace.id,
@@ -336,13 +376,13 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
         name: params.warehouse,
       })
 
-      const namespace = await store.findNamespaceByName({
+      const namespace = await findNamespaceByNameOrThrow(store, {
         tenantId: this.tenantId,
         name: params.namespace,
         catalogId: catalog.id,
       })
 
-      const dbTable = await store.findTableByName({
+      const dbTable = await findTableByNameOrThrow(store, {
         tenantId: this.tenantId,
         name: params.table,
         namespaceId: namespace.id,
@@ -363,26 +403,27 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
   }
 
   /**
-   * Checks if a table exists in the specified namespace for the current tenant
+   * Asserts that a table exists in the specified namespace for the current tenant
    *
    * Maps the tenant's namespace to an internal representation before checking.
    *
    * @param params Table exists request parameters
-   * @returns Boolean indicating if the table exists
+   * @returns Resolves with no body when the table exists
+   * @throws NoSuchTableException when the table is missing
    */
-  async tableExists(params: TableExistsRequest) {
+  async tableExists(params: TableExistsRequest): Promise<void> {
     const catalog = await this.findCatalogByName({
       tenantId: this.tenantId,
       name: params.warehouse,
     })
 
-    const namespace = await this.options.metastore.findNamespaceByName({
+    const namespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.namespace,
       catalogId: catalog.id,
     })
 
-    const dbTable = await this.options.metastore.findTableByName({
+    const dbTable = await findTableByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.table,
       namespaceId: namespace.id,
@@ -402,20 +443,21 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
   }
 
   /**
-   * Checks if a namespace exists for the current tenant
+   * Asserts that a namespace exists for the current tenant
    *
    * Maps the tenant's namespace to an internal representation before checking.
    *
    * @param params Namespace exists request parameters
-   * @returns Boolean indicating if the namespace exists
+   * @returns Resolves with no body when the namespace exists
+   * @throws NoSuchNamespaceException when the namespace is missing
    */
-  async namespaceExists(params: NamespaceExistsRequest) {
+  async namespaceExists(params: NamespaceExistsRequest): Promise<void> {
     const catalog = await this.findCatalogByName({
       tenantId: this.tenantId,
       name: params.warehouse,
     })
 
-    await this.options.metastore.findNamespaceByName({
+    await findNamespaceByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.namespace,
       catalogId: catalog.id,
@@ -477,7 +519,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       name: params.warehouse,
     })
 
-    const namespace = await this.findNamespaceByName({
+    const namespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       name: params.namespace,
       tenantId: this.tenantId,
       catalogId: catalog.id,
@@ -515,13 +557,13 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       name: params.warehouse,
     })
 
-    const namespace = await this.options.metastore.findNamespaceByName({
+    const namespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.namespace,
       catalogId: catalog.id,
     })
 
-    const dbTable = await this.options.metastore.findTableByName({
+    const dbTable = await findTableByNameOrThrow(this.options.metastore, {
       tenantId: this.tenantId,
       name: params.table,
       namespaceId: namespace.id,
@@ -589,7 +631,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       name: params.warehouse,
     })
 
-    const namespace = await this.findNamespaceByName({
+    const namespace = await findNamespaceByNameOrThrow(this.options.metastore, {
       name: params.namespace,
       tenantId: this.tenantId,
       catalogId: catalog.id,
@@ -680,7 +722,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
 
     if (namespace.endsWith('--s3-table')) {
       throw ERRORS.InvalidParameter('namespace', {
-        message: 'Resource name must not end with the reserved suffix "--iceberg"',
+        message: 'Resource name must not end with the reserved suffix "--s3-table"',
       })
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

axios is used in iceberg rest catalog client.

## What is the new behavior?

axios is replaced with native fetch.

## Additional context

Fix 404 mapping for tables operations, it was namespace before. 
Fix metadata store misses from reporting 500s.
Fix namespace validation error message.
Sign exact same url for sigv4.
Drop any usage.
Add more test coverage.
Some more resilience via timeout and keep-alive.