### PR TITLE
fix: range reads for file backend

### DIFF
--- a/acceptance/specs/s3.test.ts
+++ b/acceptance/specs/s3.test.ts
@@ -179,6 +179,8 @@ describeAcceptance(
       const keyB = `${prefix}/b.txt`
       const keyC = `${prefix}/nested/c.txt`
       const copiedPartKey = `${prefix}/copied-part.txt`
+      const copiedWholePartKey = `${prefix}/copied-whole-part.txt`
+      const copiedInvalidRangeKey = `${prefix}/copied-invalid-range.txt`
       const abortedKey = `${prefix}/aborted.txt`
       const payload = Buffer.from('acceptance-s3-extended-object')
 
@@ -216,6 +218,46 @@ describeAcceptance(
         expect(await ranged.Body?.transformToString()).toBe(payload.subarray(0, 10).toString())
         expect(ranged.ContentRange).toBe(`bytes 0-9/${payload.length}`)
 
+        const suffixRange = await client.send(
+          new GetObjectCommand({
+            Bucket: bucketName,
+            Key: keyA,
+            Range: 'bytes=-5',
+          })
+        )
+        expect(await suffixRange.Body?.transformToString()).toBe(payload.subarray(-5).toString())
+        expect(suffixRange.ContentRange).toBe(
+          `bytes ${payload.length - 5}-${payload.length - 1}/${payload.length}`
+        )
+
+        const openEndedRange = await client.send(
+          new GetObjectCommand({
+            Bucket: bucketName,
+            Key: keyA,
+            Range: `bytes=${payload.length - 5}-`,
+          })
+        )
+        expect(await openEndedRange.Body?.transformToString()).toBe(
+          payload.subarray(payload.length - 5).toString()
+        )
+        expect(openEndedRange.ContentRange).toBe(
+          `bytes ${payload.length - 5}-${payload.length - 1}/${payload.length}`
+        )
+
+        await expect(
+          client.send(
+            new GetObjectCommand({
+              Bucket: bucketName,
+              Key: keyA,
+              Range: `bytes=${payload.length}-`,
+            })
+          )
+        ).rejects.toMatchObject({
+          $metadata: {
+            httpStatusCode: 416,
+          },
+        })
+
         const listedV1 = await client.send(
           new ListObjectsCommand({
             Bucket: bucketName,
@@ -240,7 +282,7 @@ describeAcceptance(
           new UploadPartCopyCommand({
             Bucket: bucketName,
             CopySource: `${bucketName}/${keyA}`,
-            CopySourceRange: `bytes=0-${payload.length - 1}`,
+            CopySourceRange: 'bytes=0-9',
             Key: copiedPartKey,
             PartNumber: 1,
             UploadId: multipartCopy.UploadId,
@@ -260,7 +302,68 @@ describeAcceptance(
         const copiedPartHead = await client.send(
           new HeadObjectCommand({ Bucket: bucketName, Key: copiedPartKey })
         )
-        expect(copiedPartHead.ContentLength).toBe(payload.length)
+        expect(copiedPartHead.ContentLength).toBe(10)
+
+        const wholePartCopy = await client.send(
+          new CreateMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: copiedWholePartKey,
+          })
+        )
+        const wholeCopiedPart = await client.send(
+          new UploadPartCopyCommand({
+            Bucket: bucketName,
+            CopySource: `${bucketName}/${keyA}`,
+            Key: copiedWholePartKey,
+            PartNumber: 1,
+            UploadId: wholePartCopy.UploadId,
+          })
+        )
+        expect(wholeCopiedPart.CopyPartResult?.ETag).toBeTruthy()
+        await client.send(
+          new CompleteMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: copiedWholePartKey,
+            MultipartUpload: {
+              Parts: [{ ETag: wholeCopiedPart.CopyPartResult?.ETag, PartNumber: 1 }],
+            },
+            UploadId: wholePartCopy.UploadId,
+          })
+        )
+        const copiedWholePartHead = await client.send(
+          new HeadObjectCommand({ Bucket: bucketName, Key: copiedWholePartKey })
+        )
+        expect(copiedWholePartHead.ContentLength).toBe(payload.length)
+
+        const invalidRangeCopy = await client.send(
+          new CreateMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: copiedInvalidRangeKey,
+          })
+        )
+        await expect(
+          client.send(
+            new UploadPartCopyCommand({
+              Bucket: bucketName,
+              CopySource: `${bucketName}/${keyA}`,
+              CopySourceRange: 'bytes=-5',
+              Key: copiedInvalidRangeKey,
+              PartNumber: 1,
+              UploadId: invalidRangeCopy.UploadId,
+            })
+          )
+        ).rejects.toMatchObject({
+          $metadata: {
+            httpStatusCode: 400,
+          },
+        })
+        await client.send(
+          new AbortMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: copiedInvalidRangeKey,
+            UploadId: invalidRangeCopy.UploadId,
+          })
+        )
 
         const aborted = await client.send(
           new CreateMultipartUploadCommand({
@@ -284,7 +387,9 @@ describeAcceptance(
           new DeleteObjectsCommand({
             Bucket: bucketName,
             Delete: {
-              Objects: [keyA, keyB, keyC, copiedPartKey].map((Key) => ({ Key })),
+              Objects: [keyA, keyB, keyC, copiedPartKey, copiedWholePartKey].map((Key) => ({
+                Key,
+              })),
             },
           })
         )

--- a/src/storage/backend/file.test.ts
+++ b/src/storage/backend/file.test.ts
@@ -1,9 +1,11 @@
 import * as fsp from 'node:fs/promises'
+import { ErrorCode } from '@internal/errors/codes'
 import { removePath } from '@internal/fs'
 import * as xattr from 'fs-xattr'
 import os from 'os'
 import path from 'path'
 import { Readable } from 'stream'
+import { text } from 'stream/consumers'
 import { type Mock, type MockInstance, vi } from 'vitest'
 import { getConfig } from '../../config'
 import { withOptionalVersion } from './adapter'
@@ -362,5 +364,103 @@ describe('FileBackend lastModified', () => {
 
     const getResult = await backend.getObject(bucket, key, version)
     expect(getResult.metadata.lastModified).toEqual(knownMtime)
+  })
+})
+
+describe('FileBackend range reads', () => {
+  let tmpDir: string
+  let backend: FileBackend
+  let originalStoragePath: string | undefined
+  let originalFilePath: string | undefined
+  const bucket = 'range-bucket'
+  const key = 'range.txt'
+  const version = 'v1'
+  const payload = '0123456789'
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'storage-file-backend-'))
+    originalStoragePath = process.env.STORAGE_FILE_BACKEND_PATH
+    originalFilePath = process.env.FILE_STORAGE_BACKEND_PATH
+    process.env.STORAGE_FILE_BACKEND_PATH = tmpDir
+    process.env.FILE_STORAGE_BACKEND_PATH = tmpDir
+    getConfig({ reload: true })
+    backend = new FileBackend()
+
+    await backend.uploadObject(
+      bucket,
+      key,
+      version,
+      Readable.from(payload),
+      'text/plain',
+      'no-cache'
+    )
+  })
+
+  afterEach(async () => {
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_FILE_BACKEND_PATH
+    } else {
+      process.env.STORAGE_FILE_BACKEND_PATH = originalStoragePath
+    }
+    if (originalFilePath === undefined) {
+      delete process.env.FILE_STORAGE_BACKEND_PATH
+    } else {
+      process.env.FILE_STORAGE_BACKEND_PATH = originalFilePath
+    }
+    await removePath(tmpDir)
+  })
+
+  it('returns inclusive explicit byte ranges', async () => {
+    const result = await backend.getObject(bucket, key, version, { range: 'bytes=2-5' })
+
+    await expect(text(result.body as NodeJS.ReadableStream)).resolves.toBe('2345')
+    expect(result.httpStatusCode).toBe(206)
+    expect(result.metadata.contentRange).toBe('bytes 2-5/10')
+    expect(result.metadata.contentLength).toBe(4)
+    expect(result.metadata.size).toBe(4)
+  })
+
+  it('returns open-ended byte ranges', async () => {
+    const result = await backend.getObject(bucket, key, version, { range: 'bytes=7-' })
+
+    await expect(text(result.body as NodeJS.ReadableStream)).resolves.toBe('789')
+    expect(result.metadata.contentRange).toBe('bytes 7-9/10')
+    expect(result.metadata.contentLength).toBe(3)
+    expect(result.metadata.size).toBe(3)
+  })
+
+  it('returns suffix byte ranges', async () => {
+    const result = await backend.getObject(bucket, key, version, { range: 'bytes=-5' })
+
+    await expect(text(result.body as NodeJS.ReadableStream)).resolves.toBe('56789')
+    expect(result.metadata.contentRange).toBe('bytes 5-9/10')
+    expect(result.metadata.contentLength).toBe(5)
+    expect(result.metadata.size).toBe(5)
+  })
+
+  it('caps range ends at the object size', async () => {
+    const result = await backend.getObject(bucket, key, version, { range: 'bytes=8-99' })
+
+    await expect(text(result.body as NodeJS.ReadableStream)).resolves.toBe('89')
+    expect(result.metadata.contentRange).toBe('bytes 8-9/10')
+    expect(result.metadata.contentLength).toBe(2)
+    expect(result.metadata.size).toBe(2)
+  })
+
+  it.each([
+    'bytes=-0',
+    'bytes=10-12',
+    'bytes=8-4',
+    'bytes=-',
+    'bytes=a-b',
+    'items=0-1',
+  ])('rejects invalid byte range %s', async (range) => {
+    await expect(backend.getObject(bucket, key, version, { range })).rejects.toMatchObject({
+      code: ErrorCode.InvalidRange,
+      error: 'invalid_range',
+      httpStatusCode: 416,
+      userStatusCode: 416,
+      message: 'invalid range provided',
+    })
   })
 })

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -9,6 +9,7 @@ import path from 'path'
 import stream from 'stream'
 import { promisify } from 'util'
 import { getConfig } from '../../config'
