### PR TITLE
feat: add error code, normalize more errors, and exclude stack traces from 4xx errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -116,7 +116,7 @@ type StorageConfigType = {
   requestXForwardedHostRegExp?: string
   requestAllowXForwardedPrefix?: boolean
   storagePublicUrl?: string
-  logLevel?: string
+  logLevel: string
   logflareEnabled?: boolean
   logflareApiKey?: string
   logflareSourceToken?: string

--- a/src/http/plugins/xml.ts
+++ b/src/http/plugins/xml.ts
@@ -63,7 +63,7 @@ export const xmlParser = fastifyPlugin(
             (err: Error | null, parsed: unknown) => {
               if (err) {
                 const parseError: RequestError = ERRORS.InvalidRequest(
-                  new Error(`Invalid XML payload: ${err.message}`)
+                  `Invalid XML payload: ${err.message}`
                 )
                 parseError.statusCode = 400
                 done(parseError)

--- a/src/http/plugins/xml.ts
+++ b/src/http/plugins/xml.ts
@@ -1,4 +1,5 @@
 import accepts from '@fastify/accepts'
+import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import xml from 'xml2js'
@@ -61,7 +62,9 @@ export const xmlParser = fastifyPlugin(
             },
             (err: Error | null, parsed: unknown) => {
               if (err) {
-                const parseError: RequestError = new Error(`Invalid XML payload: ${err.message}`)
+                const parseError: RequestError = ERRORS.InvalidRequest(
+                  new Error(`Invalid XML payload: ${err.message}`)
+                )
                 parseError.statusCode = 400
                 done(parseError)
                 return

--- a/src/http/routes/iceberg/namespace.ts
+++ b/src/http/routes/iceberg/namespace.ts
@@ -67,7 +67,7 @@ const dropNamespaceSchema = {
     },
     required: ['prefix', 'namespace'],
   },
-  summary: 'Create a namespace',
+  summary: 'Drop a namespace',
 } as const
 
 interface createNamespaceSchemaRequest extends AuthenticatedRequest {

--- a/src/http/routes/iceberg/table.ts
+++ b/src/http/routes/iceberg/table.ts
@@ -172,7 +172,7 @@ const listTableSchema = {
     },
     required: ['prefix', 'namespace'],
   },
-  summary: 'Create a namespace',
+  summary: 'Create a table',
 } as const
 
 const loadTableSchema = {

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -1,4 +1,5 @@
 import fastifyMultipart from '@fastify/multipart'
+import { ERRORS } from '@internal/errors'
 import { FastifyInstance, RouteHandlerMethod } from 'fastify'
 import { JSONSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
@@ -76,12 +77,13 @@ export default async function routes(fastify: FastifyInstance) {
                 const isValid = compiler(data)
 
                 if (!isValid) {
-                  const validationError = new Error('Invalid request') as Error & {
+                  const validationError = ERRORS.InvalidRequest(
+                    new Error('Invalid request')
+                  ) as Error & {
                     validation?: unknown
-                    statusCode?: number
                   }
+                  // validation property is required to send correct reply in error-handler.ts
                   validationError.validation = compiler.errors
-                  validationError.statusCode = 400
                   throw validationError
                 }
 

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -77,9 +77,7 @@ export default async function routes(fastify: FastifyInstance) {
                 const isValid = compiler(data)
 
                 if (!isValid) {
-                  const validationError = ERRORS.InvalidRequest(
-                    new Error('Invalid request')
-                  ) as Error & {
+                  const validationError = ERRORS.InvalidRequest('Invalid request') as Error & {
                     validation?: unknown
                   }
                   // validation property is required to send correct reply in error-handler.ts

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -157,7 +157,7 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
         project: req.upload.tenantId,
         reqId: req.upload.reqId,
         sbReqId: req.upload.sbReqId,
-        error: e,
+        error: ERRORS.InvalidRequest(e as Error),
       })
     }
   }

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -157,7 +157,7 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
         project: req.upload.tenantId,
         reqId: req.upload.reqId,
         sbReqId: req.upload.sbReqId,
-        error: ERRORS.InvalidRequest(e as Error),
+        error: ERRORS.InvalidRequest('Failed to parse metadata', e as Error),
       })
     }
   }

--- a/src/internal/errors/codes.test.ts
+++ b/src/internal/errors/codes.test.ts
@@ -1,0 +1,111 @@
+import { IcebergError, IcebergErrorType } from '@storage/protocols/iceberg/catalog/errors'
+import { ErrorCode, normalizeRawError } from './codes'
+import { StorageBackendError } from './storage-error'
+
+describe('normalizeRawError', () => {
+  it('includes stack for 5xx errors', () => {
+    const error = new StorageBackendError({
+      code: ErrorCode.InternalError,
+      httpStatusCode: 500,
+      message: 'Internal server error',
+    })
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.statusCode).toBe(500)
+    expect(result.errorCode).toBe(ErrorCode.InternalError)
+    expect(result.stack).toBeTruthy()
+  })
+
+  it('excludes stack for 4xx errors', () => {
+    const error = new StorageBackendError({
+      code: ErrorCode.InvalidRequest,
+      httpStatusCode: 400,
+      message: 'Bad request',
+    })
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.statusCode).toBe(400)
+    expect(result.errorCode).toBe(ErrorCode.InvalidRequest)
+    expect(result.stack).toBe('')
+  })
+
+  it('includes stack for UnknownError regardless of status code', () => {
+    const error = new Error('Something unexpected')
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.errorCode).toBe(ErrorCode.UnknownError)
+    expect(result.stack).toBeTruthy()
+  })
+
+  it('includes stack when log level is debug', () => {
+    const error = new StorageBackendError({
+      code: ErrorCode.InvalidRequest,
+      httpStatusCode: 400,
+      message: 'Bad request',
+    })
+
+    const result = normalizeRawError(error, 'debug')
+
+    expect(result.stack).toBeTruthy()
+  })
+
+  it('recognizes error codes by value in KNOWN_ERROR_CODES', () => {
+    const error = new Error('test')
+    Object.assign(error, { code: ErrorCode.S3InvalidAccessKeyId })
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.errorCode).toBe(ErrorCode.S3InvalidAccessKeyId)
+  })
+
+  it('falls back to UnknownError when code is not in KNOWN_ERROR_CODES', () => {
+    const error = new Error('test')
+    Object.assign(error, { code: 'UNKNOWN_CODE' })
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.errorCode).toBe(ErrorCode.UnknownError)
+  })
+
+  it('maps Fastify error codes to ErrorCode', () => {
+    const error = new Error('Validation failed')
+    Object.assign(error, { code: 'FST_ERR_VALIDATION', statusCode: 400 })
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.errorCode).toBe(ErrorCode.InvalidRequest)
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('handles IcebergError with error property', () => {
+    const error = new IcebergError(
+      'Namespace not found',
+      IcebergErrorType.NoSuchNamespaceException,
+      400
+    )
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.errorCode).toBe(IcebergErrorType.NoSuchNamespaceException)
+    expect(result.statusCode).toBe(400)
+  })
+
+  it('handles non-Error objects', () => {
+    const result = normalizeRawError({ some: 'object' }, 'info')
+
+    expect(result).toHaveProperty('raw')
+    expect(result).not.toHaveProperty('errorCode')
+  })
+
+  it('handles unstringifiable errors', () => {
+    const circular: any = {}
+    circular.self = circular
+
+    const result = normalizeRawError(circular, 'info')
+
+    expect(result.raw).toBe('Failed to stringify error')
+  })
+})

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -149,11 +149,11 @@ export const ERRORS = {
       originalError: opts?.error,
     }),
 
