### PR TITLE
fix: always validate signed urls scope

### DIFF
--- a/.docker/docker-compose-infra-multigres-override.yml
+++ b/.docker/docker-compose-infra-multigres-override.yml
@@ -8,7 +8,9 @@
 # and point `image` below at `multigres-cluster:local`.
 services:
   tenant_db:
-    image: ghcr.io/multigres/multigres-cluster:latest
+    # Pinned because newer latest images can reject CREATE UNLOGGED TABLE, which
+    # the scanner integration tests still use for cross-connection scratch data.
+    image: ghcr.io/multigres/multigres-cluster@sha256:7fe585a6415554ef1a291221babc09964cf5f6b5f74c297a36ea3b797b8cfafe
     # Run an init process (tini) as PID 1 to reap the cluster's child processes.
     init: true
     shm_size: "1gb"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Pull Multigres cluster image
         run: |
           for i in 1 2 3; do
-            docker pull ghcr.io/multigres/multigres-cluster:latest && exit 0
+            docker pull ghcr.io/multigres/multigres-cluster@sha256:7fe585a6415554ef1a291221babc09964cf5f6b5f74c297a36ea3b797b8cfafe && exit 0
             echo "pull attempt $i failed; retrying in 10s..."
             sleep 10
           done

--- a/acceptance/specs/rest-object.test.ts
+++ b/acceptance/specs/rest-object.test.ts
@@ -19,6 +19,11 @@ interface CreateObjectResponse {
   Key: string
 }
 
+interface SignedUploadUrlResponse {
+  url: string
+  token: string
+}
+
 interface ListObjectsV2Response {
   folders: Array<{ name: string }>
   hasNext?: boolean
@@ -116,6 +121,98 @@ describeAcceptance(
             await signedResponse.body?.cancel()
           }
         }
