### PR TITLE
fix: s3 delete object idempotent

### DIFF
--- a/acceptance/API_COVERAGE.md
+++ b/acceptance/API_COVERAGE.md
@@ -15,7 +15,7 @@ These run in `smoke` / `core` profiles and are included in the default local CI 
 | REST objects           | upload, update, authenticated read/head/info, public read/head/info, delete                                                       |
 | REST object operations | list-v1, list-v2, signed URL, batch signed URLs, signed upload URL, copy, move, bulk delete                                       |
 | S3 buckets             | CreateBucket, HeadBucket, ListBuckets, GetBucketLocation, GetBucketVersioning, DeleteBucket                                       |
-| S3 objects             | PutObject, HeadObject, GetObject, Range GetObject, CopyObject, DeleteObject, DeleteObjects                                        |
+| S3 objects             | PutObject, HeadObject, GetObject, Range GetObject, CopyObject, DeleteObject idempotency, DeleteObjects                            |
 | S3 listing             | ListObjectsV2, ListObjects V1 with delimiter/common prefixes                                                                      |
 | S3 multipart           | CreateMultipartUpload, UploadPart, ListParts, CompleteMultipartUpload, UploadPartCopy, AbortMultipartUpload, ListMultipartUploads |
 | TUS                    | OPTIONS, POST create, HEAD offset, PATCH resume, DELETE termination, full upload through `tus-js-client`, signed TUS upload       |

--- a/acceptance/specs/s3.test.ts
+++ b/acceptance/specs/s3.test.ts
@@ -97,8 +97,18 @@ describeAcceptance(
         )
         expect(copied.ContentLength).toBe(payload.length)
 
-        await client.send(new DeleteObjectCommand({ Bucket: bucketName, Key: key }))
-        await client.send(new DeleteObjectCommand({ Bucket: bucketName, Key: copyKey }))
+        const existingDelete = await client.send(
+          new DeleteObjectCommand({ Bucket: bucketName, Key: key })
+        )
+        expect(existingDelete.$metadata.httpStatusCode).toBe(204)
+        const copiedDelete = await client.send(
+          new DeleteObjectCommand({ Bucket: bucketName, Key: copyKey })
+        )
+        expect(copiedDelete.$metadata.httpStatusCode).toBe(204)
+        const missingDelete = await client.send(
+          new DeleteObjectCommand({ Bucket: bucketName, Key: uniqueObjectKey('missing', 'txt') })
+        )
+        expect(missingDelete.$metadata.httpStatusCode).toBe(204)
       } finally {
         await cleanupS3Bucket(client, bucketName)
         client.destroy()
@@ -383,16 +393,29 @@ describeAcceptance(
         )
         expect(activeUploads.Uploads ?? []).toHaveLength(0)
 
-        await client.send(
+        const bulkMissingKey = uniqueObjectKey('bulk-missing', 'txt')
+        const bulkDelete = await client.send(
           new DeleteObjectsCommand({
             Bucket: bucketName,
             Delete: {
-              Objects: [keyA, keyB, keyC, copiedPartKey, copiedWholePartKey].map((Key) => ({
-                Key,
-              })),
+              Objects: [keyA, keyB, keyC, copiedPartKey, copiedWholePartKey, bulkMissingKey].map(
+                (Key) => ({ Key })
+              ),
             },
           })
         )
+        expect(bulkDelete.Deleted?.map((object) => object.Key)).toEqual(
+          expect.arrayContaining([
+            keyA,
+            keyB,
+            keyC,
+            copiedPartKey,
+            copiedWholePartKey,
+            bulkMissingKey,
+          ])
+        )
+        expect(bulkDelete.Deleted).toHaveLength(6)
+        expect(bulkDelete.Errors ?? []).toEqual([])
 
         await client.send(new DeleteBucketCommand({ Bucket: bucketName }))
       } finally {

--- a/src/http/routes/s3/commands/delete-object.ts
+++ b/src/http/routes/s3/commands/delete-object.ts
@@ -103,7 +103,9 @@ export default function DeleteObject(s3Router: S3Router) {
 
         await ctx.req.storage.backend.deleteObject(internalBucketName, req.Params['*'], undefined)
 
-        return {}
+        return {
+          statusCode: 204,
+        }
       }
     )
   }

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -241,6 +241,68 @@ describe('CompleteMultipartUpload route mapping', () => {
   })
 })
 
