### PR TITLE
fix: generate swagger ui with script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           npm ci
           npm run docs:export
+          npm run docs:export-ui
         env:
           ANON_KEY: ${{ secrets.ANON_KEY }}
           SERVICE_KEY: ${{ secrets.SERVICE_KEY }}
@@ -52,13 +53,8 @@ jobs:
           FILE_SIZE_LIMIT: "52428800"
           STORAGE_BACKEND: s3
           ENABLE_IMAGE_TRANSFORMATION: true
-
-      - name: Generate Swagger UI
-        uses: Legion2/swagger-ui-action@eff65dc3f193f0a749872be82f74baa35be0797d # v1.3.0
-        with:
-          output: swagger-ui
-          spec-file: static/api.json
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          VECTOR_ENABLED: true
+          ICEBERG_ENABLED: true
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
           FILE_SIZE_LIMIT: "52428800"
           STORAGE_BACKEND: s3
           ENABLE_IMAGE_TRANSFORMATION: true
+          VECTOR_ENABLED: true
+          ICEBERG_ENABLED: true
 
   publish:
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .idea/
 src/scripts/*.py
 .claude/
+swagger-ui/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "migration:test-idempotency": "tsx src/scripts/test-migration-idempotency.ts",
     "migrations:types": "tsx src/scripts/migrations-types.ts",
     "docs:export": "tsx ./src/scripts/export-docs.ts",
+    "docs:export-ui": "tsx ./src/scripts/export-docs-ui.ts",
     "pprof:capture": "tsx src/scripts/pprof-client.ts",
     "test:dummy-data": "tsx -r dotenv/config ./src/test/db/import-dummy-data.ts",
     "test:unit": "vitest run --config vitest.unit.config.ts",

--- a/src/scripts/export-docs-ui.ts
+++ b/src/scripts/export-docs-ui.ts
@@ -20,4 +20,7 @@ function swaggerInitializer(targetUrl: string) {
   await fs.cp(swaggerPath, targetPath, { recursive: true })
   await fs.cp(specPath, resolve(targetPath, specFile))
   await fs.writeFile(resolve(targetPath, 'swagger-initializer.js'), swaggerInitializer(specFile))
-})().catch(console.error)
+})().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/scripts/export-docs-ui.ts
+++ b/src/scripts/export-docs-ui.ts
@@ -1,0 +1,23 @@
+import { promises as fs } from 'fs'
+import { resolve } from 'path'
+
+function swaggerInitializer(targetUrl: string) {
+  return `window.onload = function () {
+    const config = {
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      url: '${targetUrl}'
+    }
+    const ui = SwaggerUIBundle(config)
+  }`
+}
+
+;(async () => {
+  const targetPath = 'swagger-ui'
+  const swaggerPath = resolve('node_modules', '@fastify', 'swagger-ui', 'static')
+  const specFile = 'api.json'
+  const specPath = resolve('static', specFile)
+  await fs.cp(swaggerPath, targetPath, { recursive: true })
+  await fs.cp(specPath, resolve(targetPath, specFile))
+  await fs.writeFile(resolve(targetPath, 'swagger-initializer.js'), swaggerInitializer(specFile))
+})().catch(console.error)

--- a/src/scripts/export-docs.ts
+++ b/src/scripts/export-docs.ts
@@ -11,6 +11,9 @@ import app from '../app'
     method: 'GET',
     url: '/documentation/json',
   })
+  if (response.statusCode !== 200) {
+    throw new Error('Unable to get api spec: ' + response.statusCode + ' ' + response.statusMessage)
+  }
 
   await fs.writeFile('static/api.json', response.body)
 
@@ -25,8 +28,19 @@ import app from '../app'
     method: 'GET',
     url: '/documentation/json',
   })
+  if (adminResponse.statusCode !== 200) {
+    throw new Error(
+      'Unable to get admin api spec: ' +
+        adminResponse.statusCode +
+        ' ' +
+        adminResponse.statusMessage
+    )
+  }
 
   await fs.writeFile('static/api-admin.json', adminResponse.body)
 
   await adminApp.close()
-})().catch(console.error)
+})().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Swagger ui github action is outdated and [fails to generate ui](https://github.com/supabase/storage/actions/runs/25011561045/job/73248354247)
- Vector and Iceberg endpoints not included in spec

## What is the new behavior?

- Replace github action with script that generates ui using existing fastify/swagger-ui
- Enable vector and iceberg when generating spec so they're included
