### PR TITLE
chore: sync biome ignore via git

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,15 +9,13 @@
       "**/*.mjs",
       "**/*.json",
       "**/*.jsonc",
-      "!!package-lock.json",
-      "!!build/**",
-      "!!coverage/**",
-      "!!dist/**",
-      "!!static/**",
-      "!!data/**",
-      "!!node_modules/**",
-      "!!.claude/**"
+      "!!package-lock.json"
     ]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

ignored files are kept in biome and gitignore

## What is the new behavior?

biome uses git so ignored files are in one place 

## Additional context

if `docs:export-ui` is run, `lint:fix` would take ages because it's checking swagger ui folder where it should have skipped since it's in gitignore.