+describe('DeleteObject route mapping', () => {
+  it('returns 204 from iceberg single-object deletes', async () => {
+    const previousIcebergDeleteEnabled = process.env.ICEBERG_S3_DELETE_ENABLED
+    process.env.ICEBERG_S3_DELETE_ENABLED = 'true'
+    vi.resetModules()
+
+    try {
+      const [{ Router: FreshRouter }, { default: DeleteObject }] = await Promise.all([
+        import('./router'),
+        import('./commands/delete-object'),
+      ])
+      const router = new FreshRouter()
+      const deleteObject = vi.fn().mockResolvedValue(undefined)
+
+      DeleteObject(router as unknown as S3Router)
+
+      const route = router
+        .routes()
+        .get('/:Bucket/*')
+        ?.find((candidate) => candidate.method === 'delete' && candidate.type === 'iceberg')
+
+      expect(route).toBeDefined()
+
+      const response = await route!.handler!(
+        {
+          Params: {
+            Bucket: 'public-bucket',
+            '*': 'metadata/file.avro',
+          },
+          Querystring: {},
+        } as never,
+        {
+          req: {
+            internalIcebergBucketName: 'internal-iceberg-bucket',
+            storage: {
+              backend: {
+                deleteObject,
+              },
+            },
+          },
+        } as never
+      )
+
+      expect(deleteObject).toHaveBeenCalledWith(
+        'internal-iceberg-bucket',
+        'metadata/file.avro',
+        undefined
+      )
+      expect(response).toEqual({
+        statusCode: 204,
+      })
+    } finally {
+      if (previousIcebergDeleteEnabled === undefined) {
+        delete process.env.ICEBERG_S3_DELETE_ENABLED
+      } else {
+        process.env.ICEBERG_S3_DELETE_ENABLED = previousIcebergDeleteEnabled
+      }
+      vi.resetModules()
+    }
+  })
+})
+
 describe('S3ProtocolHandler multipart completion regressions', () => {
   it('preserves ChecksumCRC32C when completing multipart uploads', async () => {
     const backend = {

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -1,0 +1,82 @@
+import { ERRORS, ErrorCode } from '@internal/errors'
+import { describe, expect, it, vi } from 'vitest'
+import { StorageBackendAdapter } from './backend'
+import { Database } from './database'
+import { StorageObjectLocator } from './locator'
+import { ObjectStorage } from './object'
+
+function createObjectStorage({
+  findObject = vi.fn().mockResolvedValue({
+    id: 'object-id',
+    version: 'version-1',
+  }),
+  deleteObject = vi.fn().mockResolvedValue({
+    name: 'private/file.txt',
+    version: 'version-1',
+  }),
+}: {
+  findObject?: ReturnType<typeof vi.fn>
+  deleteObject?: ReturnType<typeof vi.fn>
+} = {}) {
+  const backend = {
+    deleteObject: vi.fn(),
+  } as unknown as StorageBackendAdapter
+  const superUserDb = {
+    findObject,
+  }
+  const scopedDb = {
+    asSuperUser: vi.fn(() => superUserDb),
+    deleteObject,
+  }
+  const db = {
+    tenantId: 'tenant-id',
+    withTransaction: vi.fn((fn) => fn(scopedDb)),
+  } as unknown as Database
+  const location = {
+    getRootLocation: vi.fn(() => 'root-bucket'),
+    getKeyLocation: vi.fn(() => 'tenant-id/bucket/private/file.txt'),
+  } as unknown as StorageObjectLocator
+  const storage = new ObjectStorage(backend, db, location, 'bucket')
+
+  return {
+    backend,
+    deleteObject,
+    findObject,
+    location,
+    storage,
+  }
+}
+
+describe('ObjectStorage.deleteObject', () => {
+  it('throws AccessDenied when the object exists but scoped delete is blocked by RLS', async () => {
+    const { backend, deleteObject, findObject, storage } = createObjectStorage({
+      deleteObject: vi.fn().mockResolvedValue(undefined),
+    })
+
+    await expect(storage.deleteObject('private/file.txt')).rejects.toMatchObject({
+      code: ErrorCode.AccessDenied,
+      httpStatusCode: 403,
+      message: 'Access denied',
+    })
+
+    expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', 'id,version', {
+      forUpdate: true,
+    })
+    expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt')
+    expect(backend.deleteObject).not.toHaveBeenCalled()
+  })
+
+  it('keeps true missing objects as NoSuchKey before attempting scoped delete', async () => {
+    const { backend, deleteObject, storage } = createObjectStorage({
+      findObject: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('missing.txt')),
+    })
+
+    await expect(storage.deleteObject('missing.txt')).rejects.toMatchObject({
+      code: ErrorCode.NoSuchKey,
+      httpStatusCode: 404,
+    })
+
+    expect(deleteObject).not.toHaveBeenCalled()
+    expect(backend.deleteObject).not.toHaveBeenCalled()
+  })
+})

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -134,7 +134,7 @@ export class ObjectStorage {
       const deleted = await db.deleteObject(this.bucketId, objectName)
 
       if (!deleted) {
-        throw ERRORS.NoSuchKey(objectName)
+        throw ERRORS.AccessDenied('Access denied')
       }
 
       await this.backend.deleteObject(

--- a/src/storage/protocols/s3/s3-handler-delete.test.ts
+++ b/src/storage/protocols/s3/s3-handler-delete.test.ts
@@ -1,0 +1,108 @@
+import { ERRORS, ErrorCode } from '@internal/errors'
+import { describe, expect, it, vi } from 'vitest'
+import { S3ProtocolHandler } from './s3-handler'
+
+function createHandler(
+  remainingKeys: string[] = [],
+  findBucket = vi.fn().mockResolvedValue({ id: 'bucket' }),
+  deletedKeys: string[] = []
+) {
+  const deleteObjects = vi.fn().mockResolvedValue(deletedKeys.map((name) => ({ name })))
+  const findObjects = vi.fn().mockResolvedValue(remainingKeys.map((name) => ({ name })))
+  const scopedFrom = vi.fn(() => ({
+    deleteObjects,
+  }))
+  const superUserFrom = vi.fn(() => ({
+    findObjects,
+  }))
+  const storage = {
+    asSuperUser: vi.fn(() => ({
+      findBucket,
+      from: superUserFrom,
+    })),
+    from: scopedFrom,
+  }
+  const handler = new S3ProtocolHandler(storage as never, 'tenant-id')
+
+  return {
+    deleteObjects,
+    findBucket,
+    findObjects,
+    handler,
+    scopedFrom,
+    storage,
+    superUserFrom,
+  }
+}
+
+describe('S3ProtocolHandler.deleteObjects', () => {
+  it('reports missing keys as deleted and existing keys blocked by RLS as AccessDenied', async () => {
+    const { deleteObjects, findBucket, findObjects, handler } = createHandler(
+      ['denied.txt'],
+      undefined,
+      ['allowed.txt']
+    )
+
+    const response = await handler.deleteObjects({
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [{ Key: 'allowed.txt' }, { Key: 'missing.txt' }, { Key: 'denied.txt' }],
+      },
+    })
+
+    expect(findBucket).not.toHaveBeenCalled()
+    expect(deleteObjects).toHaveBeenCalledWith(['allowed.txt', 'missing.txt', 'denied.txt'])
+    expect(findObjects).toHaveBeenCalledWith(['missing.txt', 'denied.txt'], 'name')
+    expect(response.responseBody).toEqual({
+      DeleteResult: {
+        Deleted: [{ Key: 'allowed.txt' }, { Key: 'missing.txt' }],
+        Error: [{ Code: 'AccessDenied', Key: 'denied.txt', Message: 'Access Denied' }],
+      },
+    })
+  })
+
+  it('does not check the bucket again when requested keys were deleted', async () => {
+    const { deleteObjects, findBucket, findObjects, handler } = createHandler([], undefined, [
+      'allowed.txt',
+    ])
+
+    const response = await handler.deleteObjects({
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [{ Key: 'allowed.txt' }],
+      },
+    })
+
+    expect(findBucket).not.toHaveBeenCalled()
+    expect(deleteObjects).toHaveBeenCalledWith(['allowed.txt'])
+    expect(findObjects).not.toHaveBeenCalled()
+    expect(response.responseBody).toEqual({
+      DeleteResult: {
+        Deleted: [{ Key: 'allowed.txt' }],
+        Error: [],
+      },
+    })
+  })
+
+  it('does not report keys as deleted when the bucket does not exist', async () => {
+    const { deleteObjects, findBucket, findObjects, handler } = createHandler(
+      [],
+      vi.fn().mockRejectedValue(ERRORS.NoSuchBucket('missing-bucket'))
+    )
+
+    await expect(
+      handler.deleteObjects({
+        Bucket: 'missing-bucket',
+        Delete: {
+          Objects: [{ Key: 'missing.txt' }],
+        },
+      })
+    ).rejects.toMatchObject({
+      code: ErrorCode.NoSuchBucket,
+    })
+
+    expect(findBucket).toHaveBeenCalledWith('missing-bucket')
+    expect(deleteObjects).toHaveBeenCalledWith(['missing.txt'])
+    expect(findObjects).toHaveBeenCalledWith(['missing.txt'], 'name')
+  })
+})

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -18,7 +18,7 @@ import {
   UploadPartCopyCommandInput,
 } from '@aws-sdk/client-s3'
 import { decrypt, encrypt } from '@internal/auth'
-import { ERRORS } from '@internal/errors'
+import { ERRORS, ErrorCode, isStorageError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import { PassThrough, Readable } from 'stream'
 import stream from 'stream/promises'
@@ -1004,9 +1004,19 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingParameter('Key')
     }
 
-    await this.storage.from(Bucket).deleteObject(Key)
+    try {
+      await this.storage.from(Bucket).deleteObject(Key)
+    } catch (e) {
+      if (!isStorageError(ErrorCode.NoSuchKey, e)) {
+        throw e
+      }
 
-    return {}
+      await this.storage.asSuperUser().findBucket(Bucket)
+    }
+
+    return {
+      statusCode: 204,
+    }
   }
 
   /**
@@ -1032,29 +1042,43 @@ export class S3ProtocolHandler {
     }
 
     if (Delete.Objects.length === 0) {
-      return {}
+      await this.storage.asSuperUser().findBucket(Bucket)
+      return { responseBody: { DeleteResult: { Deleted: [], Error: [] } } }
     }
 
-    const deletedResult = await this.storage
-      .from(Bucket)
-      .deleteObjects(Delete.Objects.map((o) => o.Key || ''))
+    const requestedKeys = Delete.Objects.filter((object) => object.Key !== undefined).map(
+      (object) => object.Key || ''
+    )
 
-    const deletedNames = new Set<string>()
-    for (const result of deletedResult) {
-      deletedNames.add(result.name)
+    const deletedObjects = await this.storage.from(Bucket).deleteObjects(requestedKeys)
+    const deletedNames = new Set(deletedObjects.map((object) => object.name))
+    const unresolvedKeys = requestedKeys.filter((key) => !deletedNames.has(key))
+
+    const remainingObjects =
+      unresolvedKeys.length > 0
+        ? await this.storage.asSuperUser().from(Bucket).findObjects(unresolvedKeys, 'name')
+        : []
+
+    if (deletedObjects.length === 0 && remainingObjects.length === 0) {
+      await this.storage.asSuperUser().findBucket(Bucket)
     }
 
-    const deleted: { Key?: string }[] = []
+    const remainingNames = new Set(remainingObjects.map((object) => object.name))
+
+    const deleted: { Key: string }[] = []
     const errors: { Key?: string; Code: string; Message: string }[] = []
 
     for (const object of Delete.Objects) {
-      if (object.Key !== undefined && deletedNames.has(object.Key)) {
+      if (
+        object.Key !== undefined &&
+        (deletedNames.has(object.Key) || !remainingNames.has(object.Key))
+      ) {
         deleted.push({ Key: object.Key })
       } else {
         errors.push({
           Key: object.Key,
           Code: 'AccessDenied',
-          Message: "You do not have permission to delete this object or the object doesn't exist",
+          Message: 'Access Denied',
         })
       }
     }

--- a/src/test/rls_tests.yaml
+++ b/src/test/rls_tests.yaml
@@ -118,7 +118,7 @@ tests:
       - operation: object.delete
         role: authenticated
         status: 400
-        message: "Object not found"
+        message: "Access denied"
 
       - operation: upload
         bucketName: "bucket_{{runId}}"
@@ -180,7 +180,7 @@ tests:
       - operation: object.delete
         role: authenticated
         status: 400
-        message: "Object not found"
+        message: "Access denied"
 
   - description: "Will not empty a bucket without delete permission on objects"
     policies:
@@ -307,7 +307,7 @@ tests:
 
       - operation: object.delete
         status: 400
-        error: "Object not found"
+        error: "Access denied"
 
       - operation: bucket.update
         status: 200
@@ -344,7 +344,7 @@ tests:
 
       - operation: object.delete
         status: 400
-        error: "Object not found"
+        error: "Access denied"
 
       - operation: bucket.update
         status: 400
@@ -385,7 +385,7 @@ tests:
 
       - operation: object.delete
         status: 400
-        error: "Object not found"
+        error: "Access denied"
 
       - operation: object.delete
         role: service
@@ -661,7 +661,7 @@ tests:
 
       - operation: object.delete
         status: 400
-        error: "Object not found"
+        error: "Access denied"
 
   - description: "Operation helper any-of policies allow both list and get"
     policies:
@@ -680,4 +680,4 @@ tests:
 
       - operation: object.delete
         status: 400
-        error: "Object not found"
+        error: "Access denied"

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -40,7 +40,13 @@ import app from '../app'
 import { getConfig, mergeConfig } from '../config'
 import { EMPTY_SHA256_HASH, SignatureV4, SignatureV4Service } from '../storage/protocols/s3'
 
-const { s3ProtocolAccessKeySecret, s3ProtocolAccessKeyId, storageS3Region } = getConfig()
+const {
+  anonKeyAsync,
+  s3ProtocolAccessKeySecret,
+  s3ProtocolAccessKeyId,
+  storageS3Region,
+  tenantId,
+} = getConfig()
 const STREAMING_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
 const STREAMING_TRAILER_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER'
 async function createBucket(client: S3Client, name?: string, publicRead = true) {
@@ -1744,7 +1750,8 @@ describe('S3 Protocol', () => {
           Key: key,
         })
 
-        await client.send(deleteObject)
+        const deleteResp = await client.send(deleteObject)
+        expect(deleteResp.$metadata.httpStatusCode).toEqual(204)
 
         const getObject = new GetObjectCommand({
           Bucket: bucketName,
@@ -1755,6 +1762,34 @@ describe('S3 Protocol', () => {
           await client.send(getObject)
         } catch (e) {
           expect((e as S3ServiceException).$metadata.httpStatusCode).toEqual(404)
+        }
+      })
+
+      it('can delete non-existing object', async () => {
+        const bucketName = await createBucket(client)
+
+        const deleteObject = new DeleteObjectCommand({
+          Bucket: bucketName,
+          Key: crypto.randomUUID() + '.jpg',
+        })
+
+        const deleteResp = await client.send(deleteObject)
+        expect(deleteResp.$metadata.httpStatusCode).toEqual(204)
+      })
+
+      it('does not treat a missing bucket as an idempotent object delete', async () => {
+        const deleteObject = new DeleteObjectCommand({
+          Bucket: `missing-bucket-${randomUUID()}`,
+          Key: crypto.randomUUID() + '.jpg',
+        })
+
+        try {
+          await client.send(deleteObject)
+          throw new Error('Should not reach here')
+        } catch (e) {
+          expect((e as Error).message).not.toBe('Should not reach here')
+          expect((e as S3ServiceException).$metadata.httpStatusCode).toEqual(404)
+          expect((e as S3ServiceException).name).toEqual('NoSuchBucket')
         }
       })
     })
@@ -1865,19 +1900,14 @@ describe('S3 Protocol', () => {
           {
             Key: 'test-1.jpg',
           },
-        ])
-        expect(deleteResp.Errors).toEqual([
           {
             Key: 'test-2.jpg',
-            Code: 'AccessDenied',
-            Message: "You do not have permission to delete this object or the object doesn't exist",
           },
           {
             Key: 'test-3.jpg',
-            Code: 'AccessDenied',
-            Message: "You do not have permission to delete this object or the object doesn't exist",
           },
         ])
+        expect(deleteResp.Errors ?? []).toEqual([])
 
         const listObjectsCommand = new ListObjectsV2Command({
           Bucket: bucketName,
@@ -1885,6 +1915,125 @@ describe('S3 Protocol', () => {
 
         const resp = await client.send(listObjectsCommand)
         expect(resp.Contents).toBe(undefined)
+      })
+
+      it('does not treat a missing bucket as a successful bulk delete', async () => {
+        const deleteObjectsCommand = new DeleteObjectsCommand({
+          Bucket: `missing-bucket-${randomUUID()}`,
+          Delete: {
+            Objects: [{ Key: 'test-1.jpg' }],
+          },
+        })
+
+        try {
+          await client.send(deleteObjectsCommand)
+          throw new Error('Should not reach here')
+        } catch (e) {
+          expect((e as Error).message).not.toBe('Should not reach here')
+          expect((e as S3ServiceException).$metadata.httpStatusCode).toEqual(404)
+          expect((e as S3ServiceException).name).toEqual('NoSuchBucket')
+        }
+      })
+
+      it('returns AccessDenied for existing objects blocked by RLS', async () => {
+        const bucketName = await createBucket(client, 'delete-permission', false)
+        const allowedKey = 'allowed/delete-me.jpg'
+        const deniedKey = 'denied/keep-me.jpg'
+        const missingKey = 'missing/not-there.jpg'
+        const policyName = `s3_delete_objects_${randomUUID().replaceAll('-', '_')}`
+        const adminUser = await getServiceKeyUser(tenantId)
+        const connection = await getPostgresConnection({
+          tenantId,
+          user: adminUser,
+          superUser: adminUser,
+          host: 'localhost',
+        })
+        const db = connection.pool.acquire()
+        const anonKey = await anonKeyAsync
+        const anonClient = new S3Client({
+          endpoint: `${baseUrl}/s3`,
+          forcePathStyle: true,
+          region: storageS3Region,
+          credentials: {
+            accessKeyId: tenantId,
+            secretAccessKey: anonKey,
+            sessionToken: anonKey,
+          },
+        })
+
+        try {
+          await Promise.all([
+            uploadFile(client, bucketName, allowedKey, 1),
+            uploadFile(client, bucketName, deniedKey, 1),
+          ])
+
+          await db.raw(`
+            CREATE POLICY "${policyName}_select"
+            ON storage.objects
+            AS PERMISSIVE
+            FOR SELECT
+            TO "anon"
+            USING (bucket_id = '${bucketName}' AND name = '${allowedKey}')
+          `)
+          await db.raw(`
+            CREATE POLICY "${policyName}_delete"
+            ON storage.objects
+            AS PERMISSIVE
+            FOR DELETE
+            TO "anon"
+            USING (bucket_id = '${bucketName}' AND name = '${allowedKey}')
+          `)
+
+          const deleteResp = await anonClient.send(
+            new DeleteObjectsCommand({
+              Bucket: bucketName,
+              Delete: {
+                Objects: [{ Key: allowedKey }, { Key: missingKey }, { Key: deniedKey }],
+              },
+            })
+          )
+
+          expect(deleteResp.Deleted).toEqual([{ Key: allowedKey }, { Key: missingKey }])
+          expect(deleteResp.Errors).toEqual([
+            {
+              Key: deniedKey,
+              Code: 'AccessDenied',
+              Message: 'Access Denied',
+            },
+          ])
+
+          const allowedListResp = await client.send(
+            new ListObjectsV2Command({
+              Bucket: bucketName,
+              Prefix: allowedKey,
+            })
+          )
+          expect(allowedListResp.Contents).toBe(undefined)
+
+          const deniedListResp = await client.send(
+            new ListObjectsV2Command({
+              Bucket: bucketName,
+              Prefix: deniedKey,
+            })
+          )
+          expect(deniedListResp.Contents?.map((object) => object.Key)).toEqual([deniedKey])
+        } finally {
+          anonClient.destroy()
+          await db.raw(`DROP POLICY IF EXISTS "${policyName}_select" ON storage.objects`)
+          await db.raw(`DROP POLICY IF EXISTS "${policyName}_delete" ON storage.objects`)
+          await connection.dispose()
+          await client
+            .send(
+              new DeleteObjectsCommand({
+                Bucket: bucketName,
+                Delete: {
+                  Objects: [{ Key: allowedKey }, { Key: deniedKey }],
+                },
+              })
+            )
+            .catch(() => undefined)
+          await client.send(new DeleteBucketCommand({ Bucket: bucketName })).catch(() => undefined)
+        }
       })
     })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 delete fails with missing key and success returns 200.

## What is the new behavior?

S3 can delete non-existing object and returns 204 on success.
Missing and access are differentiated where latter returns 403.
Object endpoint status code in body (not actual status code) for lack of access will switch from 404 to 403.

## Additional context

* [Delete object](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html)
* [Delete objects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html)
