### PR TITLE
fix: sanitize imgproxy source image errors

### DIFF
--- a/.docker/docker-compose-infra.yml
+++ b/.docker/docker-compose-infra.yml
@@ -164,7 +164,7 @@ services:
       "
 
   imgproxy:
-    image: darthsim/imgproxy
+    image: darthsim/imgproxy:v3.26.0
     ports:
       - "50020:8080"
     volumes:
@@ -177,6 +177,7 @@ services:
       - IMGPROXY_USE_ETAG=true
       - IMGPROXY_ENABLE_WEBP_DETECTION=true
       - IMGPROXY_ALLOW_SECURITY_OPTIONS=true
+      - IMGPROXY_DEVELOPMENT_ERRORS_MODE=true
       - IMGPROXY_PRESETS=default=width:3000/height:8192
       - IMGPROXY_FORMAT_QUALITY=jpeg=80,avif=62,webp=80
 

--- a/acceptance/specs/cdn-render.test.ts
+++ b/acceptance/specs/cdn-render.test.ts
@@ -29,6 +29,9 @@ const onePixelPng = new Uint8Array(
     'base64'
   )
 )
+// Minimal ftypmif1 HEIF-family header without heic/avif compatible brands. imgproxy
+// v3.26 identifies it as HEIF-like, then rejects it as incompatible with heic/avif.
+const incompatibleMif1Heif = new Uint8Array(Buffer.from('00000010667479706d69663100000000', 'hex'))
 
 describeAcceptance(
   'CDN cache contract',
@@ -150,6 +153,37 @@ describeAcceptance(
             )}`
           )
         )
+      } finally {
+        await cleanupRestResources(bucketName, [objectKey], client)
+      }
+    })
+
+    it('returns bad request for no-transform imgproxy source-image validation failures', async () => {
+      const config = getAcceptanceConfig()
+      const client = createRestClient()
+      const bucketName = uniqueBucketName('render-invalid-heif')
+      const objectKey = uniqueObjectKey('render-invalid-heif', 'heic')
+
+      try {
+        await createRestBucket(bucketName, { isPublic: true })
+        await uploadRestObject(bucketName, objectKey, incompatibleMif1Heif, {
+          contentType: 'image/heic',
+        })
+
+        const rendered = await fetchRenderedImage(
+          joinUrl(
+            config.baseUrl,
+            `/render/image/public/${bucketName}/${encodePathSegments(objectKey)}`
+          )
+        )
+
+        expect(rendered.status, rendered.bodyText).toBe(400)
+        expect(rendered.contentType).not.toMatch(/^image\//)
+        expect(JSON.parse(rendered.bodyText)).toMatchObject({
+          error: 'InvalidRequest',
+          message: 'The source image is invalid or unsupported for rendering',
+          statusCode: '400',
+        })
       } finally {
         await cleanupRestResources(bucketName, [objectKey], client)
       }

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -515,10 +515,14 @@ describe('ImageRenderer fetch client', () => {
   })
 
   it.each([
-    [408, 'image request timed out'],
-    [429, 'too many image requests'],
-    [500, 'imgproxy failed'],
-  ])('preserves exhausted retry response status and body for imgproxy %i', async (statusCode, body) => {
+    [408, 'image request timed out', 'image request timed out'],
+    [429, 'too many image requests', 'too many image requests'],
+    [
+      500,
+      "Can't download source image: https://internal.example/private.png?X-Amz-Signature=secret",
+      'Internal error',
+    ],
+  ])('maps exhausted retry response for imgproxy %i', async (statusCode, body, expectedMessage) => {
     const mockUndici = await useUndiciMockAgent()
 
     try {
@@ -551,13 +555,100 @@ describe('ImageRenderer fetch client', () => {
 
       expect(result).toMatchObject({
         httpStatusCode: statusCode,
-        message: body,
+        message: expectedMessage,
       })
       mockAgent.assertNoPendingInterceptors()
     } finally {
       vi.useRealTimers()
       await mockUndici.close()
     }
+  })
+
+  it.each([
+    [
+      500,
+      "Can't download source image: Image is not compatible with heic/avif",
+      400,
+      'The source image is invalid or unsupported for rendering',
+    ],
+    [
+      500,
+      "Can't download source image: Image is not compatible with future/format",
+      400,
+      'The source image is invalid or unsupported for rendering',
+    ],
+    [
+      422,
+      "Can't download source image: Source image resolution is too big",
+      400,
+      'The source image resolution is too large to process',
+    ],
+    [
+      422,
+      "Can't download source image: Source image frame resolution is too big",
+      400,
+      'The source image frame resolution is too large to process',
+    ],
+    [
+      422,
+      "Can't download source image: Source image file is too big",
+      400,
+      'The source image file is too large to process',
+    ],
+    [
+      422,
+      "Can't download source image: Source image type not supported",
+      400,
+      'The source image is invalid or unsupported for rendering',
+    ],
+    [
+      500,
+      "Can't download source image: invalid TIFF format: image dimensions are not specified",
+      400,
+      'The source image is invalid or unsupported for rendering',
+    ],
+  ])('maps imgproxy source-image validation error %# (%i)', async (upstreamStatusCode, body, expectedStatusCode, expectedMessage) => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(body, {
+        status: upstreamStatusCode,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
+
+    expect(result).toMatchObject({
+      code: 'InvalidRequest',
+      httpStatusCode: expectedStatusCode,
+      message: expectedMessage,
+    })
+  })
+
+  it.each([
+    [
+      404,
+      "Can't download source image: https://internal.example/private.png?X-Amz-Signature=secret: 404",
+    ],
+    [422, "Can't download source image: local:///tmp/private-source.jpg: unsupported source state"],
+  ])('sanitizes unrecognized imgproxy source-image error %# (%i)', async (upstreamStatusCode, body) => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(body, {
+        status: upstreamStatusCode,
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { ImageRenderer } = await loadRendererModule()
+    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
+    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
+
+    expect(result).toMatchObject({
+      code: 'InvalidRequest',
+      httpStatusCode: upstreamStatusCode,
+      message: 'Unable to download source image',
+    })
   })
 
   it('clamps imgproxy Retry-After waits before retrying', async () => {

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -51,6 +51,37 @@ const IMGPROXY_RETRY_DELAY_BUDGET_MS = IMGPROXY_MAX_RETRIES * IMGPROXY_RETRY_MAX
 const IMGPROXY_TOTAL_TIMEOUT_MS =
   IMGPROXY_REQUEST_TIMEOUT_MS * (IMGPROXY_MAX_RETRIES + 1) + IMGPROXY_RETRY_DELAY_BUDGET_MS
 const IMAGE_RENDERER_RESPONSE_HEADERS = ['content-length', 'content-type', 'last-modified'] as const
+const IMGPROXY_INTERNAL_ERROR_MESSAGE = 'Internal error'
+const IMGPROXY_SOURCE_IMAGE_ERROR_PATTERN = /Can't download source image\b/i
+const IMGPROXY_SOURCE_IMAGE_ERROR_MESSAGE = 'Unable to download source image'
+const IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE =
+  'The source image is invalid or unsupported for rendering'
+const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /Image is not compatible with\b/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /Source image type not supported/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /invalid TIFF format:/i,
+  },
+  {
+    message: 'The source image resolution is too large to process',
+    pattern: /Source image resolution is too big/i,
+  },
+  {
+    message: 'The source image frame resolution is too large to process',
+    pattern: /Source image frame resolution is too big/i,
+  },
+  {
+    message: 'The source image file is too large to process',
+    pattern: /Source image file is too big/i,
+  },
+]
 
 const dispatcher: Dispatcher = new Agent({
   bodyTimeout: IMGPROXY_REQUEST_TIMEOUT_MS,
@@ -422,9 +453,49 @@ export class ImageRenderer extends Renderer {
       return ERRORS.InternalError(e instanceof Error ? e : undefined, formatRequestErrorMessage(e))
     }
 
-    const statusCode = error.response?.status || 500
-    return ERRORS.ImageProcessingError(statusCode, errorResponse || error.message)
+    const processingError = getImageProcessingError(
+      error.response?.status || 500,
+      errorResponse || error.message
+    )
+    return ERRORS.ImageProcessingError(processingError.statusCode, processingError.message)
   }
+}
+
+function getImageProcessingError(statusCode: number, message: string) {
+  const sourceImageError = getImgProxySourceImageValidationError(message)
+  if (sourceImageError) {
+    return {
+      message: sourceImageError.message,
+      statusCode: 400,
+    }
+  }
+
+  if (isImgProxySourceImageError(message) && statusCode < 500) {
+    return {
+      message: IMGPROXY_SOURCE_IMAGE_ERROR_MESSAGE,
+      statusCode,
+    }
+  }
+
+  if (statusCode >= 500) {
+    return {
+      message: IMGPROXY_INTERNAL_ERROR_MESSAGE,
+      statusCode,
+    }
+  }
+
+  return {
+    message,
+    statusCode,
+  }
+}
+
+function getImgProxySourceImageValidationError(message: string) {
+  return IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS.find((badRequest) => badRequest.pattern.test(message))
+}
+
+function isImgProxySourceImageError(message: string) {
+  return IMGPROXY_SOURCE_IMAGE_ERROR_PATTERN.test(message)
 }
 
 function createHeaders(headers?: ImageRendererRequestOptions['headers']) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Source image related errors are returning 500s due to genuine problems in the source such as non-image content, broken format, etc.

## What is the new behavior?

Sanitize known errors to well-known messages and return as 400s.

## Additional context

It requires enabling dev errors to match error messages. If it's not enabled, no match and current behavior doesn't change.
