### PR TITLE
fix: enable render acceptance

### DIFF
--- a/.docker/docker-compose-infra.yml
+++ b/.docker/docker-compose-infra.yml
@@ -176,6 +176,7 @@ services:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
       - IMGPROXY_ENABLE_WEBP_DETECTION=true
+      - IMGPROXY_ALLOW_SECURITY_OPTIONS=true
       - IMGPROXY_PRESETS=default=width:3000/height:8192
       - IMGPROXY_FORMAT_QUALITY=jpeg=80,avif=62,webp=80
 

--- a/.env.acceptance.sample
+++ b/.env.acceptance.sample
@@ -14,7 +14,10 @@ ACCEPTANCE_TENANT_ID=bjhaohmqunupljrqypxz
 ACCEPTANCE_ALLOW_DESTRUCTIVE=false
 ACCEPTANCE_ENABLE_ADMIN=false
 ACCEPTANCE_ENABLE_CDN=false
-ACCEPTANCE_ENABLE_RENDER=false
+# Local render acceptance needs imgproxy to reach source objects.
+# For S3-backed local runs, set STORAGE_S3_PRIVATE_ASSET_ENDPOINT
+# in the server env, not in this acceptance-runner env file.
+ACCEPTANCE_ENABLE_RENDER=true
 ACCEPTANCE_ENABLE_RLS_SETUP=false
 ACCEPTANCE_ENABLE_VECTOR=false
 ACCEPTANCE_ENABLE_ICEBERG=true

--- a/.env.sample
+++ b/.env.sample
@@ -96,6 +96,10 @@ STORAGE_S3_MAX_SOCKETS=200
 STORAGE_S3_ENDPOINT=http://127.0.0.1:9000
 STORAGE_S3_FORCE_PATH_STYLE=true
 STORAGE_S3_REGION=us-east-1
+# Optional endpoint used only when signing private source URLs
+# for internal consumers like imgproxy.
+# For local Docker imgproxy + MinIO acceptance runs, use http://minio:9000.
+STORAGE_S3_PRIVATE_ASSET_ENDPOINT=http://minio:9000
 
 AWS_ACCESS_KEY_ID=supa-storage
 AWS_SECRET_ACCESS_KEY=secret1234

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -53,6 +53,34 @@ For local backend variants, put server/runtime changes in `.env` or `.env.test`.
 `.env.acceptance` limited to acceptance runner inputs such as target URLs, client credentials,
 capability gates, and resource naming.
 
+### Local Render Tests
+
+Image rendering tests need imgproxy to read the source image URL produced by the storage server.
+The default local S3 endpoint is `http://127.0.0.1:9000`, which works for a host-run server but is
+not reachable as MinIO from the Dockerized imgproxy container.
+
+For S3-backed render coverage, keep normal S3 traffic on the host-reachable endpoint and use
+`STORAGE_S3_PRIVATE_ASSET_ENDPOINT` for the Docker-reachable URL embedded in imgproxy source links:
+
+```bash
+STORAGE_BACKEND=s3 \
+STORAGE_S3_PRIVATE_ASSET_ENDPOINT=http://minio:9000 \
+ACCEPTANCE_ENABLE_RENDER=true \
+npm run acceptance -- --profile full acceptance/specs/cdn-render.test.ts
+```
+
+The file backend also works because imgproxy mounts the local `./data` directory:
+
+```bash
+mkdir -p data
+STORAGE_BACKEND=file ACCEPTANCE_ENABLE_RENDER=true npm run acceptance -- --profile full acceptance/specs/cdn-render.test.ts
+```
+
+Local CI enables render tests for both S3 and file backend runs. The S3 matrix sets
+`STORAGE_S3_PRIVATE_ASSET_ENDPOINT=http://minio:9000`. Multitenant render tests also rely on the
+local imgproxy container allowing security processing options because tenant image limits are sent
+as `max_src_resolution`.
+
 ## GitHub Environments
 
 The workflow dispatch `acceptance_environment` input uses `local` for the managed local run. Any

