### PR TITLE
fix(auth): pass alg to importJWK for jose v6 compatibility with Auth0…

### DIFF
--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -217,6 +217,55 @@ describe('JWT', () => {
         await expect(verifyJWT(token, 'unused-secret', { keys: [jwkRS256] })).rejects.toThrow()
       })
 
+      test('it should reject an asymmetric JWK with an empty alg field', async () => {
+        const { publicKey, privateKey } = asymmetricKeyPairFactories['rsa']()
+        const kid = 'empty-alg-rsa'
+
+        const jwkWithEmptyAlg = {
+          ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+          alg: '',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'empty-alg-rsa' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'RS256', kid })
+          .sign(privateKey)
+
+        await expect(
+          verifyJWT(token, 'unused-secret', { keys: [jwkWithEmptyAlg] })
+        ).rejects.toThrow()
+      })
+
+      test('it should use a later compatible asymmetric JWK after an empty alg candidate', async () => {
+        const { publicKey, privateKey } = asymmetricKeyPairFactories['rsa']()
+        const { publicKey: incompatiblePublicKey } = asymmetricKeyPairFactories['rsa']()
+        const kid = 'compatible-rsa-after-empty-alg'
+
+        const jwkWithEmptyAlg = {
+          ...(incompatiblePublicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+          alg: '',
+        } as JwksConfigKey
+        const compatibleJwk = {
+          ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+          alg: 'RS256',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'compatible-rsa-after-empty-alg' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'RS256', kid })
+          .sign(privateKey)
+
+        const result = await verifyJWT(token, 'unused-secret', {
+          keys: [jwkWithEmptyAlg, compatibleJwk],
+        })
+        expect(result.sub).toEqual('compatible-rsa-after-empty-alg')
+      })
+
       test('it should reject a HMAC JWT when the matching jwk has a different alg', async () => {
         const rawKey = crypto.randomBytes(32)
         const kid = 'alg-mismatch-hmac'
@@ -257,6 +306,56 @@ describe('JWT', () => {
         await expect(verifyJWT(token, secret, { keys: [jwkHS512] })).rejects.toThrow(
           /does not match JWK algorithm/
         )
+      })
+
+      test('it should reject a HMAC JWK with an empty alg field', async () => {
+        const rawKey = crypto.randomBytes(32)
+        const kid = 'empty-alg-hmac'
+
+        const jwkWithEmptyAlg: JwksConfigKey = {
+          kty: 'oct',
+          k: rawKey.toString('base64url'),
+          kid,
+          alg: '',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'empty-alg-hmac' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'HS256', kid })
+          .sign(rawKey)
+
+        await expect(verifyJWT(token, 'wrong-secret', { keys: [jwkWithEmptyAlg] })).rejects.toThrow(
+          /does not match JWK algorithm/
+        )
+      })
+
+      test('it should use a later compatible HMAC JWK after an earlier alg mismatch', async () => {
+        const rawKey = crypto.randomBytes(32)
+        const kid = 'compatible-hmac-after-alg-mismatch'
+
+        const incompatibleWildcardJwk: JwksConfigKey = {
+          kty: 'oct',
+          k: crypto.randomBytes(32).toString('base64url'),
+          alg: 'HS512',
+        } as JwksConfigKey
+        const compatibleJwk: JwksConfigKey = {
+          kty: 'oct',
+          k: rawKey.toString('base64url'),
+          kid,
+          alg: 'HS256',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'compatible-hmac-after-alg-mismatch' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'HS256', kid })
+          .sign(rawKey)
+
+        const result = await verifyJWT(token, 'wrong-secret', {
+          keys: [incompatibleWildcardJwk, compatibleJwk],
+        })
+        expect(result.sub).toEqual('compatible-hmac-after-alg-mismatch')
       })
     })
 

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -168,6 +168,101 @@ describe('JWT', () => {
       })
     })
 
