### PR TITLE
chore: drop @types/cloneable-readable dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "@aws-sdk/s3-presigned-post": "^3.1023.0",
         "@biomejs/biome": "^2.4.4",
         "@types/async-retry": "^1.4.5",
-        "@types/cloneable-readable": "^2.0.3",
         "@types/js-yaml": "^4.0.5",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^24.12.0",
@@ -11887,15 +11886,6 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
-      }
-    },
-    "node_modules/@types/cloneable-readable": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cloneable-readable/-/cloneable-readable-2.0.3.tgz",
-      "integrity": "sha512-+Ihof4L4iu9k4WTzYbJSkzUxt6f1wzXn6u48fZYxgST+BsC9bBHTOJ59Buy1/4sC9j7ZWF7bxDf/n/mrtk/nzw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {
@@ -26296,15 +26286,6 @@
       "requires": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
-      }
-    },
-    "@types/cloneable-readable": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cloneable-readable/-/cloneable-readable-2.0.3.tgz",
-      "integrity": "sha512-+Ihof4L4iu9k4WTzYbJSkzUxt6f1wzXn6u48fZYxgST+BsC9bBHTOJ59Buy1/4sC9j7ZWF7bxDf/n/mrtk/nzw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/connect": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@aws-sdk/s3-presigned-post": "^3.1023.0",
     "@biomejs/biome": "^2.4.4",
     "@types/async-retry": "^1.4.5",
-    "@types/cloneable-readable": "^2.0.3",
     "@types/js-yaml": "^4.0.5",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

@types/cloneable-readable is in dev dependencies.

## What is the new behavior?

Dropped since not needed.
