### PR TITLE
fix: error listeners for pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "platformatic": "^3.52.0",
         "postgres-migrations": "^5.3.0",
         "pprof-format": "^2.2.1",
+        "safe-stable-stringify": "^2.3.1",
         "undici": "^7.24.0",
         "wattpm": "^3.52.0",
         "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "platformatic": "^3.52.0",
     "postgres-migrations": "^5.3.0",
     "pprof-format": "^2.2.1",
+    "safe-stable-stringify": "^2.3.1",
     "undici": "^7.24.0",
     "wattpm": "^3.52.0",
     "xml2js": "^0.6.2"

--- a/src/internal/database/multitenant-pg.test.ts
+++ b/src/internal/database/multitenant-pg.test.ts
@@ -12,6 +12,7 @@ type MockPgClient = {
 type MockPgPool = {
   options: MockPgPoolOptions
   ended: boolean
+  on: ReturnType<typeof vi.fn>
   connect: () => Promise<MockPgClient>
   end: () => Promise<void>
 }
@@ -78,6 +79,14 @@ describe('multitenant pg pool', () => {
       })
     )
     expect(getLatestPool().options).not.toHaveProperty('ssl')
+  })
+
+  it('installs an idle pg client error handler on the shared multitenant pool', async () => {
+    loadedModule = await loadMultitenantPgModule()
+
+    await runQuery(loadedModule)
+
+    expect(getLatestPool().on).toHaveBeenCalledWith('error', expect.any(Function))
   })
 
   it('reads the current config after runtime config changes', async () => {
@@ -214,6 +223,7 @@ function mockPgModule(): void {
     class MockPool implements MockPgPool {
       readonly options: MockPgPoolOptions
       ended = false
+      on = vi.fn()
       connect = vi.fn(async () => createMockPgClient())
       end = vi.fn(async () => {
         this.ended = true

--- a/src/internal/database/multitenant-pg.ts
+++ b/src/internal/database/multitenant-pg.ts
@@ -1,7 +1,7 @@
 import { logger, logSchema } from '@internal/monitoring'
 import { Pool, PoolConfig } from 'pg'
 import { getConfig } from '../../config'
-import { PgPoolExecutor, PgTransactionalExecutor } from './pg-connection'
+import { attachPgPoolErrorHandler, PgPoolExecutor, PgTransactionalExecutor } from './pg-connection'
 
 function buildMultitenantPgPoolConfig(config: ReturnType<typeof getConfig>): PoolConfig {
   const {
@@ -72,7 +72,9 @@ class MultitenantPgPoolOwner {
     }
 
     const oldState = this.state
-    const pool = new Pool(poolConfig)
+    const pool = attachPgPoolErrorHandler(new Pool(poolConfig), {
+      message: '[MultitenantPg] Idle pg client error',
+    })
     this.state = {
       pool,
       executor: new PgPoolExecutor(pool),

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -455,6 +455,33 @@ describe('PgTenantConnection', () => {
 })
 
 describe('PgPoolStrategy', () => {
+  it('logs idle pg pool errors without rethrowing them', async () => {
+    const strategy = new TestablePgPoolStrategy(createPoolStrategySettings())
+    const logSpy = vi.spyOn(logSchema, 'warning').mockImplementation(() => undefined)
+
+    try {
+      const pool = strategy.getCurrentPoolForTest()
+      const error = Object.assign(new Error('Connection terminated unexpectedly'), {
+        client: { ssl: { ca: 'secret root cert' } },
+      })
+
+      expect(() => pool.emit('error', error, {})).not.toThrow()
+      expect(logSpy).toHaveBeenCalledWith(
+        logger,
+        '[PgPoolStrategy] Idle pg client error',
+        expect.objectContaining({
+          type: 'db',
+          tenantId: 'pg-pool-strategy-test',
+          project: 'pg-pool-strategy-test',
+          error,
+        })
+      )
+    } finally {
+      logSpy.mockRestore()
+      await strategy.destroy()
+    }
+  })
+
   it('documents that pg-pool end does not service already queued acquires', async () => {
     const pool = new PgPool({
       Client: FakePgPoolClient,

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -48,6 +48,12 @@ export interface PgTransactionalExecutor extends PgExecutor {
   beginTransaction(options?: TransactionOptions): Promise<PgTransaction>
 }
 
+interface PgPoolErrorContext {
+  message: string
+  tenantId?: string
+  project?: string
+}
+
 type PgClientWithCancel = PoolClient & {
   processID?: number
   secretKey?: number
@@ -175,16 +181,25 @@ export class PgPoolStrategy {
       databaseSSLRootCert,
     })
 
-    return new Pool({
-      min: 0,
-      max: settings.maxConnections,
-      connectionString: settings.dbUrl,
-      connectionTimeoutMillis: databaseConnectionTimeout,
-      idleTimeoutMillis: settings.idleTimeoutMillis,
-      ssl: sslSettings ? { ...sslSettings } : undefined,
-      application_name: databaseApplicationName,
-      options: settings.searchPath ? `-c search_path=${settings.searchPath.join(',')}` : undefined,
-    })
+    return attachPgPoolErrorHandler(
+      new Pool({
+        min: 0,
+        max: settings.maxConnections,
+        connectionString: settings.dbUrl,
+        connectionTimeoutMillis: databaseConnectionTimeout,
+        idleTimeoutMillis: settings.idleTimeoutMillis,
+        ssl: sslSettings ? { ...sslSettings } : undefined,
+        application_name: databaseApplicationName,
+        options: settings.searchPath
+          ? `-c search_path=${settings.searchPath.join(',')}`
+          : undefined,
+      }),
+      {
+        message: '[PgPoolStrategy] Idle pg client error',
+        tenantId: settings.tenantId,
+        project: settings.tenantId,
+      }
+    )
   }
 
   private async drainPool(pool: Pool, reason: 'destroy' | 'rebalance'): Promise<void> {
@@ -229,6 +244,19 @@ export class PgPoolStrategy {
       metadata: JSON.stringify(metadata),
     })
   }
+}
+
+export function attachPgPoolErrorHandler(pool: Pool, context: PgPoolErrorContext): Pool {
+  pool.on('error', (error) => {
+    logSchema.warning(logger, context.message, {
+      type: 'db',
+      tenantId: context.tenantId,
+      project: context.project,
+      error,
+    })
+  })
+
+  return pool
 }
 
 function getPoolWorkStats(pool: Pool): {

--- a/src/internal/errors/codes.test.ts
+++ b/src/internal/errors/codes.test.ts
@@ -108,6 +108,25 @@ describe('normalizeRawError', () => {
 
     expect(result.raw).toBe('Failed to stringify error')
   })
+
+  it('omits pg client internals attached to Error objects', () => {
+    const error = new Error('Connection terminated unexpectedly') as Error & {
+      client?: unknown
+      code?: string
+    }
+    const client: { ssl: { ca: string }; self?: unknown } = {
+      ssl: { ca: 'secret root cert' },
+    }
+    client.self = client
+    error.client = client
+    error.code = '08006'
+
+    const result = normalizeRawError(error, 'info')
+
+    expect(result.raw).not.toContain('client')
+    expect(result.raw).not.toContain('secret root cert')
+    expect(JSON.parse(result.raw)).toEqual({ code: '08006' })
+  })
 })
 
 describe('getErrorCode', () => {

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -1,5 +1,6 @@
 import { IcebergError } from '@storage/protocols/iceberg/catalog/errors'
 import { DatabaseError } from 'pg'
+import { configure } from 'safe-stable-stringify'
 import { StorageBackendError } from './storage-error'
 
 export enum ErrorCode {
@@ -576,6 +577,7 @@ const ERROR_CODE_MAP: Record<string, ErrorCode> = {
   FST_ERR_CTP_INVALID_MEDIA_TYPE: ErrorCode.InvalidMimeType,
   FST_ERR_CTP_BODY_TOO_LARGE: ErrorCode.EntityTooLarge,
 }
+const ERROR_RAW_OMITTED_KEYS = new Set(['client'])
 
 export function isStorageError(errorType: ErrorCode, error: unknown): error is StorageBackendError {
   return error instanceof StorageBackendError && error.code === errorType
@@ -626,7 +628,7 @@ export function normalizeRawError(error: unknown, logLevel: string) {
       logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
 
     return {
-      raw: JSON.stringify(error),
+      raw: stringifyErrorRaw(error),
       name: error.name,
       message: error.message,
       stack: includeStack ? error.stack || '' : '',
@@ -643,5 +645,23 @@ export function normalizeRawError(error: unknown, logLevel: string) {
     return {
       raw: 'Failed to stringify error',
     }
+  }
+}
+
+const stableStringify = configure({
+  maximumDepth: 8,
+  maximumBreadth: 64,
+  deterministic: false,
+})
+
+function errorRawReplacer(key: string, value: unknown) {
+  return ERROR_RAW_OMITTED_KEYS.has(key) ? undefined : value
+}
+
+function stringifyErrorRaw(error: Error): string {
+  try {
+    return stableStringify(error, errorRawReplacer) ?? 'Failed to stringify error'
+  } catch {
+    return 'Failed to stringify error'
   }
 }


### PR DESCRIPTION
harden logging for errors

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Pools are missing error listeners and if it's not caught, uncaught exception will crash the server. For example, idle connection close can trigger it easily. 

## What is the new behavior?

Attach error listeners for tenant/mt. Pools are self healing but log the errors.

## Additional context

Use pino's dependency for error serialization and ignore `client` on error that could have state which shouldn't be logged.

Related to #1096
