### PR TITLE
fix: add auth schemes for open api spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:integration:coverage": "vitest run --coverage --config vitest.integration.config.ts",
-    "test": "npm run infra:restart && npm run test:dummy-data && npm run test:integration",
+    "test": "npm run infra:restart && npm run test:dummy-data && npm run test:integration && npm run test:unit",
     "test:oriole": "npm run infra:restart:oriole && npm run test:dummy-data && npm run test:integration",
     "test:coverage": "npm run infra:restart && npm run test:dummy-data && npm run test:integration:coverage",
     "test:coverage:ci": "npm run infra:restart:ci && npm run test:dummy-data && npm run test:integration:coverage",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:integration:coverage": "vitest run --coverage --config vitest.integration.config.ts",
-    "test": "npm run infra:restart && npm run test:dummy-data && npm run test:integration && npm run test:unit",
+    "test": "npm run infra:restart && npm run test:dummy-data && npm run test:unit && npm run test:integration",
     "test:oriole": "npm run infra:restart:oriole && npm run test:dummy-data && npm run test:integration",
     "test:coverage": "npm run infra:restart && npm run test:dummy-data && npm run test:integration:coverage",
     "test:coverage:ci": "npm run infra:restart:ci && npm run test:dummy-data && npm run test:integration:coverage",

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -25,6 +25,15 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
           description: 'Admin API documentation for Supabase Storage',
           version,
         },
+        components: {
+          securitySchemes: {
+            apiKeyAuth: {
+              type: 'apiKey',
+              in: 'header',
+              name: 'ApiKey',
+            },
+          },
+        },
         tags: [
           { name: 'tenant', description: 'Tenant management' },
           { name: 'object', description: 'Object management' },

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,15 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
           description: 'API documentation for Supabase Storage',
           version,
         },
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'jwt',
+            },
+          },
+        },
         tags: [
           { name: 'object', description: 'Object end-points' },
           { name: 'bucket', description: 'Bucket end-points' },

--- a/src/http/plugins/apikey.ts
+++ b/src/http/plugins/apikey.ts
@@ -1,7 +1,8 @@
+import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig } from '../../config'
 
