### PR TITLE
fix: s3 get object conditional status code

### DIFF
--- a/src/storage/protocols/s3/s3-handler.test.ts
+++ b/src/storage/protocols/s3/s3-handler.test.ts
@@ -6,7 +6,7 @@ vi.mock('fs-xattr', () => ({
   get: vi.fn(() => Promise.resolve(undefined)),
 }))
 
-import { isValidHeader } from '@storage/protocols/s3/s3-handler'
+import { isValidHeader, S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 
 // Mirror the constants in s3-handler.ts
 const MAX_HEADER_NAME_LENGTH = 1024 * 8
@@ -72,5 +72,62 @@ describe('isValidHeader', () => {
 
   it('rejects an array of values when any are invalid', () => {
     expect(isValidHeader('x-custom', ['ok', 'bad\x00value'])).toBe(false)
+  })
+})
+
+describe('S3ProtocolHandler.getObject', () => {
+  it('preserves backend not-modified responses for cache validators', async () => {
+    const backendGetObject = vi.fn().mockResolvedValue({
+      body: undefined,
+      httpStatusCode: 304,
+      metadata: {
+        cacheControl: 'no-cache',
+        contentLength: 0,
+        eTag: '"current-etag"',
+        httpStatusCode: 304,
+        lastModified: new Date(),
+        mimetype: 'text/plain',
+        size: 29,
+      },
+    })
+    const findObject = vi.fn().mockResolvedValue({
+      user_metadata: null,
+      version: 'object-version',
+    })
+    const getRootLocation = vi.fn(() => 'root-bucket')
+    const getKeyLocation = vi.fn(() => 'tenant-id/bucket/object.txt')
+    const storage = {
+      backend: {
+        getObject: backendGetObject,
+      },
+      from: vi.fn(() => ({
+        findObject,
+      })),
+      location: {
+        getKeyLocation,
+        getRootLocation,
+      },
+    }
+    const handler = new S3ProtocolHandler(storage as never, 'tenant-id')
+
+    const response = await handler.getObject({
+      Bucket: 'bucket',
+      IfNoneMatch: '"current-etag"',
+      Key: 'object.txt',
+    })
+
+    expect(response.statusCode).toBe(304)
+    expect(response.responseBody).toBeUndefined()
+    expect(backendGetObject).toHaveBeenCalledWith(
+      'root-bucket',
+      'tenant-id/bucket/object.txt',
+      'object-version',
+      {
+        ifModifiedSince: undefined,
+        ifNoneMatch: '"current-etag"',
+        range: undefined,
+      },
+      undefined
+    )
   })
 })

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -982,7 +982,7 @@ export class S3ProtocolHandler {
     return {
       headers,
       responseBody: response.body,
-      statusCode: command.Range ? 206 : 200,
+      statusCode: response.httpStatusCode,
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 handler hardcodes status code in get object but it's might be wrong if there is a conditional header.

## What is the new behavior?

Propagate backend code to the client.

## Additional context

We need to support all conditionals and add them into head object as well. 
Adding acceptance tests in #1102 
