### PR TITLE
fix: single callback for memory/handle collector

### DIFF
--- a/src/internal/monitoring/system/handles-collector.test.ts
+++ b/src/internal/monitoring/system/handles-collector.test.ts
@@ -1,0 +1,139 @@
+import { Meter, Observable } from '@opentelemetry/api'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { HandlesCollector } from './handles-collector'
+
+type ProcessWithActiveResources = NodeJS.Process & {
+  _getActiveHandles?: () => unknown[] | null | undefined
+  _getActiveRequests?: () => unknown[] | null | undefined
+}
+
+interface CapturedInstrument {
+  name: string
+  observable: Observable<Record<string, string>>
+}
+
+interface CapturedObservation {
+  name: string
+  value: number
+  labels?: Record<string, string>
+}
+
+function createMockMeter(): {
+  meter: Meter
+  invokeBatch: () => CapturedObservation[]
+} {
+  const instruments: CapturedInstrument[] = []
+  const batchCallbacks: Array<
+    (observable: {
+      observe: (
+        metric: Observable<Record<string, string>>,
+        value: number,
+        labels?: Record<string, string>
+      ) => void
+    }) => void
+  > = []
+
+  const meter = {
+    createObservableGauge(name: string) {
+      const observable = {
+        addCallback: vi.fn(),
+        removeCallback: vi.fn(),
+      }
+      instruments.push({ name, observable })
+      return observable
+    },
+    addBatchObservableCallback(callback: (observable: never) => void) {
+      batchCallbacks.push(callback as (typeof batchCallbacks)[number])
+    },
+  } as unknown as Meter
+
+  const invokeBatch = (): CapturedObservation[] => {
+    expect(batchCallbacks).toHaveLength(1)
+
+    const observations: CapturedObservation[] = []
+    const observable = {
+      observe(
+        metric: Observable<Record<string, string>>,
+        value: number,
+        labels?: Record<string, string>
+      ) {
+        const instrument = instruments.find((candidate) => candidate.observable === metric)
+        expect(instrument).toBeDefined()
+        observations.push({ name: instrument!.name, value, labels })
+      },
+    }
+
+    batchCallbacks[0](observable)
+    return observations
+  }
+
+  return { meter, invokeBatch }
+}
+
+describe('HandlesCollector', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('observes active handle and request gauges from one batch callback', () => {
+    const processWithActiveResources = process as ProcessWithActiveResources
+    const getActiveHandles = vi
+      .spyOn(processWithActiveResources, '_getActiveHandles')
+      .mockReturnValue([{}, {}])
+    const getActiveRequests = vi
+      .spyOn(processWithActiveResources, '_getActiveRequests')
+      .mockReturnValue([{}])
+
+    const { meter, invokeBatch } = createMockMeter()
+    const collector = new HandlesCollector({
+      prefix: 'test',
+      labels: { tenant: 'tenant-a' },
+    })
+
+    collector.updateMetricInstruments(meter)
+    collector.enable()
+
+    expect(invokeBatch()).toEqual([
+      {
+        name: 'test.nodejs.active_handles.total',
+        value: 2,
+        labels: { tenant: 'tenant-a' },
+      },
+      {
+        name: 'test.nodejs.active_requests.total',
+        value: 1,
+        labels: { tenant: 'tenant-a' },
+      },
+    ])
+    expect(getActiveHandles).toHaveBeenCalledTimes(1)
+    expect(getActiveRequests).toHaveBeenCalledTimes(1)
+  })
+
+  test('observes zero when active resource APIs return nullish values', () => {
+    const processWithActiveResources = process as ProcessWithActiveResources
+    vi.spyOn(processWithActiveResources, '_getActiveHandles').mockReturnValue(undefined)
+    vi.spyOn(processWithActiveResources, '_getActiveRequests').mockReturnValue(null)
+
+    const { meter, invokeBatch } = createMockMeter()
+    const collector = new HandlesCollector({
+      prefix: 'test',
+      labels: { tenant: 'tenant-a' },
+    })
+
+    collector.updateMetricInstruments(meter)
+    collector.enable()
+
+    expect(invokeBatch()).toEqual([
+      {
+        name: 'test.nodejs.active_handles.total',
+        value: 0,
+        labels: { tenant: 'tenant-a' },
+      },
+      {
+        name: 'test.nodejs.active_requests.total',
+        value: 0,
+        labels: { tenant: 'tenant-a' },
+      },
+    ])
+  })
+})

