### PR TITLE
fix: rebalance over recycle on only tenant config conn change

### DIFF
--- a/src/internal/database/pool.test.ts
+++ b/src/internal/database/pool.test.ts
@@ -696,6 +696,44 @@ describe('PoolManager cache lifecycle', () => {
     expect(recreated).not.toBe(first)
   })
 
+  test('passes all tenant rebalance options to the cached pool', async () => {
+    const poolModule = await loadPoolModule(10_000)
+
+    class TestPoolManager extends poolModule.PoolManager {
+      created: Record<string, TestPool> = {}
+
+      protected newPool(settings: TenantConnectionOptions): PoolStrategy {
+        const pool = createTestPool()
+        this.created[settings.tenantId] = pool
+        return pool
+      }
+    }
+
+    const poolManager = new TestPoolManager()
+    const pool = poolManager.getPool(createPoolSettings('tenant-rebalance-options'))
+
+    poolManager.rebalance('tenant-rebalance-options', {
+      clusterSize: 3,
+      maxConnections: 14,
+    })
+
+    expect(pool.rebalance).toHaveBeenCalledWith({
+      clusterSize: 3,
+      maxConnections: 14,
+    })
+
+    await poolManager.destroyAll()
+  })
+
+  test('does not expose recycle as a pool manager API', async () => {
+    const poolModule = await loadPoolModule(10_000)
+    const poolManager = new poolModule.PoolManager()
+
+    expect('recycle' in poolManager).toBe(false)
+
+    await poolManager.destroyAll()
+  })
+
   test('updates cached tenant pool max connections in place after rebalance', async () => {
     const poolModule = await loadPoolModule(10_000)
     const poolManager = new poolModule.PoolManager()
@@ -1127,183 +1165,6 @@ describe('PoolManager cache lifecycle', () => {
     } finally {
       await poolManager.destroyAll()
     }
-  })
-
-  test('recycle creates a fresh pool when no prior pool is cached', async () => {
-    const poolModule = await loadPoolModule(10_000)
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-no-prior-pool')
-
-    const pool = poolManager.recycle(settings.tenantId, settings)
-
-    expect(poolManager.created).toHaveLength(1)
-    expect(pool).toBe(poolManager.created[0])
-    expect(poolManager.created[0].destroy).not.toHaveBeenCalled()
-
-    // The newly recycled pool is cached and reused by subsequent getPool calls.
-    expect(poolManager.getPool(settings)).toBe(pool)
-
-    await poolManager.destroyAll()
-  })
-
-  test('recycle swaps the cached pool atomically and returns the new instance', async () => {
-    const poolModule = await loadPoolModule(10_000)
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-swap')
-
-    const original = poolManager.getPool(settings)
-    expect(poolManager.created).toHaveLength(1)
-
-    const recycled = poolManager.recycle(settings.tenantId, settings)
-
-    expect(poolManager.created).toHaveLength(2)
-    expect(recycled).toBe(poolManager.created[1])
-    expect(recycled).not.toBe(original)
-
-    // The cache swap is synchronous — any getPool right after sees the new pool.
-    expect(poolManager.getPool(settings)).toBe(recycled)
-
-    await poolManager.destroyAll()
-  })
-
-  test('recycle destroys the old pool in the background exactly once', async () => {
-    const poolModule = await loadPoolModule(10_000)
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-bg-destroy')
-
-    poolManager.getPool(settings)
-    poolManager.recycle(settings.tenantId, settings)
-
-    // destroyPoolSafely is fire-and-forget — wait for it.
-    await vi.waitFor(() => {
-      expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
-    })
-
-    // The new pool is untouched.
-    expect(poolManager.created[1].destroy).not.toHaveBeenCalled()
-
-    await poolManager.destroyAll()
-
-    // After destroyAll the new pool is also destroyed — but only once.
-    expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
-    expect(poolManager.created[1].destroy).toHaveBeenCalledTimes(1)
-  })
-
-  test('recycle does not record a cache eviction for the replaced pool', async () => {
-    const poolModule = await loadPoolModule(10_000)
-    const metricsModule = await import('@internal/monitoring/metrics')
-    const evictionSpy = vi.spyOn(metricsModule.cacheEvictionsTotal, 'add')
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-no-eviction')
-
-    poolManager.getPool(settings)
-    poolManager.recycle(settings.tenantId, settings)
-
-    // Let the background destroy + dispose hook settle.
-    await vi.waitFor(() => {
-      expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
-    })
-
-    expect(evictionSpy.mock.calls).not.toContainEqual([1, { cache: TENANT_POOL_CACHE_NAME }])
-
-    await poolManager.destroyAll()
-  })
-
-  test('destroy after recycle tears down both pools without double-destroying either', async () => {
-    const poolModule = await loadPoolModule(10_000)
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-then-destroy')
-
-    poolManager.getPool(settings)
-    poolManager.recycle(settings.tenantId, settings)
-    await poolManager.destroy(settings.tenantId)
-
-    await vi.waitFor(() => {
-      expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
-      expect(poolManager.created[1].destroy).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  test('back-to-back recycles destroy every prior pool and cache the latest', async () => {
-    const poolModule = await loadPoolModule(10_000)
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const settings = createPoolSettings('recycle-back-to-back')
-
-    poolManager.getPool(settings)
-    poolManager.recycle(settings.tenantId, settings)
-    const latest = poolManager.recycle(settings.tenantId, settings)
-
-    expect(poolManager.created).toHaveLength(3)
-    expect(poolManager.getPool(settings)).toBe(latest)
-
-    // The two earlier pools both drain in the background; the latest stays cached.
-    await vi.waitFor(() => {
-      expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
-      expect(poolManager.created[1].destroy).toHaveBeenCalledTimes(1)
-    })
-    expect(poolManager.created[2].destroy).not.toHaveBeenCalled()
-
-    await poolManager.destroyAll()
   })
 
   test('propagates explicit destroy failures without double-destroying pools', async () => {

--- a/src/internal/database/pool.ts
+++ b/src/internal/database/pool.ts
@@ -34,9 +34,7 @@ export const TENANT_POOL_CACHE_LOOKUP_LOG_MESSAGE = '[Cache] Tenant pool lookup'
 
 /**
  * Pool-level settings: everything required to build the underlying Knex/tarn
- * pool. No request-scoped fields (JWT, headers, route). Internal callers that
- * (re)build a pool outside of a request — e.g. recycle from a tenant-config
- * change — operate on this narrower shape.
+ * pool. No request-scoped fields (JWT, headers, route).
  */
 export interface PoolOptions {
   tenantId: string
@@ -277,6 +275,13 @@ export class PoolManager {
     }
   }
 
+  rebalance(tenantId: string, data: PoolRebalanceOptions) {
+    const pool = tenantPools.get(tenantId)
+    if (pool) {
+      pool.rebalance({ ...data })
+    }
+  }
+
   getPool(settings: TenantConnectionOptions) {
     const isCacheable = (settings.isSingleUse && !settings.isExternalPool) || !settings.isSingleUse
     const { value: existingPool, outcome } = tenantPools.getWithOutcome(settings.tenantId)
@@ -311,41 +316,6 @@ export class PoolManager {
       })
     }
     return Promise.resolve()
-  }
-
-  /**
-   * Replace the cached pool for a tenant with a fresh one built from `settings`.
-   *
-   * The new pool is swapped into the cache synchronously so any subsequent
-   * `getPool()` call observes it immediately. The old pool (if any) is drained
-   * and destroyed in the background via `TenantPool.destroy()` → `drainPool`,
-   * which waits for in-flight acquires/queries to settle before tearing down.
-   *
-   * Use this for tenant-config changes where the underlying DB endpoint is
-   * unchanged but the pool needs to be rebuilt with new settings (e.g.
-   * `maxConnections`). For endpoint changes (dbUrl/credentials), use
-   * `destroy()` instead — the next `getPool()` will rebuild from current
-   * settings rather than reusing the cached connection string.
-   */
-  recycle(tenantId: string, settings: PoolOptions): PoolStrategy {
-    const oldPool = tenantPools.get(tenantId)
-    const newPool = this.newPool({ ...settings, numWorkers: this.numWorkers })
-
-    // Mark the old pool so the cache `dispose` hook (fired by the `set` below
-    // for the replaced entry) doesn't race our explicit destroy.
-    if (oldPool) {
-      manuallyDestroyedPools.add(oldPool)
-    }
-
-    tenantPools.set(tenantId, newPool)
-
-    if (oldPool) {
-      void destroyPoolSafely(oldPool).finally(() => {
-        manuallyDestroyedPools.delete(oldPool)
-      })
-    }
-
-    return newPool
   }
 
   destroyAll() {

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -3,10 +3,8 @@ import {
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_CONFIG_CACHE_NAME,
 } from '@internal/cache'
-import { Cluster } from '@internal/cluster'
 import { TenantConnection } from '@internal/database/connection'
 import { lastLocalMigrationName } from '@internal/database/migrations/files'
-import type { PoolOptions } from '@internal/database/pool'
 import { ERRORS } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import {
@@ -90,7 +88,6 @@ const {
   vectorEnabled,
   multitenantDatabaseQueryTimeout,
   databaseMaxConnections,
-  databasePoolMode: globalDatabasePoolMode,
 } = getConfig()
 
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
@@ -452,13 +449,15 @@ export async function onTenantConfigChange(cacheKey: string) {
     }
 
     // 3. Max connections changed: endpoint is fine, only the budget moved.
-    //    Recycle so new traffic immediately sees the new budget while
-    //    in-flight queries on the old pool drain naturally in the background.
+    //    Rebalance the cached pool in place so new acquire attempts observe
+    //    the new budget while in-flight queries keep their checked-out clients.
     if (
       normalizeMaxConnections(newConfig.maxConnections) !==
       normalizeMaxConnections(oldConfig.maxConnections)
     ) {
-      TenantConnection.poolManager.recycle(cacheKey, buildPoolSettings(cacheKey, newConfig))
+      TenantConnection.poolManager.rebalance(cacheKey, {
+        maxConnections: resolveMaxConnections(newConfig.maxConnections),
+      })
     }
   } catch {
     // if the tenant config is not found, we can ignore it
@@ -476,19 +475,6 @@ function destroyTenantPool(cacheKey: string): Promise<void> {
       project: cacheKey,
     })
   })
-}
-
-function buildPoolSettings(tenantId: string, config: TenantConfig): PoolOptions {
-  return {
-    tenantId,
-    dbUrl: config.databasePoolUrl || config.databaseUrl,
-    isExternalPool: Boolean(config.databasePoolUrl),
-    isSingleUse: config.databasePoolMode
-      ? config.databasePoolMode !== 'recycled'
-      : !globalDatabasePoolMode || globalDatabasePoolMode === 'single_use',
-    maxConnections: resolveMaxConnections(config.maxConnections),
-    clusterSize: Cluster.size,
-  }
 }
 
 function normalizeMaxConnections(maxConnections: number | null | undefined): number | null {

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -836,7 +836,7 @@ describe('Tenant configs', () => {
     }
   })
 
-  test('Tenant config maxConnections change recycles cached pool without destroying it', async () => {
+  test('Tenant config maxConnections change rebalances cached pool without destroying it', async () => {
     const tenantId = 'pool-max-connections-change'
     const encryptedTenant = {
       anon_key: encrypt('anon'),
@@ -877,9 +877,9 @@ describe('Tenant configs', () => {
     }
     const knexTableSpy = vi.spyOn(multitenantKnex, 'table')
     const destroySpy = vi.spyOn(TenantConnection.poolManager, 'destroy').mockResolvedValue()
-    const recycleSpy = vi
-      .spyOn(TenantConnection.poolManager, 'recycle')
-      .mockReturnValue({} as never)
+    const rebalanceSpy = vi
+      .spyOn(TenantConnection.poolManager, 'rebalance')
+      .mockReturnValue(undefined)
 
     try {
       knexTableSpy.mockReturnValue(queryBuilder as unknown as TenantQueryBuilder)
@@ -887,21 +887,13 @@ describe('Tenant configs', () => {
       await getTenantConfig(tenantId)
       await onTenantConfigChange(tenantId)
 
-      expect(recycleSpy).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({
-          tenantId,
-          dbUrl: 'postgres://tenant',
-          maxConnections: 40,
-          isExternalPool: false,
-        })
-      )
+      expect(rebalanceSpy).toHaveBeenCalledWith(tenantId, { maxConnections: 40 })
       expect(destroySpy).not.toHaveBeenCalled()
     } finally {
       deleteTenantConfig(tenantId)
       knexTableSpy.mockRestore()
       destroySpy.mockRestore()
-      recycleSpy.mockRestore()
+      rebalanceSpy.mockRestore()
     }
   })
 
@@ -946,9 +938,6 @@ describe('Tenant configs', () => {
     }
     const knexTableSpy = vi.spyOn(multitenantKnex, 'table')
     const destroySpy = vi.spyOn(TenantConnection.poolManager, 'destroy').mockResolvedValue()
-    const recycleSpy = vi
-      .spyOn(TenantConnection.poolManager, 'recycle')
-      .mockReturnValue({} as never)
 
     try {
       knexTableSpy.mockReturnValue(queryBuilder as unknown as TenantQueryBuilder)
@@ -957,12 +946,10 @@ describe('Tenant configs', () => {
       await onTenantConfigChange(tenantId)
 
       expect(destroySpy).toHaveBeenCalledWith(tenantId)
-      expect(recycleSpy).not.toHaveBeenCalled()
     } finally {
       deleteTenantConfig(tenantId)
       knexTableSpy.mockRestore()
       destroySpy.mockRestore()
-      recycleSpy.mockRestore()
     }
   })
 
@@ -1007,9 +994,6 @@ describe('Tenant configs', () => {
     }
     const knexTableSpy = vi.spyOn(multitenantKnex, 'table')
     const destroySpy = vi.spyOn(TenantConnection.poolManager, 'destroy').mockResolvedValue()
-    const recycleSpy = vi
-      .spyOn(TenantConnection.poolManager, 'recycle')
-      .mockReturnValue({} as never)
 
     try {
       knexTableSpy.mockReturnValue(queryBuilder as unknown as TenantQueryBuilder)
@@ -1018,16 +1002,14 @@ describe('Tenant configs', () => {
       await onTenantConfigChange(tenantId)
 
       expect(destroySpy).toHaveBeenCalledWith(tenantId)
-      expect(recycleSpy).not.toHaveBeenCalled()
     } finally {
       deleteTenantConfig(tenantId)
       knexTableSpy.mockRestore()
       destroySpy.mockRestore()
-      recycleSpy.mockRestore()
     }
   })
 
-  test('Tenant config dbUrl change with maxConnections change destroys (does not recycle)', async () => {
+  test('Tenant config dbUrl change with maxConnections change destroys instead of rebalancing', async () => {
     const tenantId = 'pool-dburl-and-max-change'
     const encryptedTenant = {
       anon_key: encrypt('anon'),
@@ -1069,9 +1051,9 @@ describe('Tenant configs', () => {
     }
     const knexTableSpy = vi.spyOn(multitenantKnex, 'table')
     const destroySpy = vi.spyOn(TenantConnection.poolManager, 'destroy').mockResolvedValue()
-    const recycleSpy = vi
-      .spyOn(TenantConnection.poolManager, 'recycle')
-      .mockReturnValue({} as never)
+    const rebalanceSpy = vi
+      .spyOn(TenantConnection.poolManager, 'rebalance')
+      .mockReturnValue(undefined)
 
     try {
       knexTableSpy.mockReturnValue(queryBuilder as unknown as TenantQueryBuilder)
@@ -1079,14 +1061,14 @@ describe('Tenant configs', () => {
       await getTenantConfig(tenantId)
       await onTenantConfigChange(tenantId)
 
-      // dbUrl is checked first — destroy wins, recycle skipped.
+      // dbUrl is checked first — destroy wins, rebalance skipped.
       expect(destroySpy).toHaveBeenCalledWith(tenantId)
-      expect(recycleSpy).not.toHaveBeenCalled()
+      expect(rebalanceSpy).not.toHaveBeenCalled()
     } finally {
       deleteTenantConfig(tenantId)
       knexTableSpy.mockRestore()
       destroySpy.mockRestore()
-      recycleSpy.mockRestore()
+      rebalanceSpy.mockRestore()
     }
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (performance improvement)

## What is the current behavior?

On only max connections change for tenant config, pool is recycled which creates unnecessary connection/socket churn.

## What is the new behavior?

Mutates the pool in place, increases are immediate and decreases are handled by idle timeout.

## Additional context

Related to #1125 - prior approach
Related to #1096 - already has this approach
