### PR TITLE
refactor: drop axios from cluster discovery

### DIFF
--- a/src/internal/cluster/ecs.test.ts
+++ b/src/internal/cluster/ecs.test.ts
@@ -1,0 +1,120 @@
+import { ListTasksCommand } from '@aws-sdk/client-ecs'
+import { vi } from 'vitest'
+import { ClusterDiscoveryECS } from './ecs'
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+}))
+
+vi.mock('@aws-sdk/client-ecs', async () => {
+  const originalModule =
+    await vi.importActual<typeof import('@aws-sdk/client-ecs')>('@aws-sdk/client-ecs')
+
+  return {
+    ...originalModule,
+    ECSClient: vi.fn(function () {
+      return {
+        send: mockSend,
+      }
+    }),
+  }
+})
+
+describe('ClusterDiscoveryECS', () => {
+  const originalMetadataUri = process.env.ECS_CONTAINER_METADATA_URI
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+
+    if (originalMetadataUri === undefined) {
+      delete process.env.ECS_CONTAINER_METADATA_URI
+    } else {
+      process.env.ECS_CONTAINER_METADATA_URI = originalMetadataUri
+    }
+  })
+
+  it('throws when ECS task metadata URI is not configured', async () => {
+    delete process.env.ECS_CONTAINER_METADATA_URI
+
+    await expect(new ClusterDiscoveryECS().getClusterSize()).rejects.toThrow(
+      'ECS_CONTAINER_METADATA_URI is not set'
+    )
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('fetches ECS task metadata once and counts running plus pending tasks', async () => {
+    process.env.ECS_CONTAINER_METADATA_URI = 'http://169.254.170.2/v4/metadata'
+
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Cluster: 'cluster-a',
+          Family: 'storage',
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    mockSend
+      .mockResolvedValueOnce({
+        taskArns: ['task-1', 'task-2'],
+      })
+      .mockResolvedValueOnce({
+        taskArns: ['task-3'],
+      })
+
+    await expect(new ClusterDiscoveryECS().getClusterSize()).resolves.toBe(3)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('http://169.254.170.2/v4/metadata/task')
+    expect(mockSend).toHaveBeenCalledTimes(2)
+    expect(mockSend.mock.calls[0][0]).toBeInstanceOf(ListTasksCommand)
+    expect(mockSend.mock.calls[0][0].input).toEqual({
+      cluster: 'cluster-a',
+      desiredStatus: 'RUNNING',
+      family: 'storage',
+    })
+    expect(mockSend.mock.calls[1][0]).toBeInstanceOf(ListTasksCommand)
+    expect(mockSend.mock.calls[1][0].input).toEqual({
+      cluster: 'cluster-a',
+      desiredStatus: 'PENDING',
+      family: 'storage',
+    })
+  })
+
+  it('drains failed ECS task metadata responses before listing tasks', async () => {
+    process.env.ECS_CONTAINER_METADATA_URI = 'http://169.254.170.2/v4/metadata'
+
+    const cancel = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      body: {
+        cancel,
+      },
+    } as unknown as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(new ClusterDiscoveryECS().getClusterSize()).rejects.toThrow(
+      'Request failed with status code 503 Service Unavailable fetching ECS task metadata from http://169.254.170.2/v4/metadata/task'
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith('http://169.254.170.2/v4/metadata/task')
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+})

--- a/src/internal/cluster/ecs.ts
+++ b/src/internal/cluster/ecs.ts
@@ -1,6 +1,9 @@
-import { ECSClient, ListTasksCommand } from '@aws-sdk/client-ecs'
-import { DesiredStatus } from '@aws-sdk/client-ecs/dist-types/models/enums'
-import axios from 'axios'
+import { type DesiredStatus, ECSClient, ListTasksCommand } from '@aws-sdk/client-ecs'
+
+type ECSTaskMetadata = {
+  Cluster: string
+  Family: string
+}
 
 export class ClusterDiscoveryECS {
   private client: ECSClient
@@ -14,20 +17,35 @@ export class ClusterDiscoveryECS {
       throw new Error('ECS_CONTAINER_METADATA_URI is not set')
     }
 
+    const metadata = await this.getTaskMetadata(process.env.ECS_CONTAINER_METADATA_URI)
+
     const [running, pending] = await Promise.all([
-      this.listTasks('RUNNING'),
-      this.listTasks('PENDING'),
+      this.listTasks(metadata, 'RUNNING'),
+      this.listTasks(metadata, 'PENDING'),
     ])
 
     return running + pending
   }
 
-  private async listTasks(status: DesiredStatus) {
-    const respMetadata = await axios.get(`${process.env.ECS_CONTAINER_METADATA_URI}/task`)
+  private async getTaskMetadata(metadataUri: string): Promise<ECSTaskMetadata> {
+    const metadataUrl = `${metadataUri}/task`
+    const response = await fetch(metadataUrl)
 
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
+      const statusText = response.statusText ? ` ${response.statusText}` : ''
+      throw new Error(
+        `Request failed with status code ${response.status}${statusText} fetching ECS task metadata from ${metadataUrl}`
+      )
+    }
+
+    return (await response.json()) as ECSTaskMetadata
+  }
+
+  private async listTasks(metadata: ECSTaskMetadata, status: DesiredStatus) {
     const command = new ListTasksCommand({
-      family: respMetadata.data.Family,
-      cluster: respMetadata.data.Cluster,
+      family: metadata.Family,
+      cluster: metadata.Cluster,
       desiredStatus: status,
     })
     const response = await this.client.send(command)


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

Cluster discovery uses axios.

## What is the new behavior?

Axios usage is replaced by native fetch.

## Additional context

Drop unnecessary metadata fetching twice.
Adding coverage.