+    const algFixtures: { type: AsymmetricKeyType; alg: AsymmetricKeyFixture['alg'] }[] = [
+      { type: 'rsa', alg: 'RS256' },
+      { type: 'ec', alg: 'ES256' },
+      { type: 'ed25519', alg: 'EdDSA' },
+    ]
+
+    describe('JWK alg field matching', () => {
+      algFixtures.forEach(({ type, alg }) => {
+        test(`it should verify a ${alg} JWT when the matching jwk has no alg field`, async () => {
+          const { publicKey, privateKey } = asymmetricKeyPairFactories[type]()
+          const kid = `no-alg-${alg}`
+
+          const { alg: _omitted, ...jwkWithoutAlg } = {
+            ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+            kid,
+          }
+
+          const token = await new SignJWT({ sub: `test-${alg}` })
+            .setIssuedAt()
+            .setExpirationTime('1h')
+            .setProtectedHeader({ alg, kid })
+            .sign(privateKey)
+
+          const result = await verifyJWT(token, 'unused-secret', { keys: [jwkWithoutAlg as JwksConfigKey] })
+          expect(result.sub).toEqual(`test-${alg}`)
+        })
+      })
+
+      test('it should reject an asymmetric JWT when the matching jwk has a different alg', async () => {
+        const { publicKey, privateKey } = asymmetricKeyPairFactories['rsa']()
+        const kid = 'alg-mismatch-rsa'
+
+        const jwkRS256 = {
+          ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+          alg: 'RS256' as const,
+        }
+
+        const token = await new SignJWT({ sub: 'alg-mismatch-test' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'RS512', kid })
+          .sign(privateKey)
+
+        await expect(
+          verifyJWT(token, 'unused-secret', { keys: [jwkRS256] })
+        ).rejects.toThrow()
+      })
+
+      test('it should reject a HMAC JWT when the matching jwk has a different alg', async () => {
+        const rawKey = crypto.randomBytes(32)
+        const kid = 'alg-mismatch-hmac'
+
+        const jwkHS512: JwksConfigKey = {
+          kty: 'oct',
+          k: rawKey.toString('base64url'),
+          kid,
+          alg: 'HS512',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'hmac-alg-mismatch' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'HS256', kid })
+          .sign(rawKey)
+
+        await expect(
+          verifyJWT(token, 'wrong-secret', { keys: [jwkHS512] })
+        ).rejects.toThrow()
+      })
+    })
+
+    algFixtures.forEach(({ type, alg }) => {
+      test(`it should reject a ${alg} JWT when the token was signed with a key not in the jwks`, async () => {
+        const { publicKey } = asymmetricKeyPairFactories[type]()
+        const { privateKey: wrongPrivateKey } = asymmetricKeyPairFactories[type]()
+        const kid = `wrong-key-${alg}`
+
+        const { alg: _omitted, ...jwkWithoutAlg } = {
+          ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+        }
+
+        const token = await new SignJWT({ sub: `test-${alg}` })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg, kid })
+          .sign(wrongPrivateKey)
+
+        await expect(
+          verifyJWT(token, 'unused-secret', { keys: [jwkWithoutAlg as JwksConfigKey] })
+        ).rejects.toThrow()
+      })
+    })
+
     test('it should try secret if no matching jwk kty/alg found in jwks', async () => {
       const jwk = await generateHS512JWK()
       jwk.kid = 'abc123'

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -236,6 +236,28 @@ describe('JWT', () => {
 
         await expect(verifyJWT(token, 'wrong-secret', { keys: [jwkHS512] })).rejects.toThrow()
       })
+
+      test('it should reject a HMAC JWT matching a kid with a different alg instead of falling back to the static secret', async () => {
+        const secret = crypto.randomBytes(32).toString('base64url')
+        const kid = 'alg-mismatch-hmac-static-fallback'
+
+        const jwkHS512: JwksConfigKey = {
+          kty: 'oct',
+          k: crypto.randomBytes(32).toString('base64url'),
+          kid,
+          alg: 'HS512',
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'hmac-alg-mismatch-static-fallback' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'HS256', kid })
+          .sign(new TextEncoder().encode(secret))
+
+        await expect(verifyJWT(token, secret, { keys: [jwkHS512] })).rejects.toThrow(
+          /does not match JWK algorithm/
+        )
+      })
     })
 
     algFixtures.forEach(({ type, alg }) => {

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -191,7 +191,9 @@ describe('JWT', () => {
             .setProtectedHeader({ alg, kid })
             .sign(privateKey)
 
-          const result = await verifyJWT(token, 'unused-secret', { keys: [jwkWithoutAlg as JwksConfigKey] })
+          const result = await verifyJWT(token, 'unused-secret', {
+            keys: [jwkWithoutAlg as JwksConfigKey],
+          })
           expect(result.sub).toEqual(`test-${alg}`)
         })
       })
@@ -212,9 +214,7 @@ describe('JWT', () => {
           .setProtectedHeader({ alg: 'RS512', kid })
           .sign(privateKey)
 
-        await expect(
-          verifyJWT(token, 'unused-secret', { keys: [jwkRS256] })
-        ).rejects.toThrow()
+        await expect(verifyJWT(token, 'unused-secret', { keys: [jwkRS256] })).rejects.toThrow()
       })
 
       test('it should reject a HMAC JWT when the matching jwk has a different alg', async () => {
@@ -234,9 +234,7 @@ describe('JWT', () => {
           .setProtectedHeader({ alg: 'HS256', kid })
           .sign(rawKey)
 
-        await expect(
-          verifyJWT(token, 'wrong-secret', { keys: [jwkHS512] })
-        ).rejects.toThrow()
+        await expect(verifyJWT(token, 'wrong-secret', { keys: [jwkHS512] })).rejects.toThrow()
       })
     })
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -103,14 +103,22 @@ async function findJWKFromHeader(
       return encoder.encode(secret)
     }
 
-    // find the first key without a kid or with the matching kid, the "oct" type
-    const jwk = jwks.keys.find(
-      (key) => (!key.kid || key.kid === header.kid) && key.kty === 'oct' && key.k
-    )
+    // find the first compatible "oct" key without a kid or with the matching kid
+    let mismatchedJwk: JwksConfigKey | undefined
+    const jwk = jwks.keys.find((key) => {
+      if ((!key.kid || key.kid === header.kid) && key.kty === 'oct' && key.k) {
+        if (key.alg !== undefined && key.alg !== header.alg) {
+          mismatchedJwk ??= key
+          return false
+        }
+        return true
+      }
+      return false
+    })
 
