### PR TITLE
fix: drop axios from image renderer

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -95,7 +95,7 @@ jobs:
           npm run acceptance -- --profile "${ACCEPTANCE_PROFILE}"
       - name: Upload acceptance artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: acceptance-local-${{ matrix.storage_backend }}-${{ matrix.database }}-${{ matrix.tenancy }}
           path: coverage/acceptance
@@ -161,7 +161,7 @@ jobs:
           npm run acceptance:run
       - name: Upload acceptance artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: acceptance-remote
           path: coverage/acceptance

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,6 @@
         "ajv": "^8.18.0",
         "async-retry": "^1.3.3",
         "aws-sigv4-sign": "^1.2.1",
-        "axios": "^1.13.6",
-        "axios-retry": "^3.9.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
         "fastify": "^5.8.3",
@@ -2459,6 +2457,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -11525,26 +11524,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
-      }
-    },
     "node_modules/b4a": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.2.tgz",
@@ -12658,26 +12637,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -13285,17 +13244,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15241,11 +15189,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -15398,6 +15341,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -18689,6 +18633,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -24785,25 +24730,6 @@
         }
       }
     },
-    "axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "requires": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "axios-retry": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
-      }
-    },
     "b4a": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.2.tgz",
@@ -25554,11 +25480,6 @@
         "micromatch": "^4.0.2"
       }
     },
-    "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
-    },
     "form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -25967,11 +25888,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-    },
-    "is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -27183,11 +27099,6 @@
         "long": "^5.0.0"
       }
     },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -27293,7 +27204,8 @@
     "regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "ajv": "^8.18.0",
     "async-retry": "^1.3.3",
     "aws-sigv4-sign": "^1.2.1",
-    "axios": "^1.13.6",
-    "axios-retry": "^3.9.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
     "fastify": "^5.8.3",

--- a/src/storage/renderer/head.ts
+++ b/src/storage/renderer/head.ts
@@ -1,8 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyReply, FastifyRequest } from 'fastify'
-import { ObjectMetadata } from '../backend'
 import { ImageRenderer, TransformOptions } from './image'
