### PR TITLE
chore: drop busboy types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "@aws-sdk/s3-presigned-post": "^3.1023.0",
         "@biomejs/biome": "^2.4.4",
         "@types/async-retry": "^1.4.5",
-        "@types/busboy": "^1.3.0",
         "@types/cloneable-readable": "^2.0.3",
         "@types/js-yaml": "^4.0.5",
         "@types/json-bigint": "^1.0.4",
@@ -10961,15 +10960,6 @@
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
       "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/busboy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.3.0.tgz",
-      "integrity": "sha512-Qx7ehfGO/k2yiTVpRIVIu16oVgbJpG65WLjEhbNSoTPdQEoRCorFUKHsSznyHmIkdvzOg2W3JWeewCmfSwcgeA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -24298,15 +24288,6 @@
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
       "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/busboy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.3.0.tgz",
-      "integrity": "sha512-Qx7ehfGO/k2yiTVpRIVIu16oVgbJpG65WLjEhbNSoTPdQEoRCorFUKHsSznyHmIkdvzOg2W3JWeewCmfSwcgeA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@aws-sdk/s3-presigned-post": "^3.1023.0",
     "@biomejs/biome": "^2.4.4",
     "@types/async-retry": "^1.4.5",
-    "@types/busboy": "^1.3.0",
     "@types/cloneable-readable": "^2.0.3",
     "@types/js-yaml": "^4.0.5",
     "@types/json-bigint": "^1.0.4",


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

busboy types are installed but actually fastify has its own fork and not neeed.

## What is the new behavior?

drop type dev dependency 

## Additional context

related to https://github.com/supabase/storage/pull/1036