+      } finally {
+        await cleanupRestResources(bucketName, objectKeys, client)
+      }
+    })
+  }
+)
+
+describeAcceptance(
+  'Signed URL scope isolation',
+  {
+    destructive: true,
+    profiles: ['core'],
+  },
+  () => {
+    it('does not allow a download token to upload, nor an upload token to download', async () => {
+      const config = getAcceptanceConfig()
+      const client = createRestClient()
+      const bucketName = uniqueBucketName('scope')
+      const objectKey = uniqueObjectKey('scope')
+      const encodedObjectKey = encodePathSegments(objectKey)
+      const payload = `acceptance-scope-${config.runId}`
+      const objectKeys = [objectKey]
+
+      try {
+        await createRestBucket(bucketName, { isPublic: false })
+        await uploadRestObject(bucketName, objectKey, payload)
+
+        // Mint a download (read) signed URL and pull its token out of the query string
+        const signedDownload = await client.request<SignedUrlResponse>(
+          'POST',
+          `/object/sign/${bucketName}/${encodedObjectKey}`,
+          {
+            body: { expiresIn: 60 },
+            expectedStatus: 200,
+            token: requireServiceKey(config),
+          }
+        )
+        const downloadToken = new URL(
+          joinUrl(config.baseUrl, signedDownload.json?.signedURL ?? '')
+        ).searchParams.get('token')
+        expect(downloadToken).toBeTruthy()
+
+        // Mint an upload (write) signed URL and grab its token
+        const signedUpload = await client.request<SignedUploadUrlResponse>(
+          'POST',
+          `/object/upload/sign/${bucketName}/${encodedObjectKey}`,
+          {
+            expectedStatus: 200,
+            headers: { 'x-upsert': 'true' },
+            token: requireServiceKey(config),
+          }
+        )
+        const uploadToken = signedUpload.json?.token
+        expect(uploadToken).toBeTruthy()
+
+        // The download token must be rejected by the upload endpoint
+        await client.request(
+          'PUT',
+          `/object/upload/sign/${bucketName}/${encodedObjectKey}?token=${downloadToken}`,
+          {
+            body: 'should-not-be-written',
+            expectedStatus: 400,
+            headers: { 'content-type': 'text/plain' },
+          }
+        )
+
+        // The upload token must be rejected by the download endpoint
+        await client.request(
+          'GET',
+          `/object/sign/${bucketName}/${encodedObjectKey}?token=${uploadToken}`,
+          {
+            expectedStatus: 400,
+          }
+        )
+
+        // Sanity check: each token still works for its own scope
+        await client.request(
+          'GET',
+          `/object/sign/${bucketName}/${encodedObjectKey}?token=${downloadToken}`,
+          {
+            expectedStatus: 200,
+          }
+        )
+        await client.request(
+          'PUT',
+          `/object/upload/sign/${bucketName}/${encodedObjectKey}?token=${uploadToken}`,
+          {
+            body: payload,
+            expectedStatus: 200,
+            headers: { 'content-type': 'text/plain' },
+          }
+        )
       } finally {
         await cleanupRestResources(bucketName, objectKeys, client)
       }

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -1,9 +1,7 @@
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
-import { SignedToken, verifyJWT } from '../../../internal/auth'
-import { getJwtSecret } from '../../../internal/database'
-import { ERRORS } from '../../../internal/errors'
+import { SIGNED_URL_SCOPE_DOWNLOAD } from '../../../internal/auth'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
@@ -60,22 +58,9 @@ export default async function routes(fastify: FastifyInstance) {
       const { token } = request.query
       const { download } = request.query
 
-      let payload: SignedToken
-      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId)
-
-      try {
-        payload = (await verifyJWT(token, jwtSecret, jwks)) as SignedToken
-      } catch (e) {
-        const err = e as Error
-        throw ERRORS.InvalidJWT(err)
-      }
-
-      const { url, exp } = payload
-      const path = `${request.params.bucketName}/${request.params['*']}`
-
-      if (url !== path) {
-        throw ERRORS.InvalidSignature()
-      }
+      const { url, exp } = await request.storage
+        .from(request.params.bucketName)
+        .verifyObjectSignature(token, request.params['*'], SIGNED_URL_SCOPE_DOWNLOAD)
 
       const s3Key = `${request.tenantId}/${url}`
 

--- a/src/http/routes/object/uploadSignedObject.ts
+++ b/src/http/routes/object/uploadSignedObject.ts
@@ -1,4 +1,5 @@
 import fastifyMultipart from '@fastify/multipart'
+import { SIGNED_URL_SCOPE_UPLOAD } from '@internal/auth'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { ROUTE_OPERATIONS } from '../operations'
@@ -85,7 +86,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       const { owner, upsert } = await request.storage
         .from(bucketName)
-        .verifyObjectSignature(token, objectName)
+        .verifyObjectSignature(token, objectName, SIGNED_URL_SCOPE_UPLOAD)
 
       const { objectMetadata, path } = await request.storage
         .asSuperUser()

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -1,6 +1,5 @@
-import { SignedToken, verifyJWT } from '@internal/auth'
-import { getJwtSecret, getTenantConfig } from '@internal/database'
-import { ERRORS } from '@internal/errors'
+import { SIGNED_URL_SCOPE_DOWNLOAD } from '@internal/auth'
+import { getTenantConfig } from '@internal/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -57,23 +56,9 @@ export default async function routes(fastify: FastifyInstance) {
       const { token } = request.query
       const { download } = request.query
 
-      let payload: SignedToken
-      const { secret: jwtSecret, jwks } = await getJwtSecret(request.tenantId)
-
-      try {
-        payload = (await verifyJWT(token, jwtSecret, jwks)) as SignedToken
-      } catch (e) {
-        const err = e as Error
-        throw ERRORS.InvalidJWT(err)
-      }
-
-      const { url, transformations, exp } = payload
-
-      const path = `${request.params.bucketName}/${request.params['*']}`
-
-      if (url !== path) {
-        throw ERRORS.InvalidSignature()
-      }
+      const { url, transformations, exp } = await request.storage
+        .from(request.params.bucketName)
+        .verifyObjectSignature(token, request.params['*'], SIGNED_URL_SCOPE_DOWNLOAD)
 
       const s3Key = `${request.tenantId}/${url}`
 

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -1,3 +1,4 @@
+import { SIGNED_URL_SCOPE_UPLOAD } from '@internal/auth'
 import { TenantConnection } from '@internal/database'
 import { ERRORS, isRenderableError } from '@internal/errors'
 import { logSchema, RequestLogContext } from '@internal/monitoring'
@@ -91,7 +92,7 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
 
     const payload = await req.upload.storage
       .from(uploadID.bucket)
-      .verifyObjectSignature(signature, uploadID.objectName)
+      .verifyObjectSignature(signature, uploadID.objectName, SIGNED_URL_SCOPE_UPLOAD)
 
     req.upload.owner = payload.owner
     req.upload.isUpsert = payload.upsert

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -9,6 +9,10 @@ import {
   assertValidNumericJWTExpiration,
   generateHS512JWK,
   getMaxNumericJWTExpiration,
+  isDownloadScopedToken,
+  isUploadScopedToken,
+  SIGNED_URL_SCOPE_DOWNLOAD,
+  SIGNED_URL_SCOPE_UPLOAD,
   signJWT,
   verifyJWT,
   verifyJWTWithCache,
@@ -390,6 +394,53 @@ describe('JWT', () => {
         vi.doUnmock('jose')
         vi.resetModules()
       }
+    })
+  })
+})
+
+describe('signed URL scope predicates', () => {
+  describe('isUploadScopedToken', () => {
+    it('accepts an explicit upload scope', () => {
+      expect(isUploadScopedToken({ scope: SIGNED_URL_SCOPE_UPLOAD })).toBe(true)
+    })
+
+    it('accepts a legacy upload token (no scope, with upsert)', () => {
+      expect(isUploadScopedToken({ upsert: false } as never)).toBe(true)
+      expect(isUploadScopedToken({ upsert: true } as never)).toBe(true)
+    })
+
+    it('rejects a legacy download-shaped token (no scope, no upsert)', () => {
+      expect(isUploadScopedToken({ url: 'b/o' } as never)).toBe(false)
+    })
+
+    it('rejects an explicit download scope', () => {
+      expect(isUploadScopedToken({ scope: SIGNED_URL_SCOPE_DOWNLOAD })).toBe(false)
+    })
+
+    it('rejects an unknown scope even when upsert is present', () => {
+      expect(isUploadScopedToken({ scope: 'something-else', upsert: true } as never)).toBe(false)
+    })
+  })
+
+  describe('isDownloadScopedToken', () => {
+    it('accepts an explicit download scope', () => {
+      expect(isDownloadScopedToken({ scope: SIGNED_URL_SCOPE_DOWNLOAD })).toBe(true)
+    })
+
+    it('accepts a legacy download token (no scope, no upsert)', () => {
+      expect(isDownloadScopedToken({ url: 'b/o' } as never)).toBe(true)
+    })
+
+    it('rejects a legacy upload-shaped token (no scope, with upsert)', () => {
+      expect(isDownloadScopedToken({ upsert: false } as never)).toBe(false)
+    })
+
+    it('rejects an explicit upload scope', () => {
+      expect(isDownloadScopedToken({ scope: SIGNED_URL_SCOPE_UPLOAD })).toBe(false)
+    })
+
+    it('rejects an unknown scope', () => {
+      expect(isDownloadScopedToken({ scope: 'something-else' } as never)).toBe(false)
     })
   })
 })

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -26,17 +26,62 @@ const JWT_ECC_ALGOS = ['ES256', 'ES384', 'ES512']
 const JWT_ED_ALGOS = ['EdDSA']
 const MAX_ABSOLUTE_JWT_EXPIRATION_SECONDS = Math.floor(Number.MAX_SAFE_INTEGER / 1000)
 