-import { AssetResponse, Renderer, RenderOptions } from './renderer'
+import { AssetMetadata, AssetResponse, Renderer, RenderOptions } from './renderer'
 
 /**
  * HeadRenderer
@@ -16,13 +15,10 @@ export class HeadRenderer extends Renderer {
       throw ERRORS.NoSuchKey(`${options.bucket}/${options.key}/${options.version}`)
     }
 
-    const metadata = object.metadata ? { ...object.metadata } : {}
-    if (metadata.lastModified) {
-      metadata.lastModified = new Date(metadata.lastModified as string)
-    }
+    const metadata = createAssetMetadata(object.metadata)
 
     return {
-      metadata: metadata as ObjectMetadata,
+      metadata,
       transformations: ImageRenderer.applyTransformation(request.query as TransformOptions),
     }
   }
@@ -30,14 +26,14 @@ export class HeadRenderer extends Renderer {
   protected handleCacheControl(
     request: FastifyRequest<any>,
     response: FastifyReply<any>,
-    metadata: ObjectMetadata
+    metadata: AssetMetadata
   ) {
     const etag = this.findEtagHeader(request)
 
     const cacheControl = [metadata.cacheControl]
 
     if (!etag) {
-      response.header('Cache-Control', cacheControl.join(', '))
+      this.setCacheControlHeader(response, cacheControl)
       return
     }
 
@@ -47,6 +43,74 @@ export class HeadRenderer extends Renderer {
       cacheControl.push(`s-maxage=${this.sMaxAge}`)
     }
 
-    response.header('Cache-Control', cacheControl.join(', '))
+    this.setCacheControlHeader(response, cacheControl)
+  }
+}
+
+function createAssetMetadata(
+  rawMetadata: Record<string, unknown> | null | undefined
+): AssetMetadata {
+  const metadata: AssetMetadata = {}
+  const raw = rawMetadata ?? {}
+
+  if (typeof raw.cacheControl === 'string') {
+    metadata.cacheControl = raw.cacheControl
+  }
+
+  const contentLength = parseMetadataNumber(raw.contentLength)
+  if (contentLength !== undefined) {
+    metadata.contentLength = contentLength
+  }
+
+  if (typeof raw.contentRange === 'string') {
+    metadata.contentRange = raw.contentRange
+  }
+
+  if (typeof raw.eTag === 'string') {
+    metadata.eTag = raw.eTag
+  }
+
+  const httpStatusCode = parseMetadataNumber(raw.httpStatusCode)
+  if (httpStatusCode !== undefined) {
+    metadata.httpStatusCode = httpStatusCode
+  }
+
+  if (typeof raw.mimetype === 'string') {
+    metadata.mimetype = raw.mimetype
+  }
+
+  const size = parseMetadataNumber(raw.size)
+  if (size !== undefined) {
+    metadata.size = size
+  }
+
+  if (typeof raw.xRobotsTag === 'string') {
+    metadata.xRobotsTag = raw.xRobotsTag
+  }
+
+  if (
+    typeof raw.lastModified === 'string' ||
+    typeof raw.lastModified === 'number' ||
+    raw.lastModified instanceof Date
+  ) {
+    const lastModified = new Date(raw.lastModified)
+    if (!Number.isNaN(lastModified.getTime())) {
+      metadata.lastModified = lastModified
+    }
+  }
+
+  return metadata
+}
+
+function parseMetadataNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isSafeInteger(value)) {
+    return value
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number(value)
+    if (Number.isSafeInteger(parsed)) {
+      return parsed
+    }
   }
 }

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -1,0 +1,2391 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type { FastifyRequest } from 'fastify'
+import { Readable } from 'stream'
+import type { StorageBackendAdapter } from '../backend'
+
+const EXHAUSTED_RETRY_BACKOFF_MS = 50 + 100 + 200 + 400 + 800
+
+async function readStream(stream: unknown) {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of stream as AsyncIterable<Buffer | string | Uint8Array>) {
+    if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk))
+      continue
+    }
+
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function loadRendererModule(
+  overrides?: {
+    imgProxyHttpKeepAlive?: number
+    imgProxyHttpMaxSockets?: number
+    imgProxyRequestTimeout?: number
+    imgProxyURL?: string
+  },
+  options: { mockUndici?: boolean } = {}
+) {
+  vi.resetModules()
+
+  if (options.mockUndici !== false) {
+    class MockAgent {
+      compose(...handlers: unknown[]) {
+        return { __dispatcher: true, handlers }
+      }
+    }
+
+    vi.doMock('undici', () => ({
+      Agent: MockAgent,
+      interceptors: {
+        retry: vi.fn((opts: unknown) => ({ __retryOpts: opts })),
+      },
+    }))
+  }
+
+  const configModule = await import('../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({
+    imgProxyHttpMaxSockets: 0,
+    imgProxyRequestTimeout: 30,
+    imgProxyURL: 'https://imgproxy.example.test/base',
+    ...overrides,
+  })
+
+  return import('./image')
+}
+
+function createBackend(privateURL = 'https://origin.example/assets/cat.png?token=a b') {
+  return {
+    headObject: vi.fn().mockResolvedValue({
+      cacheControl: 'max-age=3600',
+      contentLength: 123,
+      eTag: '"source-etag"',
+      lastModified: new Date('2022-10-01T00:00:00.000Z'),
+      mimetype: 'image/jpeg',
+      size: 123,
+    }),
+    privateAssetUrl: vi.fn().mockResolvedValue(privateURL),
+  } as unknown as StorageBackendAdapter
+}
+
+function createRequest(headers: FastifyRequest['headers'] = {}) {
+  return { headers } as FastifyRequest
+}
+
+function createReply() {
+  const reply = {
+    header: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+  }
+
+  return reply
+}
+
+function createRenderOptions(signal = new AbortController().signal) {
+  return {
+    bucket: 'bucket',
+    key: 'folder/cat.png',
+    signal,
+    version: 'version',
+  }
+}
+
+async function waitForCondition(condition: () => boolean) {
+  const deadline = Date.now() + 500
+
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error('Timed out waiting for condition')
+}
+
+async function useUndiciMockAgent() {
+  const actualUndici = await vi.importActual<typeof import('undici')>('undici')
+  vi.stubGlobal('fetch', actualUndici.fetch)
+
+  let mockAgent: import('undici').MockAgent | undefined
+
+  vi.doMock('undici', async () => {
+    const actual = await vi.importActual<typeof import('undici')>('undici')
+    mockAgent = new actual.MockAgent()
+    mockAgent.disableNetConnect()
+
+    const Agent = vi.fn(function () {
+      return mockAgent
+    })
+
+    return {
+      ...actual,
+      Agent,
+    }
+  })
+
+  return {
+    async close() {
+      await mockAgent?.close()
+    },
+    getMockAgent() {
+      if (!mockAgent) {
+        throw new Error('MockAgent has not been created')
+      }
+
+      return mockAgent
+    },
+  }
+}
+
+describe('ImageRenderer fetch client', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.doUnmock('undici')
+    vi.useRealTimers()
+  })
+
+  it('fetches the transformed image with native fetch and maps the streamed response metadata', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+          'last-modified': 'Wed, 12 Oct 2022 11:17:02 GMT',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend()).setTransformations({
+      format: 'webp',
+      width: 100,
+    })
+
+    const result = await renderer.getAsset(
+      createRequest({ accept: 'image/avif,image/webp' }),
+      createRenderOptions()
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      'https://imgproxy.example.test/base/public/width:100/resizing_type:fill/format:webp/plain/https%3A%2F%2Forigin.example%2Fassets%2Fcat.png%3Ftoken%3Da%20b'
+    )
+    expect(init).toMatchObject({
+      method: 'GET',
+      signal: expect.any(AbortSignal),
+    })
+    expect(init?.headers).toBeInstanceOf(Headers)
+    expect((init?.headers as Headers).get('accept')).toBe('image/avif,image/webp')
+
+    await expect(readStream(result.body)).resolves.toBe('rendered-body')
+    expect(result.metadata).toMatchObject({
+      cacheControl: 'max-age=3600',
+      contentLength: 13,
+      eTag: '"source-etag"',
+      httpStatusCode: 200,
+      lastModified: new Date('2022-10-12T11:17:02.000Z'),
+      mimetype: 'image/webp',
+      size: 13,
+    })
+    expect(result.transformations).toEqual(['width:100', 'resizing_type:fill', 'format:webp'])
+  })
+
+  it('coerces numeric string object metadata for head and info renderers', async () => {
+    await loadRendererModule()
+    const [{ HeadRenderer }, { InfoRenderer }] = await Promise.all([
+      import('./head'),
+      import('./info'),
+    ])
+    const object = {
+      bucket_id: 'bucket',
+      created_at: '2022-10-01T00:00:00.000Z',
+      id: 'object-id',
+      metadata: {
+        cacheControl: 'max-age=3600',
+        contentLength: '123',
+        eTag: '"source-etag"',
+        httpStatusCode: '206',
+        lastModified: '2022-10-12T11:17:02.000Z',
+        mimetype: 'image/webp',
+        size: '123',
+      },
+      name: 'folder/cat.png',
+      updated_at: '2022-10-12T11:17:02.000Z',
+      user_metadata: { owner: 'test-user' },
+      version: 'version',
+    }
+
+    const headAsset = await new HeadRenderer().getAsset(
+      { headers: {}, query: {} } as never,
+      {
+        ...createRenderOptions(),
+        object,
+      } as never
+    )
+    const infoAsset = await new InfoRenderer().getAsset(
+      { headers: {}, query: {} } as never,
+      {
+        ...createRenderOptions(),
+        object,
+      } as never
+    )
+
+    expect(headAsset.metadata).toMatchObject({
+      contentLength: 123,
+      httpStatusCode: 206,
+      size: 123,
+    })
+    expect(infoAsset.body).toMatchObject({
+      content_type: 'image/webp',
+      size: 123,
+    })
+  })
+
+  it('drops invalid object lastModified metadata for head renderer responses', async () => {
+    await loadRendererModule()
+    const { HeadRenderer } = await import('./head')
+    const headAsset = await new HeadRenderer().getAsset(
+      { headers: {}, query: {} } as never,
+      {
+        ...createRenderOptions(),
+        object: {
+          metadata: {
+            lastModified: 'not-a-date',
+          },
+        },
+      } as never
+    )
+
+    expect(headAsset.metadata.lastModified).toBeUndefined()
+  })
+
+  it('does not emit empty Cache-Control headers when metadata has no cache control', async () => {
+    await loadRendererModule()
+    const [{ Renderer }, { HeadRenderer }, { InfoRenderer }] = await Promise.all([
+      import('./renderer'),
+      import('./head'),
+      import('./info'),
+    ])
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {},
+        }
+      }
+    }
+
+    const assetReply = createReply()
+    await new TestRenderer().render(createRequest(), assetReply as never, createRenderOptions())
+
+    expect(assetReply.header).not.toHaveBeenCalledWith('Cache-Control', expect.anything())
+
+    const headReply = createReply()
+    await new HeadRenderer().render(
+      { headers: {}, query: {} } as never,
+      headReply as never,
+      {
+        ...createRenderOptions(),
+        object: {
+          metadata: {},
+        },
+      } as never
+    )
+
+    expect(headReply.header).not.toHaveBeenCalledWith('Cache-Control', expect.anything())
+
+    const infoReply = createReply()
+    await new InfoRenderer().render(
+      { headers: {}, query: {} } as never,
+      infoReply as never,
+      {
+        ...createRenderOptions(),
+        object: {
+          bucket_id: 'bucket',
+          created_at: '2022-10-01T00:00:00.000Z',
+          id: 'object-id',
+          metadata: {},
+          name: 'folder/cat.png',
+          updated_at: '2022-10-12T11:17:02.000Z',
+          user_metadata: null,
+          version: 'version',
+        },
+      } as never
+    )
+
+    expect(infoReply.header).not.toHaveBeenCalledWith('Cache-Control', expect.anything())
+  })
+
+  it('omits nullish Cache-Control parts when only shared cache max-age applies', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class TestRenderer extends Renderer {
+      protected sMaxAge = 60
+
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {
+            eTag: '"source-etag"',
+          },
+        }
+      }
+    }
+
+    const reply = createReply()
+    await new TestRenderer().render(
+      createRequest({ 'if-none-match': '"source-etag"' }),
+      reply as never,
+      createRenderOptions()
+    )
+
+    expect(reply.header).toHaveBeenCalledWith('Cache-Control', 's-maxage=60')
+    expect(reply.header).not.toHaveBeenCalledWith(
+      'Cache-Control',
+      expect.stringContaining('undefined')
+    )
+  })
+
+  it('passes an undici dispatcher to fetch when imgproxy socket pooling is enabled', async () => {
+    const agentInstances: Array<{ instance: unknown; options: unknown }> = []
+    const composedHandlers: unknown[] = []
+    const composedDispatcher = { __composed: true }
+    class MockAgent {
+      constructor(options: unknown) {
+        agentInstances.push({ instance: this, options })
+      }
+      compose(...handlers: unknown[]) {
+        composedHandlers.push(...handlers)
+        return composedDispatcher
+      }
+    }
+    const retryStub = vi.fn((opts: unknown) => ({ __retryOpts: opts }))
+    vi.doMock('undici', () => ({
+      Agent: MockAgent,
+      interceptors: { retry: retryStub },
+    }))
+
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule(
+      {
+        imgProxyHttpKeepAlive: 11,
+        imgProxyHttpMaxSockets: 3,
+        imgProxyRequestTimeout: 7,
+      },
+      { mockUndici: false }
+    )
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(agentInstances).toEqual([
+      {
+        instance: expect.any(MockAgent),
+        options: {
+          bodyTimeout: 7000,
+          connections: 3,
+          headersTimeout: 7000,
+          keepAliveMaxTimeout: 11000,
+          keepAliveTimeout: 2000,
+        },
+      },
+    ])
+    expect(retryStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxRetries: 5,
+        maxTimeout: 1000,
+        methods: ['GET'],
+        statusCodes: [408, 429, 500, 502, 503, 504],
+        throwOnError: false,
+        errorCodes: expect.arrayContaining([
+          'ECONNRESET',
+          'ETIMEDOUT',
+          'UND_ERR_CONNECT_TIMEOUT',
+          'UND_ERR_HEADERS_TIMEOUT',
+          'UND_ERR_BODY_TIMEOUT',
+        ]),
+      })
+    )
+    expect(composedHandlers).toEqual([{ __retryOpts: expect.any(Object) }])
+    const [, init] = fetchMock.mock.calls[0]
+    const dispatcher = (init as RequestInit & { dispatcher?: unknown }).dispatcher
+    expect(dispatcher).toBe(composedDispatcher)
+    await expect(readStream(result.body)).resolves.toBe('rendered-body')
+  })
+
+  it('keeps imgproxy timeout and retry dispatcher when socket cap is disabled', async () => {
+    const agentInstances: Array<{ instance: unknown; options: Record<string, unknown> }> = []
+    const composedHandlers: unknown[] = []
+    const composedDispatcher = { __composed: true }
+    class MockAgent {
+      constructor(options: Record<string, unknown>) {
+        agentInstances.push({ instance: this, options })
+      }
+      compose(...handlers: unknown[]) {
+        composedHandlers.push(...handlers)
+        return composedDispatcher
+      }
+    }
+    const retryStub = vi.fn((opts: unknown) => ({ __retryOpts: opts }))
+    vi.doMock('undici', () => ({
+      Agent: MockAgent,
+      interceptors: { retry: retryStub },
+    }))
+
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule(
+      {
+        imgProxyHttpKeepAlive: 13,
+        imgProxyHttpMaxSockets: 0,
+        imgProxyRequestTimeout: 9,
+      },
+      { mockUndici: false }
+    )
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(agentInstances).toEqual([
+      {
+        instance: expect.any(MockAgent),
+        options: {
+          bodyTimeout: 9000,
+          headersTimeout: 9000,
+          keepAliveMaxTimeout: 13000,
+          keepAliveTimeout: 2000,
+        },
+      },
+    ])
+    expect(agentInstances[0]?.options).not.toHaveProperty('connections')
+    expect(retryStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxRetries: 5,
+        maxTimeout: 1000,
+        methods: ['GET'],
+        statusCodes: [408, 429, 500, 502, 503, 504],
+        throwOnError: false,
+        errorCodes: expect.arrayContaining([
+          'ECONNRESET',
+          'ETIMEDOUT',
+          'UND_ERR_CONNECT_TIMEOUT',
+          'UND_ERR_HEADERS_TIMEOUT',
+          'UND_ERR_BODY_TIMEOUT',
+        ]),
+      })
+    )
+    expect(composedHandlers).toEqual([{ __retryOpts: expect.any(Object) }])
+    const [, init] = fetchMock.mock.calls[0]
+    const dispatcher = (init as RequestInit & { dispatcher?: unknown }).dispatcher
+    expect(dispatcher).toBe(composedDispatcher)
+    await expect(readStream(result.body)).resolves.toBe('rendered-body')
+  })
+
+  it.each([
+    [408, 'image request timed out'],
+    [429, 'too many image requests'],
+    [500, 'imgproxy failed'],
+  ])('preserves exhausted retry response status and body for imgproxy %i', async (statusCode, body) => {
+    const mockUndici = await useUndiciMockAgent()
+
+    try {
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyHttpMaxSockets: 2,
+          imgProxyRequestTimeout: 1,
+          imgProxyURL: 'https://imgproxy.example.test/base',
+        },
+        { mockUndici: false }
+      )
+      const mockAgent = mockUndici.getMockAgent()
+      mockAgent
+        .get('https://imgproxy.example.test')
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .reply(statusCode, body)
+        .times(6)
+
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      vi.useFakeTimers()
+      const resultPromise = renderer
+        .getAsset(createRequest(), createRenderOptions())
+        .catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(EXHAUSTED_RETRY_BACKOFF_MS)
+      const result = await resultPromise
+
+      expect(result).toMatchObject({
+        httpStatusCode: statusCode,
+        message: body,
+      })
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      vi.useRealTimers()
+      await mockUndici.close()
+    }
+  })
+
+  it('clamps imgproxy Retry-After waits before retrying', async () => {
+    const mockUndici = await useUndiciMockAgent()
+
+    try {
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyHttpMaxSockets: 2,
+          imgProxyRequestTimeout: 1,
+          imgProxyURL: 'https://imgproxy.example.test/base',
+        },
+        { mockUndici: false }
+      )
+      const mockAgent = mockUndici.getMockAgent()
+      const pool = mockAgent.get('https://imgproxy.example.test')
+      pool
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .reply(429, 'retry later', {
+          headers: {
+            'retry-after': '2',
+          },
+        })
+      pool
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .reply(200, 'rendered-body', {
+          headers: {
+            'content-length': '13',
+            'content-type': 'image/webp',
+          },
+        })
+
+      vi.useFakeTimers()
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      let settled = false
+      const resultPromise = renderer
+        .getAsset(createRequest(), createRenderOptions())
+        .finally(() => {
+          settled = true
+        })
+
+      await vi.advanceTimersByTimeAsync(1000)
+      const result = await resultPromise
+
+      expect(settled).toBe(true)
+      await expect(readStream(result.body)).resolves.toBe('rendered-body')
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      vi.useRealTimers()
+      await mockUndici.close()
+    }
+  })
+
+  it('keeps enough total budget for retry sleeps and the final imgproxy attempt', async () => {
+    const mockUndici = await useUndiciMockAgent()
+
+    try {
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyHttpMaxSockets: 2,
+          imgProxyRequestTimeout: 0.2,
+          imgProxyURL: 'https://imgproxy.example.test/base',
+        },
+        { mockUndici: false }
+      )
+      const mockAgent = mockUndici.getMockAgent()
+      const pool = mockAgent.get('https://imgproxy.example.test')
+      const timeoutSignal = new AbortController().signal
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+
+      for (let retry = 0; retry < 5; retry += 1) {
+        pool
+          .intercept({
+            method: 'GET',
+            path: '/base/public/plain/local:///tmp/cat.png',
+          })
+          .reply(429, 'retry later', {
+            headers: {
+              'retry-after': '1',
+            },
+          })
+      }
+
+      pool
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .reply(200, 'rendered-body', {
+          headers: {
+            'content-length': '13',
+            'content-type': 'image/webp',
+          },
+        })
+
+      vi.useFakeTimers()
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      const resultPromise = renderer.getAsset(createRequest(), createRenderOptions())
+
+      await vi.advanceTimersByTimeAsync(5000)
+      const result = await resultPromise
+
+      expect(timeoutSpy).toHaveBeenCalledTimes(1)
+      expect(timeoutSpy).toHaveBeenCalledWith(6200)
+      await expect(readStream(result.body)).resolves.toBe('rendered-body')
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      vi.useRealTimers()
+      await mockUndici.close()
+    }
+  })
+
+  it.each([
+    ['ECONNRESET', 'connection reset', 'Error'],
+    ['ETIMEDOUT', 'connect timed out', 'Error'],
+    ['ENOTFOUND', 'dns lookup failed', 'Error'],
+    ['UND_ERR_CONNECT_TIMEOUT', 'Connect Timeout Error', 'ConnectTimeoutError'],
+    ['UND_ERR_HEADERS_TIMEOUT', 'Headers Timeout Error', 'HeadersTimeoutError'],
+    ['UND_ERR_BODY_TIMEOUT', 'Body Timeout Error', 'BodyTimeoutError'],
+  ])('retries retryable imgproxy transport error %s before returning the body', async (errorCode, errorMessage, errorName) => {
+    const mockUndici = await useUndiciMockAgent()
+
+    try {
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyHttpMaxSockets: 2,
+          imgProxyRequestTimeout: 1,
+          imgProxyURL: 'https://imgproxy.example.test/base',
+        },
+        { mockUndici: false }
+      )
+      const mockAgent = mockUndici.getMockAgent()
+      const pool = mockAgent.get('https://imgproxy.example.test')
+      pool
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .replyWithError(
+          Object.assign(new Error(errorMessage), { code: errorCode, name: errorName })
+        )
+      pool
+        .intercept({
+          method: 'GET',
+          path: '/base/public/plain/local:///tmp/cat.png',
+        })
+        .reply(200, 'rendered-body', {
+          headers: {
+            'content-length': '13',
+            'content-type': 'image/webp',
+          },
+        })
+
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      const result = await renderer.getAsset(createRequest(), createRenderOptions())
+
+      await expect(readStream(result.body)).resolves.toBe('rendered-body')
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      await mockUndici.close()
+    }
+  })
+
+  it('only exposes renderer metadata headers from fetch responses', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+          'last-modified': 'Wed, 12 Oct 2022 11:17:02 GMT',
+          'set-cookie': 'session=abc',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png')
+
+    expect(response.headers).toEqual({
+      'content-length': '13',
+      'content-type': 'image/webp',
+      'last-modified': 'Wed, 12 Oct 2022 11:17:02 GMT',
+    })
+  })
+
+  it('skips nullish request headers when fetching imgproxy', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    await renderer.getClient().get('/public/plain/local:///tmp/cat.png', {
+      headers: {
+        accept: undefined,
+        'x-null': null,
+        'x-array': ['a', 'b'],
+        'x-value': 'ok',
+      },
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = init?.headers as Headers
+    expect(headers.has('accept')).toBe(false)
+    expect(headers.has('x-null')).toBe(false)
+    expect(headers.get('x-array')).toBe('a, b')
+    expect(headers.get('x-value')).toBe('ok')
+  })
+
+  it('passes through successful imgproxy responses that omit content-type', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          'content-length': '3',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+      width: 50,
+    })
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+
+    await expect(readStream(result.body)).resolves.toBe('\u0001\u0002\u0003')
+    expect(result.metadata).toMatchObject({
+      contentLength: 3,
+      httpStatusCode: 200,
+      size: 3,
+    })
+    expect(result.metadata.mimetype).toBeUndefined()
+    expect(result.transformations).toEqual(['width:50', 'resizing_type:fill'])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps imgproxy retry resume stream failures to an actionable stream error', async () => {
+    const requestRetryError = Object.assign(
+      new Error('server does not support the range header and the payload was partially consumed'),
+      {
+        code: 'UND_ERR_REQ_RETRY',
+        name: 'RequestRetryError',
+      }
+    )
+    let sentChunk = false
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (!sentChunk) {
+              sentChunk = true
+              controller.enqueue(new Uint8Array([1, 2, 3]))
+              return
+            }
+
+            controller.error(requestRetryError)
+          },
+        }),
+        {
+          headers: {
+            'content-length': '3',
+            'content-type': 'image/webp',
+          },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+      width: 50,
+    })
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+    const streamError = await readStream(result.body).catch((error) => error)
+
+    expect(streamError).toMatchObject({
+      cause: expect.objectContaining({
+        code: 'UND_ERR_REQ_RETRY',
+        message: 'server does not support the range header and the payload was partially consumed',
+        name: 'RequestRetryError',
+      }),
+      message: 'imgproxy connection dropped mid-response: retry resume is not supported',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops invalid imgproxy Last-Modified headers before rendering', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        headers: {
+          'content-type': 'image/webp',
+          'last-modified': 'not-a-date',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions())
+
+    expect(reply.header).not.toHaveBeenCalledWith('Last-Modified', expect.anything())
+    expect(reply.send).toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels imgproxy response bodies when stream conversion fails', async () => {
+    const readerError = new Error('getReader failed')
+    const cancelSpy = vi.fn()
+    const responseBody = new ReadableStream<Uint8Array>({
+      cancel: cancelSpy,
+    })
+    vi.spyOn(responseBody, 'getReader').mockImplementation(() => {
+      throw readerError
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(responseBody))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(renderer.getClient().get('/public/plain/local:///tmp/cat.png')).rejects.toBe(
+      readerError
+    )
+    await waitForCondition(() => cancelSpy.mock.calls.length === 1)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits content-length metadata and response header when imgproxy streams without it', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+      Promise.resolve(
+        new Response('rendered-body', {
+          headers: {
+            'content-type': 'image/webp',
+          },
+        })
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+    await expect(readStream(result.body)).resolves.toBe('rendered-body')
+    expect(result.metadata.contentLength).toBeUndefined()
+    expect(result.metadata.size).toBeUndefined()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions())
+    expect(reply.header).not.toHaveBeenCalledWith('Content-Length', expect.anything())
+  })
+
+  it('drops invalid imgproxy content-length while preserving the response body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          'content-length': '3 bytes',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const warn = vi.fn()
+
+    const result = await renderer.getAsset(
+      { headers: {}, log: { warn } } as unknown as FastifyRequest,
+      createRenderOptions()
+    )
+
+    await expect(readStream(result.body)).resolves.toBe('\u0001\u0002\u0003')
+    expect(result.metadata.contentLength).toBeUndefined()
+    expect(result.metadata.size).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Invalid content-length header value: 3 bytes',
+        }),
+        type: 'imgproxy',
+      }),
+      'imgproxy returned invalid content-length'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys successful imgproxy response bodies when metadata processing throws', async () => {
+    const warnError = new Error('logger failed')
+    const cancelSpy = vi.fn()
+    const responseBody = new ReadableStream<Uint8Array>({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(responseBody, {
+        headers: {
+          'content-length': '3 bytes',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.getAsset(
+        {
+          headers: {},
+          log: {
+            warn() {
+              throw warnError
+            },
+          },
+        } as unknown as FastifyRequest,
+        createRenderOptions()
+      )
+    ).rejects.toBe(warnError)
+    await waitForCondition(() => cancelSpy.mock.calls.length === 1)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys successful imgproxy response bodies when request logging is missing', async () => {
+    const cancelSpy = vi.fn()
+    const responseBody = new ReadableStream<Uint8Array>({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(responseBody, {
+        headers: {
+          'content-length': '3 bytes',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toThrow()
+    await waitForCondition(() => cancelSpy.mock.calls.length === 1)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores malformed transformation segments with missing or empty values', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('rendered-body', {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(
+      createBackend('local:///tmp/cat.png')
+    ).setTransformationsFromString('width:100,height,quality:80,resize:')
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions())
+
+    expect(result.transformations).toEqual(['width:100', 'resizing_type:fill', 'quality:80'])
+    await expect(readStream(result.body)).resolves.toBe('rendered-body')
+  })
+
+  it('does not retry non-retryable imgproxy failures and preserves the response body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('invalid image request', {
+        status: 400,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+      height: 50,
+    })
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toMatchObject({
+      httpStatusCode: 400,
+      message: 'invalid image request',
+      metadata: {
+        transformations: ['height:50', 'resizing_type:fill'],
+      },
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the request error message when imgproxy returns an empty error body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 400 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toMatchObject({
+      httpStatusCode: 400,
+      message: 'Request failed with status code 400',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps imgproxy error response stream failures to an internal error without hanging', async () => {
+    const streamError = new Error('imgproxy stream failed')
+    const errorBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('partial error body'))
+        controller.error(streamError)
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(errorBody, {
+        status: 400,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toMatchObject({
+      httpStatusCode: 500,
+      message: 'imgproxy stream failed',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('decodes Uint8Array chunks from imgproxy error response bodies', async () => {
+    const { ImageRenderer } = await loadRendererModule()
+
+    class TestImageRenderer extends ImageRenderer {
+      readRequestError(error: never) {
+        return this.handleRequestError(error)
+      }
+    }
+
+    const errorBody = new Readable({
+      objectMode: true,
+      read() {
+        this.push(new TextEncoder().encode('invalid image request'))
+        this.push(null)
+      },
+    })
+    const renderer = new TestImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.readRequestError({
+        response: {
+          data: errorBody,
+          status: 400,
+        },
+      } as never)
+    ).resolves.toMatchObject({
+      httpStatusCode: 400,
+      message: 'invalid image request',
+    })
+  })
+
+  it('maps already-errored response streams without waiting for a future error event', async () => {
+    const { ImageRenderer } = await loadRendererModule()
+
+    class TestImageRenderer extends ImageRenderer {
+      readRequestError(error: never) {
+        return this.handleRequestError(error)
+      }
+    }
+
+    const streamError = new Error('imgproxy response failed before read')
+    const errorBody = new Readable({
+      read() {},
+    })
+    errorBody.on('error', () => {})
+    errorBody.destroy(streamError)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const renderer = new TestImageRenderer(createBackend('local:///tmp/cat.png'))
+    const result = await Promise.race([
+      renderer.readRequestError({
+        response: {
+          data: errorBody,
+          status: 400,
+        },
+      } as never),
+      new Promise((resolve) => setTimeout(() => resolve('timed out'), 100)),
+    ])
+
+    expect(result).toMatchObject({
+      httpStatusCode: 500,
+      message: 'imgproxy response failed before read',
+    })
+  })
+
+  it('bubbles caller-driven aborts without remapping them to storage errors', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      const signal = init?.signal as AbortSignal
+      controller.abort(abortError)
+      return Promise.reject(signal.reason ?? abortError)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.getAsset(createRequest(), createRenderOptions(controller.signal))
+    ).rejects.toBe(abortError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps caller-driven aborts during render to the request-aborted response', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      const signal = init?.signal as AbortSignal
+      controller.abort(abortError)
+      return Promise.reject(signal.reason ?? abortError)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps caller aborts after fetch resolves to the request-aborted response before sending headers', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const cancelError = new Error('cancel failed')
+    const cancelSpy = vi.fn(() => {
+      throw cancelError
+    })
+    const unhandledRejection = vi.fn()
+    const responseBody = new ReadableStream({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+      Promise.resolve(
+        new Response(responseBody, {
+          headers: {
+            'content-length': '13',
+            'content-type': 'image/webp',
+          },
+        })
+      ).then((response) => {
+        controller.abort(abortError)
+        return response
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    process.once('unhandledRejection', unhandledRejection)
+
+    try {
+      const { ImageRenderer } = await loadRendererModule()
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      const reply = createReply()
+
+      await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(cancelSpy).toHaveBeenCalledTimes(1)
+      expect(unhandledRejection).not.toHaveBeenCalled()
+      expect(reply.status).toHaveBeenCalledWith(499)
+      expect(reply.status).not.toHaveBeenCalledWith(200)
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      process.off('unhandledRejection', unhandledRejection)
+    }
+  })
+
+  it('waits for imgproxy response body cancellation before surfacing post-fetch caller aborts', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    let resolveCancel: (() => void) | undefined
+    const cancelStarted = vi.fn()
+    const cancelFinished = vi.fn()
+    const responseBody = new ReadableStream({
+      cancel() {
+        cancelStarted()
+        return new Promise<void>((resolve) => {
+          resolveCancel = () => {
+            cancelFinished()
+            resolve()
+          }
+        })
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+      Promise.resolve(new Response(responseBody)).then((response) => {
+        controller.abort(abortError)
+        return response
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    let settled = false
+    const resultPromise = renderer
+      .getClient()
+      .get('/public/plain/local:///tmp/cat.png', { signal: controller.signal })
+      .catch((error: unknown) => error)
+      .finally(() => {
+        settled = true
+      })
+
+    await waitForCondition(() => cancelStarted.mock.calls.length === 1)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(settled).toBe(false)
+    expect(cancelFinished).not.toHaveBeenCalled()
+
+    resolveCancel?.()
+
+    await expect(resultPromise).resolves.toBe(abortError)
+    expect(cancelFinished).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a fallback abort error when the post-fetch abort reason is undefined', async () => {
+    const cancelSpy = vi.fn()
+    const signal = {
+      aborted: false,
+      reason: undefined,
+    } as AbortSignal & { aborted: boolean; reason: undefined }
+    const responseBody = new ReadableStream({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+      Promise.resolve(new Response(responseBody)).then((response) => {
+        signal.aborted = true
+        return response
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.getClient().get('/public/plain/local:///tmp/cat.png', { signal })
+    ).rejects.toMatchObject({
+      message: 'aborted',
+      name: 'AbortError',
+    })
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors the response stream when the web body ends after the caller aborts', async () => {
+    const abortError = new Error('caller stopped')
+    const signal = {
+      aborted: false,
+      reason: abortError,
+    } as AbortSignal & { aborted: boolean }
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(responseBody))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png', {
+      signal,
+    })
+    const bodyRead = readStream(response.data)
+
+    signal.aborted = true
+    bodyController?.close()
+
+    await expect(bodyRead).rejects.toBe(abortError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors the response stream when the caller aborts while the body is streaming', async () => {
+    const abortError = new Error('caller stopped')
+    const signal = {
+      aborted: false,
+      reason: abortError,
+    } as AbortSignal & { aborted: boolean }
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(responseBody))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png', {
+      signal,
+    })
+    const bodyRead = readStream(response.data)
+
+    bodyController?.enqueue(new TextEncoder().encode('partial body'))
+    await new Promise((resolve) => setImmediate(resolve))
+    signal.aborted = true
+    bodyController?.error(abortError)
+
+    await expect(bodyRead).rejects.toBe(abortError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors the response stream when a real AbortController aborts native fetch mid-body', async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'content-type': 'image/webp',
+      })
+      response.write('partial body')
+    })
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => {
+          reject(error)
+        }
+        server.once('error', onError)
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', onError)
+          resolve()
+        })
+      })
+
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected imgproxy test server to listen on a TCP port')
+      }
+
+      const controller = new AbortController()
+      const abortError = new DOMException('caller stopped', 'AbortError')
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyURL: `http://127.0.0.1:${(address as AddressInfo).port}/base`,
+        },
+        { mockUndici: false }
+      )
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png', {
+        signal: controller.signal,
+      })
+      const chunks: Buffer[] = []
+      const bodyRead = (async () => {
+        for await (const chunk of response.data as AsyncIterable<Buffer | Uint8Array>) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+          controller.abort(abortError)
+        }
+      })()
+
+      await expect(bodyRead).rejects.toBe(abortError)
+      expect(Buffer.concat(chunks).toString('utf8')).toBe('partial body')
+    } finally {
+      if (server.listening) {
+        server.closeAllConnections()
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve()))
+        )
+      }
+    }
+  })
+
+  it('errors a real native fetch response stream when the total request budget expires mid-body', async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'content-type': 'image/webp',
+      })
+      response.write('partial body')
+    })
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => {
+          reject(error)
+        }
+        server.once('error', onError)
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', onError)
+          resolve()
+        })
+      })
+
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected imgproxy test server to listen on a TCP port')
+      }
+
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyRequestTimeout: 0.01,
+          imgProxyURL: `http://127.0.0.1:${(address as AddressInfo).port}/base`,
+        },
+        { mockUndici: false }
+      )
+      const timeoutController = new AbortController()
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal)
+      const timeoutError = new DOMException('timeout', 'TimeoutError')
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+      const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png')
+      const chunks: Buffer[] = []
+      const bodyRead = (async () => {
+        for await (const chunk of response.data as AsyncIterable<Buffer | Uint8Array>) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        }
+      })()
+
+      await waitForCondition(() => Buffer.concat(chunks).toString('utf8') === 'partial body')
+      timeoutController.abort(timeoutError)
+
+      await expect(bodyRead).rejects.toMatchObject({ name: 'TimeoutError' })
+      expect(Buffer.concat(chunks).toString('utf8')).toBe('partial body')
+      expect(timeoutSpy).toHaveBeenCalledTimes(1)
+      expect(timeoutSpy).toHaveBeenCalledWith(5060)
+    } finally {
+      if (server.listening) {
+        server.closeAllConnections()
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve()))
+        )
+      }
+    }
+  })
+
+  it('maps post-fetch aborts with undefined reason to the request-aborted response', async () => {
+    const cancelSpy = vi.fn()
+    const signal = {
+      aborted: false,
+      reason: undefined,
+    } as AbortSignal & { aborted: boolean; reason: undefined }
+    const responseBody = new ReadableStream({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+      Promise.resolve(new Response(responseBody)).then((response) => {
+        signal.aborted = true
+        return response
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(signal))
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys an asset body when the caller aborts after getAsset resolves before headers are set', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const body = new Readable({
+      read() {},
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return Promise.resolve({
+          body,
+          metadata: {},
+        }).then((asset) => {
+          controller.abort(abortError)
+          return asset
+        })
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(body.destroyed).toBe(true)
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.status).not.toHaveBeenCalledWith(200)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('destroys an asset body when header setup fails before send', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+    const body = new Readable({
+      read() {},
+    })
+    const headerError = new Error('header failure')
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body,
+          metadata: {},
+        }
+      }
+
+      protected setHeaders(): never {
+        throw headerError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions())
+    ).rejects.toBe(headerError)
+
+    expect(body.destroyed).toBe(true)
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('cancels imgproxy response bodies when header setup fails before send', async () => {
+    const headerError = new Error('header failure')
+    const cancelSpy = vi.fn()
+    const responseBody = new ReadableStream<Uint8Array>({
+      cancel: cancelSpy,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(responseBody, {
+        headers: {
+          'content-length': '13',
+          'content-type': 'image/webp',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+
+    class HeaderFailingImageRenderer extends ImageRenderer {
+      protected setHeaders(): never {
+        throw headerError
+      }
+    }
+
+    const renderer = new HeaderFailingImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions())
+    ).rejects.toBe(headerError)
+    await waitForCondition(() => cancelSpy.mock.calls.length === 1)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('does not call destroy fields on plain object response bodies during cleanup', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+    const body = { destroy: vi.fn() }
+    const headerError = new Error('header failure')
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body,
+          metadata: {},
+        }
+      }
+
+      protected setHeaders(): never {
+        throw headerError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions())
+    ).rejects.toBe(headerError)
+
+    expect(body.destroy).not.toHaveBeenCalled()
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('suppresses ReadableStream cancel rejections when header setup fails before send', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+    const headerError = new Error('header failure')
+    const cancelError = new Error('cancel failed')
+    const unhandledRejection = vi.fn()
+    const body = new ReadableStream({
+      cancel() {
+        throw cancelError
+      },
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body,
+          metadata: {},
+        }
+      }
+
+      protected setHeaders(): never {
+        throw headerError
+      }
+    }
+
+    process.once('unhandledRejection', unhandledRejection)
+
+    try {
+      const renderer = new TestRenderer()
+      const reply = createReply()
+
+      await expect(
+        renderer.render(createRequest(), reply as never, createRenderOptions())
+      ).rejects.toBe(headerError)
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(unhandledRejection).not.toHaveBeenCalled()
+      expect(reply.send).not.toHaveBeenCalled()
+    } finally {
+      process.off('unhandledRejection', unhandledRejection)
+    }
+  })
+
+  it('maps caller aborts while reading imgproxy error bodies to the request-aborted response', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    let fetchSignal: AbortSignal | undefined
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      fetchSignal = init?.signal as AbortSignal
+      const errorBody = new ReadableStream<Uint8Array>({
+        start(bodyController) {
+          fetchSignal?.addEventListener(
+            'abort',
+            () => {
+              bodyController.error(fetchSignal?.reason)
+            },
+            { once: true }
+          )
+        },
+      })
+
+      return Promise.resolve(new Response(errorBody, { status: 400 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    const renderPromise = renderer.render(
+      createRequest(),
+      reply as never,
+      createRenderOptions(controller.signal)
+    )
+    await waitForCondition(() => fetchSignal !== undefined)
+    controller.abort(abortError)
+    await renderPromise
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a null caller abort reason while reading imgproxy error bodies', async () => {
+    const { ImageRenderer } = await loadRendererModule()
+
+    class TestImageRenderer extends ImageRenderer {
+      readRequestError(error: never, signal: AbortSignal) {
+        return this.handleRequestError(error, signal)
+      }
+    }
+
+    const controller = new AbortController()
+    const streamError = new Error('imgproxy response failed while aborted')
+    const errorBody = new Readable({
+      read() {},
+    })
+    errorBody.on('error', () => {})
+    errorBody.destroy(streamError)
+    await new Promise((resolve) => setImmediate(resolve))
+    controller.abort(null)
+
+    const renderer = new TestImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.readRequestError(
+        {
+          response: {
+            data: errorBody,
+            status: 400,
+          },
+        } as never,
+        controller.signal
+      )
+    ).rejects.toBeNull()
+  })
+
+  it('maps undici-style caller abort errors during render to the request-aborted response', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    const abortError = Object.assign(new Error('request aborted'), {
+      code: 'UND_ERR_ABORTED',
+      cause: callerAbortReason,
+      name: 'RequestAbortedError',
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw abortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('maps nested caller abort causes during render to the request-aborted response', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    const intermediateError = Object.assign(new Error('wrapped abort'), {
+      cause: callerAbortReason,
+    })
+    const abortError = Object.assign(new Error('request aborted'), {
+      cause: intermediateError,
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw abortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('maps storage errors wrapping caller aborts to the request-aborted response', async () => {
+    await loadRendererModule()
+    const [{ Renderer }, { ERRORS }] = await Promise.all([
+      import('./renderer'),
+      import('@internal/errors'),
+    ])
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw ERRORS.InternalError(callerAbortReason, 'wrapped caller abort')
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('maps nested storage original errors wrapping caller aborts to the request-aborted response', async () => {
+    await loadRendererModule()
+    const [{ Renderer }, { ERRORS }] = await Promise.all([
+      import('./renderer'),
+      import('@internal/errors'),
+    ])
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    const innerError = ERRORS.InternalError(callerAbortReason, 'wrapped caller abort')
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw ERRORS.InternalError(innerError, 'outer wrapped caller abort')
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('maps fresh SDK AbortError instances after caller aborts to the request-aborted response', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    const sdkAbortError = Object.assign(new Error('Request aborted'), {
+      name: 'AbortError',
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw sdkAbortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('maps deep caller abort cause chains without recursive stack growth', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    let abortError: unknown = callerAbortReason
+    for (let i = 0; i < 10_000; i += 1) {
+      abortError = { cause: abortError }
+    }
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw abortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+  })
+
+  it('does not let throwing error cause getters poison caller abort checks', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const getterError = new Error('cause getter failed')
+    const originalError = Object.defineProperties(new Error('request failed'), {
+      cause: {
+        get() {
+          throw getterError
+        },
+      },
+      originalError: {
+        get() {
+          throw getterError
+        },
+      },
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(new DOMException('caller stopped', 'AbortError'))
+        throw originalError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+    ).rejects.toBe(originalError)
+
+    expect(reply.status).not.toHaveBeenCalledWith(499)
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('does not map unrelated abort-like errors to the request-aborted response', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const unrelatedAbortError = Object.assign(new Error('unrelated request aborted'), {
+      code: 'UND_ERR_ABORTED',
+      name: 'RequestAbortedError',
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(new DOMException('caller stopped', 'AbortError'))
+        throw unrelatedAbortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+    ).rejects.toBe(unrelatedAbortError)
+
+    expect(reply.status).not.toHaveBeenCalledWith(499)
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('does not map equal-looking abort causes to the request-aborted response', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    const controller = new AbortController()
+    const callerAbortReason = new DOMException('caller stopped', 'AbortError')
+    const differentAbortReason = new DOMException('caller stopped', 'AbortError')
+    const abortError = Object.assign(new Error('request aborted'), {
+      cause: differentAbortReason,
+      name: 'RequestAbortedError',
+    })
+
+    class TestRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        controller.abort(callerAbortReason)
+        throw abortError
+      }
+    }
+
+    const renderer = new TestRenderer()
+    const reply = createReply()
+
+    await expect(
+      renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+    ).rejects.toBe(abortError)
+
+    expect(reply.status).not.toHaveBeenCalledWith(499)
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('normalizes caller aborts without an explicit reason on the fetch path', async () => {
+    const controller = new AbortController()
+    let innerSignal: AbortSignal | undefined
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      innerSignal = init?.signal as AbortSignal
+      controller.abort()
+      return Promise.reject(innerSignal.reason)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    const result = await renderer
+      .getAsset(createRequest(), createRenderOptions(controller.signal))
+      .catch((e: unknown) => e)
+
+    expect(result).toMatchObject({ name: 'AbortError' })
+    expect(innerSignal?.reason).toBe(result)
+    expect(controller.signal.aborted).toBe(true)
+  })
+
+  it.each([
+    '',
+    0,
+  ])('preserves explicit caller abort reason %p on the fetch path', async (abortReason) => {
+    const controller = new AbortController()
+    let innerSignal: AbortSignal | undefined
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      innerSignal = init?.signal as AbortSignal
+      controller.abort(abortReason)
+      return Promise.reject(innerSignal.reason)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.getAsset(createRequest(), createRenderOptions(controller.signal))
+    ).rejects.toBe(abortReason)
+    expect(innerSignal?.reason).toBe(abortReason)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves fetch error details when abort races with a fetch failure', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const fetchError = new TypeError('network failure')
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() => {
+      controller.abort(abortError)
+      return Promise.reject(fetchError)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    const result = await renderer
+      .getAsset(createRequest(), createRenderOptions(controller.signal))
+      .catch((e: unknown) => e)
+
+    expect(result).toMatchObject({
+      httpStatusCode: 500,
+      message: 'network failure',
+    })
+    const requestError = (result as { getOriginalError(): unknown }).getOriginalError()
+    expect(requestError).toMatchObject({
+      message: 'network failure',
+      name: 'ImageRendererRequestError',
+      originalError: fetchError,
+    })
+    expect((requestError as { cause?: unknown }).cause).toBe(abortError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps abort-raced fetch failures during render to the request-aborted response', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const fetchError = new TypeError('network failure')
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(() => {
+      controller.abort(abortError)
+      return Promise.reject(fetchError)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const reply = createReply()
+
+    await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
+
+    expect(reply.status).toHaveBeenCalledWith(499)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [
+      'headers',
+      'HeadersTimeoutError',
+      'UND_ERR_HEADERS_TIMEOUT',
+      'Headers Timeout Error',
+      'imgproxy headers timeout of 1000ms exceeded',
+    ],
+    [
+      'body',
+      'BodyTimeoutError',
+      'UND_ERR_BODY_TIMEOUT',
+      'Body Timeout Error',
+      'imgproxy body timeout of 1000ms exceeded',
+    ],
+  ])('maps native fetch wrapped undici %s timeout errors to the imgproxy timeout message', async (_timeoutType, errorName, errorCode, errorMessage, expectedMessage) => {
+    const mockUndici = await useUndiciMockAgent()
+
+    try {
+      const { ImageRenderer } = await loadRendererModule(
+        {
+          imgProxyHttpMaxSockets: 2,
+          imgProxyRequestTimeout: 1,
+          imgProxyURL: 'https://imgproxy.example.test/base',
+        },
+        { mockUndici: false }
+      )
+      const mockAgent = mockUndici.getMockAgent()
+      mockAgent
+        .get('https://imgproxy.example.test')
+        .intercept({
+          method: 'GET',
+          path: '/base/public/width:50/resizing_type:fill/plain/local:///tmp/cat.png',
+        })
+        .replyWithError(
+          Object.assign(new Error(errorMessage), {
+            code: errorCode,
+            name: errorName,
+          })
+        )
+        .times(6)
+
+      const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+        width: 50,
+      })
+      vi.useFakeTimers()
+      const resultPromise = renderer
+        .getAsset(createRequest(), createRenderOptions())
+        .catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(EXHAUSTED_RETRY_BACKOFF_MS)
+      const result = await resultPromise
+
+      expect(result).toMatchObject({
+        httpStatusCode: 500,
+        metadata: {
+          transformations: ['width:50', 'resizing_type:fill'],
+        },
+        message: expectedMessage,
+      })
+      expect((result as { getOriginalError(): unknown }).getOriginalError()).toMatchObject({
+        name: 'ImageRendererRequestError',
+        originalError: expect.objectContaining({
+          cause: expect.objectContaining({
+            code: errorCode,
+            message: errorMessage,
+            name: errorName,
+          }),
+          message: 'fetch failed',
+          name: 'TypeError',
+        }),
+      })
+      mockAgent.assertNoPendingInterceptors()
+    } finally {
+      vi.useRealTimers()
+      await mockUndici.close()
+    }
+  })
+
+  it('aborts the imgproxy request when the total request budget is exceeded before headers arrive', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal
+          if (signal.aborted) {
+            reject(signal.reason)
+            return
+          }
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // total budget = request attempts + retry sleeps = 0.01s * 6 + 1000ms * 5 = 5060ms
+    const { ImageRenderer } = await loadRendererModule({
+      imgProxyRequestTimeout: 0.01,
+    })
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const timeoutController = new AbortController()
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal)
+
+    const resultPromise = renderer.getAsset(createRequest(), createRenderOptions())
+
+    timeoutController.abort(new DOMException('timeout', 'TimeoutError'))
+
+    await expect(resultPromise).rejects.toMatchObject({
+      httpStatusCode: 500,
+      message: 'imgproxy total request timeout of 5060ms exceeded',
+    })
+    expect(timeoutSpy).toHaveBeenCalledTimes(1)
+    expect(timeoutSpy).toHaveBeenCalledWith(5060)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors the response stream when the total request budget is exceeded after headers arrive', async () => {
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(responseBody))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule({
+      imgProxyRequestTimeout: 0.01,
+    })
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const timeoutController = new AbortController()
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal)
+
+    const response = await renderer.getClient().get('/public/plain/local:///tmp/cat.png')
+    const bodyRead = readStream(response.data)
+
+    timeoutController.abort(new DOMException('timeout', 'TimeoutError'))
+    bodyController?.close()
+
+    await expect(bodyRead).rejects.toMatchObject({ name: 'TimeoutError' })
+    expect(timeoutSpy).toHaveBeenCalledTimes(1)
+    expect(timeoutSpy).toHaveBeenCalledWith(5060)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves caller abort detection when the total request budget is also configured', async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException('caller stopped', 'AbortError')
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((_url, init) => {
+      const signal = init?.signal as AbortSignal
+      controller.abort(abortError)
+      return Promise.reject(signal.reason ?? abortError)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule({
+      imgProxyRequestTimeout: 0.01,
+    })
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(
+      renderer.getAsset(createRequest(), createRenderOptions(controller.signal))
+    ).rejects.toBe(abortError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps native fetch wrapped undici retry resume failures to an imgproxy range message', async () => {
+    const requestRetryError = Object.assign(
+      new Error('server does not support the range header and the payload was partially consumed'),
+      {
+        code: 'UND_ERR_REQ_RETRY',
+        name: 'RequestRetryError',
+      }
+    )
+    const fetchError = Object.assign(new TypeError('fetch failed'), {
+      cause: requestRetryError,
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+      width: 50,
+    })
+
+    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
+
+    expect(result).toMatchObject({
+      httpStatusCode: 500,
+      metadata: {
+        transformations: ['width:50', 'resizing_type:fill'],
+      },
+      message: 'imgproxy connection dropped mid-response: retry resume is not supported',
+    })
+    expect((result as { getOriginalError(): unknown }).getOriginalError()).toMatchObject({
+      name: 'ImageRendererRequestError',
+      originalError: expect.objectContaining({
+        cause: requestRetryError,
+        message: 'fetch failed',
+        name: 'TypeError',
+      }),
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps fetch network failures with transformation metadata', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new TypeError('network failure'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png')).setTransformations({
+      width: 50,
+    })
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toMatchObject({
+      httpStatusCode: 500,
+      metadata: {
+        transformations: ['width:50', 'resizing_type:fill'],
+      },
+      message: 'network failure',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['plain fetch failure', 'plain fetch failure'],
+    [null, 'Unknown request error'],
+  ])('maps non-Error fetch failures from %s', async (thrown, message) => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(thrown)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+
+    await expect(renderer.getAsset(createRequest(), createRenderOptions())).rejects.toMatchObject({
+      httpStatusCode: 500,
+      message,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -1,12 +1,12 @@
+import { text } from 'node:stream/consumers'
 import { ERRORS } from '@internal/errors'
-import Agent from 'agentkeepalive'
-import axios, { Axios, AxiosError } from 'axios'
-import axiosRetry from 'axios-retry'
+import { logSchema } from '@internal/monitoring'
 import { FastifyRequest } from 'fastify'
-import { Stream } from 'stream'
+import { Readable } from 'stream'
+import { Agent, Dispatcher, interceptors } from 'undici'
 import { getConfig } from '../../config'
-import { ObjectMetadata, StorageBackendAdapter } from '../backend'
-import { Renderer, RenderOptions } from './renderer'
+import { StorageBackendAdapter } from '../backend'
+import { AssetMetadata, Renderer, RenderOptions } from './renderer'
 
 /**
  * All the transformations options available
@@ -21,8 +21,8 @@ export interface TransformOptions {
 
 const {
   imgLimits,
-  imgProxyHttpMaxSockets,
   imgProxyHttpKeepAlive,
+  imgProxyHttpMaxSockets,
   imgProxyURL,
   imgProxyRequestTimeout,
 } = getConfig()
@@ -38,41 +38,162 @@ const LIMITS = {
   },
 }
 
-const client = axios.create({
-  baseURL: imgProxyURL,
-  timeout: imgProxyRequestTimeout * 1000,
-  httpAgent:
-    imgProxyHttpMaxSockets > 0
-      ? new Agent({
-          maxSockets: imgProxyHttpMaxSockets,
-          freeSocketTimeout: 2 * 1000,
-          keepAlive: true,
-          timeout: imgProxyHttpKeepAlive * 1000,
-        })
-      : undefined,
-})
+const IMGPROXY_REQUEST_TIMEOUT_MS = imgProxyRequestTimeout * 1000
+const IMGPROXY_MAX_RETRIES = 5
+const IMGPROXY_RETRY_MIN_TIMEOUT_MS = 50
+const IMGPROXY_RETRY_MAX_TIMEOUT_MS = 1000
+const IMGPROXY_RETRY_TIMEOUT_FACTOR = 2
+const IMGPROXY_RETRY_AFTER_ENABLED = true
+const IMGPROXY_RETRY_DELAY_BUDGET_MS = IMGPROXY_MAX_RETRIES * IMGPROXY_RETRY_MAX_TIMEOUT_MS
+// Bound the full request lifetime (DNS/connect/TLS/headers/body/streaming) since
+// dispatcher headers/body timeouts only cover idle phases. Include retry sleeps
+// so the final retry still gets a full per-attempt timeout window.
+const IMGPROXY_TOTAL_TIMEOUT_MS =
+  IMGPROXY_REQUEST_TIMEOUT_MS * (IMGPROXY_MAX_RETRIES + 1) + IMGPROXY_RETRY_DELAY_BUDGET_MS
+const IMAGE_RENDERER_RESPONSE_HEADERS = ['content-length', 'content-type', 'last-modified'] as const
 
-axiosRetry(client, {
-  retries: 5,
-  shouldResetTimeout: true,
-  retryDelay: (retryCount, error) => {
-    let exponentialTime = 50
-
-    if (error.response?.status === 500) {
-      exponentialTime = 150
-    }
-    return retryCount * exponentialTime
-  },
-  retryCondition: async (err) => {
-    return [429, 500].includes(err.response?.status || 0)
-  },
-})
+const dispatcher: Dispatcher = new Agent({
+  bodyTimeout: IMGPROXY_REQUEST_TIMEOUT_MS,
+  headersTimeout: IMGPROXY_REQUEST_TIMEOUT_MS,
+  keepAliveMaxTimeout: imgProxyHttpKeepAlive * 1000,
+  keepAliveTimeout: 2 * 1000,
+  ...(imgProxyHttpMaxSockets > 0 ? { connections: imgProxyHttpMaxSockets } : {}),
+}).compose(
+  interceptors.retry({
+    maxRetries: IMGPROXY_MAX_RETRIES,
+    maxTimeout: IMGPROXY_RETRY_MAX_TIMEOUT_MS,
+    methods: ['GET'],
+    minTimeout: IMGPROXY_RETRY_MIN_TIMEOUT_MS,
+    retryAfter: IMGPROXY_RETRY_AFTER_ENABLED,
+    throwOnError: false,
+    timeoutFactor: IMGPROXY_RETRY_TIMEOUT_FACTOR,
+    statusCodes: [408, 429, 500, 502, 503, 504],
+    errorCodes: [
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'ENOTFOUND',
+      'ENETDOWN',
+      'ENETUNREACH',
+      'EHOSTDOWN',
+      'EHOSTUNREACH',
+      'EPIPE',
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_SOCKET',
+      'UND_ERR_HEADERS_TIMEOUT',
+      'UND_ERR_BODY_TIMEOUT',
+    ],
+  })
+)
 
 interface TransformLimits {
   maxResolution?: number
 }
 
-type ImageRendererClient = Pick<Axios, 'get'>
+interface ImageRendererRequestOptions {
+  signal?: AbortSignal
+  headers?: Record<string, string | string[] | null | undefined>
+}
+
+interface ImageRendererResponse {
+  data?: Readable
+  status: number
+  headers: Record<string, string | undefined>
+}
+
+interface ImageRendererClient {
+  get(url: string, options?: ImageRendererRequestOptions): Promise<ImageRendererResponse>
+}
+
+class ImageRendererRequestError extends Error {
+  readonly originalError?: unknown
+
+  private constructor(
+    message: string,
+    readonly response?: ImageRendererResponse,
+    originalError?: unknown,
+    cause?: unknown
+  ) {
+    super(message, cause === undefined ? undefined : { cause })
+    this.name = 'ImageRendererRequestError'
+    this.originalError = originalError
+  }
+
+  static fromResponse(response: ImageRendererResponse) {
+    return new ImageRendererRequestError(
+      `Request failed with status code ${response.status}`,
+      response
+    )
+  }
+
+  static forFailure(error: unknown) {
+    return new ImageRendererRequestError(formatRequestErrorMessage(error), undefined, error)
+  }
+
+  static forAbortRace(error: unknown, abortReason: unknown) {
+    return new ImageRendererRequestError(
+      formatRequestErrorMessage(error),
+      undefined,
+      error,
+      abortReason
+    )
+  }
+}
+
+const client: ImageRendererClient = {
+  async get(url, options = {}) {
+    const requestUrl = resolveImgProxyUrl(url)
+    // bound the total request lifetime (DNS/connect/TLS/headers/body/streaming)
+    // since dispatcher headersTimeout/bodyTimeout only cover idle phases.
+    const totalTimeoutSignal = AbortSignal.timeout(IMGPROXY_TOTAL_TIMEOUT_MS)
+    const fetchSignal =
+      options.signal instanceof AbortSignal
+        ? AbortSignal.any([options.signal, totalTimeoutSignal])
+        : totalTimeoutSignal
+
+    let response: Response
+    try {
+      response = await fetch(requestUrl, {
+        method: 'GET',
+        headers: createHeaders(options.headers),
+        signal: fetchSignal,
+        dispatcher,
+      } as RequestInit & { dispatcher?: Dispatcher })
+    } catch (e) {
+      if (options.signal?.aborted) {
+        if (e === options.signal.reason) {
+          throw e
+        }
+
+        throw ImageRendererRequestError.forAbortRace(e, options.signal.reason)
+      }
+
+      if (totalTimeoutSignal.aborted) {
+        throw ImageRendererRequestError.forFailure(buildTotalTimeoutError())
+      }
+
+      throw ImageRendererRequestError.forFailure(e)
+    }
+
+    if (options.signal?.aborted) {
+      await cancelResponseBody(response)
+      throw getAbortReason(options.signal, new DOMException('aborted', 'AbortError'))
+    }
+
+    if (totalTimeoutSignal.aborted) {
+      await cancelResponseBody(response)
+      throw ImageRendererRequestError.forFailure(buildTotalTimeoutError())
+    }
+
+    const inStreamSignals = [options.signal, totalTimeoutSignal] as const
+
+    if (response.ok) {
+      return toImageRendererResponse(response, inStreamSignals)
+    }
+
+    throw ImageRendererRequestError.fromResponse(toImageRendererResponse(response, inStreamSignals))
+  },
+}
 
 /**
  * ImageRenderer
@@ -171,29 +292,34 @@ export class ImageRenderer extends Renderer {
   }
 
   setTransformationsFromString(transformations: string) {
-    const params = transformations.split(',')
+    const transformOptions: TransformOptions = {}
 
-    this.transformOptions = params.reduce((all, param) => {
-      const [name, value] = param.split(':') as [keyof TransformOptions, any]
+    for (const param of transformations.split(',')) {
+      const [name, value] = param.split(':')
+      if (value === undefined || value === '') {
+        continue
+      }
+
       switch (name) {
         case 'height':
-          all.height = parseInt(value, 10)
+          transformOptions.height = parseInt(value, 10)
           break
         case 'width':
-          all.width = parseInt(value, 10)
+          transformOptions.width = parseInt(value, 10)
           break
         case 'resize':
-          all.resize = value
+          transformOptions.resize = value as TransformOptions['resize']
           break
         case 'format':
-          all.format = value
+          transformOptions.format = value as TransformOptions['format']
           break
         case 'quality':
-          all.quality = parseInt(value, 10)
+          transformOptions.quality = parseInt(value, 10)
           break
       }
-      return all
-    }, {} as TransformOptions)
+    }
+
+    this.transformOptions = transformOptions
 
     return this
   }
@@ -220,13 +346,13 @@ export class ImageRenderer extends Renderer {
       'plain',
       privateURL.startsWith('local://') ? privateURL : encodeURIComponent(privateURL),
     ]
+    let assetBody: Readable | undefined
 
     try {
       const acceptHeader =
         this.transformOptions?.format !== 'origin' ? request.headers['accept'] : undefined
 
       const response = await this.getClient().get(url.join('/'), {
-        responseType: 'stream',
         signal: options.signal,
         headers: acceptHeader
           ? {
@@ -234,57 +360,320 @@ export class ImageRenderer extends Renderer {
             }
           : undefined,
       })
+      assetBody = response.data
 
-      const contentLength = parseInt(response.headers['content-length'], 10)
-      const lastModified = response.headers['last-modified']
-        ? new Date(response.headers['last-modified'])
-        : undefined
+      const rawContentLength = response.headers['content-length']
+      let contentLength: number | undefined
+      if (rawContentLength !== undefined) {
+        const parsedContentLength = Number(rawContentLength)
+        if (/^\d+$/.test(rawContentLength) && Number.isSafeInteger(parsedContentLength)) {
+          contentLength = parsedContentLength
+        } else {
+          logInvalidContentLength(request, rawContentLength)
+        }
+      }
+      const lastModified = parseLastModifiedHeader(response.headers['last-modified'])
+      const metadata: AssetMetadata = {
+        httpStatusCode: response.status,
+        lastModified,
+        eTag: headObj.eTag,
+        cacheControl: headObj.cacheControl,
+        mimetype: response.headers['content-type'],
+        ...(contentLength !== undefined
+          ? {
+              contentLength,
+              size: contentLength,
+            }
+          : {}),
+      }
 
       return {
-        body: response.data,
+        body: assetBody,
         transformations,
-        metadata: {
-          httpStatusCode: response.status,
-          size: contentLength,
-          contentLength,
-          lastModified,
-          eTag: headObj.eTag,
-          cacheControl: headObj.cacheControl,
-          mimetype: response.headers['content-type'],
-        } as ObjectMetadata,
+        metadata,
       }
     } catch (e) {
-      if (e instanceof AxiosError) {
-        const error = await this.handleRequestError(e)
+      if (e instanceof ImageRendererRequestError) {
+        const error = await this.handleRequestError(e, options.signal)
         throw error.withMetadata({
           transformations,
         })
       }
 
+      assetBody?.destroy()
       throw e
     }
   }
 
-  protected async handleRequestError(error: AxiosError) {
-    const stream = error.response?.data as Stream
+  protected async handleRequestError(error: ImageRendererRequestError, signal?: AbortSignal) {
+    const stream = error.response?.data
     if (!stream) {
-      throw ERRORS.InternalError(undefined, error.message)
+      return ERRORS.InternalError(error, error.message)
     }
 
-    const errorResponse = await new Promise<string>((resolve) => {
-      let errorBuffer = ''
+    let errorResponse: string
+    try {
+      errorResponse = await text(stream)
+    } catch (e) {
+      if (signal?.aborted) {
+        throw getAbortReason(signal, e)
+      }
 
-      stream.on('data', (data) => {
-        errorBuffer += data
-      })
-
-      stream.on('end', () => {
-        resolve(errorBuffer)
-      })
-    })
+      return ERRORS.InternalError(e instanceof Error ? e : undefined, formatRequestErrorMessage(e))
+    }
 
     const statusCode = error.response?.status || 500
-    return ERRORS.ImageProcessingError(statusCode, errorResponse)
+    return ERRORS.ImageProcessingError(statusCode, errorResponse || error.message)
+  }
+}
+
+function createHeaders(headers?: ImageRendererRequestOptions['headers']) {
+  const result = new Headers()
+
+  for (const [name, value] of Object.entries(headers || {})) {
+    if (value == null) {
+      continue
+    }
+
+    result.set(name, Array.isArray(value) ? value.join(', ') : value)
+  }
+
+  return result
+}
+
+function resolveImgProxyUrl(url: string) {
+  if (isAbsoluteUrl(url) || !imgProxyURL) {
+    return url
+  }
+
+  return `${imgProxyURL.replace(/\/+$/, '')}/${url.replace(/^\/+/, '')}`
+}
+
+function isAbsoluteUrl(url: string) {
+  return /^[a-z][a-z\d+\-.]*:\/\//i.test(url)
+}
+
+function toImageRendererResponse(
+  response: Response,
+  abortSignals: ReadonlyArray<AbortSignal | undefined>
+): ImageRendererResponse {
+  let data: Readable
+  try {
+    data = response.body ? readableFromWeb(response.body, abortSignals) : Readable.from([])
+  } catch (error) {
+    void cancelResponseBody(response)
+    throw error
+  }
+
+  return {
+    data,
+    status: response.status,
+    headers: imageRendererResponseHeaders(response.headers),
+  }
+}
+
+function readableFromWeb(
+  body: ReadableStream<Uint8Array>,
+  abortSignals: ReadonlyArray<AbortSignal | undefined>
+): Readable {
+  const reader = body.getReader()
+  let reading = false
+  let released = false
+
+  const releaseLock = () => {
+    if (released) {
+      return
+    }
+
+    released = true
+    try {
+      reader.releaseLock()
+    } catch {}
+  }
+
+  const cancelReader = (reason: unknown) => {
+    try {
+      void reader
+        .cancel(reason)
+        .catch(() => {})
+        .finally(releaseLock)
+    } catch {
+      releaseLock()
+    }
+  }
+
+  const stream = new Readable({
+    async read() {
+      if (reading) {
+        return
+      }
+
+      reading = true
+      try {
+        while (!stream.destroyed) {
+          const { done, value } = await reader.read()
+          if (stream.destroyed) {
+            return
+          }
+
+          if (done) {
+            releaseLock()
+            const abortedSignal = abortSignals.find((s) => s?.aborted)
+            if (abortedSignal) {
+              // defensively handle abort during stream end
+              stream.destroy(
+                normalizeStreamError(getAbortReason(abortedSignal, new Error('aborted')))
+              )
+              return
+            }
+
+            stream.push(null)
+            return
+          }
+
+          if (!stream.push(value)) {
+            return
+          }
+        }
+      } catch (error) {
+        stream.destroy(normalizeStreamError(error))
+      } finally {
+        reading = false
+      }
+    },
+    destroy(error, callback) {
+      if (!released) {
+        cancelReader(error)
+      }
+
+      callback(error)
+    },
+  })
+
+  return stream
+}
+
+async function cancelResponseBody(response: Response) {
+  try {
+    await response.body?.cancel()
+  } catch {}
+}
+
+function normalizeStreamError(error: unknown) {
+  if (isRetryResumeUnsupportedError(error)) {
+    return new Error(formatRequestErrorMessage(error), { cause: error })
+  }
+
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function parseLastModifiedHeader(value: string | undefined) {
+  if (!value) {
+    return undefined
+  }
+
+  const lastModified = new Date(value)
+  return Number.isNaN(lastModified.getTime()) ? undefined : lastModified
+}
+
+function getAbortReason(signal: AbortSignal, fallback: unknown) {
+  return signal.reason === undefined ? fallback : signal.reason
+}
+
+function buildTotalTimeoutError() {
+  return new Error(`imgproxy total request timeout of ${IMGPROXY_TOTAL_TIMEOUT_MS}ms exceeded`)
+}
+
+function imageRendererResponseHeaders(headers: Headers) {
+  const result: Record<string, string | undefined> = {}
+
+  IMAGE_RENDERER_RESPONSE_HEADERS.forEach((name) => {
+    result[name] = headers.get(name) ?? undefined
+  })
+
+  return result
+}
+
+function logInvalidContentLength(request: FastifyRequest, value: string) {
+  logSchema.warning(request.log, 'imgproxy returned invalid content-length', {
+    type: 'imgproxy',
+    tenantId: request.tenantId,
+    project: request.tenantId,
+    reqId: request.id,
+    sbReqId: request.sbReqId,
+    error: new Error(`Invalid content-length header value: ${value}`),
+  })
+}
+
+function formatRequestErrorMessage(error: unknown) {
+  if (isHeadersTimeoutError(error)) {
+    return `imgproxy headers timeout of ${IMGPROXY_REQUEST_TIMEOUT_MS}ms exceeded`
+  }
+
+  if (isBodyTimeoutError(error)) {
+    return `imgproxy body timeout of ${IMGPROXY_REQUEST_TIMEOUT_MS}ms exceeded`
+  }
+
+  if (isRetryResumeUnsupportedError(error)) {
+    return 'imgproxy connection dropped mid-response: retry resume is not supported'
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error == null) {
+    return 'Unknown request error'
+  }
+
+  return String(error)
+}
+
+function isHeadersTimeoutError(error: unknown): boolean {
+  return errorHasCode(error, 'UND_ERR_HEADERS_TIMEOUT')
+}
+
+function isBodyTimeoutError(error: unknown): boolean {
+  return errorHasCode(error, 'UND_ERR_BODY_TIMEOUT')
+}
+
+function isRetryResumeUnsupportedError(error: unknown): boolean {
+  return errorHasCode(error, 'UND_ERR_REQ_RETRY')
+}
+
+function errorHasCode(error: unknown, code: string): boolean {
+  const seen = new WeakSet<object>()
+  const stack: unknown[] = [error]
+  let visited = 0
+
+  while (stack.length > 0 && visited < 10_000) {
+    const current = stack.pop()
+    if (!current || typeof current !== 'object' || seen.has(current)) {
+      continue
+    }
+
+    seen.add(current)
+    visited += 1
+
+    if (readErrorProperty(current, 'code') === code) {
+      return true
+    }
+
+    stack.push(readErrorProperty(current, 'cause'), readErrorProperty(current, 'originalError'))
+  }
+
+  return false
+}
+
+function readErrorProperty(error: object, property: 'cause' | 'code' | 'originalError') {
+  try {
+    return (error as Record<typeof property, unknown>)[property]
+  } catch {
+    return undefined
   }
 }
 

--- a/src/storage/renderer/info.ts
+++ b/src/storage/renderer/info.ts
@@ -22,10 +22,10 @@ export class InfoRenderer extends HeadRenderer {
         name: obj.name,
         version: obj.version,
         bucket_id: obj.bucket_id,
-        size: obj.metadata?.size ?? null,
-        content_type: obj.metadata?.mimetype ?? null,
-        cache_control: obj.metadata?.cacheControl ?? null,
-        etag: obj.metadata?.eTag ?? null,
+        size: headAsset.metadata.size ?? null,
+        content_type: headAsset.metadata.mimetype ?? null,
+        cache_control: headAsset.metadata.cacheControl ?? null,
+        etag: headAsset.metadata.eTag ?? null,
         metadata: obj.user_metadata,
         last_modified: obj.updated_at,
         created_at: obj.created_at,
@@ -43,9 +43,10 @@ export class InfoRenderer extends HeadRenderer {
       .status(data.metadata.httpStatusCode ?? 200)
       .header('Content-Type', 'application/json')
       .header('ETag', data.metadata.eTag)
-      .header('Content-Length', data.metadata.contentLength)
-      .header('Last-Modified', data.metadata.lastModified?.toUTCString())
-      .header('Cache-Control', data.metadata.cacheControl)
+
+    this.setLastModifiedHeader(response, data.metadata.lastModified)
+    this.setCacheControlHeader(response, [data.metadata.cacheControl])
+    this.setContentLengthHeader(response, data.metadata.contentLength)
 
     if (data.transformations && data.transformations.length > 0) {
       response.header('X-Transformations', data.transformations.join(','))

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -18,8 +18,19 @@ export interface RenderOptions {
 
 export interface AssetResponse {
   body?: Readable | ReadableStream<any> | Blob | Buffer | Record<any, any>
-  metadata: ObjectMetadata
+  metadata: AssetMetadata
   transformations?: string[]
+}
+
+export type AssetMetadata = Omit<
+  ObjectMetadata,
+  'cacheControl' | 'contentLength' | 'eTag' | 'mimetype' | 'size'
+> & {
+  cacheControl?: string
+  contentLength?: number
+  eTag?: string
+  mimetype?: string
+  size?: number
 }
 
 const { requestEtagHeaders, responseSMaxAge } = getConfig()
@@ -43,26 +54,41 @@ export abstract class Renderer {
   async render(request: FastifyRequest<any>, response: FastifyReply<any>, options: RenderOptions) {
     try {
       if (options.signal?.aborted) {
-        return response.send({ error: 'Request aborted', statusCode: '499' })
+        return this.sendRequestAborted(response)
       }
 
       const data = await this.getAsset(request, options)
 
-      this.setHeaders(request, response, data, options)
+      if (options.signal?.aborted) {
+        destroyAssetBody(data.body)
+        return this.sendRequestAborted(response)
+      }
 
-      return response.send(data.body)
+      try {
+        this.setHeaders(request, response, data, options)
+        return response.send(data.body)
+      } catch (err) {
+        destroyAssetBody(data.body)
+        throw err
+      }
     } catch (err: any) {
-      if (err.$metadata?.httpStatusCode === 304) {
+      const metadata = err && typeof err === 'object' ? err.$metadata : undefined
+
+      if (metadata?.httpStatusCode === 304) {
         return response.status(304).send()
       }
 
-      if (err.$metadata?.httpStatusCode === 404) {
+      if (metadata?.httpStatusCode === 404) {
         response.header('cache-control', 'no-store')
         return response.status(400).send({
           error: 'Not found',
           message: 'The resource was not found',
           statusCode: '404',
         })
+      }
+
+      if (isCallerAbort(err, options.signal)) {
+        return this.sendRequestAborted(response)
       }
 
       throw err
@@ -89,9 +115,10 @@ export abstract class Renderer {
       .header('Accept-Ranges', 'bytes')
       .header('Content-Type', normalizeContentType(data.metadata.mimetype))
       .header('ETag', data.metadata.eTag)
-      .header('Content-Length', data.metadata.contentLength)
-      .header('Last-Modified', data.metadata.lastModified?.toUTCString())
       .header('X-Robots-Tag', xRobotsTag)
+
+    this.setLastModifiedHeader(response, data.metadata.lastModified)
+    this.setContentLengthHeader(response, data.metadata.contentLength)
 
     if (options.expires) {
       response.header('Expires', options.expires)
@@ -128,14 +155,14 @@ export abstract class Renderer {
   protected handleCacheControl(
     request: FastifyRequest<any>,
     response: FastifyReply<any>,
-    metadata: ObjectMetadata
+    metadata: AssetMetadata
   ) {
     const etag = this.findEtagHeader(request)
 
     const cacheControl = [metadata.cacheControl]
 
     if (!etag) {
-      response.header('Cache-Control', cacheControl.join(', '))
+      this.setCacheControlHeader(response, cacheControl)
       return
     }
 
@@ -147,7 +174,30 @@ export abstract class Renderer {
       cacheControl.push('stale-while-revalidate=30')
     }
 
-    response.header('Cache-Control', cacheControl.join(', '))
+    this.setCacheControlHeader(response, cacheControl)
+  }
+
+  protected setContentLengthHeader(response: FastifyReply<any>, contentLength: number | undefined) {
+    if (contentLength !== undefined) {
+      response.header('Content-Length', contentLength)
+    }
+  }
+
+  protected setLastModifiedHeader(response: FastifyReply<any>, lastModified: Date | undefined) {
+    if (lastModified && !Number.isNaN(lastModified.getTime())) {
+      response.header('Last-Modified', lastModified.toUTCString())
+    }
+  }
+
+  protected setCacheControlHeader(response: FastifyReply<any>, values: Array<string | undefined>) {
+    const cacheControl = values.filter((value) => typeof value === 'string' && value.length > 0)
+    if (cacheControl.length > 0) {
+      response.header('Cache-Control', cacheControl.join(', '))
+    }
+  }
+
+  protected sendRequestAborted(response: FastifyReply<any>) {
+    return response.status(499).send({ error: 'Request aborted', statusCode: '499' })
   }
 
   protected findEtagHeader(request: FastifyRequest<any>) {
@@ -158,6 +208,96 @@ export abstract class Renderer {
       }
     }
   }
+}
+
+function isCallerAbort(error: unknown, signal: AbortSignal | undefined) {
+  if (!signal?.aborted) {
+    return false
+  }
+
+  if (signal.reason === undefined) {
+    return isAbortError(error)
+  }
+
+  if (error === signal.reason || hasErrorCause(error, signal.reason)) {
+    return true
+  }
+
+  // AWS SDK via @smithy/node-http-handler creates a fresh AbortError without
+  // preserving the original reason. Once our signal is aborted, treat that as
+  // caller-driven to surface 499 instead of 500.
+  return isAbortError(error)
+}
+
+function isAbortError(error: unknown) {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const name = readErrorProperty(error, 'name')
+  return (
+    name === 'AbortError' &&
+    (error instanceof Error ||
+      (typeof DOMException !== 'undefined' && error instanceof DOMException))
+  )
+}
+
+function hasErrorCause(error: unknown, cause: unknown): boolean {
+  if (cause === undefined) {
+    return false
+  }
+
+  const seen = new WeakSet<object>()
+  const stack: unknown[] = [error]
+  let visited = 0
+
+  while (stack.length > 0 && visited < 10_000) {
+    const current = stack.pop()
+    if (!current || typeof current !== 'object' || seen.has(current)) {
+      continue
+    }
+
+    seen.add(current)
+    visited += 1
+
+    const nestedCause = readErrorProperty(current, 'cause')
+    const originalError = readErrorProperty(current, 'originalError')
+    if (nestedCause === cause || originalError === cause) {
+      return true
+    }
+
+    stack.push(nestedCause, originalError)
+  }
+
+  return false
+}
+
+function readErrorProperty(error: object, property: 'cause' | 'name' | 'originalError') {
+  try {
+    return (error as Record<typeof property, unknown>)[property]
+  } catch {
+    return undefined
+  }
+}
+
+function destroyAssetBody(body: AssetResponse['body']) {
+  if (!body || typeof body !== 'object') {
+    return
+  }
+
+  if (body instanceof Readable) {
+    body.destroy()
+    return
+  }
+
+  if (isReadableStream(body)) {
+    const result = body.cancel()
+    void result.catch(() => {})
+  }
+}
+
+function isReadableStream(body: object): body is ReadableStream {
+  return typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
 }
 
 function normalizeContentType(contentType: string | undefined): string | undefined {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { generateHS512JWK, SignedToken, signJWT, verifyJWT } from '@internal/auth'
 import dotenv from 'dotenv'
 import { FastifyInstance } from 'fastify'
@@ -36,6 +38,52 @@ function createMockRendererClient() {
     client,
     get,
   }
+}
+
+function requestRenderedImage(
+  port: number,
+  requestPath: string
+): Promise<{ body: string; ended: boolean; error?: Error; statusCode?: number }> {
+  return new Promise((resolve) => {
+    let settled = false
+    let body = ''
+
+    const finish = (result: { ended: boolean; error?: Error; statusCode?: number }) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      resolve({ body, ...result })
+    }
+
+    const request = http.get({ host: '127.0.0.1', path: requestPath, port }, (response) => {
+      response.setEncoding('utf8')
+      response.on('data', (chunk) => {
+        body += chunk
+      })
+      response.on('end', () => {
+        finish({ ended: true, statusCode: response.statusCode })
+      })
+      response.on('aborted', () => {
+        finish({
+          ended: false,
+          error: new Error('response aborted'),
+          statusCode: response.statusCode,
+        })
+      })
+      response.on('error', (error) => {
+        finish({ ended: false, error, statusCode: response.statusCode })
+      })
+    })
+
+    request.setTimeout(5000, () => {
+      request.destroy(new Error('Timed out waiting for render response'))
+    })
+    request.on('error', (error) => {
+      finish({ ended: false, error })
+    })
+  })
 }
 
 describe('image rendering routes', () => {
@@ -78,7 +126,6 @@ describe('image rendering routes', () => {
     expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
       expect.objectContaining({
-        responseType: 'stream',
         signal: expect.any(AbortSignal),
       })
     )
@@ -91,6 +138,9 @@ describe('image rendering routes', () => {
     const response = await appInstance.inject({
       method: 'GET',
       url: '/render/image/public/public-bucket-2/favicon.ico?width=100&height=100',
+      headers: {
+        accept: 'image/avif,image/webp',
+      },
     })
 
     expect(response.statusCode).toBe(200)
@@ -98,10 +148,53 @@ describe('image rendering routes', () => {
     expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fill/plain/local:///${projectRoot}/data/sadcat.jpg`,
       expect.objectContaining({
-        responseType: 'stream',
+        headers: {
+          accept: 'image/avif,image/webp',
+        },
         signal: expect.any(AbortSignal),
       })
     )
+  })
+
+  it('aborts the route response when the rendered body errors after streaming starts', async () => {
+    let pushed = false
+    const renderedBody = new Readable({
+      read() {
+        if (pushed) {
+          return
+        }
+
+        pushed = true
+        this.push('partial-body')
+        setImmediate(() => this.destroy(new Error('caller stopped')))
+      },
+    })
+    const get = vi.fn().mockResolvedValue({
+      data: renderedBody,
+      status: 200,
+      headers: {
+        'content-type': 'image/png',
+      },
+    })
+    const client: ReturnType<ImageRenderer['getClient']> = { get }
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(client)
+    await appInstance.listen({ host: '127.0.0.1', port: 0 })
+
+    const address = appInstance.server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected Fastify to listen on a TCP port')
+    }
+
+    const response = await requestRenderedImage(
+      (address as AddressInfo).port,
+      '/render/image/public/public-bucket-2/favicon.ico?width=100&height=100'
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe('partial-body')
+    expect(response.ended).toBe(false)
+    expect(response.error).toBeInstanceOf(Error)
+    expect(get).toHaveBeenCalledTimes(1)
   })
 
   it('will render a public image in all supported formats', async () => {
@@ -121,7 +214,6 @@ describe('image rendering routes', () => {
       expect(getSpy).toHaveBeenCalledWith(
         `/public/height:100/width:100/resizing_type:fill${expectFormat}/plain/local:///${projectRoot}/data/sadcat.jpg`,
         expect.objectContaining({
-          responseType: 'stream',
           signal: expect.any(AbortSignal),
         })
       )
@@ -168,7 +260,6 @@ describe('image rendering routes', () => {
     expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
       expect.objectContaining({
-        responseType: 'stream',
         signal: expect.any(AbortSignal),
       })
     )
@@ -217,7 +308,6 @@ describe('image rendering routes', () => {
     expect(getSpy).toHaveBeenCalledWith(
       `/public/height:100/width:100/resizing_type:fit/plain/local:///${projectRoot}/data/sadcat.jpg`,
       expect.objectContaining({
-        responseType: 'stream',
         signal: expect.any(AbortSignal),
       })
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

Axios and its retry package are used in image renderer.

## What is the new behavior?

They are both replaced by native fetch.

## Additional context

Add coverage.
Enable render acceptance tests and pass private asset endpoint for container to container access. Extracted to https://github.com/supabase/storage/pull/1079