### PR TITLE
fix: improve database error messages

### DIFF
--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -1,4 +1,5 @@
 import { IcebergError } from '@storage/protocols/iceberg/catalog/errors'
+import { DatabaseError } from 'pg'
 import { StorageBackendError } from './storage-error'
 
 export enum ErrorCode {
@@ -401,13 +402,20 @@ export const ERRORS = {
       originalError: e,
     }),
 
-  DatabaseSchemaMismatch: (e?: Error) =>
-    new StorageBackendError({
-      code: ErrorCode.DatabaseSchemaMismatch,
-      httpStatusCode: 503,
-      message: 'The database schema is out of sync. Please run migrations or contact support.',
-      originalError: e,
-    }),
+  DatabaseSchemaMismatch: (e: DatabaseError) =>
+    e.internalQuery && e.internalPosition // originates in trigger or RLS
+      ? new StorageBackendError({
+          code: ErrorCode.DatabaseSchemaMismatch,
+          httpStatusCode: 503,
+          message: 'There is a database schema mismatch in a trigger or RLS policy: ' + e.where,
+          originalError: e,
+        })
+      : new StorageBackendError({
+          code: ErrorCode.DatabaseSchemaMismatch,
+          httpStatusCode: 503,
+          message: 'The database schema is out of sync. Please run migrations or contact support.',
+          originalError: e,
+        }),
 
   ResourceLocked: (e?: Error) =>
     new StorageBackendError({

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -1145,7 +1145,9 @@ export class DBError extends StorageBackendError implements RenderableError {
     switch (pgError.code) {
       case '42501':
         return ERRORS.AccessDenied(
-          'new row violates row-level security policy',
+          pgError.message.includes('row-level security')
+            ? 'new row violates row-level security policy'
+            : pgError.message,
           pgError
         ).withMetadata({
           query,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

All schema mismatch errors (missing column or missing table) show an error message indicating the storage migrations are out of sync. However, user created triggers/rls can cause these errors resulting in confusion and support burden

All permission denied errors are shown as RLS errors

## What is the new behavior?

- Show error details for errors originating inside of triggers / rls
- Only show "RLS" error for "RLS" errors. For other access denied pass a more detailed error

## Example errors

### schema mismatch in RLS

```
There is a database schema mismatch in a trigger or RLS policy: PL/pgSQL function raise_42703() line 3 at EXECUTE
```

### schema mismatch in trigger

```
There is a database schema mismatch in a trigger or RLS policy: PL/pgSQL function storage_objects_broken_trigger() line 3 at PERFORM
```

### Non rls access denied

```
insert into \"objects\" (\"bucket_id\", \"metadata\", \"name\", \"owner\", \"owner_id\", \"user_metadata\", \"version\") values ($1, $2, $3, $4, $5, DEFAULT, $6) - permission denied for table secret_table
```