+/**
+ * Scope of a signed URL token. Tokens are bound to a single action so a
+ * download token can never be replayed against the upload endpoint (and
+ * vice-versa). Legacy tokens issued before this field existed have no scope.
+ */
+export const SIGNED_URL_SCOPE_DOWNLOAD = 'download'
+export const SIGNED_URL_SCOPE_UPLOAD = 'upload'
+
+export type SignedUrlScope = typeof SIGNED_URL_SCOPE_DOWNLOAD | typeof SIGNED_URL_SCOPE_UPLOAD
+
 export type SignedToken = {
+  scope?: SignedUrlScope
   url: string
   transformations?: string
   exp: number
 }
 
 export type SignedUploadToken = {
+  scope?: SignedUrlScope
   owner: string | undefined
   upsert: boolean
   url: string
   exp: number
+}
+
+/**
+ * Whether a verified signed-URL payload is authorized to **upload**.
+ *
+ * Accepts tokens explicitly scoped for upload, plus — for backward
+ * compatibility — legacy upload tokens issued before scoping existed. Those are
+ * identified by the presence of an `upsert` claim, which only the upload-signing
+ * flow ever emits. Download-shaped tokens (no `upsert`) and any other scope are
+ * rejected, which is what closes the read-token → write-replay hole.
+ *
+ * Keep this and {@link isDownloadScopedToken} as the single source of truth for
+ * signed-URL scope checks — they are duplicated security logic otherwise.
+ */
+export function isUploadScopedToken(payload: { scope?: SignedUrlScope }): boolean {
+  return (
+    payload.scope === SIGNED_URL_SCOPE_UPLOAD ||
+    (payload.scope === undefined && 'upsert' in payload)
+  )
+}
+
+/**
+ * Whether a verified signed-URL payload is authorized to **download** (read).
+ *
+ * Accepts tokens explicitly scoped for download, plus legacy download tokens
+ * (no scope and no `upsert` claim). Upload tokens, legacy upload-shaped tokens
+ * (carrying `upsert`), and any other scope are rejected.
+ */
+export function isDownloadScopedToken(payload: { scope?: SignedUrlScope }): boolean {
+  return (
+    payload.scope === SIGNED_URL_SCOPE_DOWNLOAD ||
+    (payload.scope === undefined && !('upsert' in payload))
+  )
 }
 
 const jwtJwksFingerprintCache = new WeakMap<object, string>()

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -1,5 +1,15 @@
 import { randomUUID } from 'node:crypto'
