### PR TITLE
fix: prevent double serialization for req

### DIFF
--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -8,7 +8,13 @@ function createApp(lines: string[]) {
   return Fastify({
     disableRequestLogging: true,
     loggerInstance: pino(
-      { level: 'info' },
+      {
+        level: 'info',
+        serializers: {
+          req: (request) => request,
+          res: (reply) => reply,
+        },
+      },
       new Writable({
         write(chunk, _encoding, callback) {
           lines.push(chunk.toString())
@@ -31,7 +37,10 @@ describe('log-request plugin', () => {
     await app.register(requestContext)
     await app.register(logRequest({}))
 
-    app.get('/request-log', async () => {
+    app.get('/request-log', async (_request, reply) => {
+      reply.header('etag', 'test-etag')
+      reply.header('x-secret-response', 'hidden-response')
+
       return { ok: true }
     })
   })
@@ -115,5 +124,69 @@ describe('log-request plugin', () => {
     expect(requestLogLine).toBeDefined()
     expect(requestLogLine).toContain('"tenantId":"tenant-a"')
     expect(requestLogLine).toContain('"project":"tenant-a"')
+  })
+
+  it('logs redacted urls without leaking sensitive request data', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log?token=hidden-query&keep=visible',
+      headers: {
+        authorization: 'Bearer hidden-auth',
+        'x-client-info': 'storage-js',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+    const serializedLog = JSON.stringify(requestLog)
+
+    expect(requestLog.msg).toContain('/request-log?token=redacted&keep=visible')
+    expect(requestLog.req).toMatchObject({
+      method: 'GET',
+      url: '/request-log?token=redacted&keep=visible',
+    })
+    expect(requestLog.res).toMatchObject({
+      headers: {
+        etag: 'test-etag',
+      },
+    })
+    expect(serializedLog).not.toContain('hidden-query')
+    expect(serializedLog).not.toContain('hidden-auth')
+    expect(serializedLog).not.toContain('hidden-response')
+  })
+
+  it('logs redacted urls for aborted response logs without reply metadata', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log?token=hidden-query&keep=visible',
+      simulate: {
+        close: true,
+        end: true,
+        error: false,
+        split: false,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const abortedLogLine = lines.find((line) => line.includes('ABORTED RES'))
+    expect(abortedLogLine).toBeDefined()
+
+    const abortedLog = JSON.parse(abortedLogLine ?? '{}')
+    const serializedLog = JSON.stringify(abortedLog)
+
+    expect(abortedLog.msg).toContain('ABORTED RES')
+    expect(abortedLog.msg).toContain('/request-log?token=redacted&keep=visible')
+    expect(abortedLog.req).toMatchObject({
+      method: 'GET',
+      url: '/request-log?token=redacted&keep=visible',
+    })
+    expect(abortedLog.res).toBeUndefined()
+    expect(serializedLog).not.toContain('hidden-query')
   })
 })

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -1,4 +1,4 @@
-import { logSchema, redactQueryParamFromRequest } from '@internal/monitoring'
+import { logSchema, serializeReplyLog, serializeRequestLog } from '@internal/monitoring'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 
@@ -149,13 +149,10 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
     return
   }
 
-  const rMeth = req.method
-  const rUrl = redactQueryParamFromRequest(req, [
-    'token',
-    'X-Amz-Credential',
-    'X-Amz-Signature',
-    'X-Amz-Security-Token',
-  ])
+  const requestLog = serializeRequestLog(req)
+  const replyLog = serializeReplyLog(options.reply)
+  const rMeth = requestLog.method
+  const rUrl = requestLog.url
   const uAgent = req.headers['user-agent']
   const rId = req.id
   const cIP = req.ip
@@ -206,9 +203,9 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
     project: tenantId,
     reqId: rId,
     sbReqId: req.sbReqId,
-    req,
+    req: requestLog,
     reqMetadata,
-    res: options.reply,
+    res: replyLog,
     responseTime: options.responseTime,
     executionTime: options.executionTime,
     error,

--- a/src/internal/monitoring/logger.test.ts
+++ b/src/internal/monitoring/logger.test.ts
@@ -2,6 +2,49 @@ import { vi } from 'vitest'
 
 const mockedLoggerModules = ['pino', '../../config'] as const
 
+function setupLoggerMocks(configOverrides: Record<string, unknown> = {}) {
+  const loggerStub = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    flush: vi.fn(),
+    info: vi.fn(),
+    level: 'info',
+    silent: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+  }
+  loggerStub.child.mockReturnValue(loggerStub)
+
+  const pinoMock = Object.assign(
+    vi.fn(() => loggerStub),
+    {
+      stdTimeFunctions: {
+        isoTime: vi.fn(),
+      },
+    }
+  )
+
+  vi.doMock('pino', () => ({
+    default: pinoMock,
+    Logger: class Logger {},
+  }))
+  vi.doMock('../../config', () => ({
+    getConfig: vi.fn(() => ({
+      logLevel: 'info',
+      logflareApiKey: undefined,
+      logflareBatchSize: 1,
+      logflareEnabled: false,
+      logflareSourceToken: undefined,
+      region: 'local',
+      ...configOverrides,
+    })),
+  }))
+
+  return { pinoMock }
+}
+
 describe('logger serializers', () => {
   afterEach(() => {
     for (const moduleId of mockedLoggerModules) {
@@ -12,101 +55,179 @@ describe('logger serializers', () => {
     vi.resetModules()
   })
 
-  test('res serializer tolerates synthetic replies without getHeaders', async () => {
-    let resSerializer:
-      | ((reply: { statusCode: number; getHeaders?: () => Record<string, unknown> }) => unknown)
-      | undefined
+  test('serializeRequestLog redacts sensitive query params and whitelists headers', async () => {
+    setupLoggerMocks()
+    const { serializeRequestLog } = await import('./logger')
 
-    const loggerStub = {
-      child: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-      fatal: vi.fn(),
-      flush: vi.fn(),
-      info: vi.fn(),
-      level: 'info',
-      silent: vi.fn(),
-      trace: vi.fn(),
-      warn: vi.fn(),
-    }
-    loggerStub.child.mockReturnValue(loggerStub)
+    const request = {
+      id: 'trace-1',
+      method: 'GET',
+      url: '/object?token=hidden-query&keep=visible',
+      headers: {
+        authorization: 'Bearer hidden-auth',
+        'x-client-info': 'storage-js',
+      },
+      hostname: 'storage.test',
+      ip: '127.0.0.1',
+      protocol: 'https',
+      socket: { remotePort: 1234 },
+    } as never
 
-    const pinoMock = Object.assign(
-      vi.fn((options: { serializers: { res: typeof resSerializer } }) => {
-        resSerializer = options.serializers.res
-        return loggerStub
-      }),
-      {
-        stdTimeFunctions: {
-          isoTime: vi.fn(),
-        },
-      }
-    )
-
-    vi.doMock('pino', () => ({
-      default: pinoMock,
-      Logger: class Logger {},
-    }))
-    vi.doMock('../../config', () => ({
-      getConfig: vi.fn(() => ({
-        logLevel: 'info',
-        logflareApiKey: undefined,
-        logflareBatchSize: 1,
-        logflareEnabled: false,
-        logflareSourceToken: undefined,
-        region: 'local',
-      })),
-    }))
-
-    await import('./logger')
-
-    expect(resSerializer).toBeDefined()
-    expect(() => resSerializer?.({ statusCode: 503 })).not.toThrow()
-    expect(resSerializer?.({ statusCode: 503 })).toEqual({
-      headers: {},
-      statusCode: 503,
+    expect(serializeRequestLog(request)).toEqual({
+      region: 'local',
+      traceId: 'trace-1',
+      method: 'GET',
+      url: '/object?token=redacted&keep=visible',
+      headers: { x_client_info: 'storage-js' },
+      hostname: 'storage.test',
+      remoteAddress: '127.0.0.1',
+      remotePort: 1234,
     })
   })
 
-  test('buildTransport wires logflare hooks when logflare is enabled', async () => {
-    const loggerStub = {
-      child: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-      fatal: vi.fn(),
-      flush: vi.fn(),
-      info: vi.fn(),
-      level: 'info',
-      silent: vi.fn(),
-      trace: vi.fn(),
-      warn: vi.fn(),
-    }
-    loggerStub.child.mockReturnValue(loggerStub)
+  test('serializeReplyLog whitelists reply headers and tolerates undefined replies', async () => {
+    setupLoggerMocks()
+    const { serializeReplyLog } = await import('./logger')
 
-    const pinoMock = Object.assign(
-      vi.fn(() => loggerStub),
-      {
-        stdTimeFunctions: {
-          isoTime: vi.fn(),
+    expect(serializeReplyLog(undefined)).toBeUndefined()
+
+    const getHeaders = vi.fn(() => ({ etag: 'fresh-etag', 'x-secret-response': 'hidden' }))
+    expect(serializeReplyLog({ statusCode: 200, getHeaders } as never)).toEqual({
+      statusCode: 200,
+      headers: { etag: 'fresh-etag' },
+    })
+    expect(getHeaders).toHaveBeenCalledTimes(1)
+  })
+
+  test('base req/res serializers pass through safe logs and sanitize raw fastify values', async () => {
+    const { pinoMock } = setupLoggerMocks()
+    const { serializeReplyLog, serializeRequestLog } = await import('./logger')
+
+    const pinoCalls = pinoMock.mock.calls as unknown as Array<
+      [
+        {
+          serializers: {
+            req: (request: unknown) => unknown
+            res: (reply: unknown) => unknown
+          }
         },
-      }
-    )
+      ]
+    >
+    const pinoCall = pinoCalls.at(0)
+    expect(pinoCall).toBeDefined()
+    const serializers = pinoCall![0].serializers
+    const serializedRequest = serializeRequestLog({
+      id: 'trace-1',
+      method: 'GET',
+      url: '/object?token=redacted',
+      headers: { 'x-client-info': 'storage-js' },
+      hostname: 'storage.test',
+      ip: '127.0.0.1',
+      protocol: 'https',
+      socket: { remotePort: 1234 },
+    } as never)
+    const serializedReply = serializeReplyLog({
+      statusCode: 200,
+      getHeaders: vi.fn(() => ({ etag: 'fresh-etag' })),
+    } as never)!
 
-    vi.doMock('pino', () => ({
-      default: pinoMock,
-      Logger: class Logger {},
-    }))
-    vi.doMock('../../config', () => ({
-      getConfig: vi.fn(() => ({
-        logLevel: 'debug',
-        logflareApiKey: 'api-key',
-        logflareBatchSize: 25,
-        logflareEnabled: true,
-        logflareSourceToken: 'source-token',
-        region: 'local',
+    expect(serializers.req(serializedRequest)).toBe(serializedRequest)
+    expect(serializers.res(serializedReply)).toBe(serializedReply)
+
+    const clonedRequest = {
+      ...serializedRequest,
+      url: '/object?token=hidden-query&keep=visible',
+      headers: {
+        ...serializedRequest.headers,
+        authorization: 'Bearer hidden-auth',
+      },
+      rawHeaders: ['authorization: hidden-auth'],
+    }
+    const clonedReply = {
+      ...serializedReply,
+      headers: {
+        ...serializedReply.headers,
+        set_cookie: 'hidden-cookie',
+      },
+      secretHeaders: ['set-cookie'],
+    }
+
+    expect(serializers.req(clonedRequest)).toBeUndefined()
+    expect(serializers.res(clonedReply)).toEqual({
+      statusCode: 200,
+      headers: {},
+    })
+
+    const rawRequest = {
+      id: 'trace-raw',
+      traceId: 'spoofed-trace-id',
+      method: 'GET',
+      url: '/object?token=hidden-query&keep=visible',
+      headers: {
+        authorization: 'Bearer hidden-auth',
+        cookie: 'hidden-cookie',
+        'x-client-info': 'storage-js',
+      },
+      hostname: 'storage.test',
+      ip: '127.0.0.1',
+      protocol: 'https',
+      socket: { remotePort: 4321 },
+      circular: undefined as unknown,
+    }
+    rawRequest.circular = rawRequest
+
+    const rawReply = {
+      statusCode: 201,
+      getHeaders: vi.fn(() => ({
+        etag: 'fresh-etag',
+        'set-cookie': 'hidden-cookie',
       })),
-    }))
+    }
+    const partialReply = {
+      statusCode: 202,
+      headers: { etag: 'hidden-etag' },
+      secretHeaders: ['set-cookie'],
+    }
 
+    expect(serializers.req(rawRequest)).toEqual({
+      region: 'local',
+      traceId: 'trace-raw',
+      method: 'GET',
+      url: '/object?token=redacted&keep=visible',
+      headers: { x_client_info: 'storage-js' },
+      hostname: 'storage.test',
+      remoteAddress: '127.0.0.1',
+      remotePort: 4321,
+    })
+    expect(serializers.res(rawReply)).toEqual({
+      statusCode: 201,
+      headers: { etag: 'fresh-etag' },
+    })
+    expect(rawReply.getHeaders).toHaveBeenCalledTimes(1)
+    expect(serializers.res(partialReply)).toEqual({
+      statusCode: 202,
+      headers: {},
+    })
+
+    const serializedRawValues = JSON.stringify({
+      clonedRes: serializers.res(clonedReply),
+      req: serializers.req(rawRequest),
+      res: serializers.res(rawReply),
+      partialRes: serializers.res(partialReply),
+    })
+    expect(serializedRawValues).not.toContain('hidden-query')
+    expect(serializedRawValues).not.toContain('hidden-auth')
+    expect(serializedRawValues).not.toContain('hidden-cookie')
+  })
+
+  test('buildTransport wires logflare hooks when logflare is enabled', async () => {
+    setupLoggerMocks({
+      logLevel: 'debug',
+      logflareApiKey: 'api-key',
+      logflareBatchSize: 25,
+      logflareEnabled: true,
+      logflareSourceToken: 'source-token',
+    })
     const { buildTransport } = await import('./logger')
     interface LogflareTransportOptions {
       apiKey: string

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -5,6 +5,35 @@ import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
 import pino, { Logger } from 'pino'
 import { getConfig } from '../../config'
 
+const serializedRequestLogSymbol: unique symbol = Symbol('SerializedRequestLog')
+const serializedReplyLogSymbol: unique symbol = Symbol('SerializedReplyLog')
+
+export type SafeLogHeaders = Record<string, string>
+
+interface SerializedRequestLogShape {
+  region: string
+  traceId: string
+  method: string
+  url: string
+  headers: SafeLogHeaders
+  hostname: string
+  remoteAddress: string
+  remotePort?: number
+}
+
+export interface SerializedRequestLog extends SerializedRequestLogShape {
+  readonly [serializedRequestLogSymbol]: true
+}
+
+interface SerializedReplyLogShape {
+  statusCode: number
+  headers: SafeLogHeaders
+}
+
+export interface SerializedReplyLog extends SerializedReplyLogShape {
+  readonly [serializedReplyLogSymbol]: true
+}
+
 const {
   logLevel,
   logflareApiKey,
@@ -21,14 +50,6 @@ export const baseLogger = pino({
     error(error) {
       return normalizeRawError(error, logLevel)
     },
-    res(reply: Pick<FastifyReply, 'statusCode'> & Partial<Pick<FastifyReply, 'getHeaders'>>) {
-      const headers = typeof reply.getHeaders === 'function' ? reply.getHeaders() : {}
-
-      return {
-        statusCode: reply.statusCode,
-        headers: whitelistHeaders(headers),
-      }
-    },
     reqMetadata(metadata?: Record<string, unknown>) {
       if (!metadata) {
         return undefined
@@ -40,23 +61,11 @@ export const baseLogger = pino({
         // no-op
       }
     },
-    req(request) {
-      return {
-        region,
-        traceId: request.id,
-        method: request.method,
-        url: redactQueryParamFromRequest(request, [
-          'token',
-          'X-Amz-Credential',
-          'X-Amz-Signature',
-          'X-Amz-Security-Token',
-        ]),
-        headers: whitelistHeaders(request.headers),
-        hostname: request.hostname,
-        remoteAddress: request.ip,
-        remotePort: request.socket?.remotePort,
-      }
-    },
+    // doRequestLog passes branded values from serializeRequestLog/serializeReplyLog,
+    // so the common path is a passthrough. If Fastify's auto-logger ever emits raw
+    // FastifyRequest/Reply values, fall back to the safe serializers.
+    req: serializeRequestLogValue,
+    res: serializeReplyLogValue,
   },
   level: logLevel,
   timestamp: pino.stdTimeFunctions.isoTime,
@@ -77,8 +86,8 @@ export interface RequestLogContext {
 
 export interface RequestLog extends RequestLogContext {
   type: 'request'
-  req: FastifyRequest
-  res?: FastifyReply
+  req: SerializedRequestLog
+  res?: SerializedReplyLog
   reqMetadata?: Record<string, unknown>
   responseTime: number
   executionTime?: number
@@ -170,65 +179,161 @@ export function buildTransport(): pino.TransportMultiOptions {
   }
 }
 
-const allowlistedHeaders = new Set([
-  'accept',
-  'cf-connecting-ip',
-  'cf-ipcountry',
-  'host',
-  'user-agent',
-  'x-forwarded-proto',
-  'x-forwarded-host',
-  'x-forwarded-port',
-  'x-forwarded-prefix',
-  'referer',
-  'content-length',
-  'x-real-ip',
-  'x-client-info',
-  'x-forwarded-user-agent',
-  'x-client-trace-id',
-  'x-upsert',
-  'content-type',
-  'if-none-match',
-  'if-modified-since',
-  'upload-metadata',
-  'upload-length',
-  'upload-offset',
-  'tus-resumable',
-  'range',
-  'cf-cache-status',
-  'cf-ray',
-  'location',
-  'cache-control',
-  'content-location',
-  'content-range',
-  'date',
-  'transfer-encoding',
-  'x-kong-proxy-latency',
-  'x-kong-upstream-latency',
-  'sb-request-id',
-  'sb-gateway-mode',
-  'sb-gateway-version',
-  'x-transformations',
-  'expires',
-  'etag',
-  'content-disposition',
-  'last-modified',
-])
+const allowlistedHeaderKeys = new Map<string, string>(
+  [
+    'accept',
+    'cf-connecting-ip',
+    'cf-ipcountry',
+    'host',
+    'user-agent',
+    'x-forwarded-proto',
+    'x-forwarded-host',
+    'x-forwarded-port',
+    'x-forwarded-prefix',
+    'referer',
+    'content-length',
+    'x-real-ip',
+    'x-client-info',
+    'x-forwarded-user-agent',
+    'x-client-trace-id',
+    'x-upsert',
+    'content-type',
+    'if-none-match',
+    'if-modified-since',
+    'upload-metadata',
+    'upload-length',
+    'upload-offset',
+    'tus-resumable',
+    'range',
+    'cf-cache-status',
+    'cf-ray',
+    'location',
+    'cache-control',
+    'content-location',
+    'content-range',
+    'date',
+    'transfer-encoding',
+    'x-kong-proxy-latency',
+    'x-kong-upstream-latency',
+    'sb-request-id',
+    'sb-gateway-mode',
+    'sb-gateway-version',
+    'x-transformations',
+    'expires',
+    'etag',
+    'content-disposition',
+    'last-modified',
+  ].map((header) => [header, header.replaceAll('-', '_')])
+)
 
-const whitelistHeaders = (headers: Record<string, unknown>) => {
-  const responseMetadata: Record<string, unknown> = {}
+const redactedQueryParams = ['token', 'X-Amz-Credential', 'X-Amz-Signature', 'X-Amz-Security-Token']
+
+const whitelistHeaders = (headers: Record<string, unknown>): SafeLogHeaders => {
+  const responseMetadata: SafeLogHeaders = {}
 
   for (const header in headers) {
-    if (allowlistedHeaders.has(header)) {
-      responseMetadata[header.replaceAll('-', '_')] = `${headers[header]}`
+    const safeKey = allowlistedHeaderKeys.get(header)
+    if (safeKey !== undefined) {
+      responseMetadata[safeKey] = `${headers[header]}`
     }
   }
 
   return responseMetadata
 }
 
-export function redactQueryParamFromRequest(req: FastifyRequest, params: string[]) {
-  const url = req.url
+export function serializeRequestLog(req: FastifyRequest): SerializedRequestLog {
+  const log: SerializedRequestLogShape = {
+    region,
+    traceId: req.id,
+    method: req.method,
+    url: redactLogUrl(req.url),
+    headers: whitelistHeaders(req.headers),
+    hostname: req.hostname,
+    remoteAddress: req.ip,
+    remotePort: req.socket?.remotePort,
+  }
+  return markSerializedRequestLog(log)
+}
+
+export function serializeReplyLog(reply: FastifyReply | undefined): SerializedReplyLog | undefined {
+  if (!reply) {
+    return undefined
+  }
+
+  const log: SerializedReplyLogShape = {
+    statusCode: reply.statusCode,
+    headers: whitelistHeaders(reply.getHeaders()),
+  }
+  return markSerializedReplyLog(log)
+}
+
+function serializeRequestLogValue(request: unknown) {
+  if (isRecord(request) && request[serializedRequestLogSymbol] === true) {
+    return request
+  }
+
+  if (isFastifyRequestLogValue(request)) {
+    return serializeRequestLog(request)
+  }
+}
+
+function serializeReplyLogValue(reply: unknown) {
+  if (isRecord(reply) && reply[serializedReplyLogSymbol] === true) {
+    return reply
+  }
+
+  if (isFastifyReplyLogValue(reply)) {
+    return serializeReplyLog(reply)
+  }
+
+  if (isPartialReplyLogValue(reply)) {
+    return markSerializedReplyLog({
+      statusCode: reply.statusCode,
+      headers: {},
+    })
+  }
+}
+
+function isFastifyRequestLogValue(request: unknown): request is FastifyRequest {
+  return (
+    isRecord(request) &&
+    typeof request.id === 'string' &&
+    typeof request.method === 'string' &&
+    typeof request.url === 'string' &&
+    isRecord(request.headers) &&
+    typeof request.hostname === 'string' &&
+    typeof request.ip === 'string' &&
+    typeof request.protocol === 'string'
+  )
+}
+
+function isFastifyReplyLogValue(reply: unknown): reply is FastifyReply {
+  return (
+    isRecord(reply) &&
+    typeof reply.statusCode === 'number' &&
+    typeof reply.getHeaders === 'function'
+  )
+}
+
+function isPartialReplyLogValue(reply: unknown): reply is { statusCode: number } {
+  return isRecord(reply) && typeof reply.statusCode === 'number'
+}
+
+function markSerializedRequestLog(log: SerializedRequestLogShape): SerializedRequestLog {
+  Object.defineProperty(log, serializedRequestLogSymbol, { value: true })
+  return log as SerializedRequestLog
+}
+
+function markSerializedReplyLog(log: SerializedReplyLogShape): SerializedReplyLog {
+  Object.defineProperty(log, serializedReplyLogSymbol, { value: true })
+  return log as SerializedReplyLog
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function redactLogUrl(url: string) {
   const qIdx = url.indexOf('?')
 
   // Fast path: no query string, nothing to redact
@@ -236,10 +341,10 @@ export function redactQueryParamFromRequest(req: FastifyRequest, params: string[
 
   const query = url.slice(qIdx + 1)
   // Fast path: no sensitive params present
-  if (!params.some((p) => query.includes(p))) return url
+  if (!redactedQueryParams.some((p) => query.includes(p))) return url
 
-  const lUrl = new URL(url, `${req.protocol}://${req.hostname}`)
-  params.forEach((param) => {
+  const lUrl = new URL(url, 'http://storage.local')
+  redactedQueryParams.forEach((param) => {
     if (lUrl.searchParams.has(param)) {
       lUrl.searchParams.set(param, 'redacted')
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for performance

## What is the current behavior?

Pino serializers walk request/reply again

## What is the new behavior?

Do the work once and use passthrough serializers.
Do header normalization in module initialization once.

## Additional context

Serializers have a guard for security. If called wrong (normally type would catch but defense in depth), they will do the sanitization themselves.