### PR TITLE
fix: duplicated instance label from autoconversion

### DIFF
--- a/monitoring/otel/config/otel-collector-config.yml
+++ b/monitoring/otel/config/otel-collector-config.yml
@@ -27,6 +27,14 @@ processors:
           - set(attributes["service_instance_id"], resource.attributes["service.instance.id"]) where resource.attributes["service.instance.id"] != nil
           - set(attributes["worker_id"], resource.attributes["worker.id"]) where resource.attributes["worker.id"] != nil
           - set(attributes["platformatic_application_id"], resource.attributes["platformatic.application.id"]) where resource.attributes["platformatic.application.id"] != nil
+  # Prometheus exporter maps resource service.instance.id to the reserved
+  # instance label. Keep the explicit service_instance_id datapoint label above,
+  # but remove the resource attribute so it does not collide with host instance.
+  transform/drop_prometheus_reserved_resource_attrs:
+    metric_statements:
+      - context: resource
+        statements:
+          - delete_key(attributes, "service.instance.id")
   # Add storage_api_otel_ prefix to all metrics
   # Note: storage_api_ transform must be FIRST to avoid double prefix
   metricstransform/host:
@@ -173,7 +181,13 @@ service:
     metrics/otel:
       receivers: [otlp]
       processors:
-        [memory_limiter, transform/add_resource_attributes, metricstransform/host, batch/metrics]
+        [
+          memory_limiter,
+          transform/add_resource_attributes,
+          transform/drop_prometheus_reserved_resource_attrs,
+          metricstransform/host,
+          batch/metrics,
+        ]
       exporters: [prometheusremotewrite]
     metrics/prometheus:
       receivers: [otlp]
@@ -181,6 +195,7 @@ service:
         [
           memory_limiter,
           transform/add_resource_attributes,
+          transform/drop_prometheus_reserved_resource_attrs,
           metricstransform/prom_prefix,
           batch/metrics,
         ]

--- a/src/internal/monitoring/otel-metrics.test.ts
+++ b/src/internal/monitoring/otel-metrics.test.ts
@@ -509,4 +509,13 @@ describe('otel metrics', () => {
       'set(attributes["platformatic_application_id"], resource.attributes["platformatic.application.id"])'
     )
   })
+
+  test('collector removes service instance resource before Prometheus conversion', () => {
+    const collectorConfig = fs.readFileSync(
+      'monitoring/otel/config/otel-collector-config.yml',
+      'utf8'
+    )
+
+    expect(collectorConfig).toContain('delete_key(attributes, "service.instance.id")')
+  })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`service.instance.id` is automatically converted to reserved `instance` and duplicates.

## What is the new behavior?

Drop `service.instance.id` and keep converted `service_instance_id`.

## Additional context

Related to #1134