### PR TITLE
fix: correctly categorize errors related to saturated project databases

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -33,6 +33,8 @@ export const setErrorHandler = (
         'no more connections allowed',
         'sorry, too many clients already',
         'server login has been failing, try again later',
+        'server login has been failing, cached error: connect timeout (server_login_retry)',
+        'server login has been failing, cached error: the database system is not accepting connections (server_login_retry)',
       ].some((msg) => (error as DatabaseError).message.includes(msg))
     ) {
       return reply.status(429).send(

--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -1,7 +1,7 @@
 import { FastifyError } from '@fastify/error'
 import { ErrorCode, isRenderableError, StorageBackendError, StorageError } from '@internal/errors'
+import { isDatabaseSlowDownError } from '@internal/errors/database-error'
 import { FastifyInstance } from 'fastify'
-import { DatabaseError } from 'pg'
 
 /**
  * The global error handler for all the uncaught exceptions within a request.
@@ -24,19 +24,7 @@ export const setErrorHandler = (
     request.executionError = error
 
     // database error
-    if (
-      error instanceof DatabaseError &&
-      [
-        'Authentication error', // supavisor specific
-        'Max client connections reached',
-        'remaining connection slots are reserved for non-replication superuser connections',
-        'no more connections allowed',
-        'sorry, too many clients already',
-        'server login has been failing, try again later',
-        'server login has been failing, cached error: connect timeout (server_login_retry)',
-        'server login has been failing, cached error: the database system is not accepting connections (server_login_retry)',
-      ].some((msg) => (error as DatabaseError).message.includes(msg))
-    ) {
+    if (isDatabaseSlowDownError(error)) {
       return reply.status(429).send(
         formatter({
           statusCode: `429`,

--- a/src/http/routes/s3/error-handler.ts
+++ b/src/http/routes/s3/error-handler.ts
@@ -1,9 +1,9 @@
 import { S3ServiceException } from '@aws-sdk/client-s3'
 import { FastifyError } from '@fastify/error'
 import { ErrorCode, StorageBackendError } from '@internal/errors'
+import { isDatabaseSlowDownError } from '@internal/errors/database-error'
 import { FastifyReply } from 'fastify/types/reply'
 import { FastifyRequest } from 'fastify/types/request'
-import { DatabaseError } from 'pg'
 
 type ValidationIssue = {
   instancePath?: string
@@ -46,16 +46,7 @@ export const s3ErrorHandler = (
   }
 
   // database error
-  if (
-    error instanceof DatabaseError &&
-    [
-      'Max client connections reached',
-      'remaining connection slots are reserved for non-replication superuser connections',
-      'no more connections allowed',
-      'sorry, too many clients already',
-      'server login has been failing, try again later',
-    ].some((msg) => (error as DatabaseError).message.includes(msg))
-  ) {
+  if (isDatabaseSlowDownError(error)) {
     return reply.status(429).send({
       Error: {
         Resource: resource,

--- a/src/internal/database/connection.ts
+++ b/src/internal/database/connection.ts
@@ -135,15 +135,6 @@ export class TenantConnection {
         throw ERRORS.DatabaseTimeout(e)
       }
 
-      // Handle database connection limit errors
-      if (
-        e instanceof DatabaseError &&
-        ((e.code === '08P01' && e.message.includes('no more connections allowed')) ||
-          e.message.includes('Max client connections reached'))
-      ) {
-        throw ERRORS.DatabaseConnectionLimit(e)
-      }
-
       throw e
     }
   }

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -20,7 +20,6 @@ export enum ErrorCode {
   KeyAlreadyExists = 'KeyAlreadyExists',
   BucketAlreadyExists = 'BucketAlreadyExists',
   DatabaseTimeout = 'DatabaseTimeout',
-  DatabaseConnectionLimit = 'DatabaseConnectionLimit',
   DatabaseReadOnly = 'DatabaseReadOnly',
   DatabaseInvalidObjectDefinition = 'DatabaseInvalidObjectDefinition',
   DatabaseSchemaMismatch = 'DatabaseSchemaMismatch',
@@ -383,15 +382,6 @@ export const ERRORS = {
       code: ErrorCode.DatabaseTimeout,
       httpStatusCode: 544,
       message: 'The connection to the database timed out',
-      originalError: e,
-    }),
-
-  DatabaseConnectionLimit: (e?: Error) =>
-    new StorageBackendError({
-      code: ErrorCode.DatabaseConnectionLimit,
-      httpStatusCode: 503,
-      message:
-        'The database has reached its maximum number of connections. Please try again later.',
       originalError: e,
     }),
 

--- a/src/internal/errors/database-error.ts
+++ b/src/internal/errors/database-error.ts
@@ -1,0 +1,17 @@
+import { DatabaseError } from 'pg'
+
+export function isDatabaseSlowDownError(error: Error): boolean {
+  return (
+    error instanceof DatabaseError &&
+    [
+      'Authentication error', // supavisor specific
+      'Max client connections reached',
+      'remaining connection slots are reserved for non-replication superuser connections',
+      'no more connections allowed',
+      'sorry, too many clients already',
+      'server login has been failing, try again later',
+      'server login has been failing, cached error: connect timeout (server_login_retry)',
+      'server login has been failing, cached error: the database system is not accepting connections (server_login_retry)',
+    ].some((msg) => error.message.includes(msg))
+  )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

These errors caused by projects under extreme load throw as 500 errors

- 'server login has been failing, cached error: connect timeout (server_login_retry)',
- 'server login has been failing, cached error: the database system is not accepting connections (server_login_retry)',

This [previous change](https://github.com/supabase/storage/pull/947/changes#diff-230c7c8b84befeba072a468151e75decacdc7e40dc9a99f08fa41ef862b200dcR138) miscategorized `no more connections allowed` as a 503. Without this it is correctly handled in error-hanler.ts as a 429

## What is the new behavior?

Errors related to project databases being overloaded throw as `429 slow down`