-import { SignedUploadToken, signJWT, verifyJWT } from '@internal/auth'
+import {
+  isDownloadScopedToken,
+  isUploadScopedToken,
+  SIGNED_URL_SCOPE_DOWNLOAD,
+  SIGNED_URL_SCOPE_UPLOAD,
+  SignedToken,
+  SignedUploadToken,
+  SignedUrlScope,
+  signJWT,
+  verifyJWT,
+} from '@internal/auth'
 import { getJwtSecret } from '@internal/database'
 import { ERRORS } from '@internal/errors'
 import { StorageObjectLocator } from '@storage/locator'
@@ -735,13 +745,23 @@ export class ObjectStorage {
     }, metadata || {})
 
     // security-in-depth: as signObjectUrl could be used as a signing oracle,
-    // make sure it's never able to specify a role JWT claim
+    // make sure it's never able to specify a role JWT claim, nor the claims that
+    // identify an upload token (upsert/owner) — otherwise a download token could
+    // be crafted to satisfy the upload-endpoint's legacy compatibility check.
     delete metadata['role']
+    delete metadata['upsert']
+    delete metadata['owner']
 
     const urlParts = url.split('/')
     const urlToSign = decodeURI(urlParts.splice(3).join('/'))
     const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
-    const token = await signJWT({ url: urlToSign, ...metadata }, urlSigningKey, expiresIn)
+    // `url` and `scope` are spread last so attacker-controlled metadata can never
+    // override the intended object path or the token scope (token-forgery defense).
+    const token = await signJWT(
+      { ...metadata, url: urlToSign, scope: SIGNED_URL_SCOPE_DOWNLOAD },
+      urlSigningKey,
+      expiresIn
+    )
 
     let urlPath = 'object'
 
