### PR TITLE
fix: drive ssl for mt through conn string

### DIFF
--- a/src/internal/database/multitenant-pg.test.ts
+++ b/src/internal/database/multitenant-pg.test.ts
@@ -4,7 +4,6 @@ type MultitenantPgModule = typeof import('./multitenant-pg')
 type MockPgPoolOptions = {
   connectionString?: string
   max?: number
-  ssl?: unknown
 }
 type MockPgClient = {
   query: () => Promise<{ rows: unknown[] }>
@@ -48,7 +47,7 @@ describe('multitenant pg pool', () => {
     vi.resetModules()
   })
 
-  it('plumbs DATABASE_SSL_ROOT_CERT into the shared multitenant pool config', async () => {
+  it('does not pass DATABASE_SSL_ROOT_CERT into the shared multitenant pool config', async () => {
     loadedModule = await loadMultitenantPgModule({
       databaseSSLRootCert: 'root-cert',
     })
@@ -59,14 +58,12 @@ describe('multitenant pg pool', () => {
       expect.objectContaining({
         connectionString: 'postgres://user:password@db.example.test:5432/postgres',
         max: 3,
-        ssl: {
-          ca: 'root-cert',
-        },
       })
     )
+    expect(getLatestPool().options).not.toHaveProperty('ssl')
   })
 
-  it('uses the pool URL for SSL settings and pool sizing when configured', async () => {
+  it('uses the pool URL for sizing without injecting SSL settings', async () => {
     loadedModule = await loadMultitenantPgModule({
       databaseSSLRootCert: 'root-cert',
       multitenantDatabasePoolUrl: 'postgres://user:password@1.2.3.4:6432/postgres',
@@ -78,12 +75,9 @@ describe('multitenant pg pool', () => {
       expect.objectContaining({
         connectionString: 'postgres://user:password@1.2.3.4:6432/postgres',
         max: 30,
-        ssl: {
-          ca: 'root-cert',
-          rejectUnauthorized: false,
-        },
       })
     )
+    expect(getLatestPool().options).not.toHaveProperty('ssl')
   })
 
   it('reads the current config after runtime config changes', async () => {

--- a/src/internal/database/multitenant-pg.ts
+++ b/src/internal/database/multitenant-pg.ts
@@ -2,12 +2,10 @@ import { logger, logSchema } from '@internal/monitoring'
 import { Pool, PoolConfig } from 'pg'
 import { getConfig } from '../../config'
 import { PgPoolExecutor, PgTransactionalExecutor } from './pg-connection'
-import { getSslSettings } from './ssl'
 
 function buildMultitenantPgPoolConfig(config: ReturnType<typeof getConfig>): PoolConfig {
   const {
     databaseApplicationName,
-    databaseSSLRootCert,
     multitenantDatabasePoolUrl,
     multitenantDatabaseUrl,
     multitenantMaxConnections,
@@ -17,12 +15,6 @@ function buildMultitenantPgPoolConfig(config: ReturnType<typeof getConfig>): Poo
   const poolSize = multitenantDatabasePoolUrl
     ? multitenantMaxConnections * 10
     : multitenantMaxConnections
-  const sslSettings = connectionString
-    ? getSslSettings({
-        connectionString,
-        databaseSSLRootCert,
-      })
-    : undefined
 
   return {
     connectionString,
@@ -31,7 +23,6 @@ function buildMultitenantPgPoolConfig(config: ReturnType<typeof getConfig>): Poo
     min: 0,
     max: poolSize,
     idleTimeoutMillis: 5000,
-    ssl: sslSettings ? { ...sslSettings } : undefined,
   }
 }
 
@@ -151,7 +142,6 @@ function getPoolConfigSignature(config: PoolConfig): string {
     idleTimeoutMillis: config.idleTimeoutMillis,
     max: config.max,
     min: config.min,
-    ssl: config.ssl,
   })
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

ssl settings are passed to mt pool in #1096

## What is the new behavior?

restore pre-#1096 behavior to let connection string to drive ssl settings 

## Additional context

related to #1096
