### PR TITLE
fix: bump tus version to resolve zero byte upload bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@shopify/semaphore": "^3.0.2",
         "@smithy/node-http-handler": "^2.3.1",
         "@tus/file-store": "2.0.0",
-        "@tus/s3-store": "2.0.2",
+        "@tus/s3-store": "2.0.3",
         "@tus/server": "2.2.1",
         "agentkeepalive": "^4.5.0",
         "ajv": "^8.18.0",
@@ -10847,17 +10847,26 @@
       }
     },
     "node_modules/@tus/s3-store": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.2.tgz",
-      "integrity": "sha512-wXrlb8k0BikpSs5FuMSTjEOK0QrL+xBEqPrmROcLOWMAaximPHtzHjvG6QDc5UbjBaV8PTqMnWhtXj85vvn3tw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.3.tgz",
+      "integrity": "sha512-rsOHKkLrf/LPFwjopmeBKZbSgW+PN3Z6E4Fe+S+Ci8xNgGyFab8xybyuTpRGs6VKXHgsSApcmm0IvkENhxjh4Q==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@shopify/semaphore": "^3.1.0",
-        "@tus/utils": "^0.6.0",
+        "@tus/utils": "^0.7.0",
         "debug": "^4.3.4",
         "multistream": "^4.1.0"
       },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@tus/s3-store/node_modules/@tus/utils": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@tus/utils/-/utils-0.7.0.tgz",
+      "integrity": "sha512-BPom8lVwR4fkk1EynPeQwuN0e5bH2gBphwt69uF5rS4wRD2N7IyHDPqdjcAY0I7gNEWfUitPyDodywbD4r7dEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
       }
@@ -24220,15 +24229,22 @@
       }
     },
     "@tus/s3-store": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.2.tgz",
-      "integrity": "sha512-wXrlb8k0BikpSs5FuMSTjEOK0QrL+xBEqPrmROcLOWMAaximPHtzHjvG6QDc5UbjBaV8PTqMnWhtXj85vvn3tw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.3.tgz",
+      "integrity": "sha512-rsOHKkLrf/LPFwjopmeBKZbSgW+PN3Z6E4Fe+S+Ci8xNgGyFab8xybyuTpRGs6VKXHgsSApcmm0IvkENhxjh4Q==",
       "requires": {
         "@aws-sdk/client-s3": "^3.758.0",
         "@shopify/semaphore": "^3.1.0",
-        "@tus/utils": "^0.6.0",
+        "@tus/utils": "^0.7.0",
         "debug": "^4.3.4",
         "multistream": "^4.1.0"
+      },
+      "dependencies": {
+        "@tus/utils": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@tus/utils/-/utils-0.7.0.tgz",
+          "integrity": "sha512-BPom8lVwR4fkk1EynPeQwuN0e5bH2gBphwt69uF5rS4wRD2N7IyHDPqdjcAY0I7gNEWfUitPyDodywbD4r7dEQ=="
+        }
       }
     },
     "@tus/server": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@shopify/semaphore": "^3.0.2",
     "@smithy/node-http-handler": "^2.3.1",
     "@tus/file-store": "2.0.0",
-    "@tus/s3-store": "2.0.2",
+    "@tus/s3-store": "2.0.3",
     "@tus/server": "2.2.1",
     "agentkeepalive": "^4.5.0",
     "ajv": "^8.18.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Storage uses @tus/s3-store@2.0.2 which is has a bug that causes zero byte uploads to fail with a 500 error when using S3 backend

## What is the new behavior?

Update to @tus/s3-store@2.0.3 which gracefully handles zero byte uploads to S3

## Additional context

Upstream fix: https://github.com/tus/tus-node-server/pull/824

