### PR TITLE
fix: add optimized functions that were disabled in 0036

### DIFF
--- a/migrations/tenant/0060-optimize-existing-functions-again.sql
+++ b/migrations/tenant/0060-optimize-existing-functions-again.sql
@@ -1,0 +1,51 @@
+-- update functions to match ones defined in 0036
+-- fix typing issue in get_size_by_bucket
+
+CREATE OR REPLACE FUNCTION storage.extension(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+    _filename text;
+BEGIN
+    -- Split on "/" to get path segments
+    SELECT string_to_array(name, '/') INTO _parts;
+    -- Get the last path segment (the actual filename)
+    SELECT _parts[array_length(_parts, 1)] INTO _filename;
+    -- Extract extension: reverse, split on '.', then reverse again
+    RETURN reverse(split_part(reverse(_filename), '.', 1));
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION storage.foldername(name text)
+    RETURNS text[]
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+BEGIN
+    -- Split on "/" to get path segments
+    SELECT string_to_array(name, '/') INTO _parts;
+    -- Return everything except the last segment
+    RETURN _parts[1 : array_length(_parts,1) - 1];
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION storage.get_size_by_bucket()
+    RETURNS TABLE (
+          size BIGINT,
+          bucket_id text
+    )
+    LANGUAGE plpgsql
+    STABLE
+AS $function$
+BEGIN
+    return query
+        select sum((metadata->>'size')::bigint)::bigint as size, obj.bucket_id
+        from "storage".objects as obj
+        group by obj.bucket_id;
+END
+$function$;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -59,4 +59,5 @@ export const DBMigration = {
   's3-multipart-uploads-metadata': 57,
   'operation-ergonomics': 58,
   'drop-unused-functions': 59,
+  'optimize-existing-functions-again': 60,
 } as const


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some function optimization is not applied for new projects because migration [0036 was disabled](https://github.com/supabase/storage/blob/master/migrations/tenant/0036-optimise-existing-functions.sql)

Projects created after the migrations were disabled have the versions defined in [0002](https://github.com/supabase/storage/blob/master/migrations/tenant/0002-storage-schema.sql) and [0006](https://github.com/supabase/storage/blob/master/migrations/tenant/0006-change-column-name-in-get-size.sql) instead.

Additionally, the version of `storage.get_size_by_bucket()` defined in 0036 throws an error...

```
Failed to run sql query: ERROR:  42804: structure of query does not match function result type
DETAIL:  Returned type numeric does not match expected type bigint in column 1.
CONTEXT:  SQL statement "select sum((metadata->>'size')::bigint) as size, obj.bucket_id
        from "storage".objects as obj
        group by obj.bucket_id"
PL/pgSQL function storage.get_size_by_bucket() line 3 at RETURN QUERY
```

## What is the new behavior?

- Apply optimizations from migration 0036 (`extension()`, `foldername()`, `get_size_by_bucket`)
- cast sum in `get_size_by_bucket` to bigint to prevent error
