### PR TITLE
Encapsulate storage database transaction APIs

### DIFF
--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -54,6 +54,41 @@ export interface ListBucketOptions {
   search?: string
 }
 
+type ObjectWriteData = Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+  bucket_id: string
+  name: string
+  version: string
+}
+
+type ObjectMoveData = Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string }
+
+type DeletedObject = Pick<Obj, 'name' | 'version' | 'metadata'>
+
+type LockedDeletedObject = Pick<Obj, 'version' | 'metadata'>
+
+type UploadObject = Pick<
+  Obj,
+  | 'id'
+  | 'name'
+  | 'bucket_id'
+  | 'owner'
+  | 'owner_id'
+  | 'metadata'
+  | 'user_metadata'
+  | 'version'
+  | 'created_at'
+  | 'updated_at'
+  | 'last_accessed_at'
+>
+
+type PreviousUploadObject = Pick<Obj, 'id' | 'version' | 'metadata'>
+
+type ReplacedObject = Pick<Obj, 'name' | 'bucket_id' | 'version'>
+
+type MovedObject = Pick<Obj, 'id' | 'name' | 'bucket_id' | 'version' | 'owner' | 'metadata'>
+
+type SourceMoveObject = Pick<Obj, 'id' | 'version' | 'metadata' | 'user_metadata'>
+
 export interface Database {
   tenantHost: string
   tenantId: string
@@ -66,14 +101,7 @@ export interface Database {
 
   asSuperUser(): Database
 
-  testObjectPermission(
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
-      bucket_id: string
-      name: string
-      version: string
-    },
-    isUpsert?: boolean
-  ): Promise<void>
+  testObjectPermission(data: ObjectWriteData, isUpsert?: boolean): Promise<void>
 
   testMoveObjectPermission(
     sourceBucketId: string,
@@ -87,35 +115,31 @@ export interface Database {
 
   deleteEmptyBucket(bucketId: string): Promise<number>
 
-  deleteObjectWithLock(bucketId: string, objectName: string): Promise<Obj>
+  deleteObjectWithLock(bucketId: string, objectName: string): Promise<LockedDeletedObject>
 
-  deleteObjectsTransaction(bucketId: string, objectNames: string[], by: keyof Obj): Promise<Obj[]>
+  deleteObjectsTransaction(
+    bucketId: string,
+    objectNames: string[],
+    by: keyof Obj
+  ): Promise<DeletedObject[]>
 
   completeUploadTransaction(
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
-      bucket_id: string
-      name: string
-      version: string
-    }
-  ): Promise<{ obj: Obj; isNew: boolean; previousObject?: Obj }>
+    data: ObjectWriteData
+  ): Promise<{ obj: UploadObject; isNew: boolean; previousObject?: PreviousUploadObject }>
 
   upsertCopyDestination(
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
-      bucket_id: string
-      name: string
-      version: string
-    }
-  ): Promise<{ destinationObject: Obj; replacedObject?: Obj }>
+    data: ObjectWriteData
+  ): Promise<{ destinationObject: UploadObject; replacedObject?: ReplacedObject }>
 
   moveObjectDestination(
     sourceBucketId: string,
     sourceObjectName: string,
     destinationBucketId: string,
     destinationObjectName: string,
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string }
+    data: ObjectMoveData
   ): Promise<{
-    destObject: Pick<Obj, 'id' | 'name' | 'bucket_id' | 'version' | 'owner' | 'metadata'>
-    sourceObject: Obj
+    destObject: MovedObject
+    sourceObject: SourceMoveObject
   }>
 
   acquireObjectLockForTransaction(

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -66,12 +66,95 @@ export interface Database {
 
   asSuperUser(): Database
 
-  withTransaction<T>(
-    fn: (db: Database) => Promise<T>,
-    transactionOptions?: TransactionOptions
-  ): Promise<T>
+  testObjectPermission(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    isUpsert?: boolean
+  ): Promise<void>
 
-  testPermission<T>(fn: (db: Database) => T | Promise<T>): Promise<Awaited<T>>
+  testMoveObjectPermission(
+    sourceBucketId: string,
+    sourceObjectName: string,
+    data: Pick<Obj, 'name' | 'bucket_id' | 'owner' | 'version'>
+  ): Promise<void>
+
+  testDeleteObjectPermission(bucketId: string, objectName: string): Promise<void>
+
+  createAnalyticsBucketWithEvent(
+    data: Pick<Bucket, 'name'>,
+    onCreate: (bucket: IcebergCatalog, tenant: { ref: string; host: string }) => Promise<void>
+  ): Promise<IcebergCatalog>
+
+  deleteEmptyBucket(bucketId: string): Promise<number>
+
+  deleteObjectWithLock(
+    bucketId: string,
+    objectName: string,
+    onDelete: (object: Obj, tenantId: string) => Promise<void>
+  ): Promise<Obj>
+
+  deleteObjectsWithCallbacks(
+    bucketId: string,
+    objectNames: string[],
+    by: keyof Obj,
+    onDelete: (
+      objects: Obj[],
+      tenant: { ref: string; host: string },
+      tenantId: string
+    ) => Promise<void>
+  ): Promise<Obj[]>
+
+  completeUploadTransaction(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    onComplete: (newObject: Obj, currentObject: Obj | undefined, isNew: boolean) => Promise<void>
+  ): Promise<{ obj: Obj; isNew: boolean }>
+
+  upsertCopyDestination(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    onReplaced: (object: Obj) => Promise<void>
+  ): Promise<Obj>
+
+  moveObjectDestination(
+    sourceBucketId: string,
+    sourceObjectName: string,
+    destinationBucketId: string,
+    destinationObjectName: string,
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string },
+    onMoved: (sourceObject: Obj) => Promise<void>
+  ): Promise<Pick<Obj, 'id' | 'name' | 'bucket_id' | 'version' | 'owner' | 'metadata'>>
+
+  acquireObjectLockForTransaction(
+    bucketId: string,
+    objectName: string,
+    version: string | undefined,
+    hold: () => Promise<void>,
+    transactionOptions?: TransactionOptions
+  ): Promise<void>
+
+  adjustMultipartUploadProgress(
+    uploadId: string,
+    diff: number,
+    signProgress: (progress: number) => string
+  ): Promise<void>
+
+  prepareMultipartUploadPart(
+    uploadId: string,
+    contentLength: number,
+    maxFileSize: number,
+    verifySignature: (signature: string, progress: number) => void,
+    signProgress: (progress: number) => string
+  ): Promise<S3MultipartUpload>
 
   createBucket(
     data: Pick<

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -83,77 +83,54 @@ export interface Database {
 
   testDeleteObjectPermission(bucketId: string, objectName: string): Promise<void>
 
-  createAnalyticsBucketWithEvent(
-    data: Pick<Bucket, 'name'>,
-    onCreate: (bucket: IcebergCatalog, tenant: { ref: string; host: string }) => Promise<void>
-  ): Promise<IcebergCatalog>
+  createAnalyticsBucketTransaction(data: Pick<Bucket, 'name'>): Promise<IcebergCatalog>
 
   deleteEmptyBucket(bucketId: string): Promise<number>
 
-  deleteObjectWithLock(
-    bucketId: string,
-    objectName: string,
-    onDelete: (object: Obj, tenantId: string) => Promise<void>
-  ): Promise<Obj>
+  deleteObjectWithLock(bucketId: string, objectName: string): Promise<Obj>
 
-  deleteObjectsWithCallbacks(
-    bucketId: string,
-    objectNames: string[],
-    by: keyof Obj,
-    onDelete: (
-      objects: Obj[],
-      tenant: { ref: string; host: string },
-      tenantId: string
-    ) => Promise<void>
-  ): Promise<Obj[]>
+  deleteObjectsTransaction(bucketId: string, objectNames: string[], by: keyof Obj): Promise<Obj[]>
 
   completeUploadTransaction(
     data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
       bucket_id: string
       name: string
       version: string
-    },
-    onComplete: (newObject: Obj, currentObject: Obj | undefined, isNew: boolean) => Promise<void>
-  ): Promise<{ obj: Obj; isNew: boolean }>
+    }
+  ): Promise<{ obj: Obj; isNew: boolean; previousObject?: Obj }>
 
   upsertCopyDestination(
     data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
       bucket_id: string
       name: string
       version: string
-    },
-    onReplaced: (object: Obj) => Promise<void>
-  ): Promise<Obj>
+    }
+  ): Promise<{ destinationObject: Obj; replacedObject?: Obj }>
 
   moveObjectDestination(
     sourceBucketId: string,
     sourceObjectName: string,
     destinationBucketId: string,
     destinationObjectName: string,
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string },
-    onMoved: (sourceObject: Obj) => Promise<void>
-  ): Promise<Pick<Obj, 'id' | 'name' | 'bucket_id' | 'version' | 'owner' | 'metadata'>>
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string }
+  ): Promise<{
+    destObject: Pick<Obj, 'id' | 'name' | 'bucket_id' | 'version' | 'owner' | 'metadata'>
+    sourceObject: Obj
+  }>
 
   acquireObjectLockForTransaction(
     bucketId: string,
     objectName: string,
     version: string | undefined,
-    hold: () => Promise<void>,
     transactionOptions?: TransactionOptions
   ): Promise<void>
 
