### PR TITLE
fix: persist iceberg namespace metadata updates

### DIFF
--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
@@ -501,7 +501,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
         tenantId: this.options.tenantId,
       })
 
-      return { namespace: [namespace.name], properties: params.properties || {} }
+      return { namespace: [namespace.name], properties: namespace.metadata || {} }
     })
   }
 

--- a/src/storage/protocols/iceberg/knex.ts
+++ b/src/storage/protocols/iceberg/knex.ts
@@ -459,6 +459,7 @@ export class KnexMetastore implements Metastore<Knex.Transaction> {
       .onConflict(conflictColumns)
       .merge({
         updated_at: new Date(),
+        metadata: this.db.raw('?? || excluded.??', ['iceberg_namespaces.metadata', 'metadata']),
       })
       .returning<NamespaceIndex[]>('*')
 
@@ -466,10 +467,7 @@ export class KnexMetastore implements Metastore<Knex.Transaction> {
       throw ERRORS.NoSuchKey(params.name)
     }
 
-    return {
-      ...namespaceIndex,
-      id: result[0].id,
-    }
+    return result[0]
   }
 
   async listNamespaces(params: ListNamespaceParams) {

--- a/src/test/iceberg.test.ts
+++ b/src/test/iceberg.test.ts
@@ -206,6 +206,85 @@ describe('Iceberg Catalog', () => {
       })
     })
 
+    it('updates namespace properties when creating an existing namespace', async () => {
+      const bucketName = t.random.name('ice-bucket')
+      await t.storage.createIcebergBucket({
+        name: bucketName,
+      })
+
+      const namespaceName = t.random.name('namespace')
+
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: `/iceberg/v1/${bucketName}/namespaces`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+        payload: {
+          namespace: namespaceName,
+          properties: {
+            stable: 'kept',
+            overwrite: 'old',
+          },
+        },
+      })
+
+      expect(createResponse.statusCode).toBe(200)
+      expect(await createResponse.json()).toEqual({
+        namespace: [namespaceName],
+        properties: {
+          stable: 'kept',
+          overwrite: 'old',
+        },
+      })
+
+      const updateResponse = await app.inject({
+        method: 'POST',
+        url: `/iceberg/v1/${bucketName}/namespaces`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+        payload: {
+          namespace: namespaceName,
+          properties: {
+            overwrite: 'new',
+            added: 'value',
+          },
+        },
+      })
+
+      expect(updateResponse.statusCode).toBe(200)
+      expect(await updateResponse.json()).toEqual({
+        namespace: [namespaceName],
+        properties: {
+          stable: 'kept',
+          overwrite: 'new',
+          added: 'value',
+        },
+      })
+
+      const loadResponse = await app.inject({
+        method: 'GET',
+        url: `/iceberg/v1/${bucketName}/namespaces/${namespaceName}`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+      })
+
+      expect(loadResponse.statusCode).toBe(200)
+      expect(await loadResponse.json()).toEqual({
+        namespace: [namespaceName],
+        properties: {
+          stable: 'kept',
+          overwrite: 'new',
+          added: 'value',
+        },
+      })
+    })
+
     it('returns InvalidParameter for invalid namespace names', async () => {
       const bucketName = t.random.name('ice-bucket')
       await t.storage.createIcebergBucket({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Iceberg create namespace behaves partially idempotent but ignores metadata.

## What is the new behavior?

Merge metadata correctly and return stored metadata back to the client.