-  InvalidRequest: (error: Error) =>
+  InvalidRequest: (message: string, error?: Error) =>
     new StorageBackendError({
       code: ErrorCode.InvalidRequest,
       httpStatusCode: 400,
-      message: error.message || 'Invalid Request',
+      message: message || 'Invalid Request',
       originalError: error,
     }),
 
@@ -565,8 +565,8 @@ const ERROR_CODE_MAP: Record<string, ErrorCode> = {
   FST_ERR_CTP_EMPTY_JSON_BODY: ErrorCode.InvalidRequest,
   FST_ERR_CTP_INVALID_JSON_BODY: ErrorCode.InvalidRequest,
   FST_ERR_CTP_INVALID_CONTENT_LENGTH: ErrorCode.InvalidRequest,
-  FST_ERR_CTP_INVALID_MEDIA_TYPE: ErrorCode.InvalidRequest,
-  FST_ERR_CTP_BODY_TOO_LARGE: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_INVALID_MEDIA_TYPE: ErrorCode.InvalidMimeType,
+  FST_ERR_CTP_BODY_TOO_LARGE: ErrorCode.EntityTooLarge,
 }
 
 export function isStorageError(errorType: ErrorCode, error: unknown): error is StorageBackendError {
@@ -584,10 +584,12 @@ function hasStringErrorCode(error: Error): error is Error & { code: string } {
 function getErrorCode(error: Error): string {
   if (error instanceof IcebergError && error.error) {
     return error.error
-  } else if (hasStringErrorCode(error)) {
+  }
+  if (hasStringErrorCode(error)) {
     if (KNOWN_ERROR_CODES.has(error.code)) {
       return error.code as ErrorCode
-    } else if (error.code in ERROR_CODE_MAP) {
+    }
+    if (error.code in ERROR_CODE_MAP) {
       return ERROR_CODE_MAP[error.code]
     }
   }
@@ -597,9 +599,11 @@ function getErrorCode(error: Error): string {
 function getErrorStatusCode(error: Error): number {
   if (error instanceof StorageBackendError && error.httpStatusCode) {
     return error.httpStatusCode
-  } else if (error instanceof IcebergError) {
+  }
+  if (error instanceof IcebergError) {
     return error.code
-  } else if (hasNumericStatusCode(error)) {
+  }
+  if (hasNumericStatusCode(error)) {
     // Fastify validation errors include statusCode we can use
     return error.statusCode
   }

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -59,6 +59,7 @@ export enum ErrorCode {
   NoAvailableShard = 'NoAvailableShard',
   ShardNotFound = 'ShardNotFound',
 }
+const KNOWN_ERROR_CODES = new Set<string>(Object.values(ErrorCode))
 
 export const ERRORS = {
   BucketNotEmpty: (bucket: string, e?: Error) =>
@@ -581,37 +582,36 @@ function hasStringErrorCode(error: Error): error is Error & { code: string } {
 }
 
 function getErrorCode(error: Error): string {
-  let code: string = ErrorCode.UnknownError
   if (error instanceof IcebergError && error.error) {
-    code = error.error
+    return error.error
   } else if (hasStringErrorCode(error)) {
-    if (error.code in ErrorCode) {
-      code = error.code as ErrorCode
+    if (KNOWN_ERROR_CODES.has(error.code)) {
+      return error.code as ErrorCode
     } else if (error.code in ERROR_CODE_MAP) {
-      code = ERROR_CODE_MAP[error.code]
+      return ERROR_CODE_MAP[error.code]
     }
   }
-  return code
+  return ErrorCode.UnknownError
 }
 
 function getErrorStatusCode(error: Error): number {
-  let statusCode = 0
   if (error instanceof StorageBackendError && error.httpStatusCode) {
-    statusCode = error.httpStatusCode
+    return error.httpStatusCode
   } else if (error instanceof IcebergError) {
-    statusCode = error.code
+    return error.code
   } else if (hasNumericStatusCode(error)) {
     // Fastify validation errors include statusCode we can use
-    statusCode = error.statusCode
+    return error.statusCode
   }
-  return statusCode
+  return 0
 }
 
 export function normalizeRawError(error: unknown, logLevel: string) {
   if (error instanceof Error) {
     const statusCode = getErrorStatusCode(error)
     const errorCode = getErrorCode(error)
-    const includeStack = logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
+    const includeStack =
+      logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
 
     return {
       raw: JSON.stringify(error),

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -611,10 +611,7 @@ export function normalizeRawError(error: unknown, logLevel: string) {
   if (error instanceof Error) {
     const statusCode = getErrorStatusCode(error)
     const errorCode = getErrorCode(error)
-    const includeStack =
-      logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
-        ? true
-        : false
+    const includeStack = logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
 
     return {
       raw: JSON.stringify(error),

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -1,3 +1,4 @@
+import { IcebergError } from '@storage/protocols/iceberg/catalog/errors'
 import { StorageBackendError } from './storage-error'
 
 export enum ErrorCode {
@@ -49,7 +50,7 @@ export enum ErrorCode {
   IcebergMaximumResourceLimit = 'IcebergMaximumResourceLimit',
   IcebergResourceNotEmpty = 'IcebergResourceNotEmpty',
   NoSuchCatalog = 'NoSuchCatalog',
-
+  UnknownError = 'UnknownError',
   S3VectorConflictException = 'ConflictException',
   S3VectorNotFoundException = 'NotFoundException',
   S3VectorBucketNotEmpty = 'VectorBucketNotEmpty',
@@ -145,6 +146,14 @@ export const ERRORS = {
       httpStatusCode: 400,
       message: opts?.message || `Invalid Parameter ${parameter}`,
       originalError: opts?.error,
+    }),
+
+  InvalidRequest: (error: Error) =>
+    new StorageBackendError({
+      code: ErrorCode.InvalidRequest,
+      httpStatusCode: 400,
+      message: error.message || 'Invalid Request',
+      originalError: error,
     }),
 
   InvalidJWT: (e?: Error) =>
@@ -550,30 +559,70 @@ export const ERRORS = {
   },
 }
 
-export function isStorageError(errorType: ErrorCode, error: any): error is StorageBackendError {
+const ERROR_CODE_MAP: Record<string, ErrorCode> = {
+  FST_ERR_VALIDATION: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_EMPTY_JSON_BODY: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_INVALID_JSON_BODY: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_INVALID_CONTENT_LENGTH: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_INVALID_MEDIA_TYPE: ErrorCode.InvalidRequest,
+  FST_ERR_CTP_BODY_TOO_LARGE: ErrorCode.InvalidRequest,
+}
+
+export function isStorageError(errorType: ErrorCode, error: unknown): error is StorageBackendError {
   return error instanceof StorageBackendError && error.code === errorType
 }
 
-function hasStatusCode(error: Error): error is Error & { statusCode: number } {
-  return 'statusCode' in error && typeof (error as any).statusCode === 'number'
+function hasNumericStatusCode(error: Error): error is Error & { statusCode: number } {
+  return 'statusCode' in error && typeof error.statusCode === 'number'
 }
 
-export function normalizeRawError(error: any) {
-  if (error instanceof Error) {
-    let statusCode = 0
-    if (error instanceof StorageBackendError && error.httpStatusCode) {
-      statusCode = error.httpStatusCode
-    } else if (hasStatusCode(error)) {
-      // Fastify validation errors include statusCode we can use
-      statusCode = error.statusCode
+function hasStringErrorCode(error: Error): error is Error & { code: string } {
+  return 'code' in error && typeof error.code === 'string'
+}
+
+function getErrorCode(error: Error): string {
+  let code: string = ErrorCode.UnknownError
+  if (error instanceof IcebergError && error.error) {
+    code = error.error
+  } else if (hasStringErrorCode(error)) {
+    if (error.code in ErrorCode) {
+      code = error.code as ErrorCode
+    } else if (error.code in ERROR_CODE_MAP) {
+      code = ERROR_CODE_MAP[error.code]
     }
+  }
+  return code
+}
+
+function getErrorStatusCode(error: Error): number {
+  let statusCode = 0
+  if (error instanceof StorageBackendError && error.httpStatusCode) {
+    statusCode = error.httpStatusCode
+  } else if (error instanceof IcebergError) {
+    statusCode = error.code
+  } else if (hasNumericStatusCode(error)) {
+    // Fastify validation errors include statusCode we can use
+    statusCode = error.statusCode
+  }
+  return statusCode
+}
+
+export function normalizeRawError(error: unknown, logLevel: string) {
+  if (error instanceof Error) {
+    const statusCode = getErrorStatusCode(error)
+    const errorCode = getErrorCode(error)
+    const includeStack =
+      logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
+        ? true
+        : false
 
     return {
       raw: JSON.stringify(error),
       name: error.name,
       message: error.message,
-      stack: error.stack,
+      stack: includeStack ? error.stack || '' : '',
       statusCode,
+      errorCode,
     }
   }
 

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -19,7 +19,7 @@ export const baseLogger = pino({
   transport: buildTransport(),
   serializers: {
     error(error) {
-      return normalizeRawError(error)
+      return normalizeRawError(error, logLevel)
     },
     res(reply: Pick<FastifyReply, 'statusCode'> & Partial<Pick<FastifyReply, 'getHeaders'>>) {
       const headers = typeof reply.getHeaders === 'function' ? reply.getHeaders() : {}

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -899,7 +899,7 @@ function decodeContinuationToken(token: string): ContinuationToken {
   for (const part of decodedParts) {
     const partMatch = part.match(/^(\S):(.*)/)
     if (!partMatch || partMatch.length !== 3 || !(partMatch[1] in CONTINUATION_TOKEN_PART_MAP)) {
-      throw new Error('Invalid continuation token')
+      throw ERRORS.InvalidParameter('continuation token')
     }
     result[CONTINUATION_TOKEN_PART_MAP[partMatch[1]]] = partMatch[2]
   }

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1467,7 +1467,7 @@ function decodeContinuationToken(token: string) {
   const decoded = Buffer.from(token, 'base64').toString().split(':')
 
   if (decoded.length === 0) {
-    throw new Error('Invalid continuation token')
+    throw ERRORS.InvalidParameter('continuation token')
   }
 
   return decoded[1]

--- a/src/storage/protocols/s3/signature-v4-stream.test.ts
+++ b/src/storage/protocols/s3/signature-v4-stream.test.ts
@@ -158,7 +158,7 @@ describe('ChunkSignatureV4Parser', () => {
       () => {
         parser.end('abc')
       },
-      /Header exceeds 2 bytes/
+      /header exceeded 2 bytes/
     )
   })
 
@@ -169,7 +169,7 @@ describe('ChunkSignatureV4Parser', () => {
       () => {
         parser.end('abc\r\n')
       },
-      /Header exceeds 2 bytes/
+      /header exceeded 2 bytes/
     )
   })
 

--- a/src/storage/protocols/s3/signature-v4-stream.ts
+++ b/src/storage/protocols/s3/signature-v4-stream.ts
@@ -324,18 +324,18 @@ export class ChunkSignatureV4Parser extends Transform {
       switch (this.state) {
         case 'HEADER':
           if (this.buffer.length > 0) {
-            throw ERRORS.InvalidRequest(new Error('Incomplete chunk header'))
+            throw ERRORS.InvalidRequest('Incomplete chunk header')
           }
           if (!this.completedFinalChunk) {
-            throw ERRORS.InvalidRequest(new Error('Missing final chunk'))
+            throw ERRORS.InvalidRequest('Missing final chunk')
           }
           break
         case 'DATA':
-          throw ERRORS.InvalidRequest(new Error('Unexpected end of chunk data'))
+          throw ERRORS.InvalidRequest('Unexpected end of chunk data')
         case 'FOOTER':
-          throw ERRORS.InvalidRequest(new Error('Missing CRLF after chunk data'))
+          throw ERRORS.InvalidRequest('Missing CRLF after chunk data')
         case 'TRAILER':
-          throw ERRORS.InvalidRequest(new Error('Incomplete trailer section'))
+          throw ERRORS.InvalidRequest('Incomplete trailer section')
       }
 
       callback()
@@ -351,7 +351,7 @@ export class ChunkSignatureV4Parser extends Transform {
       'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER',
     ]
     if (!validAlgorithms.includes(alg)) {
-      throw ERRORS.InvalidRequest(new Error(`Invalid streaming algorithm: ${alg}`))
+      throw ERRORS.InvalidRequest(`Invalid streaming algorithm: ${alg}`)
     }
   }
 
@@ -367,15 +367,15 @@ export class ChunkSignatureV4Parser extends Transform {
     if (signedHeaderParts.length === 2) {
       const [sizeHex, signature] = signedHeaderParts
       if (!CHUNK_SIZE_PATTERN.test(sizeHex) || !this.signaturePattern.test(signature)) {
-        throw ERRORS.InvalidRequest(new Error('Invalid chunk header'))
+        throw ERRORS.InvalidRequest('Invalid chunk header')
       }
       size = parseInt(sizeHex, 16)
       sig = signature
     } else if (signedHeaderParts.length > 2) {
-      throw ERRORS.InvalidRequest(new Error('Invalid chunk header'))
+      throw ERRORS.InvalidRequest('Invalid chunk header')
     } else {
       if (!CHUNK_SIZE_PATTERN.test(line)) {
-        throw ERRORS.InvalidRequest(new Error('Invalid chunk size'))
+        throw ERRORS.InvalidRequest('Invalid chunk size')
       }
       size = parseInt(line, 16)
       // signature required for signed algorithms
@@ -393,7 +393,7 @@ export class ChunkSignatureV4Parser extends Transform {
     if (this.buffer.length === 0) return false
 
     if (this.completedFinalChunk) {
-      throw ERRORS.InvalidRequest(new Error('Unexpected data after final chunk'))
+      throw ERRORS.InvalidRequest('Unexpected data after final chunk')
     }
 
     const idx = this.buffer.find(CRLF, this.headerSearchOffset)
@@ -475,7 +475,7 @@ export class ChunkSignatureV4Parser extends Transform {
 
     const footer = this.buffer.peek(CRLF.length)
     if (footer[0] !== 0x0d || footer[1] !== 0x0a) {
-      throw ERRORS.InvalidRequest(new Error('Missing CRLF after chunk data'))
+      throw ERRORS.InvalidRequest('Missing CRLF after chunk data')
     }
 
     this.emitCurrentSignatureForVerification()

--- a/src/storage/protocols/s3/signature-v4-stream.ts
+++ b/src/storage/protocols/s3/signature-v4-stream.ts
@@ -37,7 +37,7 @@ class SegmentedBufferQueue {
     }
 
     if (length > this.totalLength) {
-      throw new Error('Insufficient buffered data')
+      throw ERRORS.InternalError(undefined, 'Insufficient buffered data')
     }
 
     const head = this.segments[this.headIndex]
@@ -324,18 +324,18 @@ export class ChunkSignatureV4Parser extends Transform {
       switch (this.state) {
         case 'HEADER':
           if (this.buffer.length > 0) {
-            throw new Error('Incomplete chunk header')
+            throw ERRORS.InvalidRequest(new Error('Incomplete chunk header'))
           }
           if (!this.completedFinalChunk) {
-            throw new Error('Missing final chunk')
+            throw ERRORS.InvalidRequest(new Error('Missing final chunk'))
           }
           break
         case 'DATA':
-          throw new Error('Unexpected end of chunk data')
+          throw ERRORS.InvalidRequest(new Error('Unexpected end of chunk data'))
         case 'FOOTER':
-          throw new Error('Missing CRLF after chunk data')
+          throw ERRORS.InvalidRequest(new Error('Missing CRLF after chunk data'))
         case 'TRAILER':
-          throw new Error('Incomplete trailer section')
+          throw ERRORS.InvalidRequest(new Error('Incomplete trailer section'))
       }
 
       callback()
@@ -351,7 +351,7 @@ export class ChunkSignatureV4Parser extends Transform {
       'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER',
     ]
     if (!validAlgorithms.includes(alg)) {
-      throw new Error(`Invalid streaming algorithm: ${alg}`)
+      throw ERRORS.InvalidRequest(new Error(`Invalid streaming algorithm: ${alg}`))
     }
   }
 
@@ -367,15 +367,15 @@ export class ChunkSignatureV4Parser extends Transform {
     if (signedHeaderParts.length === 2) {
       const [sizeHex, signature] = signedHeaderParts
       if (!CHUNK_SIZE_PATTERN.test(sizeHex) || !this.signaturePattern.test(signature)) {
-        throw new Error('Invalid chunk header')
+        throw ERRORS.InvalidRequest(new Error('Invalid chunk header'))
       }
       size = parseInt(sizeHex, 16)
       sig = signature
     } else if (signedHeaderParts.length > 2) {
-      throw new Error('Invalid chunk header')
+      throw ERRORS.InvalidRequest(new Error('Invalid chunk header'))
     } else {
       if (!CHUNK_SIZE_PATTERN.test(line)) {
-        throw new Error('Invalid chunk size')
+        throw ERRORS.InvalidRequest(new Error('Invalid chunk size'))
       }
       size = parseInt(line, 16)
       // signature required for signed algorithms
@@ -383,7 +383,7 @@ export class ChunkSignatureV4Parser extends Transform {
         this.alg === 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD' ||
         this.alg === 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER'
       ) {
-        throw new Error('Missing chunk signature')
+        throw ERRORS.InvalidSignature('Missing chunk signature')
       }
     }
     return { size, signature: sig }
@@ -393,7 +393,7 @@ export class ChunkSignatureV4Parser extends Transform {
     if (this.buffer.length === 0) return false
 
     if (this.completedFinalChunk) {
-      throw new Error('Unexpected data after final chunk')
+      throw ERRORS.InvalidRequest(new Error('Unexpected data after final chunk'))
     }
 
     const idx = this.buffer.find(CRLF, this.headerSearchOffset)
@@ -401,21 +401,21 @@ export class ChunkSignatureV4Parser extends Transform {
       const effectiveHeaderLength =
         this.buffer.length - (this.buffer.peekLastByte() === CRLF[0] ? 1 : 0)
       if (effectiveHeaderLength > this.maxHeaderLength) {
-        throw new Error(`Header exceeds ${this.maxHeaderLength} bytes`)
+        throw ERRORS.EntityTooLarge(undefined, 'chunk header', `${this.maxHeaderLength} bytes`)
       }
       this.headerSearchOffset = Math.max(0, this.buffer.length - (CRLF.length - 1))
       return false
     }
 
     if (idx > this.maxHeaderLength) {
-      throw new Error(`Header exceeds ${this.maxHeaderLength} bytes`)
+      throw ERRORS.EntityTooLarge(undefined, 'chunk header', `${this.maxHeaderLength} bytes`)
     }
 
     const line = this.buffer.readUtf8(idx)
     const { size, signature } = this.parseHeaderLine(line)
 
     if (size > this.opts.maxChunkSize) {
-      throw new Error(`Chunk size exceeds ${this.opts.maxChunkSize} bytes`)
+      throw ERRORS.EntityTooLarge(undefined, 'chunk', `${this.opts.maxChunkSize} bytes`)
     }
 
     this.currentChunkSize = size
@@ -460,7 +460,7 @@ export class ChunkSignatureV4Parser extends Transform {
     this.dataRead += toConsume
 
     if (this.dataRead > this.opts.maxChunkSize) {
-      throw new Error(`Chunk size exceeds ${this.opts.maxChunkSize} bytes`)
+      throw ERRORS.EntityTooLarge(undefined, 'chunk', `${this.opts.maxChunkSize} bytes`)
     }
 
     if (this.bytesRemaining === 0) {
@@ -475,7 +475,7 @@ export class ChunkSignatureV4Parser extends Transform {
 
     const footer = this.buffer.peek(CRLF.length)
     if (footer[0] !== 0x0d || footer[1] !== 0x0a) {
-      throw new Error('Missing CRLF after chunk data')
+      throw ERRORS.InvalidRequest(new Error('Missing CRLF after chunk data'))
     }
 
     this.emitCurrentSignatureForVerification()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

- logs all stack traces. 404, 400, etc are very noisy and not useful and loading all stack traces adds up to real performance impact at scale
- error code can only be accessed via error.raw
- several errors were missing data (error code and/or status code)

## What is the new behavior?

Only log stack traces for http errors >= 500 and unknown errors

Add `errorCode` to logged errors to expose the [error codes defined in the docs](https://supabase.com/docs/guides/storage/debugging/error-codes?queryGroups=language&language=js#storage-error-codes). Prior to this change these can only be accessed by digging in to error.raw

### Normalized Errors

- Missing error code. These errors had no error code
  - TUS metadata parse error = InvalidRequest
  - S3 continuation error = InvalidParameter
  - S3 invalid XML = InvalidRequest
  - S3 AJV validation errors = InvalidRequest
  - S3 stream errors = various... see: signature-v4-stream.ts
  - Iceberg errors
    - Map values from iceberg error format which differs from other storage api errors
- Fastify Validation (map to InvalidRequest)
  - FST_ERR_VALIDATION
  - FST_ERR_CTP_INVALID_JSON_BODY
  - FST_ERR_CTP_INVALID_CONTENT_LENGTH
  - FST_ERR_CTP_INVALID_MEDIA_TYPE
  - FST_ERR_CTP_BODY_TOO_LARGE