--- a/src/internal/monitoring/system/handles-collector.ts
+++ b/src/internal/monitoring/system/handles-collector.ts
@@ -3,27 +3,33 @@ import { BaseCollector } from './base-collector'
 
 export class HandlesCollector extends BaseCollector {
   updateMetricInstruments(meter: Meter): void {
-    meter
-      .createObservableGauge(`${this.namePrefix}nodejs.active_handles.total`, {
+    const activeHandlesGauge = meter.createObservableGauge(
+      `${this.namePrefix}nodejs.active_handles.total`,
+      {
         description: 'Number of active libuv handles',
-      })
-      .addCallback((observable) => {
-        if (!this._enabled) return
-        // @ts-expect-error - _getActiveHandles is not in types but exists
-        const handles = process._getActiveHandles?.() || []
-        observable.observe(handles.length, this.labels)
-      })
+      }
+    )
 
-    meter
-      .createObservableGauge(`${this.namePrefix}nodejs.active_requests.total`, {
+    const activeRequestsGauge = meter.createObservableGauge(
+      `${this.namePrefix}nodejs.active_requests.total`,
+      {
         description: 'Number of active libuv requests',
-      })
-      .addCallback((observable) => {
+      }
+    )
+
+    meter.addBatchObservableCallback(
+      (observable) => {
         if (!this._enabled) return
+
+        // @ts-expect-error - _getActiveHandles is not in types but exists
+        const handles = process._getActiveHandles?.() ?? []
         // @ts-expect-error - _getActiveRequests is not in types but exists
-        const requests = process._getActiveRequests?.() || []
-        observable.observe(requests.length, this.labels)
-      })
+        const requests = process._getActiveRequests?.() ?? []
+        observable.observe(activeHandlesGauge, handles.length, this.labels)
+        observable.observe(activeRequestsGauge, requests.length, this.labels)
+      },
+      [activeHandlesGauge, activeRequestsGauge]
+    )
   }
 
   protected internalEnable(): void {

--- a/src/internal/monitoring/system/memory-collector.test.ts
+++ b/src/internal/monitoring/system/memory-collector.test.ts
@@ -1,0 +1,111 @@
+import { Meter, Observable } from '@opentelemetry/api'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { ExternalMemoryCollector } from './memory-collector'
+
+interface CapturedInstrument {
+  name: string
+  observable: Observable<Record<string, string>>
+}
+
+interface CapturedObservation {
+  name: string
+  value: number
+  labels?: Record<string, string>
+}
+
+function createMockMeter(): {
+  meter: Meter
+  instruments: CapturedInstrument[]
+  invokeBatch: () => CapturedObservation[]
+} {
+  const instruments: CapturedInstrument[] = []
+  const batchCallbacks: Array<
+    (observable: {
+      observe: (
+        metric: Observable<Record<string, string>>,
+        value: number,
+        labels?: Record<string, string>
+      ) => void
+    }) => void
+  > = []
+
+  const meter = {
+    createObservableGauge(name: string) {
+      const observable = {
+        addCallback: vi.fn(),
+        removeCallback: vi.fn(),
+      }
+      instruments.push({ name, observable })
+      return observable
+    },
+    addBatchObservableCallback(callback: (observable: never) => void) {
+      batchCallbacks.push(callback as (typeof batchCallbacks)[number])
+    },
+  } as unknown as Meter
+
+  const invokeBatch = (): CapturedObservation[] => {
+    expect(batchCallbacks).toHaveLength(1)
+
+    const observations: CapturedObservation[] = []
+    const observable = {
+      observe(
+        metric: Observable<Record<string, string>>,
+        value: number,
+        labels?: Record<string, string>
+      ) {
+        const instrument = instruments.find((candidate) => candidate.observable === metric)
+        expect(instrument).toBeDefined()
+        observations.push({ name: instrument!.name, value, labels })
+      },
+    }
+
+    batchCallbacks[0](observable)
+    return observations
+  }
+
+  return { meter, instruments, invokeBatch }
+}
+
+describe('ExternalMemoryCollector', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('observes all memory gauges from one process.memoryUsage read', () => {
+    const memoryUsage = vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 10,
+      heapTotal: 20,
+      heapUsed: 30,
+      external: 40,
+      arrayBuffers: 50,
+    })
+
+    const { meter, invokeBatch } = createMockMeter()
+    const collector = new ExternalMemoryCollector({
+      prefix: 'test',
+      labels: { tenant: 'tenant-a' },
+    })
+
+    collector.updateMetricInstruments(meter)
+    collector.enable()
+
+    expect(invokeBatch()).toEqual([
+      {
+        name: 'test.nodejs.memory.external',
+        value: 40,
+        labels: { tenant: 'tenant-a' },
+      },
+      {
+        name: 'test.nodejs.memory.array_buffers',
+        value: 50,
+        labels: { tenant: 'tenant-a' },
+      },
+      {
+        name: 'test.nodejs.memory.rss',
+        value: 10,
+        labels: { tenant: 'tenant-a' },
+      },
+    ])
+    expect(memoryUsage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/internal/monitoring/system/memory-collector.ts
+++ b/src/internal/monitoring/system/memory-collector.ts
@@ -3,54 +3,46 @@ import { BaseCollector } from './base-collector'
 
 export class ExternalMemoryCollector extends BaseCollector {
   updateMetricInstruments(meter: Meter): void {
-    meter
-      .createObservableGauge(`${this.namePrefix}nodejs.memory.external`, {
+    const externalMemoryGauge = meter.createObservableGauge(
+      `${this.namePrefix}nodejs.memory.external`,
+      {
         description: 'Node.js external memory size in bytes',
         unit: 'By',
-      })
-      .addCallback((observable) => {
+      }
+    )
+
+    const arrayBuffersMemoryGauge = meter.createObservableGauge(
+      `${this.namePrefix}nodejs.memory.array_buffers`,
+      {
+        description: 'Node.js ArrayBuffers memory size in bytes',
+        unit: 'By',
+      }
+    )
+
+    const rssMemoryGauge = meter.createObservableGauge(`${this.namePrefix}nodejs.memory.rss`, {
+      description: 'Resident Set Size - total memory allocated for the process',
+      unit: 'By',
+    })
+
+    meter.addBatchObservableCallback(
+      (observable) => {
         if (!this._enabled) return
+
         try {
           const mem = process.memoryUsage()
           if (mem.external !== undefined) {
-            observable.observe(mem.external, this.labels)
+            observable.observe(externalMemoryGauge, mem.external, this.labels)
           }
-        } catch {
-          // ignore errors
-        }
-      })
-
-    meter
-      .createObservableGauge(`${this.namePrefix}nodejs.memory.array_buffers`, {
-        description: 'Node.js ArrayBuffers memory size in bytes',
-        unit: 'By',
-      })
-      .addCallback((observable) => {
-        if (!this._enabled) return
-        try {
-          const mem = process.memoryUsage()
           if (mem.arrayBuffers !== undefined) {
-            observable.observe(mem.arrayBuffers, this.labels)
+            observable.observe(arrayBuffersMemoryGauge, mem.arrayBuffers, this.labels)
           }
+          observable.observe(rssMemoryGauge, mem.rss, this.labels)
         } catch {
           // ignore errors
         }
-      })
-
-    meter
-      .createObservableGauge(`${this.namePrefix}nodejs.memory.rss`, {
-        description: 'Resident Set Size - total memory allocated for the process',
-        unit: 'By',
-      })
-      .addCallback((observable) => {
-        if (!this._enabled) return
-        try {
-          const mem = process.memoryUsage()
-          observable.observe(mem.rss, this.labels)
-        } catch {
-          // ignore errors
-        }
-      })
+      },
+      [externalMemoryGauge, arrayBuffersMemoryGauge, rssMemoryGauge]
+    )
   }
 
   protected internalEnable(): void {


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

Each memory/handle metric is using a separate observable callback which does calculation which could be shared.

## What is the new behavior?

Do a single batch callback instead that does computation once and shares between metrics.