-    if (jwk?.alg && jwk.alg !== header.alg) {
+    if (!jwk && mismatchedJwk) {
       throw ERRORS.AccessDenied(
-        `JWT algorithm "${header.alg}" does not match JWK algorithm "${jwk.alg}"`
+        `JWT algorithm "${header.alg}" does not match JWK algorithm "${mismatchedJwk.alg}"`
       )
     }
 
@@ -136,7 +144,7 @@ async function findJWKFromHeader(
     return (
       ((!key.kid && !header.kid) || key.kid === header.kid) &&
       key.kty === kty &&
-      (!key.alg || key.alg === header.alg)
+      (key.alg === undefined || key.alg === header.alg)
     )
   })
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -134,7 +134,7 @@ async function findJWKFromHeader(
     // couldn't find a matching JWK, try to use the secret
     return encoder.encode(secret)
   }
-  return await importJWK(jwk)
+  return await importJWK(jwk, header.alg)
 }
 
 function getJWTVerificationKey(secret: string, jwks: JwksConfig | null): JWTVerifyGetKey {

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -103,9 +103,13 @@ async function findJWKFromHeader(
       return encoder.encode(secret)
     }
 
-    // find the first key without a kid or with the matching kid and the "oct" type
+    // find the first key without a kid or with the matching kid, the "oct" type, and a compatible alg
     const jwk = jwks.keys.find(
-      (key) => (!key.kid || key.kid === header.kid) && key.kty === 'oct' && key.k
+      (key) =>
+        (!key.kid || key.kid === header.kid) &&
+        key.kty === 'oct' &&
+        key.k &&
+        (!key.alg || key.alg === header.alg)
     )
 
     if (!jwk) {
@@ -125,16 +129,20 @@ async function findJWKFromHeader(
     kty = 'OKP'
   }
 
-  // find the first key with a matching kid (or no kid if none is specified in the JWT header) and the correct key type
+  // find the first key with a matching kid (or no kid if none is specified in the JWT header), the correct key type, and a compatible alg
   const jwk = jwks.keys.find((key) => {
-    return ((!key.kid && !header.kid) || key.kid === header.kid) && key.kty === kty
+    return (
+      ((!key.kid && !header.kid) || key.kid === header.kid) &&
+      key.kty === kty &&
+      (!key.alg || key.alg === header.alg)
+    )
   })
 
   if (!jwk) {
     // couldn't find a matching JWK, try to use the secret
     return encoder.encode(secret)
   }
-  return await importJWK(jwk, header.alg)
+  return await importJWK(jwk, jwk.alg || header.alg)
 }
 
 function getJWTVerificationKey(secret: string, jwks: JwksConfig | null): JWTVerifyGetKey {

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -103,14 +103,16 @@ async function findJWKFromHeader(
       return encoder.encode(secret)
     }
 
-    // find the first key without a kid or with the matching kid, the "oct" type, and a compatible alg
+    // find the first key without a kid or with the matching kid, the "oct" type
     const jwk = jwks.keys.find(
-      (key) =>
-        (!key.kid || key.kid === header.kid) &&
-        key.kty === 'oct' &&
-        key.k &&
-        (!key.alg || key.alg === header.alg)
+      (key) => (!key.kid || key.kid === header.kid) && key.kty === 'oct' && key.k
     )
+
+    if (jwk?.alg && jwk.alg !== header.alg) {
+      throw ERRORS.AccessDenied(
+        `JWT algorithm "${header.alg}" does not match JWK algorithm "${jwk.alg}"`
+      )
+    }
 
     if (!jwk) {
       // jwt is probably signed with the static secret
@@ -142,7 +144,7 @@ async function findJWKFromHeader(
     // couldn't find a matching JWK, try to use the secret
     return encoder.encode(secret)
   }
-  return await importJWK(jwk, jwk.alg || header.alg)
+  return await importJWK(jwk, jwk.alg ?? header.alg)
 }
 
 function getJWTVerificationKey(secret: string, jwks: JwksConfig | null): JWTVerifyGetKey {


### PR DESCRIPTION
Bug fix

## What is the current behavior?

Any authenticated Storage request fails with HTTP 403 when the configured JWKS contains RSA keys that omit the `"alg"` field.

The error thrown is [from here](https://github.com/panva/jose/blob/9c8658647f1b9c3fe4d7d15812ddc51fedbf2416/src/lib/jwk_to_key.ts#L107): `"alg" argument is required when "jwk.alg" is not present`

jose v6 removed algorithm inference from `importJWK()`. It now requires either `jwk.alg` to be set on the key object, or the algorithm passed explicitly as the second argument. Storage was calling `importJWK(jwk)` without either, causing jose to throw before the key could be imported.

## What is the new behavior?

`importJWK` is called as `importJWK(jwk, header.alg)`

## Additional context

n/a
