### PR TITLE
fix(s3): add no-transform cache-control directive to prevent payload mutation

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -977,6 +977,12 @@ export class S3ProtocolHandler {
       headers['expires'] = command.ResponseExpires.toUTCString()
     }
 
+    if (headers['cache-control']) {
+      headers['cache-control'] += ', no-transform'
+    } else {
+      headers['cache-control'] = 'no-transform'
+    }
+
     return {
       headers,
       responseBody: response.body,


### PR DESCRIPTION
### What kind of change does this PR introduce?
[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)

### What is the current behavior?
When downloading HTML files via the S3-compatible API, Cloudflare's Email Address Obfuscation (Scrape Shield) intercepts and modifies the response body on the fly to hide `mailto:` links. Because the origin server (Supabase) has already set the `Content-Length` header based on the original unmutated file size, this on-the-fly mutation causes a size mismatch. 

Strict S3 clients like `rclone` detect that the downloaded body length does not match the `Content-Length` header and drop the connection, failing the sync/copy operation.

Fixes supabase/supabase#45584

### What is the new behavior?
This PR appends the `no-transform` directive to the `Cache-Control` header for S3 `GetObject` responses. According to RFC 7234, this explicitly instructs intermediate proxies (like Cloudflare) not to modify the payload. 

By enforcing byte-for-byte fidelity, `Content-Length` headers remain perfectly accurate, and strict S3 clients like `rclone` can copy HTML files without connection failures.

### Additional context
Tested locally to ensure headers merge correctly if a `Cache-Control` policy is already applied to the object.