+import { parseRangeHeader } from '../range'
 import {
   BrowserCacheHeaders,
   ObjectMetadata,
@@ -129,23 +130,19 @@ export class FileBackend implements StorageBackendAdapter {
     }
 
     if (headers?.range) {
-      const parts = headers.range.replace(/bytes=/, '').split('-')
-      const startRange = parseInt(parts[0], 10)
-      const endRange = parts[1] ? parseInt(parts[1], 10) : fileSize - 1
-      const size = endRange - startRange
-      const chunkSize = size + 1
-      const body = fs.createReadStream(file, { start: startRange, end: endRange })
+      const range = parseRangeHeader(headers.range, fileSize)
+      const body = fs.createReadStream(file, { start: range.fromByte, end: range.toByte })
 
       return {
         metadata: {
           cacheControl: cacheControl || 'no-cache',
           mimetype: contentType || 'application/octet-stream',
           lastModified,
-          contentRange: `bytes ${startRange}-${endRange}/${fileSize}`,
+          contentRange: `bytes ${range.fromByte}-${range.toByte}/${fileSize}`,
           httpStatusCode: 206,
-          size,
+          size: range.size,
           eTag,
-          contentLength: chunkSize,
+          contentLength: range.size,
         },
         httpStatusCode: 206,
         body,

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -24,6 +24,7 @@ import { PassThrough, Readable } from 'stream'
 import stream from 'stream/promises'
 import { getConfig } from '../../../config'
 import { getFileSizeLimit, mustBeValidBucketName, mustBeValidKey } from '../../limits'
+import { parseCopySourceRangeHeader } from '../../range'
 import { S3MultipartUpload } from '../../schemas'
 import { Storage } from '../../storage'
 import { Uploader, validateMimeType } from '../../uploader'
@@ -1222,10 +1223,6 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingParameter('CopySource')
     }
 
-    if (!CopySourceRange) {
-      throw ERRORS.MissingParameter('CopySourceRange')
-    }
-
     const sourceBucketName = (
       CopySource.startsWith('/') ? CopySource.replace('/', '').split('/') : CopySource.split('/')
     ).shift()
@@ -1250,25 +1247,14 @@ export class S3ProtocolHandler {
       'id,name,version,metadata'
     )
 
-    let copySize = copySource.metadata?.size || 0
+    const sourceSize = Number(copySource.metadata?.size ?? 0)
+    let copySize = sourceSize
     let rangeBytes: { fromByte: number; toByte: number } | undefined = undefined
 
     if (CopySourceRange) {
-      const bytes = CopySourceRange.split('=')[1].split('-')
-
-      if (bytes.length !== 2) {
-        throw ERRORS.InvalidRange()
-      }
-
-      const fromByte = Number(bytes[0])
-      const toByte = Number(bytes[1])
-
-      if (isNaN(fromByte) || isNaN(toByte)) {
-        throw ERRORS.InvalidRange()
-      }
-
-      rangeBytes = { fromByte, toByte }
-      copySize = toByte - fromByte
+      const range = parseCopySourceRangeHeader(CopySourceRange, sourceSize)
+      rangeBytes = range
+      copySize = range.size
     }
 
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)

--- a/src/storage/range.test.ts
+++ b/src/storage/range.test.ts
@@ -1,0 +1,69 @@
+import { ErrorCode } from '@internal/errors'
+import { parseCopySourceRangeHeader, parseRangeHeader } from './range'
+
+describe('byte range parsing', () => {
+  describe('parseRangeHeader', () => {
+    it.each([
+      ['bytes=0-0', { fromByte: 0, size: 1, toByte: 0 }],
+      ['bytes=2-5', { fromByte: 2, size: 4, toByte: 5 }],
+      ['bytes=7-', { fromByte: 7, size: 3, toByte: 9 }],
+      ['bytes=-5', { fromByte: 5, size: 5, toByte: 9 }],
+      ['bytes=8-99', { fromByte: 8, size: 2, toByte: 9 }],
+      ['bytes=9-9', { fromByte: 9, size: 1, toByte: 9 }],
+      ['bytes=0-9', { fromByte: 0, size: 10, toByte: 9 }],
+      ['bytes=-99', { fromByte: 0, size: 10, toByte: 9 }],
+    ])('parses %s', (range, expected) => {
+      expect(parseRangeHeader(range, 10)).toEqual(expected)
+    })
+
+    it.each([
+      'bytes=-0',
+      'bytes=10-12',
+      'bytes=8-4',
+      'bytes=-',
+      'bytes=a-b',
+      'items=0-1',
+    ])('rejects invalid range %s', (range) => {
+      expectInvalidRange(() => parseRangeHeader(range, 10), 416)
+    })
+  })
+
+  describe('parseCopySourceRangeHeader', () => {
+    it.each([
+      ['bytes=0-0', { fromByte: 0, size: 1, toByte: 0 }],
+      ['bytes=2-5', { fromByte: 2, size: 4, toByte: 5 }],
+      ['bytes=9-9', { fromByte: 9, size: 1, toByte: 9 }],
+      ['bytes=0-9', { fromByte: 0, size: 10, toByte: 9 }],
+    ])('parses inclusive explicit copy source range %s', (range, expected) => {
+      expect(parseCopySourceRangeHeader(range, 10)).toEqual(expected)
+    })
+
+    it.each([
+      'bytes=-5',
+      'bytes=7-',
+      'bytes=10-12',
+      'bytes=8-4',
+      'bytes=a-b',
+      'items=0-1',
+    ])('rejects invalid copy source range %s', (range) => {
+      expectInvalidRange(() => parseCopySourceRangeHeader(range, 10), 400)
+    })
+  })
+})
+
+function expectInvalidRange(fn: () => unknown, statusCode: number) {
+  try {
+    fn()
+  } catch (error) {
+    expect(error).toMatchObject({
+      code: ErrorCode.InvalidRange,
+      error: 'invalid_range',
+      httpStatusCode: statusCode,
+      userStatusCode: statusCode,
+      message: 'invalid range provided',
+    })
+    return
+  }
+
+  throw new Error('expected invalid range error')
+}

--- a/src/storage/range.ts
+++ b/src/storage/range.ts
@@ -1,0 +1,87 @@
+import { ERRORS, ErrorCode, StorageBackendError } from '@internal/errors'
+
+export interface ByteRange {
+  fromByte: number
+  size: number
+  toByte: number
+}
+
+export function parseRangeHeader(range: string, fileSize: number): ByteRange {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(range)
+  if (!match || fileSize <= 0) {
+    throw invalidRangeHeaderError()
+  }
+
+  const [, startValue, endValue] = match
+  if (!startValue && !endValue) {
+    throw invalidRangeHeaderError()
+  }
+
+  if (!startValue) {
+    const suffixLength = Number(endValue)
+    if (!Number.isSafeInteger(suffixLength) || suffixLength <= 0) {
+      throw invalidRangeHeaderError()
+    }
+
+    const fromByte = Math.max(fileSize - suffixLength, 0)
+    const toByte = fileSize - 1
+    return {
+      fromByte,
+      size: toByte - fromByte + 1,
+      toByte,
+    }
+  }
+
+  const fromByte = Number(startValue)
+  const toByte = endValue ? Number(endValue) : fileSize - 1
+  if (!isValidRange(fromByte, toByte, fileSize)) {
+    throw invalidRangeHeaderError()
+  }
+
+  const clampedToByte = Math.min(toByte, fileSize - 1)
+  return {
+    fromByte,
+    size: clampedToByte - fromByte + 1,
+    toByte: clampedToByte,
+  }
+}
+
+function invalidRangeHeaderError() {
+  return StorageBackendError.withStatusCode(416, {
+    error: 'invalid_range',
+    code: ErrorCode.InvalidRange,
+    httpStatusCode: 416,
+    message: 'invalid range provided',
+  })
+}
+
+export function parseCopySourceRangeHeader(range: string, sourceSize: number): ByteRange {
+  const match = /^bytes=(\d+)-(\d+)$/.exec(range)
+  if (!match) {
+    throw ERRORS.InvalidRange()
+  }
+
+  const [, startValue, endValue] = match
+  const fromByte = Number(startValue)
+  const toByte = Number(endValue)
+
+  if (!isValidRange(fromByte, toByte, sourceSize) || toByte >= sourceSize) {
+    throw ERRORS.InvalidRange()
+  }
+
+  return {
+    fromByte,
+    size: toByte - fromByte + 1,
+    toByte,
+  }
+}
+
+function isValidRange(fromByte: number, toByte: number, objectSize: number): boolean {
+  return (
+    Number.isSafeInteger(fromByte) &&
+    Number.isSafeInteger(toByte) &&
+    fromByte >= 0 &&
+    toByte >= fromByte &&
+    fromByte < objectSize
+  )
+}

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -2298,6 +2298,128 @@ describe('S3 Protocol', () => {
     })
 
     describe('UploadPartCopyCommand', () => {
+      it('copies inclusive source ranges without dropping boundary bytes', async () => {
+        const bucket = await createBucket(client)
+
+        const sourceKey = `source-${randomUUID()}.txt`
+        const payload = Buffer.from('0123456789')
+
+        await client.send(
+          new PutObjectCommand({
+            Bucket: bucket,
+            Key: sourceKey,
+            Body: payload,
+            ContentType: 'text/plain',
+          })
+        )
+
+        const rangeCases: Array<[string, Buffer]> = [
+          ['bytes=0-0', Buffer.from('0')],
+          ['bytes=9-9', Buffer.from('9')],
+          ['bytes=0-9', payload],
+          ['bytes=2-5', Buffer.from('2345')],
+        ]
+
+        for (const [copySourceRange, expected] of rangeCases) {
+          const targetKey = `range-copy-${randomUUID()}.txt`
+          const multipart = await client.send(
+            new CreateMultipartUploadCommand({
+              Bucket: bucket,
+              Key: targetKey,
+              ContentType: 'text/plain',
+            })
+          )
+
+          const copiedPart = await client.send(
+            new UploadPartCopyCommand({
+              Bucket: bucket,
+              Key: targetKey,
+              UploadId: multipart.UploadId,
+              PartNumber: 1,
+              CopySource: `${bucket}/${sourceKey}`,
+              CopySourceRange: copySourceRange,
+            })
+          )
+
+          expect(copiedPart.CopyPartResult?.ETag).toBeTruthy()
+
+          await client.send(
+            new CompleteMultipartUploadCommand({
+              Bucket: bucket,
+              Key: targetKey,
+              UploadId: multipart.UploadId,
+              MultipartUpload: {
+                Parts: [
+                  {
+                    PartNumber: 1,
+                    ETag: copiedPart.CopyPartResult?.ETag,
+                  },
+                ],
+              },
+            })
+          )
+
+          const copiedObject = await client.send(
+            new GetObjectCommand({
+              Bucket: bucket,
+              Key: targetKey,
+            })
+          )
+          const copiedBytes = await copiedObject.Body?.transformToByteArray()
+
+          expect(copiedObject.ContentLength).toBe(expected.length)
+          expect(Buffer.from(copiedBytes || [])).toEqual(expected)
+        }
+      })
+
+      it('accounts source ranges inclusively when enforcing max file size', async () => {
+        const bucket = await createBucket(client)
+        const sourceKey = `source-${randomUUID()}.txt`
+        const targetKey = `range-copy-limit-${randomUUID()}.txt`
+
+        await client.send(
+          new PutObjectCommand({
+            Bucket: bucket,
+            Key: sourceKey,
+            Body: Buffer.from('0123456789'),
+            ContentType: 'text/plain',
+          })
+        )
+
+        mergeConfig({
+          uploadFileSizeLimit: 1,
+        })
+
+        const multipart = await client.send(
+          new CreateMultipartUploadCommand({
+            Bucket: bucket,
+            Key: targetKey,
+            ContentType: 'text/plain',
+          })
+        )
+
+        try {
+          await client.send(
+            new UploadPartCopyCommand({
+              Bucket: bucket,
+              Key: targetKey,
+              UploadId: multipart.UploadId,
+              PartNumber: 1,
+              CopySource: `${bucket}/${sourceKey}`,
+              CopySourceRange: 'bytes=0-1',
+            })
+          )
+          throw new Error('Should not reach here')
+        } catch (e) {
+          expect((e as Error).message).not.toEqual('Should not reach here')
+          expect((e as S3ServiceException).$metadata.httpStatusCode).toEqual(413)
+          expect((e as S3ServiceException).message).toEqual(
+            'The object exceeded the maximum allowed size'
+          )
+          expect((e as S3ServiceException).name).toEqual('EntityTooLarge')
+        }
+      })
+
       it('will copy a part from an existing object and upload it as a part', async () => {
         const bucket = await createBucket(client)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

File backend range header parser assumes both numeric.
Upload part copy requires a range header. It also has off by one error.

## What is the new behavior?

Parser is permissive as expected.
Upload part copy a range is [optional](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html). Size check is done correctly.