@@ -785,7 +805,11 @@ export class ObjectStorage {
         let signedURL = null
         if (nameSet.has(path)) {
           const urlToSign = `${this.bucketId}/${path}`
-          const token = await signJWT({ url: urlToSign }, urlSigningKey, expiresIn)
+          const token = await signJWT(
+            { url: urlToSign, scope: SIGNED_URL_SCOPE_DOWNLOAD },
+            urlSigningKey,
+            expiresIn
+          )
           signedURL = `/object/sign/${urlToSign}?token=${token}`
         } else {
           error = 'Either the object does not exist or you do not have access to it'
@@ -830,7 +854,7 @@ export class ObjectStorage {
 
     const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
     const token = await signJWT(
-      { owner, url, upsert: Boolean(options?.upsert) },
+      { owner, url, upsert: Boolean(options?.upsert), scope: SIGNED_URL_SCOPE_UPLOAD },
       urlSigningKey,
       expiresIn
     )
@@ -839,32 +863,47 @@ export class ObjectStorage {
   }
 
   /**
-   * Verify the signature for a specific object
+   * Verify a signed-URL token for a specific object, enforcing that it was issued
+   * for the requested action. This is the single place that validates a signed
+   * token: signature, scope, object-path binding, and expiry.
    * @param token
    * @param objectName
+   * @param scope the action the token must be authorized for (download or upload)
    */
-  async verifyObjectSignature(token: string, objectName: string) {
+  async verifyObjectSignature<Scope extends SignedUrlScope>(
+    token: string,
+    objectName: string,
+    scope: Scope
+  ): Promise<Scope extends typeof SIGNED_URL_SCOPE_UPLOAD ? SignedUploadToken : SignedToken> {
     const { secret: jwtSecret, jwks } = await getJwtSecret(this.db.tenantId)
 
-    let payload: SignedUploadToken
+    let payload: SignedToken | SignedUploadToken
     try {
-      payload = (await verifyJWT(token, jwtSecret, jwks)) as SignedUploadToken
+      payload = await verifyJWT<SignedToken | SignedUploadToken>(token, jwtSecret, jwks)
     } catch (e) {
       const err = e as Error
       throw ERRORS.InvalidJWT(err)
     }
 
-    const { url, exp } = payload
+    const hasValidScope =
+      scope === SIGNED_URL_SCOPE_UPLOAD
+        ? isUploadScopedToken(payload)
+        : isDownloadScopedToken(payload)
+    if (!hasValidScope) {
+      throw ERRORS.InvalidSignature(`Token is not scoped for ${scope}`)
+    }
 
-    if (url !== `${this.bucketId}/${objectName}`) {
+    if (payload.url !== `${this.bucketId}/${objectName}`) {
       throw ERRORS.InvalidSignature()
     }
 
-    if (exp * 1000 < Date.now()) {
+    if (payload.exp * 1000 < Date.now()) {
       throw ERRORS.ExpiredSignature()
     }
 
-    return payload
+    // the scope check above guarantees the payload matches the requested scope;
+    // TS can't correlate the runtime value with the conditional return type.
+    return payload as Scope extends typeof SIGNED_URL_SCOPE_UPLOAD ? SignedUploadToken : SignedToken
   }
 }
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -5,6 +5,8 @@ vi.hoisted(() => {
 import {
   generateHS512JWK,
   getMaxNumericJWTExpiration,
+  SIGNED_URL_SCOPE_DOWNLOAD,
+  SIGNED_URL_SCOPE_UPLOAD,
   SignedToken,
   signJWT,
   verifyJWT,
@@ -21,7 +23,7 @@ import { getConfig, JwksConfig, JwksConfigKeyOCT, mergeConfig } from '../config'
 import { backends, Obj } from '../storage'
 import { ObjectAdminDelete } from '../storage/events'
 import { useMockObject, useMockQueue } from './common'
-import { withDeleteEnabled } from './utils/storage'
+import { useStorage, withDeleteEnabled } from './utils/storage'
 
 const { jwtSecret, serviceKeyAsync, tenantId } = getConfig()
 const anonKey = process.env.ANON_KEY || ''
@@ -2125,7 +2127,11 @@ describe('testing uploading with generated signed upload URL', () => {
     const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
     const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
 
-    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, 100)
+    const jwtToken = await signJWT(
+      { owner, url: urlToSign, scope: SIGNED_URL_SCOPE_UPLOAD },
+      jwtSecret,
+      100
+    )
     const response = await appInstance.inject({
       method: 'PUT',
       url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
@@ -2193,6 +2199,90 @@ describe('testing uploading with generated signed upload URL', () => {
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
 
+  test('rejects a download-scoped token on the upload endpoint', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const urlToSign = `bucket2/public/sadcat-upload1.png`
+    // A token minted by the download-signing flow must not be replayable to upload
+    const downloadToken = await signJWT(
+      { url: urlToSign, scope: SIGNED_URL_SCOPE_DOWNLOAD },
+      jwtSecret,
+      100
+    )
+
+    const response = await appInstance.inject({
+      method: 'PUT',
+      url: `/object/upload/sign/${urlToSign}?token=${downloadToken}`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({ error: ErrorCode.InvalidSignature })
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('rejects a legacy download-shaped token (no upsert) on the upload endpoint', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const urlToSign = `bucket2/public/sadcat-upload1.png`
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+    // No scope claim and no `upsert` claim — i.e. a download-shaped token — is rejected,
+    // even though it predates scoping. Only legacy *upload* tokens (with upsert) are honored.
+    const unscopedToken = await signJWT({ owner, url: urlToSign }, jwtSecret, 100)
+
+    const response = await appInstance.inject({
+      method: 'PUT',
+      url: `/object/upload/sign/${urlToSign}?token=${unscopedToken}`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({ error: ErrorCode.InvalidSignature })
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('accepts a legacy upload token (no scope, with upsert) for backward compatibility', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const BUCKET_ID = 'bucket2'
+    const OBJECT_NAME = 'public/sadcat-legacy-upload.png'
+    const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+    // Token shaped exactly like one minted before scoping existed: owner + url + upsert, no scope
+    const legacyUploadToken = await signJWT(
+      { owner, url: urlToSign, upsert: false },
+      jwtSecret,
+      100
+    )
+
+    const response = await appInstance.inject({
+      method: 'PUT',
+      url: `/object/upload/sign/${urlToSign}?token=${legacyUploadToken}`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.uploadObject).toHaveBeenCalled()
+
+    // cleanup so the test can be re-run against the same dataset
+    const db = await getSuperuserPostgrestClient()
+    await withDeleteEnabled(db, async (db) => {
+      await db.from<Obj>('objects').where({ name: OBJECT_NAME, bucket_id: BUCKET_ID }).delete()
+    })
+  })
+
   test('upload object with an expired JWT', async () => {
     const form = new FormData()
     form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
@@ -2205,7 +2295,11 @@ describe('testing uploading with generated signed upload URL', () => {
     const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
     const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
 
-    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, '-1s')
+    const jwtToken = await signJWT(
+      { owner, url: urlToSign, scope: SIGNED_URL_SCOPE_UPLOAD },
+      jwtSecret,
+      '-1s'
+    )
     const response = await appInstance.inject({
       method: 'PUT',
       url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
@@ -2227,7 +2321,11 @@ describe('testing uploading with generated signed upload URL', () => {
     const OBJECT_NAME = 'public/sadcat-upload1.png'
     const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
     const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
-    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, 100)
+    const jwtToken = await signJWT(
+      { owner, url: urlToSign, scope: SIGNED_URL_SCOPE_UPLOAD },
+      jwtSecret,
+      100
+    )
     const signatureStart = jwtToken.lastIndexOf('.') + 1
     const signatureChar = jwtToken[signatureStart]
     const tamperedToken = `${jwtToken.slice(0, signatureStart)}${
@@ -2318,7 +2416,11 @@ describe('testing uploading with generated signed upload URL', () => {
 
     expect(resp.statusCode).toBe(200)
 
-    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, 100)
+    const jwtToken = await signJWT(
+      { owner, url: urlToSign, scope: SIGNED_URL_SCOPE_UPLOAD },
+      jwtSecret,
+      100
+    )
     const response = await appInstance.inject({
       method: 'PUT',
       url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
@@ -2436,6 +2538,38 @@ describe('testing generating signed URLs', () => {
 // these tests are written in bucket.test.ts since its easier
 
 /**
+ * signObjectUrl payload hardening (signing-oracle defense)
+ */
+describe('signObjectUrl token claim hardening', () => {
+  const h = useStorage()
+
+  test('attacker-controlled metadata cannot override url/scope or inject upload claims', async () => {
+    const objectName = 'public/sadcat-upload.png'
+    const signedURL = await h.storage
+      .from('bucket2')
+      .signObjectUrl(objectName, `/object/sign/bucket2/${objectName}`, 100, {
+        // a future caller passing these must never be able to forge the token
+        url: 'other-bucket/secret.png',
+        scope: SIGNED_URL_SCOPE_UPLOAD,
+        role: 'service_role',
+        upsert: true,
+        owner: 'attacker',
+      } as never)
+
+    const token = signedURL.split('?token=').pop() as string
+    const payload = (await verifyJWT(token, jwtSecret)) as Record<string, unknown>
+
+    // url stays pinned to the real object path, scope stays 'download'
+    expect(payload.url).toBe(`bucket2/${objectName}`)
+    expect(payload.scope).toBe(SIGNED_URL_SCOPE_DOWNLOAD)
+    // role and the upload-discriminating claims are stripped entirely
+    expect(payload.role).toBeUndefined()
+    expect(payload.upsert).toBeUndefined()
+    expect(payload.owner).toBeUndefined()
+  })
+})
+
+/**
  * GET /sign/
  */
 describe('testing retrieving signed URL', () => {
@@ -2489,6 +2623,51 @@ describe('testing retrieving signed URL', () => {
       ifModifiedSince: 'Thu, 12 Aug 2021 16:00:00 GMT',
       ifNoneMatch: 'abc',
     })
+  })
+
+  test('rejects an upload-scoped token on the download endpoint', async () => {
+    const urlToSign = 'bucket2/public/sadcat-upload.png'
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+    // A token minted by the upload-signing flow must not be replayable to download
+    const uploadToken = await signJWT(
+      { owner, url: urlToSign, upsert: false, scope: SIGNED_URL_SCOPE_UPLOAD },
+      jwtSecret,
+      100
+    )
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/sign/${urlToSign}?token=${uploadToken}`,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json<{ error: string }>().error).toBe('InvalidSignature')
+  })
+
+  test('still serves a legacy unscoped download token', async () => {
+    const urlToSign = 'bucket2/public/sadcat-upload.png'
+    // Tokens issued before scoping existed (no scope claim, no upsert) remain valid for download
+    const legacyToken = await signJWT({ url: urlToSign }, jwtSecret, 100)
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/sign/${urlToSign}?token=${legacyToken}`,
+    })
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('rejects a legacy upload-shaped token (with upsert) on the download endpoint', async () => {
+    const urlToSign = 'bucket2/public/sadcat-upload.png'
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+    // A legacy upload token (no scope, but carrying upsert) must not be replayable to read
+    const legacyUploadToken = await signJWT(
+      { owner, url: urlToSign, upsert: false },
+      jwtSecret,
+      100
+    )
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/sign/${urlToSign}?token=${legacyUploadToken}`,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json<{ error: string }>().error).toBe('InvalidSignature')
   })
 
   test('get object with incorrect url in jwt', async () => {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -1,6 +1,12 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { generateHS512JWK, SignedToken, signJWT, verifyJWT } from '@internal/auth'
+import {
+  generateHS512JWK,
+  SIGNED_URL_SCOPE_UPLOAD,
+  SignedToken,
+  signJWT,
+  verifyJWT,
+} from '@internal/auth'
 import dotenv from 'dotenv'
 import { FastifyInstance } from 'fastify'
 import fs from 'fs/promises'
@@ -322,6 +328,26 @@ describe('image rendering routes', () => {
     expect(response.statusCode).toBe(400)
     const body = response.json<{ error: string }>()
     expect(body.error).toBe('InvalidJWT')
+  })
+
+  it('will reject an upload-scoped token on the signed render endpoint', async () => {
+    const token = await signJWT(
+      {
+        url: 'bucket2/authenticated/casestudy.png',
+        owner: '317eadce-631a-4429-a0bb-f19a7a517b4a',
+        upsert: false,
+        scope: SIGNED_URL_SCOPE_UPLOAD,
+      },
+      jwtSecret,
+      100
+    )
+    const url = '/render/image/sign/bucket2/authenticated/casestudy.png?token=' + token
+    const response = await appInstance.inject({ method: 'GET', url })
+
+    expect(S3Backend.prototype.privateAssetUrl).not.toHaveBeenCalled()
+    expect(response.statusCode).toBe(400)
+    const body = response.json<{ error: string }>()
+    expect(body.error).toBe('InvalidSignature')
   })
 
   it('will reject jwt with incorrect url payload', async () => {


### PR DESCRIPTION
What kind of change does this PR introduce?

  Bug fix (security) — scopes signed-URL tokens to a single action.                                                                       

  What is the current behavior?

  Signed download and signed upload URLs are minted with the same signing key and carry no claim distinguishing one from the other. Verification only checks the url and exp claims, so the tokens are interchangeable

  - A download (read) signed-URL token can be replayed against PUT /object/upload/sign/... to overwrite the object at that path.
  - An upload token can likewise be replayed against the download/render endpoints.

Because download URLs are frequently shared widely and signed with long expiries, this allows a read-only link to be escalated into a write.

What is the new behavior?
  
Each token now carries an explicit scope claim ('download' or 'upload'), and every consuming endpoint enforces it. The check is a whitelist — accept only the matching shape, reject everything else — applied symmetrically:

## Additional context

**Backward compatibility** — no breakage on deploy:
  - Pre-existing download URLs (no scope, no upsert) keep working — important since they can be long-lived.
  - Pre-existing upload URLs keep working via the upsert-claim fallback: only the upload-signing flow ever emits upsert (Boolean(...), always serialized), so its presence reliably identifies a legacy upload token.
  - Cross-use is now rejected: a download token can't upload, and an upload/upload-shaped token can't download.