### PR TITLE
fix: widen v8js.gc.duration histogram buckets

### DIFF
--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -100,10 +100,7 @@ const histogramAggregation = {
 // GC pauses span sub-millisecond incremental slices to multi-second major
 // collections, so the default 4-boundary [10ms, 100ms, 1s, 10s] histogram is
 // too coarse to distinguish incremental/minor GC and lacks resolution above 1s.
-const gcDurationBuckets = [
-  0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
-  30,
-]
+const gcDurationBuckets = [0.0001, 0.00025, ...durationBuckets, 30]
 
 const gcHistogramAggregation = {
   type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,

--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -97,6 +97,19 @@ const histogramAggregation = {
   options: { boundaries: durationBuckets },
 } as const
 
+// GC pauses span sub-millisecond incremental slices to multi-second major
+// collections, so the default 4-boundary [10ms, 100ms, 1s, 10s] histogram is
+// too coarse to distinguish incremental/minor GC and lacks resolution above 1s.
+const gcDurationBuckets = [
+  0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+  30,
+]
+
+const gcHistogramAggregation = {
+  type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+  options: { boundaries: gcDurationBuckets },
+} as const
+
 const dropAggregation = { type: AggregationType.DROP } as const
 
 // Views — custom histogram buckets + drop auto-instrumentation duplicates.
@@ -126,6 +139,13 @@ const views = [
     meterName: 'storage-api',
     instrumentName: 's3_upload_part_seconds',
     aggregation: histogramAggregation,
+  },
+  // Override the RuntimeNodeInstrumentation default GC buckets ([10ms, 100ms,
+  // 1s, 10s]) with sub-ms boundaries so incremental/minor pauses are visible.
+  {
+    meterName: '@opentelemetry/instrumentation-runtime-node',
+    instrumentName: 'v8js.gc.duration',
+    aggregation: gcHistogramAggregation,
   },
   // Drop duplicate HTTP metrics from auto-instrumentations — we have our own in metrics.ts
   {


### PR DESCRIPTION
## Summary
The `v8js.gc.duration` histogram emitted by `@opentelemetry/instrumentation-runtime-node` uses 4 hardcoded bucket boundaries: `[10ms, 100ms, 1s, 10s]`. This is one bucket per decade, which:

- collapses every incremental and minor GC pause (typically sub-millisecond to a few ms) into the first bucket, making them indistinguishable, and
- provides no resolution above 1s, so a 1.2s major-GC pause and a 9s one land in the same bucket.

This PR adds a `View` on the runtime-node meter that overrides the buckets for `v8js.gc.duration` only, with boundaries (in seconds):

```
100µs, 250µs, 500µs, 1ms, 2.5ms, 5ms, 10ms, 25ms, 50ms,
100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 30s
```

Sub-ms boundaries surface incremental/minor pauses; the 2.5s/5s/10s/30s tail keeps long major collections visible before the overflow bucket.

No other metric is affected — the override is scoped to `meterName: '@opentelemetry/instrumentation-runtime-node'`, `instrumentName: 'v8js.gc.duration'`.

## Test plan
- [x] `npx tsc -noEmit`
- [x] `npm run lint`
- [x] `npx vitest run --config vitest.unit.config.ts src/internal/monitoring` (69 tests pass)
- [ ] After deploy, verify `v8js_gc_duration_bucket` series in Prometheus/OTLP backend exposes the new `le` values and that incremental-kind samples populate buckets below 10ms.