-export default fastifyPlugin(
+const apiKeyPlugin = fastifyPlugin(
   async (fastify) => {
     const { adminApiKeys } = getConfig()
     const apiKeys = new Set(adminApiKeys.split(','))
@@ -13,3 +14,11 @@ export default fastifyPlugin(
   },
   { name: 'auth-admin-api-key' }
 )
+
+export function registerApiKeyAuth(fastify: FastifyInstance) {
+  fastify.addHook('onRoute', (routeOptions) => {
+    routeOptions.schema = routeOptions.schema || {}
+    routeOptions.schema.security = [{ apiKeyAuth: [] }]
+  })
+  fastify.register(apiKeyPlugin)
+}

--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -1,6 +1,7 @@
 import { verifyJWT, verifyJWTWithCache } from '@internal/auth'
 import { getJwtSecret } from '@internal/database'
 import { ERRORS } from '@internal/errors'
+import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import { JWTPayload } from 'jose'
 import { getConfig } from '../../config'
@@ -27,7 +28,7 @@ const { jwtCachingEnabled } = getConfig()
 
 const BEARER = /^Bearer\s+/i
 
-export const jwt = fastifyPlugin<JWTPluginOptions>(
+const jwtPlugin = fastifyPlugin<JWTPluginOptions>(
   async (fastify, opts) => {
     fastify.decorateRequest('jwt', '')
     fastify.decorateRequest('jwtPayload', undefined)
@@ -96,3 +97,11 @@ export const enforceJwtRole = fastifyPlugin<EnforceJWTRoleOptions>(
   },
   { name: 'allow-invalid-jwt' }
 )
+
+export function registerJwtAuth(fastify: FastifyInstance, opts: JWTPluginOptions = {}) {
+  fastify.addHook('onRoute', (routeOptions) => {
+    routeOptions.schema = routeOptions.schema || {}
+    routeOptions.schema.security = [{ bearerAuth: [] }]
+  })
+  fastify.register(jwtPlugin, opts)
+}

--- a/src/http/routes/admin/jwks.ts
+++ b/src/http/routes/admin/jwks.ts
@@ -4,7 +4,7 @@ import { logSchema } from '@internal/monitoring'
 import { JwksRollUrlSigningKey } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const addSchema = {
   body: {
@@ -105,7 +105,7 @@ function validateAddJwkRequest({ jwk, kind }: JwksAddRequestInterface['Body']): 
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.post<JwksAddRequestInterface>(
     '/:tenantId/jwks',

--- a/src/http/routes/admin/metrics.ts
+++ b/src/http/routes/admin/metrics.ts
@@ -1,7 +1,7 @@
 import { getMetricsConfig, setMetricsEnabled } from '@internal/monitoring/metrics'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const updateMetricsConfigSchema = {
   body: {
@@ -28,7 +28,7 @@ interface UpdateMetricsConfigRequest extends RequestGenericInterface {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.get('/config', { schema: { tags: ['metrics'] } }, async (_request, reply) => {
     return reply.send({

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -8,7 +8,7 @@ import { PG_BOSS_SCHEMA, Queue } from '@internal/queue'
 import { RunMigrationsOnTenants } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { getConfig } from '../../../config'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const { pgQueueEnable } = getConfig()
 const migrationQueueName = RunMigrationsOnTenants.getQueueName()
@@ -20,7 +20,7 @@ interface FailedMigrationsRequest extends RequestGenericInterface {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.post('/migrate/fleet', { schema: { tags: ['migration'] } }, async (req, reply) => {
     if (!pgQueueEnable) {

--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -4,7 +4,7 @@ import { ObjectScanner } from '@storage/scanner/scanner'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FastifyReply } from 'fastify/types/reply'
 import { dbSuperUser, storage } from '../../plugins'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const listOrphanedObjects = {
   description: 'List Orphaned Objects',
@@ -72,7 +72,7 @@ interface SyncOrphanObjectsRequest extends RequestGenericInterface {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
   fastify.register(dbSuperUser, {
     disableHostCheck: true,
     maxConnections: 5,

--- a/src/http/routes/admin/pprof.test.ts
+++ b/src/http/routes/admin/pprof.test.ts
@@ -34,7 +34,7 @@ vi.mock('@platformatic/globals', () => ({
 }))
 
 vi.mock('../../plugins/apikey', () => ({
-  async default() {},
+  async registerApiKeyAuth() {},
 }))
 
 vi.mock('@internal/monitoring/pprof/multipart', async (importOriginal) => {

--- a/src/http/routes/admin/pprof.ts
+++ b/src/http/routes/admin/pprof.ts
@@ -28,7 +28,7 @@ import type {
 import { RuntimeApiClient } from '@platformatic/control'
 import { FastifyInstance, FastifyReply, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const CPU_PROFILE_SECONDS_DEFAULT = 10
 const HEAP_PROFILE_SECONDS_DEFAULT = 10
@@ -311,7 +311,7 @@ async function stopActivePprofSessions(client: ProfilingRuntimeApiClient) {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
   fastify.addHook('onClose', async () => {
     if (activePprofSessions.size === 0) {
       return

--- a/src/http/routes/admin/queue.ts
+++ b/src/http/routes/admin/queue.ts
@@ -3,7 +3,7 @@ import { MoveJobs, UpgradePgBossV10 } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const { pgQueueEnable } = getConfig()
 
@@ -31,7 +31,7 @@ interface MoveJobsRequestInterface extends RequestGenericInterface {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.post('/migrate/pgboss-v10', { schema: { tags: ['queue'] } }, async (req, reply) => {
     if (!pgQueueEnable) {

--- a/src/http/routes/admin/s3.ts
+++ b/src/http/routes/admin/s3.ts
@@ -3,7 +3,7 @@ import { ERRORS } from '@internal/errors'
 import { isUuid } from '@storage/limits'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 
 const createCredentialsSchema = {
   description: 'Create S3 Credentials',
@@ -82,7 +82,7 @@ interface ListCredentialsRequest extends RequestGenericInterface {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.post<CreateCredentialsRequest>(
     '/:tenantId/credentials',

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -22,7 +22,7 @@ import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig, JwksConfigKey } from '../../../config'
 import { dbSuperUser, storage } from '../../plugins'
-import apiKey from '../../plugins/apikey'
+import { registerApiKeyAuth } from '../../plugins/apikey'
 import { registerJsonParserAllowingEmptyBody } from '../../plugins/empty-json-body'
 
 const patchSchema = {
@@ -143,7 +143,7 @@ async function markTenantMigrationsCompleted(tenantId: string) {
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(apiKey)
+  registerApiKeyAuth(fastify)
 
   fastify.get('/', { schema: { tags: ['tenant'] } }, async () => {
     const tenants = await multitenantKnex('tenants').select()

--- a/src/http/routes/bucket/index.ts
+++ b/src/http/routes/bucket/index.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify'
-import { db, jwt, storage } from '../../plugins'
+import { db, registerJwtAuth, storage } from '../../plugins'
 import createBucket from './createBucket'
 import deleteBucket from './deleteBucket'
 import emptyBucket from './emptyBucket'
@@ -8,7 +8,7 @@ import getBucket from './getBucket'
 import updateBucket from './updateBucket'
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(jwt)
+  registerJwtAuth(fastify)
   fastify.register(db)
   fastify.register(storage)
 

--- a/src/http/routes/cdn/index.ts
+++ b/src/http/routes/cdn/index.ts
@@ -1,13 +1,13 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
-import { db, jwt, requireTenantFeature, storage } from '../../plugins'
+import { db, registerJwtAuth, requireTenantFeature, storage } from '../../plugins'
 import purgeCache from './purgeCache'
 
 const { dbServiceRole } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(async function authenticated(fastify) {
-    fastify.register(jwt, {
+    registerJwtAuth(fastify, {
       enforceJwtRoles: [dbServiceRole],
     })
     fastify.register(requireTenantFeature('purgeCache'))

--- a/src/http/routes/health/index.ts
+++ b/src/http/routes/health/index.ts
@@ -1,9 +1,9 @@
 import { FastifyInstance } from 'fastify'
-import { dbSuperUser, jwt, storage } from '../../plugins'
+import { dbSuperUser, registerJwtAuth, storage } from '../../plugins'
 import healthcheck from './healthcheck'
 
 export default async function routes(fastify: FastifyInstance) {
-  fastify.register(jwt)
+  registerJwtAuth(fastify)
   fastify.register(dbSuperUser)
   fastify.register(storage)
   fastify.register(healthcheck)

--- a/src/http/routes/iceberg/index.ts
+++ b/src/http/routes/iceberg/index.ts
@@ -1,7 +1,13 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
 import { setErrorHandler } from '../../error-handler'
-import { db, icebergRestCatalog, jwt, requireTenantFeature, storage } from '../../plugins'
+import {
+  db,
+  icebergRestCatalog,
+  registerJwtAuth,
+  requireTenantFeature,
+  storage,
+} from '../../plugins'
 import bucket from './bucket'
 import catalogue from './catalog'
 import namespace from './namespace'
@@ -16,7 +22,7 @@ export default async function routes(fastify: FastifyInstance) {
   }
 
   fastify.register(async function authenticated(fastify) {
-    fastify.register(jwt, {
+    registerJwtAuth(fastify, {
       enforceJwtRoles: [dbServiceRole],
     })
 

--- a/src/http/routes/object/index.ts
+++ b/src/http/routes/object/index.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify'
-import { db, dbSuperUser, jwt, storage } from '../../plugins'
+import { db, dbSuperUser, registerJwtAuth, storage } from '../../plugins'
 import copyObject from './copyObject'
 import createObject from './createObject'
 import deleteObject from './deleteObject'
@@ -22,7 +22,7 @@ import uploadSignedObject from './uploadSignedObject'
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(async function authenticated(fastify) {
-    fastify.register(jwt)
+    registerJwtAuth(fastify)
     fastify.register(db)
     fastify.register(storage)
 

--- a/src/http/routes/render/index.ts
+++ b/src/http/routes/render/index.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
-import { db, dbSuperUser, jwt, requireTenantFeature, storage } from '../../plugins'
+import { db, dbSuperUser, registerJwtAuth, requireTenantFeature, storage } from '../../plugins'
 import { rateLimiter } from './rate-limiter'
 import renderAuthenticatedImage from './renderAuthenticatedImage'
 import renderPublicImage from './renderPublicImage'
@@ -20,7 +20,7 @@ export default async function routes(fastify: FastifyInstance) {
       fastify.register(rateLimiter)
     }
 
-    fastify.register(jwt)
+    registerJwtAuth(fastify)
     fastify.register(db)
     fastify.register(storage)
 

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -15,7 +15,7 @@ import fastifyPlugin from 'fastify-plugin'
 import * as http from 'http'
 import type { ServerRequest as Request } from 'srvx'
 import { getConfig } from '../../../config'
-import { db, dbSuperUser, jwt, storage } from '../../plugins'
+import { db, dbSuperUser, registerJwtAuth, storage } from '../../plugins'
 import { ROUTE_OPERATIONS } from '../operations'
 import {
   generateUrl,
@@ -185,7 +185,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   // authenticated routes
   fastify.register(async (fastify) => {
-    fastify.register(jwt)
+    registerJwtAuth(fastify)
     fastify.register(db)
     fastify.register(storage)
 

--- a/src/http/routes/vector/index.ts
+++ b/src/http/routes/vector/index.ts
@@ -5,7 +5,7 @@ import { setErrorHandler } from '../../error-handler'
 import {
   dbSuperUser,
   enforceJwtRole,
-  jwt,
+  registerJwtAuth,
   requireTenantFeature,
   s3vector,
   signatureV4,
@@ -42,7 +42,7 @@ export default async function routes(fastify: FastifyInstance) {
       skipIfJwtToken: true,
     })
 
-    fastify.register(jwt, {
+    registerJwtAuth(fastify, {
       skipIfAlreadyAuthenticated: true,
     })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix to open api specs

## What is the current behavior?

Open API spec does not include auth schemes. This makes the swagger UI unusable as you cannot authenticate

## What is the new behavior?

Add auth schemes to all authenticated endpoints (api and admin api). This makes the open api json more accurate and also enables authentication in the swagger UI when developing which allows executing endpoints directly in the swagger UI (http://localhost:5000/documentation)