-  adjustMultipartUploadProgress(
-    uploadId: string,
-    diff: number,
-    signProgress: (progress: number) => string
-  ): Promise<void>
+  adjustMultipartUploadProgress(uploadId: string, diff: number): Promise<void>
 
   prepareMultipartUploadPart(
     uploadId: string,
     contentLength: number,
-    maxFileSize: number,
-    verifySignature: (signature: string, progress: number) => void,
-    signProgress: (progress: number) => string
+    maxFileSize: number
   ): Promise<S3MultipartUpload>
 
   createBucket(
@@ -277,7 +254,6 @@ export interface Database {
     bucketId: string,
     objectName: string,
     version: string,
-    signature: string,
     owner?: string,
     userMetadata?: Record<string, string | null>,
     metadata?: Partial<ObjectMetadata>

--- a/src/storage/database/knex.test.ts
+++ b/src/storage/database/knex.test.ts
@@ -34,8 +34,9 @@ function createStorageKnexTestHarness() {
 describe('StorageKnexDB.testPermission', () => {
   it('returns the callback result after rolling back the transaction', async () => {
     const { db, connection, transaction } = createStorageKnexTestHarness()
+    const testPermission = db['testPermission'].bind(db)
 
-    const result = await db.testPermission(async (txDb) => {
+    const result = await testPermission(async (txDb) => {
       expect(txDb).toBeInstanceOf(StorageKnexDB)
       expect(txDb).not.toBe(db)
       return 'allowed'
@@ -52,8 +53,10 @@ describe('StorageKnexDB.testPermission', () => {
     const { db, transaction } = createStorageKnexTestHarness()
     const error = new Error('permission denied')
 
+    const testPermission = db['testPermission'].bind(db)
+
     await expect(
-      db.testPermission(async () => {
+      testPermission(async () => {
         throw error
       })
     ).rejects.toBe(error)

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -64,10 +64,10 @@ export class StorageKnexDB implements Database {
     this.latestMigration = options.latestMigration
   }
 
-  async withTransaction<T>(
-    fn: (db: Database) => Promise<T>,
+  private async withTransaction<T extends (db: Database) => Promise<unknown>>(
+    fn: T,
     opts?: TransactionOptions
-  ): Promise<T> {
+  ): Promise<Awaited<ReturnType<T>>> {
     const tnx = await this.connection.transactionProvider(this.options.tnx, opts)()
 
     try {
@@ -80,7 +80,7 @@ export class StorageKnexDB implements Database {
       const opts = { ...this.options, tnx }
       const storageWithTnx = new StorageKnexDB(this.connection, opts)
 
-      const result = await fn(storageWithTnx)
+      const result = (await fn(storageWithTnx)) as Awaited<ReturnType<T>>
       await tnx.commit()
       return result
     } catch (e) {
@@ -104,7 +104,7 @@ export class StorageKnexDB implements Database {
     })
   }
 
-  async testPermission<T>(fn: (db: Database) => T | Promise<T>): Promise<Awaited<T>> {
+  private async testPermission<T>(fn: (db: Database) => T | Promise<T>): Promise<Awaited<T>> {
     return this.withTransaction(async (db) => {
       const result = await fn(db)
       throw new TestPermissionRollbackError(result)
@@ -114,6 +114,247 @@ export class StorageKnexDB implements Database {
       }
 
       throw e
+    })
+  }
+
+  async testObjectPermission(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    isUpsert?: boolean
+  ) {
+    await this.testPermission((db) => {
+      return isUpsert ? db.upsertObject(data) : db.createObject(data)
+    })
+  }
+
+  async testMoveObjectPermission(
+    sourceBucketId: string,
+    sourceObjectName: string,
+    data: Pick<Obj, 'name' | 'bucket_id' | 'owner' | 'version'>
+  ) {
+    await this.testPermission((db) => {
+      return Promise.all([
+        db.findObject(sourceBucketId, sourceObjectName, 'id'),
+        db.updateObject(sourceBucketId, sourceObjectName, data),
+      ])
+    })
+  }
+
+  async testDeleteObjectPermission(bucketId: string, objectName: string) {
+    await this.testPermission(async (db) => {
+      const deleted = await db.deleteObject(bucketId, objectName)
+
+      if (!deleted) {
+        throw ERRORS.NoSuchKey(objectName)
+      }
+    })
+  }
+
+  createAnalyticsBucketWithEvent(
+    data: Pick<Bucket, 'name'>,
+    onCreate: (bucket: IcebergCatalog, tenant: { ref: string; host: string }) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      const result = await db.createAnalyticsBucket(data)
+      await onCreate(result, { ref: db.tenantId, host: db.tenantHost })
+      return result
+    })
+  }
+
+  deleteEmptyBucket(bucketId: string) {
+    return this.withTransaction(async (db) => {
+      await db.asSuperUser().findBucketById(bucketId, 'id', { forUpdate: true })
+      const countObjects = await db.asSuperUser().countObjectsInBucket(bucketId, 1)
+
+      if (countObjects && countObjects > 0) {
+        throw ERRORS.BucketNotEmpty(bucketId)
+      }
+
+      const deleted = await db.deleteBucket(bucketId)
+
+      if (!deleted) {
+        throw ERRORS.NoSuchBucket(bucketId)
+      }
+
+      return deleted
+    })
+  }
+
+  deleteObjectWithLock(
+    bucketId: string,
+    objectName: string,
+    onDelete: (object: Obj, tenantId: string) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      const obj = await db.asSuperUser().findObject(bucketId, objectName, 'id,version,metadata', {
+        forUpdate: true,
+      })
+
+      const deleted = await db.deleteObject(bucketId, objectName)
+
+      if (!deleted) {
+        throw ERRORS.AccessDenied('Access denied')
+      }
+
+      await onDelete(obj, db.tenantId)
+      return obj
+    })
+  }
+
+  deleteObjectsWithCallbacks(
+    bucketId: string,
+    objectNames: string[],
+    by: keyof Obj,
+    onDelete: (
+      objects: Obj[],
+      tenant: { ref: string; host: string },
+      tenantId: string
+    ) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      const deleted = await db.deleteObjects(bucketId, objectNames, by)
+      if (deleted.length > 0) {
+        await onDelete(deleted, db.tenant(), db.tenantId)
+      }
+      return deleted
+    })
+  }
+
+  completeUploadTransaction(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    onComplete: (newObject: Obj, currentObject: Obj | undefined, isNew: boolean) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      await db.waitObjectLock(data.bucket_id, data.name, undefined, { timeout: 5000 })
+      const currentObj = await db.findObject(data.bucket_id, data.name, 'id, version, metadata', {
+        forUpdate: true,
+        dontErrorOnEmpty: true,
+      })
+      const isNew = !Boolean(currentObj)
+      const newObject = await db.upsertObject(data)
+      await onComplete(newObject, currentObj, isNew)
+      return { obj: newObject, isNew }
+    })
+  }
+
+  upsertCopyDestination(
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & {
+      bucket_id: string
+      name: string
+      version: string
+    },
+    onReplaced: (object: Obj) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      await db.waitObjectLock(data.bucket_id, data.name, undefined, { timeout: 3000 })
+      const existingDestObject = await db.findObject(
+        data.bucket_id,
+        data.name,
+        'id,name,metadata,version,bucket_id',
+        { dontErrorOnEmpty: true, forUpdate: true }
+      )
+      const destinationObject = await db.upsertObject(data)
+      if (existingDestObject) {
+        await onReplaced(existingDestObject)
+      }
+      return destinationObject
+    })
+  }
+
+  moveObjectDestination(
+    sourceBucketId: string,
+    sourceObjectName: string,
+    destinationBucketId: string,
+    destinationObjectName: string,
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string },
+    onMoved: (sourceObject: Obj) => Promise<void>
+  ) {
+    return this.withTransaction(async (db) => {
+      await db.waitObjectLock(sourceBucketId, destinationObjectName, undefined, { timeout: 5000 })
+      const sourceObject = await db.findObject(
+        sourceBucketId,
+        sourceObjectName,
+        'id,version,metadata,user_metadata',
+        { forUpdate: true, dontErrorOnEmpty: false }
+      )
+      await db.updateObject(sourceBucketId, sourceObjectName, {
+        name: destinationObjectName,
+        bucket_id: destinationBucketId,
+        version: data.version,
+        owner: data.owner,
+        metadata: data.metadata,
+        user_metadata: data.user_metadata,
+      })
+      await onMoved(sourceObject)
+      return {
+        id: sourceObject.id,
+        name: destinationObjectName,
+        bucket_id: destinationBucketId,
+        version: data.version,
+        owner: data.owner,
+        metadata: data.metadata,
+      }
+    })
+  }
+
+  acquireObjectLockForTransaction(
+    bucketId: string,
+    objectName: string,
+    version: string | undefined,
+    hold: () => Promise<void>,
+    transactionOptions?: TransactionOptions
+  ) {
+    return this.withTransaction(async (db) => {
+      await db.mustLockObject(bucketId, objectName, version)
+      await hold()
+    }, transactionOptions)
+  }
+
+  adjustMultipartUploadProgress(
+    uploadId: string,
+    diff: number,
+    signProgress: (progress: number) => string
+  ) {
+    return this.withTransaction(async (db) => {
+      const multipart = await db.findMultipartUpload(uploadId, 'in_progress_size', {
+        forUpdate: true,
+      })
+      const progress = multipart.in_progress_size + diff
+      await db.updateMultipartUploadProgress(uploadId, progress, signProgress(progress))
+    })
+  }
+
+  prepareMultipartUploadPart(
+    uploadId: string,
+    contentLength: number,
+    maxFileSize: number,
+    verifySignature: (signature: string, progress: number) => void,
+    signProgress: (progress: number) => string
+  ) {
+    return this.withTransaction(async (db) => {
+      const multipart = await db.findMultipartUpload(
+        uploadId,
+        'in_progress_size,version,upload_signature,user_metadata,metadata',
+        { forUpdate: true }
+      )
+      verifySignature(multipart.upload_signature, multipart.in_progress_size)
+      const currentProgress = multipart.in_progress_size + contentLength
+      if (currentProgress > maxFileSize) {
+        throw ERRORS.EntityTooLarge()
+      }
+      await db.updateMultipartUploadProgress(
+        uploadId,
+        currentProgress,
+        signProgress(currentProgress)
+      )
+      return multipart
     })
   }
 

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -1,3 +1,4 @@
+import { decrypt, encrypt } from '@internal/auth'
 import { TenantConnection } from '@internal/database'
 import { DBMigration, tenantHasMigrations } from '@internal/database/migrations'
 import {
@@ -153,14 +154,9 @@ export class StorageKnexDB implements Database {
     })
   }
 
-  createAnalyticsBucketWithEvent(
-    data: Pick<Bucket, 'name'>,
-    onCreate: (bucket: IcebergCatalog, tenant: { ref: string; host: string }) => Promise<void>
-  ) {
+  createAnalyticsBucketTransaction(data: Pick<Bucket, 'name'>) {
     return this.withTransaction(async (db) => {
-      const result = await db.createAnalyticsBucket(data)
-      await onCreate(result, { ref: db.tenantId, host: db.tenantHost })
-      return result
+      return db.createAnalyticsBucket(data)
     })
   }
 
@@ -183,11 +179,7 @@ export class StorageKnexDB implements Database {
     })
   }
 
-  deleteObjectWithLock(
-    bucketId: string,
-    objectName: string,
-    onDelete: (object: Obj, tenantId: string) => Promise<void>
-  ) {
+  deleteObjectWithLock(bucketId: string, objectName: string) {
     return this.withTransaction(async (db) => {
       const obj = await db.asSuperUser().findObject(bucketId, objectName, 'id,version,metadata', {
         forUpdate: true,
@@ -199,27 +191,13 @@ export class StorageKnexDB implements Database {
         throw ERRORS.AccessDenied('Access denied')
       }
 
-      await onDelete(obj, db.tenantId)
       return obj
     })
   }
 
-  deleteObjectsWithCallbacks(
-    bucketId: string,
-    objectNames: string[],
-    by: keyof Obj,
-    onDelete: (
-      objects: Obj[],
-      tenant: { ref: string; host: string },
-      tenantId: string
-    ) => Promise<void>
-  ) {
+  deleteObjectsTransaction(bucketId: string, objectNames: string[], by: keyof Obj) {
     return this.withTransaction(async (db) => {
-      const deleted = await db.deleteObjects(bucketId, objectNames, by)
-      if (deleted.length > 0) {
-        await onDelete(deleted, db.tenant(), db.tenantId)
-      }
-      return deleted
+      return db.deleteObjects(bucketId, objectNames, by)
     })
   }
 
@@ -228,8 +206,7 @@ export class StorageKnexDB implements Database {
       bucket_id: string
       name: string
       version: string
-    },
-    onComplete: (newObject: Obj, currentObject: Obj | undefined, isNew: boolean) => Promise<void>
+    }
   ) {
     return this.withTransaction(async (db) => {
       await db.waitObjectLock(data.bucket_id, data.name, undefined, { timeout: 5000 })
@@ -239,8 +216,7 @@ export class StorageKnexDB implements Database {
       })
       const isNew = !Boolean(currentObj)
       const newObject = await db.upsertObject(data)
-      await onComplete(newObject, currentObj, isNew)
-      return { obj: newObject, isNew }
+      return { obj: newObject, isNew, previousObject: currentObj }
     })
   }
 
@@ -249,8 +225,7 @@ export class StorageKnexDB implements Database {
       bucket_id: string
       name: string
       version: string
-    },
-    onReplaced: (object: Obj) => Promise<void>
+    }
   ) {
     return this.withTransaction(async (db) => {
       await db.waitObjectLock(data.bucket_id, data.name, undefined, { timeout: 3000 })
@@ -261,10 +236,7 @@ export class StorageKnexDB implements Database {
         { dontErrorOnEmpty: true, forUpdate: true }
       )
       const destinationObject = await db.upsertObject(data)
-      if (existingDestObject) {
-        await onReplaced(existingDestObject)
-      }
-      return destinationObject
+      return { destinationObject, replacedObject: existingDestObject }
     })
   }
 
@@ -273,8 +245,7 @@ export class StorageKnexDB implements Database {
     sourceObjectName: string,
     destinationBucketId: string,
     destinationObjectName: string,
-    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string },
-    onMoved: (sourceObject: Obj) => Promise<void>
+    data: Pick<Obj, 'owner' | 'metadata' | 'user_metadata'> & { version: string }
   ) {
     return this.withTransaction(async (db) => {
       await db.waitObjectLock(sourceBucketId, destinationObjectName, undefined, { timeout: 5000 })
@@ -292,14 +263,16 @@ export class StorageKnexDB implements Database {
         metadata: data.metadata,
         user_metadata: data.user_metadata,
       })
-      await onMoved(sourceObject)
       return {
-        id: sourceObject.id,
-        name: destinationObjectName,
-        bucket_id: destinationBucketId,
-        version: data.version,
-        owner: data.owner,
-        metadata: data.metadata,
+        destObject: {
+          id: sourceObject.id,
+          name: destinationObjectName,
+          bucket_id: destinationBucketId,
+          version: data.version,
+          owner: data.owner,
+          metadata: data.metadata,
+        },
+        sourceObject,
       }
     })
   }
@@ -308,43 +281,39 @@ export class StorageKnexDB implements Database {
     bucketId: string,
     objectName: string,
     version: string | undefined,
-    hold: () => Promise<void>,
     transactionOptions?: TransactionOptions
   ) {
     return this.withTransaction(async (db) => {
       await db.mustLockObject(bucketId, objectName, version)
-      await hold()
     }, transactionOptions)
   }
 
-  adjustMultipartUploadProgress(
-    uploadId: string,
-    diff: number,
-    signProgress: (progress: number) => string
-  ) {
+  adjustMultipartUploadProgress(uploadId: string, diff: number) {
     return this.withTransaction(async (db) => {
       const multipart = await db.findMultipartUpload(uploadId, 'in_progress_size', {
         forUpdate: true,
       })
       const progress = multipart.in_progress_size + diff
-      await db.updateMultipartUploadProgress(uploadId, progress, signProgress(progress))
+      await db.updateMultipartUploadProgress(
+        uploadId,
+        progress,
+        multipartUploadProgressSignature(progress)
+      )
     })
   }
 
-  prepareMultipartUploadPart(
-    uploadId: string,
-    contentLength: number,
-    maxFileSize: number,
-    verifySignature: (signature: string, progress: number) => void,
-    signProgress: (progress: number) => string
-  ) {
+  prepareMultipartUploadPart(uploadId: string, contentLength: number, maxFileSize: number) {
     return this.withTransaction(async (db) => {
       const multipart = await db.findMultipartUpload(
         uploadId,
         'in_progress_size,version,upload_signature,user_metadata,metadata',
         { forUpdate: true }
       )
-      verifySignature(multipart.upload_signature, multipart.in_progress_size)
+
+      if (multipartUploadProgress(multipart.upload_signature) !== multipart.in_progress_size) {
+        throw ERRORS.InvalidUploadSignature()
+      }
+
       const currentProgress = multipart.in_progress_size + contentLength
       if (currentProgress > maxFileSize) {
         throw ERRORS.EntityTooLarge()
@@ -352,7 +321,7 @@ export class StorageKnexDB implements Database {
       await db.updateMultipartUploadProgress(
         uploadId,
         currentProgress,
-        signProgress(currentProgress)
+        multipartUploadProgressSignature(currentProgress)
       )
       return multipart
     })
@@ -1159,7 +1128,6 @@ export class StorageKnexDB implements Database {
     bucketId: string,
     objectName: string,
     version: string,
-    signature: string,
     owner?: string,
     userMetadata?: Record<string, string | null>,
     metadata?: Partial<ObjectMetadata>
@@ -1170,7 +1138,7 @@ export class StorageKnexDB implements Database {
         bucket_id: bucketId,
         key: objectName,
         version,
-        upload_signature: signature,
+        upload_signature: multipartUploadProgressSignature(0),
         owner_id: owner,
         user_metadata: userMetadata,
       }
@@ -1374,6 +1342,16 @@ export class StorageKnexDB implements Database {
       throw e
     }
   }
+}
+
+function multipartUploadProgressSignature(progress: number) {
+  return `${encrypt('progress:' + progress.toString())}`
+}
+
+function multipartUploadProgress(signature: string) {
+  const originalSignature = decrypt(signature)
+  const [, value] = originalSignature.split(':')
+  return parseInt(value, 10)
 }
 
 export class DBError extends StorageBackendError implements RenderableError {

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -72,14 +72,11 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
             moreObjectsToDelete = true
           }
 
-          await storage.db.withTransaction(async (trx) => {
-            const deleted = await trx.deleteObjects(
-              bucketId,
-              objects.map(({ id }) => id!),
-              'id'
-            )
-
-            if (deleted && deleted.length > 0) {
+          await storage.db.deleteObjectsWithCallbacks(
+            bucketId,
+            objects.map(({ id }) => id!),
+            'id',
+            async (deleted) => {
               const prefixes: string[] = []
 
               for (const { name, version } of deleted) {
@@ -104,7 +101,7 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
                 )
               )
             }
-          })
+          )
         }
 
         if (!moreObjectsToDelete) {

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -72,36 +72,37 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
             moreObjectsToDelete = true
           }
 
-          await storage.db.deleteObjectsWithCallbacks(
+          const deleted = await storage.db.deleteObjectsTransaction(
             bucketId,
             objects.map(({ id }) => id!),
-            'id',
-            async (deleted) => {
-              const prefixes: string[] = []
-
-              for (const { name, version } of deleted) {
-                const fileName = withOptionalVersion(`${tenantId}/${bucketId}/${name}`, version)
-                prefixes.push(fileName)
-                prefixes.push(fileName + '.info')
-              }
-
-              await backend.deleteObjects(storageS3Bucket, prefixes)
-
-              await Promise.allSettled(
-                deleted.map((object) =>
-                  ObjectRemoved.sendWebhook({
-                    tenant: job.data.tenant,
-                    name: object.name,
-                    bucketId,
-                    reqId: job.data.reqId,
-                    sbReqId: job.data.sbReqId,
-                    version: object.version,
-                    metadata: object.metadata,
-                  })
-                )
-              )
-            }
+            'id'
           )
+
+          if (deleted.length > 0) {
+            const prefixes: string[] = []
+
+            for (const { name, version } of deleted) {
+              const fileName = withOptionalVersion(`${tenantId}/${bucketId}/${name}`, version)
+              prefixes.push(fileName)
+              prefixes.push(fileName + '.info')
+            }
+
+            await backend.deleteObjects(storageS3Bucket, prefixes)
+
+            await Promise.allSettled(
+              deleted.map((object) =>
+                ObjectRemoved.sendWebhook({
+                  tenant: job.data.tenant,
+                  name: object.name,
+                  bucketId,
+                  reqId: job.data.reqId,
+                  sbReqId: job.data.sbReqId,
+                  version: object.version,
+                  metadata: object.metadata,
+                })
+              )
+            )
+          }
         }
 
         if (!moreObjectsToDelete) {

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -6,31 +6,18 @@ import { StorageObjectLocator } from './locator'
 import { ObjectStorage } from './object'
 
 function createObjectStorage({
-  findObject = vi.fn().mockResolvedValue({
-    id: 'object-id',
-    version: 'version-1',
-  }),
-  deleteObject = vi.fn().mockResolvedValue({
-    name: 'private/file.txt',
+  deleteObjectWithLock = vi.fn().mockResolvedValue({
     version: 'version-1',
   }),
 }: {
-  findObject?: ReturnType<typeof vi.fn>
-  deleteObject?: ReturnType<typeof vi.fn>
+  deleteObjectWithLock?: ReturnType<typeof vi.fn>
 } = {}) {
   const backend = {
     deleteObject: vi.fn(),
   } as unknown as StorageBackendAdapter
-  const superUserDb = {
-    findObject,
-  }
-  const scopedDb = {
-    asSuperUser: vi.fn(() => superUserDb),
-    deleteObject,
-  }
   const db = {
     tenantId: 'tenant-id',
-    withTransaction: vi.fn((fn) => fn(scopedDb)),
+    deleteObjectWithLock,
   } as unknown as Database
   const location = {
     getRootLocation: vi.fn(() => 'root-bucket'),
@@ -40,8 +27,7 @@ function createObjectStorage({
 
   return {
     backend,
-    deleteObject,
-    findObject,
+    deleteObjectWithLock,
     location,
     storage,
   }
@@ -49,8 +35,8 @@ function createObjectStorage({
 
 describe('ObjectStorage.deleteObject', () => {
   it('throws AccessDenied when the object exists but scoped delete is blocked by RLS', async () => {
-    const { backend, deleteObject, findObject, storage } = createObjectStorage({
-      deleteObject: vi.fn().mockResolvedValue(undefined),
+    const { backend, deleteObjectWithLock, storage } = createObjectStorage({
+      deleteObjectWithLock: vi.fn().mockRejectedValue(ERRORS.AccessDenied('Access denied')),
     })
 
     await expect(storage.deleteObject('private/file.txt')).rejects.toMatchObject({
@@ -59,16 +45,13 @@ describe('ObjectStorage.deleteObject', () => {
       message: 'Access denied',
     })
 
-    expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', 'id,version', {
-      forUpdate: true,
-    })
-    expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt')
+    expect(deleteObjectWithLock).toHaveBeenCalledWith('bucket', 'private/file.txt')
     expect(backend.deleteObject).not.toHaveBeenCalled()
   })
 
   it('keeps true missing objects as NoSuchKey before attempting scoped delete', async () => {
-    const { backend, deleteObject, storage } = createObjectStorage({
-      findObject: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('missing.txt')),
+    const { backend, deleteObjectWithLock, storage } = createObjectStorage({
+      deleteObjectWithLock: vi.fn().mockRejectedValue(ERRORS.NoSuchKey('missing.txt')),
     })
 
     await expect(storage.deleteObject('missing.txt')).rejects.toMatchObject({
@@ -76,7 +59,7 @@ describe('ObjectStorage.deleteObject', () => {
       httpStatusCode: 404,
     })
 
-    expect(deleteObject).not.toHaveBeenCalled()
+    expect(deleteObjectWithLock).toHaveBeenCalledWith('bucket', 'missing.txt')
     expect(backend.deleteObject).not.toHaveBeenCalled()
   })
 })

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -126,29 +126,21 @@ export class ObjectStorage {
    * @param objectName
    */
   async deleteObject(objectName: string) {
-    const obj = await this.db.withTransaction(async (db) => {
-      const obj = await db.asSuperUser().findObject(this.bucketId, objectName, 'id,version', {
-        forUpdate: true,
-      })
-
-      const deleted = await db.deleteObject(this.bucketId, objectName)
-
-      if (!deleted) {
-        throw ERRORS.AccessDenied('Access denied')
+    const obj = await this.db.deleteObjectWithLock(
+      this.bucketId,
+      objectName,
+      async (obj, tenantId) => {
+        await this.backend.deleteObject(
+          this.location.getRootLocation(),
+          this.location.getKeyLocation({
+            tenantId,
+            bucketId: this.bucketId,
+            objectName,
+          }),
+          obj.version
+        )
       }
-
-      await this.backend.deleteObject(
-        this.location.getRootLocation(),
-        this.location.getKeyLocation({
-          tenantId: this.db.tenantId,
-          bucketId: this.bucketId,
-          objectName,
-        }),
-        obj.version
-      )
-
-      return obj
-    })
+    )
 
     await ObjectRemoved.sendWebhook({
       tenant: this.db.tenant(),
@@ -179,18 +171,17 @@ export class ObjectStorage {
         urlParamLength += encodeURIComponent(prefix).length + 9 // length of '%22%2C%22'
       }
 
-      await this.db.withTransaction(async (db) => {
-        const data = await db.deleteObjects(this.bucketId, prefixesSubset, 'name')
-
-        if (data.length > 0) {
-          results = results.concat(data)
-
+      const data = await this.db.deleteObjectsWithCallbacks(
+        this.bucketId,
+        prefixesSubset,
+        'name',
+        async (data, tenant, tenantId) => {
           // if successfully deleted, delete from s3 too
           // todo: consider moving this to a queue
           const prefixesToDelete = data.reduce((all, { name, version }) => {
             all.push(
               this.location.getKeyLocation({
-                tenantId: db.tenantId,
+                tenantId,
                 bucketId: this.bucketId,
                 objectName: name,
                 version,
@@ -200,7 +191,7 @@ export class ObjectStorage {
             if (version) {
               all.push(
                 this.location.getKeyLocation({
-                  tenantId: db.tenantId,
+                  tenantId,
                   bucketId: this.bucketId,
                   objectName: name,
                   version,
@@ -215,7 +206,7 @@ export class ObjectStorage {
           await Promise.allSettled(
             data.map((object) =>
               ObjectRemoved.sendWebhook({
-                tenant: db.tenant(),
+                tenant,
                 name: object.name,
                 bucketId: this.bucketId,
                 reqId: this.db.reqId,
@@ -226,7 +217,9 @@ export class ObjectStorage {
             )
           )
         }
-      })
+      )
+
+      results = results.concat(data)
     }
 
     return results
@@ -366,22 +359,8 @@ export class ObjectStorage {
         newVersion
       )
 
-      const destinationObject = await this.db.asSuperUser().withTransaction(async (db) => {
-        await db.waitObjectLock(destinationBucket, destinationKey, undefined, {
-          timeout: 3000,
-        })
-
-        const existingDestObject = await db.findObject(
-          destinationBucket,
-          destinationKey,
-          'id,name,metadata,version,bucket_id',
-          {
-            dontErrorOnEmpty: true,
-            forUpdate: true,
-          }
-        )
-
-        const destinationObject = await db.upsertObject({
+      const destinationObject = await this.db.asSuperUser().upsertCopyDestination(
+        {
           ...originObject,
           bucket_id: destinationBucket,
           name: destinationKey,
@@ -393,9 +372,8 @@ export class ObjectStorage {
           },
           user_metadata: destinationUserMetadata,
           version: newVersion,
-        })
-
-        if (existingDestObject) {
+        },
+        async (existingDestObject) => {
           await ObjectAdminDelete.send({
             name: existingDestObject.name,
             bucketId: existingDestObject.bucket_id ?? destinationBucket,
@@ -405,9 +383,7 @@ export class ObjectStorage {
             sbReqId: this.db.sbReqId,
           })
         }
-
-        return destinationObject
-      })
+      )
 
       await ObjectCreatedCopyEvent.sendWebhook({
         tenant: this.db.tenant(),
@@ -468,16 +444,11 @@ export class ObjectStorage {
       objectName: destinationObjectName,
     })
 
-    await this.db.testPermission((db) => {
-      return Promise.all([
-        db.findObject(this.bucketId, sourceObjectName, 'id'),
-        db.updateObject(this.bucketId, sourceObjectName, {
-          name: destinationObjectName,
-          version: newVersion,
-          bucket_id: destinationBucket,
-          owner,
-        }),
-      ])
+    await this.db.testMoveObjectPermission(this.bucketId, sourceObjectName, {
+      name: destinationObjectName,
+      version: newVersion,
+      bucket_id: destinationBucket,
+      owner,
     })
 
     const sourceObj = await this.db
@@ -505,78 +476,58 @@ export class ObjectStorage {
         newVersion
       )
 
-      return this.db.asSuperUser().withTransaction(async (db) => {
-        await db.waitObjectLock(this.bucketId, destinationObjectName, undefined, {
-          timeout: 5000,
-        })
-
-        const sourceObject = await db.findObject(
-          this.bucketId,
-          sourceObjectName,
-          'id,version,metadata,user_metadata',
-          {
-            forUpdate: true,
-            dontErrorOnEmpty: false,
-          }
-        )
-
-        await db.updateObject(this.bucketId, sourceObjectName, {
-          name: destinationObjectName,
-          bucket_id: destinationBucket,
+      const destObject = await this.db.asSuperUser().moveObjectDestination(
+        this.bucketId,
+        sourceObjectName,
+        destinationBucket,
+        destinationObjectName,
+        {
           version: newVersion,
           owner,
           metadata,
           user_metadata: sourceObj.user_metadata,
-        })
-
-        await ObjectAdminDelete.send({
-          name: sourceObjectName,
-          bucketId: this.bucketId,
-          tenant: this.db.tenant(),
-          version: sourceObj.version,
-          reqId: this.db.reqId,
-          sbReqId: this.db.sbReqId,
-        })
-
-        await Promise.allSettled([
-          ObjectRemovedMove.sendWebhook({
-            tenant: this.db.tenant(),
+        },
+        async (sourceObject) => {
+          await ObjectAdminDelete.send({
             name: sourceObjectName,
             bucketId: this.bucketId,
+            tenant: this.db.tenant(),
+            version: sourceObj.version,
             reqId: this.db.reqId,
             sbReqId: this.db.sbReqId,
-            version: sourceObject.version,
-            metadata: sourceObject.metadata,
-          }),
-          ObjectCreatedMove.sendWebhook({
-            tenant: this.db.tenant(),
-            name: destinationObjectName,
-            version: newVersion,
-            bucketId: destinationBucket,
-            metadata,
-            uploadType,
-            oldObject: {
+          })
+
+          await Promise.allSettled([
+            ObjectRemovedMove.sendWebhook({
+              tenant: this.db.tenant(),
               name: sourceObjectName,
               bucketId: this.bucketId,
               reqId: this.db.reqId,
+              sbReqId: this.db.sbReqId,
               version: sourceObject.version,
-            },
-            reqId: this.db.reqId,
-            sbReqId: this.db.sbReqId,
-          }),
-        ])
-
-        return {
-          destObject: {
-            id: sourceObject.id,
-            name: destinationObjectName,
-            bucket_id: destinationBucket,
-            version: newVersion,
-            owner,
-            metadata,
-          },
+              metadata: sourceObject.metadata,
+            }),
+            ObjectCreatedMove.sendWebhook({
+              tenant: this.db.tenant(),
+              name: destinationObjectName,
+              version: newVersion,
+              bucketId: destinationBucket,
+              metadata,
+              uploadType,
+              oldObject: {
+                name: sourceObjectName,
+                bucketId: this.bucketId,
+                reqId: this.db.reqId,
+                version: sourceObject.version,
+              },
+              reqId: this.db.reqId,
+              sbReqId: this.db.sbReqId,
+            }),
+          ])
         }
-      })
+      )
+
+      return { destObject }
     } catch (e) {
       await ObjectAdminDelete.send({
         name: destinationObjectName,

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -126,20 +126,16 @@ export class ObjectStorage {
    * @param objectName
    */
   async deleteObject(objectName: string) {
-    const obj = await this.db.deleteObjectWithLock(
-      this.bucketId,
-      objectName,
-      async (obj, tenantId) => {
-        await this.backend.deleteObject(
-          this.location.getRootLocation(),
-          this.location.getKeyLocation({
-            tenantId,
-            bucketId: this.bucketId,
-            objectName,
-          }),
-          obj.version
-        )
-      }
+    const obj = await this.db.deleteObjectWithLock(this.bucketId, objectName)
+
+    await this.backend.deleteObject(
+      this.location.getRootLocation(),
+      this.location.getKeyLocation({
+        tenantId: this.db.tenantId,
+        bucketId: this.bucketId,
+        objectName,
+      }),
+      obj.version
     )
 
     await ObjectRemoved.sendWebhook({
@@ -171,53 +167,50 @@ export class ObjectStorage {
         urlParamLength += encodeURIComponent(prefix).length + 9 // length of '%22%2C%22'
       }
 
-      const data = await this.db.deleteObjectsWithCallbacks(
-        this.bucketId,
-        prefixesSubset,
-        'name',
-        async (data, tenant, tenantId) => {
-          // if successfully deleted, delete from s3 too
-          // todo: consider moving this to a queue
-          const prefixesToDelete = data.reduce((all, { name, version }) => {
+      const data = await this.db.deleteObjectsTransaction(this.bucketId, prefixesSubset, 'name')
+
+      if (data.length > 0) {
+        // if successfully deleted, delete from s3 too
+        // todo: consider moving this to a queue
+        const prefixesToDelete = data.reduce((all, { name, version }) => {
+          all.push(
+            this.location.getKeyLocation({
+              tenantId: this.db.tenantId,
+              bucketId: this.bucketId,
+              objectName: name,
+              version,
+            })
+          )
+
+          if (version) {
             all.push(
               this.location.getKeyLocation({
-                tenantId,
+                tenantId: this.db.tenantId,
                 bucketId: this.bucketId,
                 objectName: name,
                 version,
-              })
+              }) + '.info'
             )
+          }
+          return all
+        }, [] as string[])
 
-            if (version) {
-              all.push(
-                this.location.getKeyLocation({
-                  tenantId,
-                  bucketId: this.bucketId,
-                  objectName: name,
-                  version,
-                }) + '.info'
-              )
-            }
-            return all
-          }, [] as string[])
+        await this.backend.deleteObjects(this.location.getRootLocation(), prefixesToDelete)
 
-          await this.backend.deleteObjects(this.location.getRootLocation(), prefixesToDelete)
-
-          await Promise.allSettled(
-            data.map((object) =>
-              ObjectRemoved.sendWebhook({
-                tenant,
-                name: object.name,
-                bucketId: this.bucketId,
-                reqId: this.db.reqId,
-                sbReqId: this.db.sbReqId,
-                version: object.version,
-                metadata: object.metadata,
-              })
-            )
+        await Promise.allSettled(
+          data.map((object) =>
+            ObjectRemoved.sendWebhook({
+              tenant: this.db.tenant(),
+              name: object.name,
+              bucketId: this.bucketId,
+              reqId: this.db.reqId,
+              sbReqId: this.db.sbReqId,
+              version: object.version,
+              metadata: object.metadata,
+            })
           )
-        }
-      )
+        )
+      }
 
       results = results.concat(data)
     }
@@ -359,8 +352,9 @@ export class ObjectStorage {
         newVersion
       )
 
-      const destinationObject = await this.db.asSuperUser().upsertCopyDestination(
-        {
+      const { destinationObject, replacedObject } = await this.db
+        .asSuperUser()
+        .upsertCopyDestination({
           ...originObject,
           bucket_id: destinationBucket,
           name: destinationKey,
@@ -372,18 +366,18 @@ export class ObjectStorage {
           },
           user_metadata: destinationUserMetadata,
           version: newVersion,
-        },
-        async (existingDestObject) => {
-          await ObjectAdminDelete.send({
-            name: existingDestObject.name,
-            bucketId: existingDestObject.bucket_id ?? destinationBucket,
-            tenant: this.db.tenant(),
-            version: existingDestObject.version,
-            reqId: this.db.reqId,
-            sbReqId: this.db.sbReqId,
-          })
-        }
-      )
+        })
+
+      if (replacedObject) {
+        await ObjectAdminDelete.send({
+          name: replacedObject.name,
+          bucketId: replacedObject.bucket_id ?? destinationBucket,
+          tenant: this.db.tenant(),
+          version: replacedObject.version,
+          reqId: this.db.reqId,
+          sbReqId: this.db.sbReqId,
+        })
+      }
 
       await ObjectCreatedCopyEvent.sendWebhook({
         tenant: this.db.tenant(),
@@ -476,56 +470,57 @@ export class ObjectStorage {
         newVersion
       )
 
-      const destObject = await this.db.asSuperUser().moveObjectDestination(
-        this.bucketId,
-        sourceObjectName,
-        destinationBucket,
-        destinationObjectName,
-        {
+      const { destObject, sourceObject } = await this.db
+        .asSuperUser()
+        .moveObjectDestination(
+          this.bucketId,
+          sourceObjectName,
+          destinationBucket,
+          destinationObjectName,
+          {
+            version: newVersion,
+            owner,
+            metadata,
+            user_metadata: sourceObj.user_metadata,
+          }
+        )
+
+      await ObjectAdminDelete.send({
+        name: sourceObjectName,
+        bucketId: this.bucketId,
+        tenant: this.db.tenant(),
+        version: sourceObj.version,
+        reqId: this.db.reqId,
+        sbReqId: this.db.sbReqId,
+      })
+
+      await Promise.allSettled([
+        ObjectRemovedMove.sendWebhook({
+          tenant: this.db.tenant(),
+          name: sourceObjectName,
+          bucketId: this.bucketId,
+          reqId: this.db.reqId,
+          sbReqId: this.db.sbReqId,
+          version: sourceObject.version,
+          metadata: sourceObject.metadata,
+        }),
+        ObjectCreatedMove.sendWebhook({
+          tenant: this.db.tenant(),
+          name: destinationObjectName,
           version: newVersion,
-          owner,
+          bucketId: destinationBucket,
           metadata,
-          user_metadata: sourceObj.user_metadata,
-        },
-        async (sourceObject) => {
-          await ObjectAdminDelete.send({
+          uploadType,
+          oldObject: {
             name: sourceObjectName,
             bucketId: this.bucketId,
-            tenant: this.db.tenant(),
-            version: sourceObj.version,
             reqId: this.db.reqId,
-            sbReqId: this.db.sbReqId,
-          })
-
-          await Promise.allSettled([
-            ObjectRemovedMove.sendWebhook({
-              tenant: this.db.tenant(),
-              name: sourceObjectName,
-              bucketId: this.bucketId,
-              reqId: this.db.reqId,
-              sbReqId: this.db.sbReqId,
-              version: sourceObject.version,
-              metadata: sourceObject.metadata,
-            }),
-            ObjectCreatedMove.sendWebhook({
-              tenant: this.db.tenant(),
-              name: destinationObjectName,
-              version: newVersion,
-              bucketId: destinationBucket,
-              metadata,
-              uploadType,
-              oldObject: {
-                name: sourceObjectName,
-                bucketId: this.bucketId,
-                reqId: this.db.reqId,
-                version: sourceObject.version,
-              },
-              reqId: this.db.reqId,
-              sbReqId: this.db.sbReqId,
-            }),
-          ])
-        }
-      )
+            version: sourceObject.version,
+          },
+          reqId: this.db.reqId,
+          sbReqId: this.db.sbReqId,
+        }),
+      ])
 
       return { destObject }
     } catch (e) {

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -17,7 +17,6 @@ import {
   UploadPartCommandInput,
   UploadPartCopyCommandInput,
 } from '@aws-sdk/client-s3'
-import { decrypt, encrypt } from '@internal/auth'
 import { ERRORS, ErrorCode, isStorageError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import { PassThrough, Readable } from 'stream'
@@ -445,19 +444,11 @@ export class S3ProtocolHandler {
       throw ERRORS.InvalidUploadId(uploadId)
     }
 
-    const signature = this.uploadSignature({ in_progress_size: 0 })
     await this.storage.db
       .asSuperUser()
-      .createMultipartUpload(
-        uploadId,
-        Bucket,
-        Key,
-        version,
-        signature,
-        this.owner,
-        command.Metadata,
-        { mimetype: command.ContentType }
-      )
+      .createMultipartUpload(uploadId, Bucket, Key, version, this.owner, command.Metadata, {
+        mimetype: command.ContentType,
+      })
 
     return {
       responseBody: {
@@ -671,11 +662,7 @@ export class S3ProtocolHandler {
       }
     } catch (e) {
       try {
-        await this.storage.db
-          .asSuperUser()
-          .adjustMultipartUploadProgress(UploadId, -ContentLength, (progress) =>
-            this.uploadSignature({ in_progress_size: progress })
-          )
+        await this.storage.db.asSuperUser().adjustMultipartUploadProgress(UploadId, -ContentLength)
       } catch (e) {
         logSchema.error(logger, 'Failed to update multipart upload progress', {
           type: 's3',
@@ -1368,37 +1355,14 @@ export class S3ProtocolHandler {
     return metadata
   }
 
-  protected uploadSignature({ in_progress_size }: { in_progress_size: number }) {
-    return `${encrypt('progress:' + in_progress_size.toString())}`
-  }
-
-  protected decryptUploadSignature(signature: string) {
-    const originalSignature = decrypt(signature)
-    const [, value] = originalSignature.split(':')
-
-    return {
-      progress: parseInt(value, 10),
-    }
-  }
-
   protected async shouldAllowPartUpload(
     uploadId: string,
     contentLength: number,
     maxFileSize: number
   ) {
-    return this.storage.db.asSuperUser().prepareMultipartUploadPart(
-      uploadId,
-      contentLength,
-      maxFileSize,
-      (signature, storedProgress) => {
-        const { progress } = this.decryptUploadSignature(signature)
-
-        if (progress !== storedProgress) {
-          throw ERRORS.InvalidUploadSignature()
-        }
-      },
-      (progress) => this.uploadSignature({ in_progress_size: progress })
-    )
+    return this.storage.db
+      .asSuperUser()
+      .prepareMultipartUploadPart(uploadId, contentLength, maxFileSize)
   }
 }
 

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -671,15 +671,11 @@ export class S3ProtocolHandler {
       }
     } catch (e) {
       try {
-        await this.storage.db.asSuperUser().withTransaction(async (db) => {
-          const multipart = await db.findMultipartUpload(UploadId, 'in_progress_size', {
-            forUpdate: true,
-          })
-
-          const diff = multipart.in_progress_size - ContentLength
-          const signature = this.uploadSignature({ in_progress_size: diff })
-          await db.updateMultipartUploadProgress(UploadId, diff, signature)
-        })
+        await this.storage.db
+          .asSuperUser()
+          .adjustMultipartUploadProgress(UploadId, -ContentLength, (progress) =>
+            this.uploadSignature({ in_progress_size: progress })
+          )
       } catch (e) {
         logSchema.error(logger, 'Failed to update multipart upload progress', {
           type: 's3',
@@ -1283,12 +1279,10 @@ export class S3ProtocolHandler {
 
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)
 
-    const [destinationBucket] = await this.storage.db.asSuperUser().withTransaction(async (db) => {
-      return Promise.all([
-        db.findBucketById(Bucket, 'file_size_limit'),
-        db.findBucketById(sourceBucketName, 'id'),
-      ])
-    })
+    const [destinationBucket] = await Promise.all([
+      this.storage.db.asSuperUser().findBucketById(Bucket, 'file_size_limit'),
+      this.storage.db.asSuperUser().findBucketById(sourceBucketName, 'id'),
+    ])
     const maxFileSize = await getFileSizeLimit(
       this.storage.db.tenantId,
       destinationBucket?.file_size_limit
@@ -1392,31 +1386,19 @@ export class S3ProtocolHandler {
     contentLength: number,
     maxFileSize: number
   ) {
-    return this.storage.db.asSuperUser().withTransaction(async (db) => {
-      const multipart = await db.findMultipartUpload(
-        uploadId,
-        'in_progress_size,version,upload_signature,user_metadata,metadata',
-        {
-          forUpdate: true,
+    return this.storage.db.asSuperUser().prepareMultipartUploadPart(
+      uploadId,
+      contentLength,
+      maxFileSize,
+      (signature, storedProgress) => {
+        const { progress } = this.decryptUploadSignature(signature)
+
+        if (progress !== storedProgress) {
+          throw ERRORS.InvalidUploadSignature()
         }
-      )
-
-      const { progress } = this.decryptUploadSignature(multipart.upload_signature)
-
-      if (progress !== multipart.in_progress_size) {
-        throw ERRORS.InvalidUploadSignature()
-      }
-
-      const currentProgress = multipart.in_progress_size + contentLength
-
-      if (currentProgress > maxFileSize) {
-        throw ERRORS.EntityTooLarge()
-      }
-
-      const signature = this.uploadSignature({ in_progress_size: currentProgress })
-      await db.updateMultipartUploadProgress(uploadId, currentProgress, signature)
-      return multipart
-    })
+      },
+      (progress) => this.uploadSignature({ in_progress_size: progress })
+    )
   }
 }
 

--- a/src/storage/protocols/tus/postgres-locker.ts
+++ b/src/storage/protocols/tus/postgres-locker.ts
@@ -73,42 +73,7 @@ export class PgLock implements Lock {
 
   async lock(stopSignal: AbortSignal, cancelReq: RequestRelease): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      this.db
-        .withTransaction(
-          async (db) => {
-            const abortController = new AbortController()
-            let onAbort: (() => void) | undefined
-
-            try {
-              onAbort = () => {
-                abortController.abort()
-              }
-              stopSignal.addEventListener('abort', onAbort)
-
-              const acquired = await Promise.race([
-                this.waitTimeout(5000, abortController.signal),
-                this.acquireLock(db, this.id, abortController.signal),
-              ])
-
-              if (!acquired) {
-                throw ERRORS.LockTimeout()
-              }
-
-              this.isLocked = true
-
-              await new Promise<void>((innerResolve) => {
-                this.tnxResolver = innerResolve
-                resolve()
-              })
-            } finally {
-              abortController.abort()
-            }
-          },
-          {
-            timeout: 5 * 60 * 1000, // 5 minutes
-          }
-        )
-        .catch(reject)
+      this.holdLockTransaction(stopSignal, resolve).catch(reject)
     })
 
     this.notifier.onRelease(this.id, () => cancelReq())
@@ -129,31 +94,60 @@ export class PgLock implements Lock {
     }
   }
 
-  protected async acquireLock(db: Database, id: string, signal: AbortSignal) {
-    const uploadId = UploadId.fromString(id)
+  protected async holdLockTransaction(stopSignal: AbortSignal, resolve: () => void) {
+    const abortController = new AbortController()
+    const uploadId = UploadId.fromString(this.id)
+    const onAbort = () => abortController.abort()
 
-    while (!signal.aborted) {
-      try {
-        await db.mustLockObject(uploadId.bucket, uploadId.objectName, uploadId.version)
-        return true
-      } catch (e) {
-        if (e instanceof StorageBackendError && e.code === ErrorCode.ResourceLocked) {
-          await this.notifier.release(id)
-          await new Promise((resolve) => {
-            const timeoutId = setTimeout(resolve, 500)
-            const cleanup = () => {
-              clearTimeout(timeoutId)
-              signal.removeEventListener('abort', cleanup)
+    try {
+      stopSignal.addEventListener('abort', onAbort)
+
+      const acquired = await Promise.race([
+        this.waitTimeout(5000, abortController.signal),
+        (async () => {
+          while (!abortController.signal.aborted) {
+            try {
+              await this.db.acquireObjectLockForTransaction(
+                uploadId.bucket,
+                uploadId.objectName,
+                uploadId.version,
+                async () => {
+                  this.isLocked = true
+                  await new Promise<void>((innerResolve) => {
+                    this.tnxResolver = innerResolve
+                    resolve()
+                  })
+                },
+                { timeout: 5 * 60 * 1000 }
+              )
+              return true
+            } catch (e) {
+              if (e instanceof StorageBackendError && e.code === ErrorCode.ResourceLocked) {
+                await this.notifier.release(this.id)
+                await new Promise((resolve) => {
+                  const timeoutId = setTimeout(resolve, 500)
+                  const cleanup = () => {
+                    clearTimeout(timeoutId)
+                    abortController.signal.removeEventListener('abort', cleanup)
+                  }
+                  abortController.signal.addEventListener('abort', cleanup, { once: true })
+                })
+                continue
+              }
+              throw e
             }
-            signal.addEventListener('abort', cleanup, { once: true })
-          })
-          continue
-        }
-        throw e
-      }
-    }
+          }
+          return false
+        })(),
+      ])
 
-    return false
+      if (!acquired) {
+        throw ERRORS.LockTimeout()
+      }
+    } finally {
+      abortController.abort()
+      stopSignal.removeEventListener('abort', onAbort)
+    }
   }
 
   protected waitTimeout(timeout: number, signal: AbortSignal) {

--- a/src/storage/protocols/tus/postgres-locker.ts
+++ b/src/storage/protocols/tus/postgres-locker.ts
@@ -111,15 +111,12 @@ export class PgLock implements Lock {
                 uploadId.bucket,
                 uploadId.objectName,
                 uploadId.version,
-                async () => {
-                  this.isLocked = true
-                  await new Promise<void>((innerResolve) => {
-                    this.tnxResolver = innerResolve
-                    resolve()
-                  })
-                },
-                { timeout: 5 * 60 * 1000 }
+                {
+                  timeout: 5 * 60 * 1000,
+                }
               )
+              this.isLocked = true
+              resolve()
               return true
             } catch (e) {
               if (e instanceof StorageBackendError && e.code === ErrorCode.ResourceLocked) {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -145,19 +145,14 @@ export class Storage {
   }
 
   async createIcebergBucket(data: Parameters<Database['createAnalyticsBucket']>[0]) {
-    return this.db.withTransaction(async (db) => {
-      const result = await db.createAnalyticsBucket(data)
-
+    return this.db.createAnalyticsBucketWithEvent(data, async (result, tenant) => {
       await BucketCreatedEvent.invokeOrSend(
         {
           bucketId: result.id,
           bucketName: result.name,
           type: 'ANALYTICS',
-          tenant: {
-            ref: db.tenantId,
-            host: db.tenantHost,
-          },
-          sbReqId: db.sbReqId,
+          tenant,
+          sbReqId: this.db.sbReqId,
         },
         {
           sendWhenError: (error) => {
@@ -166,17 +161,15 @@ export class Storage {
             }
 
             logSchema.error(logger, 'Failed to invoke BucketCreatedEvent handler', {
-              project: db.tenantId,
+              project: tenant.ref,
               type: 'event',
               error,
-              sbReqId: db.sbReqId,
+              sbReqId: this.db.sbReqId,
             })
             return true
           },
         }
       )
-
-      return result
     })
   }
 
@@ -223,25 +216,7 @@ export class Storage {
    * @param id
    */
   async deleteBucket(id: string) {
-    return this.db.withTransaction(async (db) => {
-      await db.asSuperUser().findBucketById(id, 'id', {
-        forUpdate: true,
-      })
-
-      const countObjects = await db.asSuperUser().countObjectsInBucket(id, 1)
-
-      if (countObjects && countObjects > 0) {
-        throw ERRORS.BucketNotEmpty(id)
-      }
-
-      const deleted = await db.deleteBucket(id)
-
-      if (!deleted) {
-        throw ERRORS.NoSuchBucket(id)
-      }
-
-      return deleted
-    })
+    return this.db.deleteEmptyBucket(id)
   }
 
   async deleteIcebergBucket(name: string) {
@@ -291,13 +266,7 @@ export class Storage {
     }
 
     // ensure delete permissions
-    await this.db.testPermission(async (db) => {
-      const deleted = await db.deleteObject(bucketId, objects[0].name)
-
-      if (!deleted) {
-        throw ERRORS.NoSuchKey(objects[0].name)
-      }
-    })
+    await this.db.testDeleteObjectPermission(bucketId, objects[0].name)
 
     // use queue to recursively delete all objects created before the specified time
     await ObjectAdminDeleteAllBefore.send({

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -145,32 +145,35 @@ export class Storage {
   }
 
   async createIcebergBucket(data: Parameters<Database['createAnalyticsBucket']>[0]) {
-    return this.db.createAnalyticsBucketWithEvent(data, async (result, tenant) => {
-      await BucketCreatedEvent.invokeOrSend(
-        {
-          bucketId: result.id,
-          bucketName: result.name,
-          type: 'ANALYTICS',
-          tenant,
-          sbReqId: this.db.sbReqId,
-        },
-        {
-          sendWhenError: (error) => {
-            if (error instanceof StorageBackendError) {
-              return false
-            }
+    const result = await this.db.createAnalyticsBucketTransaction(data)
+    const tenant = this.db.tenant()
 
-            logSchema.error(logger, 'Failed to invoke BucketCreatedEvent handler', {
-              project: tenant.ref,
-              type: 'event',
-              error,
-              sbReqId: this.db.sbReqId,
-            })
-            return true
-          },
-        }
-      )
-    })
+    await BucketCreatedEvent.invokeOrSend(
+      {
+        bucketId: result.id,
+        bucketName: result.name,
+        type: 'ANALYTICS',
+        tenant,
+        sbReqId: this.db.sbReqId,
+      },
+      {
+        sendWhenError: (error) => {
+          if (error instanceof StorageBackendError) {
+            return false
+          }
+
+          logSchema.error(logger, 'Failed to invoke BucketCreatedEvent handler', {
+            project: tenant.ref,
+            type: 'event',
+            error,
+            sbReqId: this.db.sbReqId,
+          })
+          return true
+        },
+      }
+    )
+
+    return result
   }
 
   /**

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -199,71 +199,68 @@ export class Uploader {
       const abController = new AbortController()
       db.connection.setAbortSignal(abController.signal)
 
-      const result = await db.completeUploadTransaction(
-        {
-          bucket_id: bucketId,
-          name: objectName,
-          metadata: objectMetadata,
-          user_metadata: userMetadata,
-          version,
-          owner,
-        },
-        async (_newObject, currentObj, isNew) => {
-          const events: Promise<unknown>[] = []
+      const result = await db.completeUploadTransaction({
+        bucket_id: bucketId,
+        name: objectName,
+        metadata: objectMetadata,
+        user_metadata: userMetadata,
+        version,
+        owner,
+      })
 
-          // schedule the deletion of the previous file
-          if (currentObj && currentObj.version !== version) {
-            events.push(
-              ObjectAdminDelete.send({
+      const events: Promise<unknown>[] = []
+
+      // schedule the deletion of the previous file
+      if (result.previousObject && result.previousObject.version !== version) {
+        events.push(
+          ObjectAdminDelete.send({
+            name: objectName,
+            bucketId,
+            tenant: this.db.tenant(),
+            version: result.previousObject.version,
+            reqId: this.db.reqId,
+            sbReqId: this.db.sbReqId,
+          })
+        )
+      }
+
+      const event = isUpsert && !result.isNew ? ObjectCreatedPutEvent : ObjectCreatedPostEvent
+
+      events.push(
+        event
+          .sendWebhook({
+            tenant: this.db.tenant(),
+            name: objectName,
+            version,
+            bucketId,
+            metadata: objectMetadata,
+            reqId: this.db.reqId,
+            sbReqId: this.db.sbReqId,
+            uploadType,
+          })
+          .catch((e) => {
+            logSchema.error(logger, 'Failed to send webhook', {
+              type: 'event',
+              error: e,
+              project: this.db.tenantId,
+              sbReqId: this.db.sbReqId,
+              metadata: JSON.stringify({
                 name: objectName,
-                bucketId,
-                tenant: this.db.tenant(),
-                version: currentObj.version,
-                reqId: this.db.reqId,
-                sbReqId: this.db.sbReqId,
-              })
-            )
-          }
-
-          const event = isUpsert && !isNew ? ObjectCreatedPutEvent : ObjectCreatedPostEvent
-
-          events.push(
-            event
-              .sendWebhook({
-                tenant: this.db.tenant(),
-                name: objectName,
-                version,
                 bucketId,
                 metadata: objectMetadata,
                 reqId: this.db.reqId,
-                sbReqId: this.db.sbReqId,
                 uploadType,
-              })
-              .catch((e) => {
-                logSchema.error(logger, 'Failed to send webhook', {
-                  type: 'event',
-                  error: e,
-                  project: this.db.tenantId,
-                  sbReqId: this.db.sbReqId,
-                  metadata: JSON.stringify({
-                    name: objectName,
-                    bucketId,
-                    metadata: objectMetadata,
-                    reqId: this.db.reqId,
-                    uploadType,
-                  }),
-                })
-              })
-          )
-
-          await Promise.all(events)
-
-          fileUploadedSuccess.add(1, {
-            uploadType,
-            tenantId: this.db.tenantId,
+              }),
+            })
           })
-        }
       )
+
+      await Promise.all(events)
+
+      fileUploadedSuccess.add(1, {
+        uploadType,
+        tenantId: this.db.tenantId,
+      })
 
       return { ...result, metadata: objectMetadata }
     } catch (e) {

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -72,29 +72,17 @@ export class Uploader {
   async canUpload(options: CanUploadOptions) {
     const shouldCreateObject = !options.isUpsert
 
-    if (shouldCreateObject) {
-      await this.db.testPermission((db) => {
-        return db.createObject({
-          bucket_id: options.bucketId,
-          name: options.objectName,
-          version: '1',
-          owner: options.owner,
-          metadata: options.metadata,
-          user_metadata: options.userMetadata,
-        })
-      })
-    } else {
-      await this.db.testPermission((db) => {
-        return db.upsertObject({
-          bucket_id: options.bucketId,
-          name: options.objectName,
-          version: '1',
-          owner: options.owner,
-          metadata: options.metadata,
-          user_metadata: options.userMetadata,
-        })
-      })
-    }
+    await this.db.testObjectPermission(
+      {
+        bucket_id: options.bucketId,
+        name: options.objectName,
+        version: '1',
+        owner: options.owner,
+        metadata: options.metadata,
+        user_metadata: options.userMetadata,
+      },
+      !shouldCreateObject
+    )
   }
 
   /**
@@ -211,84 +199,73 @@ export class Uploader {
       const abController = new AbortController()
       db.connection.setAbortSignal(abController.signal)
 
-      return await db.withTransaction(async (db) => {
-        await db.waitObjectLock(bucketId, objectName, undefined, {
-          timeout: 5000,
-        })
-
-        const currentObj = await db.findObject(bucketId, objectName, 'id, version, metadata', {
-          forUpdate: true,
-          dontErrorOnEmpty: true,
-        })
-
-        const isNew = !Boolean(currentObj)
-
-        // update object
-        const newObject = await db.upsertObject({
+      const result = await db.completeUploadTransaction(
+        {
           bucket_id: bucketId,
           name: objectName,
           metadata: objectMetadata,
           user_metadata: userMetadata,
           version,
           owner,
-        })
+        },
+        async (_newObject, currentObj, isNew) => {
+          const events: Promise<unknown>[] = []
 
-        const events: Promise<unknown>[] = []
-
-        // schedule the deletion of the previous file
-        if (currentObj && currentObj.version !== version) {
-          events.push(
-            ObjectAdminDelete.send({
-              name: objectName,
-              bucketId,
-              tenant: this.db.tenant(),
-              version: currentObj.version,
-              reqId: this.db.reqId,
-              sbReqId: this.db.sbReqId,
-            })
-          )
-        }
-
-        const event = isUpsert && !isNew ? ObjectCreatedPutEvent : ObjectCreatedPostEvent
-
-        events.push(
-          event
-            .sendWebhook({
-              tenant: this.db.tenant(),
-              name: objectName,
-              version,
-              bucketId,
-              metadata: objectMetadata,
-              reqId: this.db.reqId,
-              sbReqId: this.db.sbReqId,
-              uploadType,
-            })
-            .catch((e) => {
-              logSchema.error(logger, 'Failed to send webhook', {
-                type: 'event',
-                error: e,
-                project: this.db.tenantId,
+          // schedule the deletion of the previous file
+          if (currentObj && currentObj.version !== version) {
+            events.push(
+              ObjectAdminDelete.send({
+                name: objectName,
+                bucketId,
+                tenant: this.db.tenant(),
+                version: currentObj.version,
+                reqId: this.db.reqId,
                 sbReqId: this.db.sbReqId,
-                metadata: JSON.stringify({
-                  name: objectName,
-                  bucketId,
-                  metadata: objectMetadata,
-                  reqId: this.db.reqId,
-                  uploadType,
-                }),
               })
-            })
-        )
+            )
+          }
 
-        await Promise.all(events)
+          const event = isUpsert && !isNew ? ObjectCreatedPutEvent : ObjectCreatedPostEvent
 
-        fileUploadedSuccess.add(1, {
-          uploadType,
-          tenantId: this.db.tenantId,
-        })
+          events.push(
+            event
+              .sendWebhook({
+                tenant: this.db.tenant(),
+                name: objectName,
+                version,
+                bucketId,
+                metadata: objectMetadata,
+                reqId: this.db.reqId,
+                sbReqId: this.db.sbReqId,
+                uploadType,
+              })
+              .catch((e) => {
+                logSchema.error(logger, 'Failed to send webhook', {
+                  type: 'event',
+                  error: e,
+                  project: this.db.tenantId,
+                  sbReqId: this.db.sbReqId,
+                  metadata: JSON.stringify({
+                    name: objectName,
+                    bucketId,
+                    metadata: objectMetadata,
+                    reqId: this.db.reqId,
+                    uploadType,
+                  }),
+                })
+              })
+          )
 
-        return { obj: newObject, isNew, metadata: objectMetadata }
-      })
+          await Promise.all(events)
+
+          fileUploadedSuccess.add(1, {
+            uploadType,
+            tenantId: this.db.tenantId,
+          })
+        }
+      )
+
+      return { ...result, metadata: objectMetadata }
     } catch (e) {
       await ObjectAdminDelete.send({
         name: objectName,

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -2948,7 +2948,6 @@ describe('Migration compatibility', () => {
             bucketId,
             'test-pre-migration.txt',
             randomUUID(),
-            'sig',
             undefined,
             undefined,
             {
@@ -2981,7 +2980,6 @@ describe('Migration compatibility', () => {
             bucketId,
             'test-post-migration.txt',
             randomUUID(),
-            'sig',
             undefined,
             undefined,
             metadata
@@ -3004,7 +3002,6 @@ describe('Migration compatibility', () => {
           bucketId,
           'test-find.txt',
           randomUUID(),
-          'sig',
           undefined,
           undefined,
           {

--- a/src/test/uploader.test.ts
+++ b/src/test/uploader.test.ts
@@ -13,7 +13,7 @@ type CompleteUploadResult = Awaited<ReturnType<Uploader['completeUpload']>>
 function createUploader(
   backend: Partial<UploaderBackend> & Pick<UploaderBackend, 'uploadObject'>,
   db: Partial<UploaderDatabase> &
-    Pick<UploaderDatabase, 'tenantId' | 'reqId' | 'tenant' | 'testPermission'>
+    Pick<UploaderDatabase, 'tenantId' | 'reqId' | 'tenant' | 'testObjectPermission'>
 ) {
   return new Uploader(
     backend as UploaderBackend,
@@ -305,7 +305,7 @@ describe('fileUploadFromRequest', () => {
         tenantId: 'stub-tenant',
         reqId: 'req-1',
         tenant: () => ({ ref: 'stub-tenant', host: 'stub-tenant.local' }),
-        testPermission: vi.fn().mockResolvedValue(undefined),
+        testObjectPermission: vi.fn().mockResolvedValue(undefined),
       }
     )
 
@@ -344,16 +344,9 @@ describe('fileUploadFromRequest', () => {
       tenantId: 'stub-tenant',
       reqId: 'req-1',
       tenant: () => ({ ref: 'stub-tenant', host: 'stub-tenant.local' }),
-      testPermission: vi.fn(async (fn) =>
-        fn({
-          createObject: vi.fn(async (payload: { metadata?: { contentLength?: number } }) => {
-            capturedWrites.push(payload)
-          }),
-          upsertObject: vi.fn(async (payload: { metadata?: { contentLength?: number } }) => {
-            capturedWrites.push(payload)
-          }),
-        })
-      ),
+      testObjectPermission: vi.fn(async (payload) => {
+        capturedWrites.push(payload as { metadata?: { contentLength?: number } })
+      }),
     })
     const completeUploadSpy = vi.spyOn(uploader, 'completeUpload').mockResolvedValue({
       metadata: { eTag: '"etag"' },


### PR DESCRIPTION
## Summary
- remove generic transaction/permission callback utilities from the public storage `Database` interface
- replace them with domain-specific database operations for permission checks, bucket/object mutations, uploads, multipart progress, and TUS lock acquisition
- keep external side effects such as backend deletes and webhook dispatch outside database transaction helpers
- narrow the newly added database operation result types instead of returning broad `Obj` shapes

## Validation
- `npx biome check src/storage/database/adapter.ts src/storage/database/knex.ts src/storage/events/objects/object-admin-delete-all-before.ts src/storage/object.ts src/storage/protocols/s3/s3-handler.ts src/storage/protocols/tus/postgres-locker.ts src/storage/storage.ts src/storage/uploader.ts src/test/s3-protocol.test.ts`
- `npm run build`
