### PR TITLE
chore: bump tus-js-client for wrong types

### DIFF
--- a/acceptance/specs/tus.test.ts
+++ b/acceptance/specs/tus.test.ts
@@ -34,13 +34,12 @@ describeAcceptance(
       const bucketName = uniqueBucketName('tus')
       const objectKey = uniqueObjectKey('tus')
       const payload = Buffer.from(`acceptance-tus-${config.runId}`)
-      const uploadPayload = new Blob([payload])
 
       try {
         await createRestBucket(bucketName)
         await new Promise<void>((resolve, reject) => {
-          const upload = new tus.Upload(uploadPayload, {
-            chunkSize: uploadPayload.size,
+          const upload = new tus.Upload(payload, {
+            chunkSize: payload.length,
             endpoint: config.tusEndpoint,
             headers: withAcceptanceHeaders({
               authorization: `Bearer ${requireServiceKey(config)}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "resolve-tspaths": "^0.8.19",
         "stream-buffers": "^3.0.2",
         "tsx": "^4.16.0",
-        "tus-js-client": "^3.1.0",
+        "tus-js-client": "^4.3.1",
         "typescript": "5.9.3",
         "vitest": "^4.1.4"
       },
@@ -16316,10 +16316,11 @@
       }
     },
     "node_modules/tus-js-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-3.1.0.tgz",
-      "integrity": "sha512-Hfpc8ho4C9Lhs/OflPUA/nHUHZJUrKD5upoPBq7dYJJ9DQhWocsjJU2RZYfN16Y5n19j9dFDszwCvVZ5sfcogw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-4.3.1.tgz",
+      "integrity": "sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.1.2",
         "combine-errors": "^3.0.3",
@@ -16328,6 +16329,9 @@
         "lodash.throttle": "^4.1.1",
         "proper-lockfile": "^4.1.2",
         "url-parse": "^1.5.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/type-fest": {
@@ -27902,9 +27906,9 @@
       }
     },
     "tus-js-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-3.1.0.tgz",
-      "integrity": "sha512-Hfpc8ho4C9Lhs/OflPUA/nHUHZJUrKD5upoPBq7dYJJ9DQhWocsjJU2RZYfN16Y5n19j9dFDszwCvVZ5sfcogw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-4.3.1.tgz",
+      "integrity": "sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "resolve-tspaths": "^0.8.19",
     "stream-buffers": "^3.0.2",
     "tsx": "^4.16.0",
-    "tus-js-client": "^3.1.0",
+    "tus-js-client": "^4.3.1",
     "typescript": "5.9.3",
     "vitest": "^4.1.4"
   },

--- a/src/test/rls.test.ts
+++ b/src/test/rls.test.ts
@@ -635,8 +635,11 @@ async function tusUploadFile(
   } catch (e) {
     if (!(e instanceof DetailedError)) throw e
 
-    statusCode = e.originalResponse.getStatus()
-    message = e.originalResponse.getBody()
+    const response = e.originalResponse
+    if (!response) throw e
+
+    statusCode = response.getStatus()
+    message = response.getBody()
   }
 
   const body = message ? { message } : {}

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -25,6 +25,18 @@ const localServerAddress = 'http://127.0.0.1:8999'
 const backend = backends.createStorageBackend(storageBackendType)
 const client = backend.client
 
+function expectTusErrorResponse(error: unknown) {
+  expect(error).toBeInstanceOf(DetailedError)
+
+  const response = (error as DetailedError).originalResponse
+  expect(response).not.toBeNull()
+  if (!response) {
+    throw error
+  }
+
+  return response
+}
+
 describe('Tus multipart', () => {
   let db: StorageKnexDB
   let storage: Storage
@@ -188,11 +200,9 @@ describe('Tus multipart', () => {
 
         throw Error('it should error with max-size exceeded')
       } catch (e) {
-        expect(e).toBeInstanceOf(DetailedError)
-
-        const err = e as DetailedError
-        expect(err.originalResponse.getBody()).toEqual('Bucket not found')
-        expect(err.originalResponse.getStatus()).toEqual(404)
+        const response = expectTusErrorResponse(e)
+        expect(response.getBody()).toEqual('Bucket not found')
+        expect(response.getStatus()).toEqual(404)
       }
     })
 
@@ -237,11 +247,9 @@ describe('Tus multipart', () => {
 
         throw Error('it should error with max-size exceeded')
       } catch (e) {
-        expect(e).toBeInstanceOf(DetailedError)
-
-        const err = e as DetailedError
-        expect(err.originalResponse.getBody()).toEqual('Maximum size exceeded\n')
-        expect(err.originalResponse.getStatus()).toEqual(413)
+        const response = expectTusErrorResponse(e)
+        expect(response.getBody()).toEqual('Maximum size exceeded\n')
+        expect(response.getStatus()).toEqual(413)
       }
     })
   })
@@ -432,9 +440,9 @@ describe('Tus multipart', () => {
       } catch (e) {
         expect((e as Error).message).not.toEqual('it should error with expired token')
 
-        const err = e as DetailedError
-        expect(err.originalResponse.getBody()).toEqual('"exp" claim timestamp check failed')
-        expect(err.originalResponse.getStatus()).toEqual(400)
+        const response = expectTusErrorResponse(e)
+        expect(response.getBody()).toEqual('"exp" claim timestamp check failed')
+        expect(response.getStatus()).toEqual(400)
       }
     })
 
@@ -480,9 +488,9 @@ describe('Tus multipart', () => {
       } catch (e) {
         expect((e as Error).message).not.toEqual('it should error with expired token')
 
-        const err = e as DetailedError
-        expect(err.originalResponse.getBody()).toEqual('Invalid Compact JWS')
-        expect(err.originalResponse.getStatus()).toEqual(400)
+        const response = expectTusErrorResponse(e)
+        expect(response.getBody()).toEqual('Invalid Compact JWS')
+        expect(response.getStatus()).toEqual(400)
       }
     })
 
@@ -525,9 +533,9 @@ describe('Tus multipart', () => {
       } catch (e) {
         expect((e as Error).message).not.toEqual('it should error with expired token')
 
-        const err = e as DetailedError
-        expect(err.originalResponse.getBody()).toEqual('Missing x-signature header')
-        expect(err.originalResponse.getStatus()).toEqual(400)
+        const response = expectTusErrorResponse(e)
+        expect(response.getBody()).toEqual('Missing x-signature header')
+        expect(response.getStatus()).toEqual(400)
       }
     })
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

tus-js-client types are wrong, expects blob what requires buffer/readable.

## What is the new behavior?

Runtime behaves accordingly with types.

## Additional context

It's a test only dependency but get more important for acceptance tests.
Extracted from https://github.com/supabase/storage/pull/1071#discussion_r3167547935
