### PR TITLE
fix: put-vector relax metadata validation

### DIFF
--- a/src/http/routes/vector/put-vectors.ts
+++ b/src/http/routes/vector/put-vectors.ts
@@ -34,7 +34,7 @@ const putVector = {
             metadata: {
               type: 'object',
               additionalProperties: {
-                oneOf: [{ type: 'string' }, { type: 'boolean' }, { type: 'number' }],
+                anyOf: [{ type: 'string' }, { type: 'boolean' }, { type: 'number' }],
               },
             },
             key: { type: 'string' },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Metadata can be of a single type only

## What is the new behavior?

Metadata can be of any of the types

## Additional context

Add any other context or screenshots.
