### PR TITLE
test: cover v8js.gc.duration histogram view override

### DIFF
--- a/src/internal/monitoring/otel-metrics.test.ts
+++ b/src/internal/monitoring/otel-metrics.test.ts
@@ -173,6 +173,112 @@ describe('otel metrics', () => {
     )
   })
 
+  test('registers a view overriding v8js.gc.duration buckets on the runtime-node meter', async () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+
+    const registerInstrumentations = vi.fn(() => vi.fn())
+    const HostMetrics = vi.fn(function () {
+      return {
+        start: vi.fn(),
+      }
+    })
+    const MeterProvider = vi.fn(function () {
+      return {
+        shutdown: vi.fn().mockResolvedValue(undefined),
+        getMeter: vi.fn(() => ({})),
+      }
+    })
+    const PrometheusExporter = vi.fn(function () {
+      return {
+        getMetricsRequestHandler: vi.fn(),
+      }
+    })
+    const RuntimeNodeInstrumentation = vi.fn(function () {
+      return {}
+    })
+    const StorageNodeInstrumentation = vi.fn(function () {
+      return {}
+    })
+
+    vi.doMock('../../config', () => ({
+      getConfig: vi.fn(() => ({
+        version: 'test-version',
+        otelMetricsExportIntervalMs: 1000,
+        otelMetricsEnabled: true,
+        otelMetricsTemporality: 'CUMULATIVE',
+        prometheusMetricsEnabled: false,
+        region: 'local',
+      })),
+    }))
+    vi.doMock('@internal/monitoring/logger', () => ({
+      logger: { info: vi.fn() },
+      logSchema: { error: vi.fn(), info: vi.fn() },
+    }))
+    vi.doMock('@internal/monitoring/system', () => ({
+      StorageNodeInstrumentation,
+    }))
+    vi.doMock('@opentelemetry/api', () => ({
+      metrics: {
+        setGlobalMeterProvider: vi.fn(),
+      },
+    }))
+    vi.doMock('@opentelemetry/exporter-metrics-otlp-grpc', () => ({
+      OTLPMetricExporter: vi.fn(function () {
+        return {}
+      }),
+    }))
+    vi.doMock('@opentelemetry/exporter-prometheus', () => ({
+      PrometheusExporter,
+    }))
+    vi.doMock('@opentelemetry/host-metrics', () => ({
+      HostMetrics,
+    }))
+    vi.doMock('@opentelemetry/instrumentation', () => ({
+      registerInstrumentations,
+    }))
+    vi.doMock('@opentelemetry/instrumentation-runtime-node', () => ({
+      RuntimeNodeInstrumentation,
+    }))
+    vi.doMock('@opentelemetry/resources', () => ({
+      resourceFromAttributes: vi.fn(() => ({})),
+    }))
+    vi.doMock('@opentelemetry/sdk-metrics', () => ({
+      AggregationTemporality: {
+        CUMULATIVE: 'CUMULATIVE',
+        DELTA: 'DELTA',
+      },
+      AggregationType: {
+        DROP: 'DROP',
+        EXPLICIT_BUCKET_HISTOGRAM: 'EXPLICIT_BUCKET_HISTOGRAM',
+      },
+      MeterProvider,
+      PeriodicExportingMetricReader: vi.fn(),
+    }))
+
+    await importOtelMetricsModule()
+
+    expect(MeterProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        views: expect.arrayContaining([
+          {
+            meterName: '@opentelemetry/instrumentation-runtime-node',
+            instrumentName: 'v8js.gc.duration',
+            aggregation: {
+              type: 'EXPLICIT_BUCKET_HISTOGRAM',
+              options: {
+                boundaries: [
+                  0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+                  1, 2.5, 5, 10, 30,
+                ],
+              },
+            },
+          },
+        ]),
+      })
+    )
+  })
+
   test('does not create a Prometheus reader when Prometheus metrics are disabled', async () => {
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
     delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary
Follow-up to #1119 addressing a review request: assert that the new View on `v8js.gc.duration` is actually wired into the `MeterProvider`.

This PR is stacked on top of #1119 (both commits are included in the diff because GitHub cross-fork PRs cannot target an in-flight branch). Once #1119 merges, this PR rebases down to a single test commit.

The new test mocks `MeterProvider` and asserts it is constructed with a `views` entry matching:
- `meterName: '@opentelemetry/instrumentation-runtime-node'`
- `instrumentName: 'v8js.gc.duration'`
- `aggregation.type: 'EXPLICIT_BUCKET_HISTOGRAM'`
- `aggregation.options.boundaries: [100µs … 30s]` (the 17 boundaries from the override)

So a regression that drops, renames, or rebuckets the override is caught at unit-test time instead of in dashboards.

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run --config vitest.unit.config.ts src/internal/monitoring/otel-metrics.test.ts` (3 tests pass)