### PR TITLE
fix: drop axios from cdn cache manager

### DIFF
--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -1,0 +1,237 @@
+import type { Storage } from '@storage/storage'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type CdnConfig = {
+  cdnPurgeEndpointURL?: string
+  cdnPurgeEndpointKey?: string
+}
+
+async function importCdnCacheManager(config: CdnConfig = {}) {
+  vi.resetModules()
+
+  const configModule = await import('../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig(config)
+
+  return import('./cdn-cache-manager')
+}
+
+function createStorageMock(findObject = vi.fn().mockResolvedValue({ id: 'object-id' })) {
+  const asSuperUser = vi.fn(() => ({ findObject }))
+  const from = vi.fn(() => ({ asSuperUser }))
+
+  return {
+    storage: { from } as unknown as Storage,
+    from,
+    asSuperUser,
+    findObject,
+  }
+}
+
+describe('CdnCacheManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('sends a purge request for an existing object', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const timeoutSignal = new AbortController().signal
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const storage = createStorageMock()
+
+    await new CdnCacheManager(storage.storage).purge({
+      tenant: 'tenant-ref',
+      bucket: 'bucket-id',
+      objectName: 'folder/image.png',
+    })
+
+    expect(storage.from).toHaveBeenCalledWith('bucket-id')
+    expect(storage.asSuperUser).toHaveBeenCalledTimes(1)
+    expect(storage.findObject).toHaveBeenCalledWith('folder/image.png')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [input, init] = fetchMock.mock.calls[0]
+    const requestInit = init as RequestInit & { dispatcher?: unknown }
+    const headers = requestInit.headers as Headers
+
+    expect(input.toString()).toBe('https://cdn.example.com/stub/cache/purge')
+    expect(requestInit.method).toBe('POST')
+    expect(headers.get('authorization')).toBe('Bearer test-key')
+    expect(headers.get('content-type')).toBe('application/json')
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      tenant: {
+        ref: 'tenant-ref',
+      },
+      bucketId: 'bucket-id',
+      objectName: 'folder/image.png',
+    })
+    expect(requestInit.dispatcher).toBeDefined()
+    expect(requestInit.signal).toBe(timeoutSignal)
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000)
+  })
+
+  it('omits the authorization header when the purge endpoint key is not configured', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: undefined,
+    })
+    const storage = createStorageMock()
+
+    await new CdnCacheManager(storage.storage).purge({
+      tenant: 'tenant-ref',
+      bucket: 'bucket-id',
+      objectName: 'folder/image.png',
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = (init as RequestInit).headers as Headers
+
+    expect(headers.has('authorization')).toBe(false)
+    expect(headers.get('content-type')).toBe('application/json')
+  })
+
+  it('wraps non-success purge responses and drains the response body', async () => {
+    const cancel = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 503,
+      body: {
+        cancel,
+      },
+    } as unknown as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const storage = createStorageMock()
+
+    await expect(
+      new CdnCacheManager(storage.storage).purge({
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError: expect.objectContaining({
+        message: 'Request failed with status code 503',
+      }),
+    })
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps network failures from fetch', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error('socket hang up'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const storage = createStorageMock()
+
+    await expect(
+      new CdnCacheManager(storage.storage).purge({
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError: expect.objectContaining({
+        message: 'socket hang up',
+      }),
+    })
+  })
+
+  it('wraps non-Error rejections from fetch', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue('socket hang up')
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const storage = createStorageMock()
+
+    await expect(
+      new CdnCacheManager(storage.storage).purge({
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError: expect.objectContaining({
+        message: 'socket hang up',
+      }),
+    })
+  })
+
+  it('does not call the purge endpoint when the object lookup fails', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const lookupError = new Error('object not found')
+    const storage = createStorageMock(vi.fn().mockRejectedValue(lookupError))
+
+    await expect(
+      new CdnCacheManager(storage.storage).purge({
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'missing.png',
+      })
+    ).rejects.toBe(lookupError)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('requires a CDN purge endpoint URL before checking object existence', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointKey: 'test-key',
+    })
+    const storage = createStorageMock()
+
+    await expect(
+      new CdnCacheManager(storage.storage).purge({
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'MissingParameter',
+      message: 'Missing Required Parameter CDN_PURGE_ENDPOINT_URL is not set',
+    })
+
+    expect(storage.from).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/storage/cdn/cdn-cache-manager.ts
+++ b/src/storage/cdn/cdn-cache-manager.ts
@@ -1,27 +1,25 @@
 import { ERRORS } from '@internal/errors'
 import { Storage } from '@storage/storage'
-import { HttpsAgent } from 'agentkeepalive'
-import axios, { AxiosError } from 'axios'
+import { Agent } from 'undici'
 
 import { getConfig } from '../../config'
 
 const { cdnPurgeEndpointURL, cdnPurgeEndpointKey } = getConfig()
 
-const httpsAgent = new HttpsAgent({
-  keepAlive: true,
-  maxFreeSockets: 20,
-  maxSockets: 200,
-  freeSocketTimeout: 1000 * 2,
+const CDN_PURGE_TIMEOUT_MS = 10_000
+
+const dispatcher = new Agent({
+  connections: 200,
+  keepAliveTimeout: 1000 * 2,
+  keepAliveMaxTimeout: 1000 * 2,
 })
 
-const client = axios.create({
-  baseURL: cdnPurgeEndpointURL,
-  httpsAgent,
-  headers: {
-    Authorization: `Bearer ${cdnPurgeEndpointKey}`,
-    'Content-Type': 'application/json',
-  },
+const defaultHeaders = new Headers({
+  'Content-Type': 'application/json',
+  ...(cdnPurgeEndpointKey ? { Authorization: `Bearer ${cdnPurgeEndpointKey}` } : {}),
 })
+
+const cdnPurgeUrl = cdnPurgeEndpointURL ? resolvePurgeUrl(cdnPurgeEndpointURL) : undefined
 
 export interface PurgeCacheInput {
   tenant: string
@@ -29,11 +27,28 @@ export interface PurgeCacheInput {
   objectName: string
 }
 
+function resolvePurgeUrl(baseURL: string) {
+  const url = new URL(baseURL)
+  url.pathname = url.pathname.endsWith('/') ? `${url.pathname}purge` : `${url.pathname}/purge`
+  url.search = ''
+  url.hash = ''
+
+  return url.toString()
+}
+
+async function assertOkResponse(response: Response) {
+  if (response.ok) {
+    return
+  }
+
+  throw new Error(`Request failed with status code ${response.status}`)
+}
+
 export class CdnCacheManager {
   constructor(protected readonly storage: Storage) {}
 
   async purge(opts: PurgeCacheInput) {
-    if (!cdnPurgeEndpointURL) {
+    if (!cdnPurgeUrl) {
       throw ERRORS.MissingParameter('CDN_PURGE_ENDPOINT_URL is not set')
     }
 
@@ -42,19 +57,32 @@ export class CdnCacheManager {
 
     // Purge cache
     try {
-      await client.post('/purge', {
-        tenant: {
-          ref: opts.tenant,
-        },
-        bucketId: opts.bucket,
-        objectName: opts.objectName,
-      })
-    } catch (e) {
-      if (e instanceof AxiosError) {
-        throw ERRORS.InternalError(e, 'Error purging cache')
+      const requestInit: RequestInit & { dispatcher: Agent } = {
+        method: 'POST',
+        headers: defaultHeaders,
+        body: JSON.stringify({
+          tenant: {
+            ref: opts.tenant,
+          },
+          bucketId: opts.bucket,
+          objectName: opts.objectName,
+        }),
+        dispatcher,
+        signal: AbortSignal.timeout(CDN_PURGE_TIMEOUT_MS),
       }
 
-      throw e
+      const response = await fetch(cdnPurgeUrl, requestInit)
+
+      try {
+        await assertOkResponse(response)
+      } finally {
+        await response.body?.cancel().catch(() => {})
+      }
+    } catch (e) {
+      throw ERRORS.InternalError(
+        e instanceof Error ? e : new Error(String(e)),
+        'Error purging cache'
+      )
     }
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

reafactor

## What is the current behavior?

Axios is used in cdn cache manager.

## What is the new behavior?

Native fetch replaces axios.

## Additional context

Added some unit test coverage.