### PR TITLE
fix: share s3 client for tus s3 locker

### DIFF
--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -79,6 +79,19 @@ function createTusServer(
   agent: { httpsAgent: https.Agent; httpAgent: http.Agent }
 ) {
   const datastore = createTusStore(agent)
+  const sharedS3Client =
+    tusLockType === 's3'
+      ? new S3Client({
+          requestHandler: new NodeHttpHandler({
+            ...agent,
+            connectionTimeout: 5000,
+            requestTimeout: storageS3ClientTimeout,
+          }),
+          region: storageS3Region,
+          endpoint: storageS3Endpoint,
+          forcePathStyle: storageS3ForcePathStyle,
+        })
+      : undefined
   const serverOptions: ServerOptions & {
     datastore: DataStore
   } = {
@@ -105,16 +118,7 @@ function createTusServer(
             maxRetries: 10,
             retryDelayMs: 250,
             renewalIntervalMs: 10 * 1000, // 10 seconds
-            s3Client: new S3Client({
-              requestHandler: new NodeHttpHandler({
-                ...agent,
-                connectionTimeout: 5000,
-                requestTimeout: storageS3ClientTimeout,
-              }),
-              region: storageS3Region,
-              endpoint: storageS3Endpoint,
-              forcePathStyle: storageS3ForcePathStyle,
-            }),
+            s3Client: sharedS3Client!,
             notifier: lockNotifier,
           })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Tus s3 locker creates a S3 client per request. There is no state, it could be shared.

## What is the new behavior?

Hoisted to share the same S3 client.

## Additional context

S3 branch is disabled by config right now but still good to fix since config can change and cause degradation.
