### PR TITLE
refactor: drop axios from tests and webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "platformatic": "^3.52.0",
         "postgres-migrations": "^5.3.0",
         "pprof-format": "^2.2.1",
+        "undici": "^7.24.0",
         "wattpm": "^3.52.0",
         "xml2js": "^0.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "platformatic": "^3.52.0",
     "postgres-migrations": "^5.3.0",
     "pprof-format": "^2.2.1",
+    "undici": "^7.24.0",
     "wattpm": "^3.52.0",
     "xml2js": "^0.6.2"
   },

--- a/src/storage/events/lifecycle/webhook.ts
+++ b/src/storage/events/lifecycle/webhook.ts
@@ -1,8 +1,7 @@
 import { getTenantConfig } from '@internal/database'
 import { logger, logSchema } from '@internal/monitoring'
-import HttpAgent, { HttpsAgent } from 'agentkeepalive'
-import axios from 'axios'
 import { Job, SendOptions, WorkOptions } from 'pg-boss'
+import { Agent } from 'undici'
 import { getConfig } from '../../../config'
 import { BaseEvent } from '../base-event'
 
@@ -14,6 +13,11 @@ const {
   webhookMaxConnections,
   webhookQueueMaxFreeSockets,
 } = getConfig()
+const WEBHOOK_TIMEOUT_MS = 4000
+const webhookKeepAliveTimeoutMs = Math.min(
+  Math.max(webhookQueueMaxFreeSockets, 1) * 1000,
+  WEBHOOK_TIMEOUT_MS
+)
 
 interface WebhookEvent {
   event: {
@@ -30,30 +34,76 @@ interface WebhookEvent {
   }
 }
 
-const httpAgent = webhookURL?.startsWith('https://')
-  ? {
-      httpsAgent: new HttpsAgent({
-        maxSockets: webhookMaxConnections,
-        maxFreeSockets: webhookQueueMaxFreeSockets,
-      }),
-    }
-  : {
-      httpAgent: new HttpAgent({
-        maxSockets: webhookMaxConnections,
-        maxFreeSockets: webhookQueueMaxFreeSockets,
-      }),
+interface WebhookRequest {
+  type: 'Webhook'
+  event: WebhookEvent['event']
+  sentAt: Date
+  tenant: WebhookEvent['tenant']
+}
+
+interface WebhookClient {
+  post(url: string, payload: WebhookRequest): Promise<void>
+}
+
+const dispatcher = new Agent({
+  connections: webhookMaxConnections,
+  // `undici` cannot cap idle socket count like `agentkeepalive.maxFreeSockets`,
+  // so use the old knob to make idle sockets expire sooner when a small free pool is desired.
+  keepAliveTimeout: webhookKeepAliveTimeoutMs,
+  keepAliveMaxTimeout: webhookKeepAliveTimeoutMs,
+})
+
+const defaultHeaders = new Headers({
+  'content-type': 'application/json',
+  ...(webhookApiKey ? { authorization: `Bearer ${webhookApiKey}` } : {}),
+})
+
+async function assertOkResponse(response: Response) {
+  if (response.ok) {
+    return
+  }
+
+  throw new Error(`Request failed with status code ${response.status}`)
+}
+
+function normalizeWebhookError(error: unknown) {
+  if (error instanceof DOMException && error.name === 'TimeoutError') {
+    return new Error(`timeout of ${WEBHOOK_TIMEOUT_MS}ms exceeded`)
+  }
+
+  if (error instanceof Error) {
+    return error
+  }
+
+  return new Error(String(error))
+}
+
+const client: WebhookClient = {
+  async post(url, payload) {
+    const requestInit: RequestInit & { dispatcher: Agent } = {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: defaultHeaders,
+      dispatcher,
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     }
 
-const client = axios.create({
-  ...httpAgent,
-  timeout: 4000,
-  headers: {
-    ...(webhookApiKey ? { authorization: `Bearer ${webhookApiKey}` } : {}),
+    const response = await fetch(url, requestInit)
+
+    try {
+      await assertOkResponse(response)
+    } finally {
+      await response.body?.cancel().catch(() => {})
+    }
   },
-})
+}
 
 export class Webhook extends BaseEvent<WebhookEvent> {
   static queueName = 'webhooks'
+
+  protected static getClient() {
+    return client
+  }
 
   static getWorkerOptions(): WorkOptions {
     return {
@@ -110,16 +160,18 @@ export class Webhook extends BaseEvent<WebhookEvent> {
     })
 
     try {
-      await client.post(webhookURL, {
+      await this.getClient().post(webhookURL, {
         type: 'Webhook',
         event: job.data.event,
         sentAt: new Date(),
         tenant: job.data.tenant,
       })
     } catch (e) {
+      const error = normalizeWebhookError(e)
+
       logger.error(
         {
-          error: (e as Error)?.message,
+          error: error.message,
           jodId: job.id,
           type: 'event',
           event: job.data.event.type,
@@ -134,9 +186,7 @@ export class Webhook extends BaseEvent<WebhookEvent> {
         `[Lifecycle]: ${job.data.event.type} ${path} - FAILED`
       )
       throw new Error(
-        `Failed to send webhook for event ${job.data.event.type} to ${webhookURL}: ${
-          (e as Error).message
-        }`
+        `Failed to send webhook for event ${job.data.event.type} to ${webhookURL}: ${error.message}`
       )
     }
 

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -72,6 +72,8 @@ interface TransformLimits {
   maxResolution?: number
 }
 
+type ImageRendererClient = Pick<Axios, 'get'>
+
 /**
  * ImageRenderer
  * renders an image by applying transformations
@@ -79,7 +81,7 @@ interface TransformLimits {
  * Interacts with an imgproxy backend for the actual transformation
  */
 export class ImageRenderer extends Renderer {
-  private readonly client: Axios
+  private readonly client: ImageRendererClient
   private transformOptions?: TransformOptions
   private limits?: TransformLimits
 

--- a/src/test/cdn.test.ts
+++ b/src/test/cdn.test.ts
@@ -1,40 +1,15 @@
+import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
+import { FastifyInstance } from 'fastify'
+import { SignJWT } from 'jose'
+import { Readable } from 'stream'
 import { getConfig, mergeConfig } from '../config'
+import { useStorage } from './utils/storage'
 
 getConfig()
 mergeConfig({
   cdnPurgeEndpointURL: 'http://localhost/stub/cache',
   cdnPurgeEndpointKey: 'test-key',
 })
-
-vi.mock('axios', () => {
-  const instance = {
-    post: vi.fn(),
-    interceptors: {
-      request: {
-        use: vi.fn(),
-      },
-      response: {
-        use: vi.fn(),
-      },
-    },
-  }
-
-  const axiosMock = {
-    create: vi.fn().mockReturnValue(instance),
-    ...instance,
-  }
-
-  return {
-    default: axiosMock,
-    ...axiosMock,
-  }
-})
-
-import axios from 'axios'
-import { FastifyInstance } from 'fastify'
-import { SignJWT } from 'jose'
-import { Readable } from 'stream'
-import { useStorage } from './utils/storage'
 
 const { serviceKeyAsync, anonKeyAsync, tenantId, jwtSecret } = getConfig()
 
@@ -58,6 +33,7 @@ describe('CDN Cache Manager', () => {
 
   afterEach(async () => {
     await appInstance.close()
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
@@ -108,9 +84,7 @@ describe('CDN Cache Manager', () => {
       },
     })
 
-    const spy = vi
-      .spyOn(axios, 'post')
-      .mockReturnValue(Promise.resolve({ data: { message: 'success' } }))
+    const purgeSpy = vi.spyOn(CdnCacheManager.prototype, 'purge').mockResolvedValue(undefined)
 
     const response = await appInstance.inject({
       method: 'DELETE',
@@ -124,11 +98,9 @@ describe('CDN Cache Manager', () => {
 
     const body = await response.json()
     expect(body).toEqual({ message: 'success' })
-    expect(spy).toHaveBeenCalledWith('/purge', {
-      tenant: {
-        ref: tenantId,
-      },
-      bucketId: bucketName,
+    expect(purgeSpy).toHaveBeenCalledWith({
+      tenant: tenantId,
+      bucket: bucketName,
       objectName,
     })
   })

--- a/src/test/queue-mocks.test.ts
+++ b/src/test/queue-mocks.test.ts
@@ -1,31 +1,202 @@
-/**
- * Real unit tests for queue event handlers
- * Tests real business logic with mocked external dependencies
- */
+const {
+  mockGetTenantConfig,
+  mockLoggerDebug,
+  mockLoggerError,
+  mockLogEvent,
+  mockRunMigrationsOnTenant,
+} = vi.hoisted(() => ({
+  mockGetTenantConfig: vi.fn(),
+  mockLoggerDebug: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLogEvent: vi.fn(),
+  mockRunMigrationsOnTenant: vi.fn(),
+}))
 
-// Mock only used external dependencies
-vi.mock('axios')
 vi.mock('@internal/database', () => ({
-  getTenantConfig: vi.fn(),
+  getTenantConfig: mockGetTenantConfig,
 }))
+
 vi.mock('@internal/database/migrations', () => ({
-  runMigrationsOnTenant: vi.fn(),
+  runMigrationsOnTenant: mockRunMigrationsOnTenant,
 }))
 
-import { getTenantConfig } from '@internal/database'
-import { runMigrationsOnTenant } from '@internal/database/migrations'
-import axios from 'axios'
+vi.mock('@internal/monitoring', () => ({
+  logger: {
+    debug: mockLoggerDebug,
+    error: mockLoggerError,
+  },
+  logSchema: {
+    event: mockLogEvent,
+  },
+}))
 
-const mockAxios = vi.mocked(axios)
-const mockGetTenantConfig = vi.mocked(getTenantConfig)
-const mockRunMigrationsOnTenant = vi.mocked(runMigrationsOnTenant)
+vi.mock('../storage/events/base-event', () => ({
+  BaseEvent: class {},
+}))
 
-describe('Error Handling Patterns', () => {
-  it('should handle network errors gracefully', async () => {
-    const networkError = new Error('Network error')
-    mockAxios.post.mockRejectedValue(networkError)
+function makePayload() {
+  return {
+    event: {
+      $version: 'v1',
+      type: 'ObjectCreated:Post',
+      region: 'local',
+      applyTime: 1,
+      payload: {
+        bucketId: 'bucket-a',
+        name: 'path/file.png',
+        reqId: 'req-123',
+        sbReqId: 'sb-req-123',
+      },
+    },
+    sentAt: '2026-04-23T00:00:00.000Z',
+    tenant: {
+      ref: 'tenant-a',
+      host: 'local.test',
+    },
+  }
+}
 
-    await expect(mockAxios.post('https://example.com/webhook', {})).rejects.toThrow('Network error')
+function makeJob() {
+  return {
+    id: 'job-1',
+    data: makePayload(),
+  }
+}
+
+async function loadWebhookModule() {
+  vi.resetModules()
+
+  const configModule = await import('../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({
+    isMultitenant: true,
+    webhookURL: 'https://example.com/webhook',
+    webhookQueuePullInterval: 1000,
+    webhookMaxConnections: 10,
+    webhookQueueMaxFreeSockets: 2,
+  })
+
+  return import('../storage/events/lifecycle/webhook')
+}
+
+describe('Webhook queue handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetTenantConfig.mockResolvedValue({ disableEvents: [] })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('skips sends when the tenant disables a specific webhook target', async () => {
+    const { Webhook } = await loadWebhookModule()
+    const payload = makePayload()
+
+    mockGetTenantConfig.mockResolvedValue({
+      disableEvents: ['Webhook:ObjectCreated:Post:bucket-a/path/file.png'],
+    })
+
+    await expect(Webhook.shouldSend(payload)).resolves.toBe(false)
+    expect(mockGetTenantConfig).toHaveBeenCalledWith('tenant-a')
+  })
+
+  it('posts webhook payloads with fetch and preserves headers/body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { Webhook } = await loadWebhookModule()
+
+    await expect(Webhook.handle(makeJob() as never)).resolves.toEqual(makeJob())
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/webhook',
+      expect.objectContaining({
+        body: expect.any(String),
+        dispatcher: expect.anything(),
+        headers: expect.any(Headers),
+        method: 'POST',
+        signal: expect.anything(),
+      })
+    )
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = init?.headers as Headers
+    const body = JSON.parse(init?.body as string)
+
+    expect(headers.get('content-type')).toBe('application/json')
+    expect(headers.get('authorization')).toBeNull()
+    expect(body).toEqual({
+      type: 'Webhook',
+      event: makePayload().event,
+      sentAt: expect.any(String),
+      tenant: makePayload().tenant,
+    })
+  })
+
+  it('fails the job on non-2xx webhook responses', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('upstream failure', {
+        status: 500,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { Webhook } = await loadWebhookModule()
+
+    await expect(Webhook.handle(makeJob() as never)).rejects.toThrow(
+      'Failed to send webhook for event ObjectCreated:Post to https://example.com/webhook: Request failed with status code 500'
+    )
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'Request failed with status code 500',
+        tenantId: 'tenant-a',
+        reqId: 'req-123',
+        sbReqId: 'sb-req-123',
+      }),
+      '[Lifecycle]: ObjectCreated:Post tenant-a/bucket-a/path/file.png - FAILED'
+    )
+  })
+
+  it('wraps webhook timeout failures with event context', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(
+        new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { Webhook } = await loadWebhookModule()
+
+    await expect(Webhook.handle(makeJob() as never)).rejects.toThrow(
+      'Failed to send webhook for event ObjectCreated:Post to https://example.com/webhook: timeout of 4000ms exceeded'
+    )
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      '[Lifecycle]: ObjectCreated:Post tenant-a/bucket-a/path/file.png',
+      expect.objectContaining({
+        tenantId: 'tenant-a',
+        reqId: 'req-123',
+        sbReqId: 'sb-req-123',
+      })
+    )
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'timeout of 4000ms exceeded',
+        tenantId: 'tenant-a',
+        reqId: 'req-123',
+        sbReqId: 'sb-req-123',
+      }),
+      '[Lifecycle]: ObjectCreated:Post tenant-a/bucket-a/path/file.png - FAILED'
+    )
   })
 
   it('should handle database errors gracefully', async () => {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -1,9 +1,9 @@
 import { generateHS512JWK, SignedToken, signJWT, verifyJWT } from '@internal/auth'
-import axios from 'axios'
 import dotenv from 'dotenv'
 import { FastifyInstance } from 'fastify'
 import fs from 'fs/promises'
 import path from 'path'
+import { Readable } from 'stream'
 import app from '../app'
 import { getConfig, JwksConfig, mergeConfig } from '../config'
 import { S3Backend } from '../storage/backend'
@@ -11,10 +11,32 @@ import { ImageRenderer } from '../storage/renderer'
 import { useMockObject } from './common'
 
 dotenv.config({ path: '.env.test' })
-const { imgProxyURL, jwtSecret } = getConfig()
+const { jwtSecret } = getConfig()
 let appInstance: FastifyInstance
 
 const projectRoot = path.join(__dirname, '..', '..')
+const renderedBodyText = 'mock-rendered-image-body'
+
+function createMockRendererClient() {
+  const bodyChunks = [Buffer.from('mock-rendered-'), Buffer.from('image-body')]
+  const body = Buffer.concat(bodyChunks)
+  const get = vi.fn().mockResolvedValue({
+    data: Readable.from(bodyChunks),
+    status: 200,
+    headers: {
+      'content-length': String(body.length),
+      'content-type': 'image/png',
+      'last-modified': 'Wed, 12 Oct 2022 11:17:02 GMT',
+    },
+  })
+  const client: ReturnType<ImageRenderer['getClient']> = { get }
+
+  return {
+    body,
+    client,
+    get,
+  }
+}
 
 describe('image rendering routes', () => {
   beforeAll(async () => {
@@ -34,13 +56,13 @@ describe('image rendering routes', () => {
 
   afterEach(async () => {
     await appInstance.close()
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
   it('will render an authenticated image applying transformations using external image processing', async () => {
-    const testAxios = axios.create({ baseURL: imgProxyURL })
-    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
-    const axiosSpy = vi.spyOn(testAxios, 'get')
+    const { client: testClient, get: getSpy } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
 
     const response = await appInstance.inject({
       method: 'GET',
@@ -51,17 +73,20 @@ describe('image rendering routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
+    expect(response.body).toBe(renderedBodyText)
     expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
-    expect(axiosSpy).toHaveBeenCalledWith(
+    expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
-      { responseType: 'stream', signal: expect.any(AbortSignal) }
+      expect.objectContaining({
+        responseType: 'stream',
+        signal: expect.any(AbortSignal),
+      })
     )
   })
 
   it('will render a public image applying transformations using external image processing', async () => {
-    const testAxios = axios.create({ baseURL: imgProxyURL })
-    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
-    const axiosSpy = vi.spyOn(testAxios, 'get')
+    const { client: testClient, get: getSpy } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
 
     const response = await appInstance.inject({
       method: 'GET',
@@ -70,17 +95,19 @@ describe('image rendering routes', () => {
 
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
-    expect(axiosSpy).toHaveBeenCalledWith(
+    expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
-      { responseType: 'stream', signal: expect.any(AbortSignal) }
+      expect.objectContaining({
+        responseType: 'stream',
+        signal: expect.any(AbortSignal),
+      })
     )
   })
 
   it('will render a public image in all supported formats', async () => {
     const formats = ['origin', 'webp', 'avif']
-    const testAxios = axios.create({ baseURL: imgProxyURL })
-    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
-    const axiosSpy = vi.spyOn(testAxios, 'get')
+    const { client: testClient, get: getSpy } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
 
     for (let format of formats) {
       const response = await appInstance.inject({
@@ -91,9 +118,12 @@ describe('image rendering routes', () => {
       expect(response.statusCode).toBe(200)
       expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
       const expectFormat = format === 'origin' ? '' : `/format:${format}`
-      expect(axiosSpy).toHaveBeenCalledWith(
+      expect(getSpy).toHaveBeenCalledWith(
         `/public/height:100/width:100/resizing_type:fill${expectFormat}/plain/local:///${projectRoot}/data/sadcat.jpg`,
-        { responseType: 'stream', signal: expect.any(AbortSignal) }
+        expect.objectContaining({
+          responseType: 'stream',
+          signal: expect.any(AbortSignal),
+        })
       )
       vi.clearAllMocks()
     }
@@ -125,9 +155,8 @@ describe('image rendering routes', () => {
     const jwtData = (await verifyJWT(token, jwtSecret)) as SignedToken
     expect(jwtData.url).toBe(assetUrl)
 
-    const testAxios = axios.create({ baseURL: imgProxyURL })
-    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
-    const axiosSpy = vi.spyOn(testAxios, 'get')
+    const { client: testClient, get: getSpy } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
 
     const response = await appInstance.inject({
       method: 'GET',
@@ -136,9 +165,12 @@ describe('image rendering routes', () => {
 
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
-    expect(axiosSpy).toHaveBeenCalledWith(
+    expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
-      { responseType: 'stream', signal: expect.any(AbortSignal) }
+      expect.objectContaining({
+        responseType: 'stream',
+        signal: expect.any(AbortSignal),
+      })
     )
   })
 
@@ -172,9 +204,8 @@ describe('image rendering routes', () => {
     const jwtData = (await verifyJWT(token, 'invalid-old-jwt-secret', jwtJWKS)) as SignedToken
     expect(jwtData.url).toBe(assetUrl)
 
-    const testAxios = axios.create({ baseURL: imgProxyURL })
-    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testAxios)
-    const axiosSpy = vi.spyOn(testAxios, 'get')
+    const { client: testClient, get: getSpy } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
 
     const response = await appInstance.inject({
       method: 'GET',
@@ -183,9 +214,12 @@ describe('image rendering routes', () => {
 
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.privateAssetUrl).toHaveBeenCalledTimes(1)
-    expect(axiosSpy).toHaveBeenCalledWith(
+    expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
-      { responseType: 'stream', signal: expect.any(AbortSignal) }
+      expect.objectContaining({
+        responseType: 'stream',
+        signal: expect.any(AbortSignal),
+      })
     )
   })
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -33,7 +33,6 @@ import { DBMigration } from '@internal/database/migrations'
 import { ERRORS } from '@internal/errors'
 import { StorageKnexDB } from '@storage/database'
 import { Uploader } from '@storage/uploader'
-import axios from 'axios'
 import { createHash, createHmac, randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
 import { ReadableStreamBuffer } from 'stream-buffers'
@@ -878,9 +877,7 @@ describe('S3 Protocol', () => {
         const data = Buffer.alloc(1024)
         formData.set('file', new Blob([data]), 'test.jpg')
 
-        const resp = await axios.post(signedURL.url, formData, {
-          validateStatus: () => true,
-        })
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
 
         expect(resp.status).toBe(200)
       })
@@ -907,9 +904,7 @@ describe('S3 Protocol', () => {
         const data = Buffer.alloc(1024 * 2)
         formData.set('file', new Blob([data]), 'test.jpg')
 
-        const resp = await axios.post(signedURL.url, formData, {
-          validateStatus: () => true,
-        })
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
 
         expect(resp.status).toBe(413)
         expect(resp.statusText).toBe('Payload Too Large')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Axios is used/mocked in tests and webhooks. 

## What is the new behavior?

Use native fetch/undici agent or improve mock to test the contract.

## Additional context

Next one in dropping axios, related to #1038, #1042 