--- a/acceptance/specs/cdn-render.test.ts
+++ b/acceptance/specs/cdn-render.test.ts
@@ -149,9 +149,14 @@ async function expectRenderedImage(url: string, token?: string) {
       ),
     })
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('content-type')).toMatch(/^image\//)
-    expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0)
+    const contentType = response.headers.get('content-type') ?? ''
+    const body = await response.arrayBuffer()
+    const isImageResponse = /^image\//.test(contentType)
+    const failureBody = isImageResponse ? '' : new TextDecoder().decode(body)
+
+    expect(response.status, failureBody).toBe(200)
+    expect(contentType, failureBody).toMatch(/^image\//)
+    expect(body.byteLength, failureBody).toBeGreaterThan(0)
   } finally {
     if (response && !response.bodyUsed) {
       await response.body?.cancel()

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ type StorageConfigType = {
   storageS3UploadQueueSize: number
   storageS3Bucket: string
   storageS3Endpoint?: string
+  storageS3PrivateAssetEndpoint?: string
   storageS3ForcePathStyle?: boolean
   storageS3Region: string
   storageS3ClientTimeout: number
@@ -378,6 +379,10 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       getOptionalConfigFromEnv('STORAGE_S3_ENABLED_METRICS') === 'true',
     storageS3Bucket: getOptionalConfigFromEnv('STORAGE_S3_BUCKET', 'GLOBAL_S3_BUCKET'),
     storageS3Endpoint: getOptionalConfigFromEnv('STORAGE_S3_ENDPOINT', 'GLOBAL_S3_ENDPOINT'),
+    storageS3PrivateAssetEndpoint: getOptionalConfigFromEnv(
+      'STORAGE_S3_PRIVATE_ASSET_ENDPOINT',
+      'GLOBAL_S3_PRIVATE_ASSET_ENDPOINT'
+    ),
     storageS3ForcePathStyle:
       getOptionalConfigFromEnv('STORAGE_S3_FORCE_PATH_STYLE', 'GLOBAL_S3_FORCE_PATH_STYLE') ===
       'true',

--- a/src/storage/backend/index.ts
+++ b/src/storage/backend/index.ts
@@ -7,8 +7,13 @@ export * from './adapter'
 export * from './file'
 export * from './s3'
 
-const { storageS3Region, storageS3Endpoint, storageS3ForcePathStyle, storageS3ClientTimeout } =
-  getConfig()
+const {
+  storageS3Region,
+  storageS3Endpoint,
+  storageS3PrivateAssetEndpoint,
+  storageS3ForcePathStyle,
+  storageS3ClientTimeout,
+} = getConfig()
 
 type ConfigForStorage<Type extends StorageBackendType> = Type extends 's3'
   ? S3ClientOptions
@@ -26,6 +31,7 @@ export function createStorageBackend<Type extends StorageBackendType>(
     const defaultOptions: S3ClientOptions = {
       region: storageS3Region,
       endpoint: storageS3Endpoint,
+      privateAssetEndpoint: storageS3PrivateAssetEndpoint,
       forcePathStyle: storageS3ForcePathStyle,
       requestTimeout: storageS3ClientTimeout,
       ...(config ? config : {}),

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -1,9 +1,11 @@
-import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { ErrorCode, isStorageError } from '@internal/errors'
 import { Readable } from 'stream'
 import { type Mock, vi } from 'vitest'
 import { getConfig } from '../../../config'
+import { withOptionalVersion } from '../adapter'
 import { MAX_PUT_OBJECT_SIZE, S3Backend } from './adapter'
 
 vi.mock('@aws-sdk/client-s3', async () => {
@@ -27,6 +29,10 @@ vi.mock('@aws-sdk/lib-storage', async () => {
     Upload: vi.fn(function () {}),
   }
 })
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn().mockResolvedValue('http://signed.example.com/test-bucket/test-key'),
+}))
 
 type UploadOptionsShape = {
   queueSize?: number
@@ -144,6 +150,57 @@ describe('S3Backend', () => {
       const result = await backend.getObject('test-bucket', 'test-key', undefined)
 
       expect(result.metadata.mimetype).toBe('image/png')
+    })
+  })
+
+  describe('privateAssetUrl', () => {
+    test('uses the primary S3 client when no private asset endpoint is configured', async () => {
+      const backend = createBackend()
+
+      await expect(backend.privateAssetUrl('test-bucket', 'test-key', undefined)).resolves.toBe(
+        'http://signed.example.com/test-bucket/test-key'
+      )
+
+      const s3ClientMock = S3Client as unknown as Mock
+      const defaultClient = s3ClientMock.mock.results[0].value
+      expect(s3ClientMock).toHaveBeenCalledTimes(1)
+      expect(getSignedUrl).toHaveBeenCalledWith(defaultClient, expect.any(GetObjectCommand), {
+        expiresIn: 600,
+      })
+    })
+
+    test('uses the private asset endpoint when signing private asset URLs', async () => {
+      const backend = new S3Backend({
+        region: 'us-east-1',
+        endpoint: 'http://127.0.0.1:9000',
+        privateAssetEndpoint: 'http://minio:9000',
+        forcePathStyle: true,
+      })
+
+      await backend.privateAssetUrl('test-bucket', 'test-key', 'version-id')
+
+      const s3ClientMock = S3Client as unknown as Mock
+      expect(s3ClientMock).toHaveBeenCalledTimes(2)
+      expect(s3ClientMock.mock.calls[0][0]).toMatchObject({
+        endpoint: 'http://127.0.0.1:9000',
+        forcePathStyle: true,
+        region: 'us-east-1',
+      })
+      expect(s3ClientMock.mock.calls[1][0]).toMatchObject({
+        endpoint: 'http://minio:9000',
+        forcePathStyle: true,
+        region: 'us-east-1',
+      })
+
+      const privateAssetClient = s3ClientMock.mock.results[1].value
+      const privateAssetCommand = (getSignedUrl as Mock).mock.calls[0][1] as GetObjectCommand
+      expect(privateAssetCommand.input).toMatchObject({
+        Bucket: 'test-bucket',
+        Key: withOptionalVersion('test-key', 'version-id'),
+      })
+      expect(getSignedUrl).toHaveBeenCalledWith(privateAssetClient, privateAssetCommand, {
+        expiresIn: 600,
+      })
     })
   })
 

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -46,6 +46,7 @@ export const MAX_PUT_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 // 5GB
 
 export interface S3ClientOptions {
   endpoint?: string
+  privateAssetEndpoint?: string
   region?: string
   forcePathStyle?: boolean
   accessKey?: string
@@ -61,6 +62,7 @@ export interface S3ClientOptions {
  */
 export class S3Backend implements StorageBackendAdapter {
   client: S3Client
+  private privateAssetClient: S3Client
   agent: InstrumentedAgent
 
   constructor(options: S3ClientOptions) {
@@ -80,6 +82,15 @@ export class S3Backend implements StorageBackendAdapter {
       name: 's3_default',
       httpAgent: this.agent,
     })
+
+    this.privateAssetClient = options.privateAssetEndpoint
+      ? this.createS3Client({
+          ...options,
+          endpoint: options.privateAssetEndpoint,
+          name: 's3_private_asset',
+          httpAgent: this.agent,
+        })
+      : this.client
   }
 
   /**
@@ -505,7 +516,7 @@ export class S3Backend implements StorageBackendAdapter {
     }
 
     const command = new GetObjectCommand(input)
-    return getSignedUrl(this.client, command, { expiresIn: 600 })
+    return getSignedUrl(this.privateAssetClient, command, { expiresIn: 600 })
   }
 
   async createMultiPartUpload(


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

No acceptance tests for render that interacts with imgproxy.

## What is the new behavior?

Acceptance tests are enabled.

## Additional context

In local setup, containers can't talk to each other. That's why locally we pass a different endpoint and use a different s3 client.
Also add allow security options to local imgproxy for max resolution in multi tenant mode. 
