### PR TITLE
fix: harden pg connection and admin timeouts

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,6 +6,7 @@ const CONFIG_ENV_KEYS = [
   'TENANT_POOL_CACHE_TTL_MS',
   'TENANT_POOL_CACHE_HIT_LOG_SAMPLE_RATE',
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
+  'DATABASE_POOL_MODE',
   'DATABASE_POOL_DRAIN_TIMEOUT',
 ] as const
 
@@ -56,6 +57,29 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheHitLogSampleRate).toBe(0)
     expect(config.tenantPoolCacheMissLogSampleRate).toBe(0)
     expect(config.databasePoolDrainTimeout).toBe(30_000)
+  })
+
+  test('falls back to recycled pool mode for invalid DATABASE_POOL_MODE env values', async () => {
+    setConfigEnv({
+      DATABASE_POOL_MODE: 'garbage',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.databasePoolMode).toBe('recycled')
+  })
+
+  test('preserves legacy tenant-row recycle semantics on read', async () => {
+    const { normalizeDatabasePoolModeForRead } = await import('./config')
+
+    expect(normalizeDatabasePoolModeForRead('recycle')).toBe('single_use')
+  })
+
+  test('falls back for invalid tenant-row pool mode values on read', async () => {
+    const { normalizeDatabasePoolModeForRead } = await import('./config')
+
+    expect(normalizeDatabasePoolModeForRead('garbage', 'recycled')).toBe('recycled')
   })
 
   test('parses database pool drain timeout in milliseconds', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -272,6 +272,37 @@ export function normalizeDatabasePoolMode(
   throw new Error(`Invalid database pool mode "${mode}". Expected "single_use" or "recycled".`)
 }
 
+export function normalizeDatabasePoolModeForRead(
+  mode: string | null | undefined,
+  fallback?: DatabasePoolMode
+): DatabasePoolMode | null | undefined {
+  if (mode === null) {
+    return null
+  }
+
+  if (mode === undefined || mode === '') {
+    return undefined
+  }
+
+  if (mode === 'single_use' || mode === 'recycled') {
+    return mode
+  }
+
+  if (mode === 'recycle') {
+    return 'single_use'
+  }
+
+  return fallback
+}
+
+function normalizeDatabasePoolModeFromEnv(mode: string | undefined): DatabasePoolMode | undefined {
+  try {
+    return normalizeDatabasePoolMode(mode) ?? undefined
+  } catch {
+    return 'recycled'
+  }
+}
+
 export function normalizeDatabaseEngine(engine: string | null | undefined): DatabaseEngine {
   if (engine === null || engine === undefined || engine === '') {
     return 'postgres'
@@ -493,7 +524,9 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     databaseEngine: normalizeDatabaseEngine(getOptionalConfigFromEnv('DATABASE_ENGINE')),
     databaseURL: getOptionalIfMultitenantConfigFromEnv('DATABASE_URL') || '',
     databasePoolURL: getOptionalConfigFromEnv('DATABASE_POOL_URL') || '',
-    databasePoolMode: normalizeDatabasePoolMode(getOptionalConfigFromEnv('DATABASE_POOL_MODE')),
+    databasePoolMode: normalizeDatabasePoolModeFromEnv(
+      getOptionalConfigFromEnv('DATABASE_POOL_MODE')
+    ),
     databaseMaxConnections: parseInt(
       getOptionalConfigFromEnv('DATABASE_MAX_CONNECTIONS') || '20',
       10

--- a/src/http/plugins/vector.test.ts
+++ b/src/http/plugins/vector.test.ts
@@ -1,0 +1,102 @@
+import Fastify from 'fastify'
+import { vi } from 'vitest'
+
+type VectorPluginModule = typeof import('./vector')
+type MockPgPoolOptions = {
+  application_name?: string
+  connectionString?: string
+  max?: number
+  min?: number
+}
+type MockPgPool = {
+  options: MockPgPoolOptions
+  on: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+}
+
+let createdPools: MockPgPool[] = []
+
+async function loadVectorPlugin(
+  configOverrides: Record<string, unknown> = {}
+): Promise<VectorPluginModule> {
+  vi.resetModules()
+  mockPgModule()
+
+  const configModule = await import('../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({
+    databaseApplicationName: 'storage-test',
+    isMultitenant: false,
+    vectorBucketProvider: 'pgvector',
+    vectorDatabaseCreate: false,
+    vectorDatabaseURL: 'postgres://user:password@db.example.test:5432/storage_vectors',
+    ...configOverrides,
+  } as Parameters<typeof configModule.mergeConfig>[0])
+
+  return import('./vector')
+}
+
+function getLatestPool(): MockPgPool {
+  const pool = createdPools.at(-1)
+
+  if (!pool) {
+    throw new Error('Expected pg Pool to be created')
+  }
+
+  return pool
+}
+
+function mockPgModule(): void {
+  createdPools = []
+
+  vi.doMock('pg', () => {
+    const types = {
+      setTypeParser: vi.fn(),
+    }
+
+    class DatabaseError extends Error {}
+
+    class MockPool implements MockPgPool {
+      readonly options: MockPgPoolOptions
+      on = vi.fn()
+      end = vi.fn(async () => undefined)
+
+      constructor(options: MockPgPoolOptions) {
+        this.options = options
+        createdPools.push(this)
+      }
+    }
+
+    return {
+      DatabaseError,
+      Pool: MockPool,
+      types,
+      default: {
+        DatabaseError,
+        Pool: MockPool,
+        types,
+      },
+    }
+  })
+}
+
+describe('s3vector plugin', () => {
+  afterEach(() => {
+    vi.doUnmock('pg')
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('installs an idle error handler on the single-tenant pgvector pool', async () => {
+    const { s3vector } = await loadVectorPlugin()
+    const app = Fastify()
+
+    try {
+      await app.register(s3vector)
+
+      expect(getLatestPool().on).toHaveBeenCalledWith('error', expect.any(Function))
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/http/plugins/vector.ts
+++ b/src/http/plugins/vector.ts
@@ -1,4 +1,9 @@
-import { getTenantConfig, multitenantPgExecutor, PgPoolExecutor } from '@internal/database'
+import {
+  attachPgPoolErrorHandler,
+  getTenantConfig,
+  multitenantPgExecutor,
+  PgPoolExecutor,
+} from '@internal/database'
 import { deriveVectorDatabaseUrl } from '@internal/database/vector-store-url'
 import { ERRORS } from '@internal/errors'
 import {
@@ -55,12 +60,17 @@ export const s3vector = fastifyPlugin(async function (fastify: FastifyInstance) 
     const connectionString = vectorDatabaseCreate
       ? deriveVectorDatabaseUrl(vectorDatabaseURL)
       : vectorDatabaseURL
-    stPgVectorPool = new PgPool({
-      connectionString,
-      application_name: databaseApplicationName,
-      min: 0,
-      max: 10,
-    })
+    stPgVectorPool = attachPgPoolErrorHandler(
+      new PgPool({
+        connectionString,
+        application_name: databaseApplicationName,
+        min: 0,
+        max: 10,
+      }),
+      {
+        message: '[Vector] Idle pgvector client error',
+      }
+    )
     stPgVectorAdapter = new PgVectorStore(new PgPoolExecutor(stPgVectorPool))
     fastify.addHook('onClose', async () => {
       await stPgVectorPool?.end()

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -1,4 +1,8 @@
-import { MigrationAdminStorePg, multitenantPgExecutor } from '@internal/database'
+import {
+  MIGRATION_ADMIN_JOB_LIMIT,
+  MigrationAdminStorePg,
+  multitenantPgExecutor,
+} from '@internal/database'
 import {
   isDBMigrationName,
   resetMigrationsOnTenants,
@@ -70,7 +74,10 @@ export default async function routes(fastify: FastifyInstance) {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
-    const data = await migrationAdminStorePg.listActiveJobs(migrationQueueName, 2000)
+    const data = await migrationAdminStorePg.listActiveJobs(
+      migrationQueueName,
+      MIGRATION_ADMIN_JOB_LIMIT
+    )
 
     return reply.send(data)
   })
@@ -79,7 +86,10 @@ export default async function routes(fastify: FastifyInstance) {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
-    const data = await migrationAdminStorePg.completeActiveJobs(migrationQueueName)
+    const data = await migrationAdminStorePg.completeActiveJobs(
+      migrationQueueName,
+      MIGRATION_ADMIN_JOB_LIMIT
+    )
 
     return reply.send(data)
   })

--- a/src/http/routes/admin/migrations.ts
+++ b/src/http/routes/admin/migrations.ts
@@ -79,7 +79,7 @@ export default async function routes(fastify: FastifyInstance) {
     if (!pgQueueEnable) {
       return reply.code(400).send({ message: 'Queue is not enabled' })
     }
-    const data = await migrationAdminStorePg.completeActiveJobs(migrationQueueName, 2000)
+    const data = await migrationAdminStorePg.completeActiveJobs(migrationQueueName)
 
     return reply.send(data)
   })

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -4,6 +4,7 @@ import {
   getTenantCapabilities,
   getTenantConfig,
   jwksManager,
+  MIGRATION_ADMIN_JOB_LIMIT,
   MigrationAdminStorePg,
   multitenantPgExecutor,
   onTenantConfigChange,
@@ -251,11 +252,19 @@ function getTenantDatabaseUrl(tenantId: string) {
 }
 
 function listTenantMigrationJobs(tenantId: string) {
-  return migrationAdminStorePg.listTenantJobs(tenantId, migrationQueueName, 100)
+  return migrationAdminStorePg.listTenantJobs(
+    tenantId,
+    migrationQueueName,
+    MIGRATION_ADMIN_JOB_LIMIT
+  )
 }
 
 function deleteTenantMigrationJobs(tenantId: string) {
-  return migrationAdminStorePg.deleteTenantJobs(tenantId, migrationQueueName)
+  return migrationAdminStorePg.deleteTenantJobs(
+    tenantId,
+    migrationQueueName,
+    MIGRATION_ADMIN_JOB_LIMIT
+  )
 }
 
 export default async function routes(fastify: FastifyInstance) {

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -6,6 +6,7 @@ import {
   jwksManager,
   MigrationAdminStorePg,
   multitenantPgExecutor,
+  onTenantConfigChange,
   TenantConfigStorePg,
   TenantMigrationStatus,
 } from '@internal/database'
@@ -23,7 +24,12 @@ import { PG_BOSS_SCHEMA } from '@internal/queue'
 import { RunMigrationsOnTenants } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import { getConfig, JwksConfigKey, normalizeDatabasePoolMode } from '../../../config'
+import {
+  getConfig,
+  JwksConfigKey,
+  normalizeDatabasePoolMode,
+  normalizeDatabasePoolModeForRead,
+} from '../../../config'
 import { dbSuperUser, storage } from '../../plugins'
 import { registerApiKeyAuth } from '../../plugins/apikey'
 import { registerJsonParserAllowingEmptyBody } from '../../plugins/empty-json-body'
@@ -139,8 +145,13 @@ interface tenantDBInterface {
   disable_events?: string[] | null
 }
 
-const { dbMigrationFreezeAt, icebergEnabled, vectorEnabled, adminReturnTenantSensitiveData } =
-  getConfig()
+const {
+  dbMigrationFreezeAt,
+  icebergEnabled,
+  vectorEnabled,
+  adminReturnTenantSensitiveData,
+  databasePoolMode,
+} = getConfig()
 const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 const tenantConfigStorePg = new TenantConfigStorePg(multitenantPgExecutor)
 const migrationAdminStorePg = new MigrationAdminStorePg(multitenantPgExecutor, PG_BOSS_SCHEMA)
@@ -244,7 +255,7 @@ function listTenantMigrationJobs(tenantId: string) {
 }
 
 function deleteTenantMigrationJobs(tenantId: string) {
-  return migrationAdminStorePg.deleteTenantJobs(tenantId, migrationQueueName, 100)
+  return migrationAdminStorePg.deleteTenantJobs(tenantId, migrationQueueName)
 }
 
 export default async function routes(fastify: FastifyInstance) {
@@ -291,7 +302,7 @@ export default async function routes(fastify: FastifyInstance) {
               serviceKey: decrypt(service_key),
             }
           : {}),
-        databasePoolMode: normalizeDatabasePoolMode(database_pool_mode),
+        databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
         migrationVersion: migrations_version,
@@ -378,7 +389,7 @@ export default async function routes(fastify: FastifyInstance) {
               serviceKey: decrypt(service_key),
             }
           : {}),
-        databasePoolMode: normalizeDatabasePoolMode(database_pool_mode),
+        databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
         capabilities,
@@ -475,7 +486,7 @@ export default async function routes(fastify: FastifyInstance) {
         progressiveMigrations.addTenant(tenantId)
       }
 
-      deleteTenantConfig(tenantId)
+      void onTenantConfigChange(tenantId)
       reply.code(201).send()
     }
   )
@@ -548,7 +559,7 @@ export default async function routes(fastify: FastifyInstance) {
         }
       }
 
-      deleteTenantConfig(tenantId)
+      void onTenantConfigChange(tenantId)
       reply.code(204).send()
     }
   )
@@ -648,7 +659,7 @@ export default async function routes(fastify: FastifyInstance) {
         progressiveMigrations.addTenant(tenantId)
       }
 
-      deleteTenantConfig(tenantId)
+      void onTenantConfigChange(tenantId)
       reply.code(204).send()
     }
   )

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -1,6 +1,6 @@
 import { Cluster } from '@internal/cluster'
 import { ERRORS } from '@internal/errors'
-import { getConfig, normalizeDatabasePoolMode } from '../../config'
+import { getConfig } from '../../config'
 import { PgTenantConnection } from './pg-connection'
 import { User } from './pool'
 import { getTenantConfig } from './tenant'
@@ -75,8 +75,7 @@ async function getDbSettings(
     dbUrl = tenant.databasePoolUrl || tenant.databaseUrl
     isExternalPool = Boolean(tenant.databasePoolUrl)
     maxConnections = tenant.maxConnections ?? maxConnections
-    const tenantDatabasePoolMode = normalizeDatabasePoolMode(tenant.databasePoolMode)
-    isSingleUse = tenantDatabasePoolMode ? tenantDatabasePoolMode === 'single_use' : isSingleUse
+    isSingleUse = tenant.databasePoolMode ? tenant.databasePoolMode === 'single_use' : isSingleUse
   }
 
   return {

--- a/src/internal/database/migration-admin-store-pg.test.ts
+++ b/src/internal/database/migration-admin-store-pg.test.ts
@@ -30,23 +30,28 @@ describe('MigrationAdminStorePg', () => {
     expect(query).toHaveBeenCalledWith(expect.anything())
   })
 
-  it('completes all active jobs instead of a limited page', async () => {
+  it('completes only a limited page of active jobs', async () => {
     const { query, store } = createMigrationAdminStore()
 
-    await store.completeActiveJobs('migrations')
+    await store.completeActiveJobs('migrations', 2000)
 
     const statement = getLastStatement(query)
-    expect(statement.text).not.toMatch(/\bLIMIT\b/i)
-    expect(statement.values).toEqual(['migrations'])
+    expect(statement.text).toMatch(/\bWITH jobs_to_update AS\b/i)
+    expect(statement.text).toMatch(/\bLIMIT \$2\b/i)
+    expect(statement.text).toMatch(
+      /WHERE job\.id = jobs_to_update\.id\s+AND job\.state = 'active'/i
+    )
+    expect(statement.values).toEqual(['migrations', 2000])
   })
 
-  it('deletes all tenant jobs instead of a limited page', async () => {
+  it('deletes only a limited page of tenant jobs', async () => {
     const { query, store } = createMigrationAdminStore()
 
-    await store.deleteTenantJobs('tenant-id', 'migrations')
+    await store.deleteTenantJobs('tenant-id', 'migrations', 100)
 
     const statement = getLastStatement(query)
-    expect(statement.text).not.toMatch(/\bLIMIT\b/i)
-    expect(statement.values).toEqual(['tenant-id', 'migrations'])
+    expect(statement.text).toMatch(/\bWITH jobs_to_delete AS\b/i)
+    expect(statement.text).toMatch(/\bLIMIT \$3\b/i)
+    expect(statement.values).toEqual(['tenant-id', 'migrations', 100])
   })
 })

--- a/src/internal/database/migration-admin-store-pg.test.ts
+++ b/src/internal/database/migration-admin-store-pg.test.ts
@@ -1,0 +1,52 @@
+import { MigrationAdminStorePg } from './migration-admin-store-pg'
+import type { PgExecutor, PgStatement } from './pg-connection'
+
+function createMigrationAdminStore() {
+  const query = vi.fn().mockResolvedValue({
+    rows: [],
+    rowCount: 1,
+  })
+  const store = new MigrationAdminStorePg({ query } as unknown as PgExecutor, 'pgboss')
+
+  return { query, store }
+}
+
+function getLastStatement(query: ReturnType<typeof vi.fn>): PgStatement {
+  const [statement] = query.mock.calls.at(-1) || []
+
+  if (!statement || typeof statement === 'string') {
+    throw new Error('Expected a PgStatement query')
+  }
+
+  return statement
+}
+
+describe('MigrationAdminStorePg', () => {
+  it('does not add an internal timeout to admin pg-boss queries', async () => {
+    const { query, store } = createMigrationAdminStore()
+
+    await store.listActiveJobs('migrations', 2000)
+
+    expect(query).toHaveBeenCalledWith(expect.anything())
+  })
+
+  it('completes all active jobs instead of a limited page', async () => {
+    const { query, store } = createMigrationAdminStore()
+
+    await store.completeActiveJobs('migrations')
+
+    const statement = getLastStatement(query)
+    expect(statement.text).not.toMatch(/\bLIMIT\b/i)
+    expect(statement.values).toEqual(['migrations'])
+  })
+
+  it('deletes all tenant jobs instead of a limited page', async () => {
+    const { query, store } = createMigrationAdminStore()
+
+    await store.deleteTenantJobs('tenant-id', 'migrations')
+
+    const statement = getLastStatement(query)
+    expect(statement.text).not.toMatch(/\bLIMIT\b/i)
+    expect(statement.values).toEqual(['tenant-id', 'migrations'])
+  })
+})

--- a/src/internal/database/migration-admin-store-pg.ts
+++ b/src/internal/database/migration-admin-store-pg.ts
@@ -3,6 +3,8 @@ import { PgExecutor } from './pg-connection'
 import { quoteIdentifier } from './sql'
 import { TenantCursorRow } from './tenant-store-pg'
 
+export const MIGRATION_ADMIN_JOB_LIMIT = 2000
+
 export class MigrationAdminStorePg {
   private readonly jobTable: string
 
@@ -29,15 +31,24 @@ export class MigrationAdminStorePg {
     return result.rows
   }
 
-  async completeActiveJobs(queueName: string): Promise<number> {
+  async completeActiveJobs(queueName: string, limit: number): Promise<number> {
     const result = await this.query({
       text: `
+        WITH jobs_to_update AS (
+          SELECT id
+          FROM ${this.jobTable}
+          WHERE state = 'active'
+            AND name = $1
+          ORDER BY created_on DESC
+          LIMIT $2
+        )
         UPDATE ${this.jobTable} AS job
         SET state = 'completed'
-        WHERE state = 'active'
-          AND name = $1
+        FROM jobs_to_update
+        WHERE job.id = jobs_to_update.id
+          AND job.state = 'active'
       `,
-      values: [queueName],
+      values: [queueName, limit],
     })
 
     return result.rowCount || 0
@@ -63,14 +74,22 @@ export class MigrationAdminStorePg {
     return result.rows
   }
 
-  async deleteTenantJobs(tenantId: string, queueName: string): Promise<number> {
+  async deleteTenantJobs(tenantId: string, queueName: string, limit: number): Promise<number> {
     const result = await this.query({
       text: `
-        DELETE FROM ${this.jobTable}
-        WHERE data->'tenant'->>'ref' = $1
-          AND name = $2
+        WITH jobs_to_delete AS (
+          SELECT id
+          FROM ${this.jobTable}
+          WHERE data->'tenant'->>'ref' = $1
+            AND name = $2
+          ORDER BY created_on DESC
+          LIMIT $3
+        )
+        DELETE FROM ${this.jobTable} AS job
+        USING jobs_to_delete
+        WHERE job.id = jobs_to_delete.id
       `,
-      values: [tenantId, queueName],
+      values: [tenantId, queueName, limit],
     })
 
     return result.rowCount || 0

--- a/src/internal/database/migration-admin-store-pg.ts
+++ b/src/internal/database/migration-admin-store-pg.ts
@@ -1,10 +1,7 @@
 import { QueryResultRow } from 'pg'
-import { getConfig } from '../../config'
 import { PgExecutor } from './pg-connection'
 import { quoteIdentifier } from './sql'
 import { TenantCursorRow } from './tenant-store-pg'
-
-const { multitenantDatabaseQueryTimeout } = getConfig()
 
 export class MigrationAdminStorePg {
   private readonly jobTable: string
@@ -32,23 +29,15 @@ export class MigrationAdminStorePg {
     return result.rows
   }
 
-  async completeActiveJobs(queueName: string, limit: number): Promise<number> {
+  async completeActiveJobs(queueName: string): Promise<number> {
     const result = await this.query({
       text: `
-        WITH jobs_to_update AS (
-          SELECT id
-          FROM ${this.jobTable}
-          WHERE state = 'active'
-            AND name = $1
-          ORDER BY created_on DESC
-          LIMIT $2
-        )
         UPDATE ${this.jobTable} AS job
         SET state = 'completed'
-        FROM jobs_to_update
-        WHERE job.id = jobs_to_update.id
+        WHERE state = 'active'
+          AND name = $1
       `,
-      values: [queueName, limit],
+      values: [queueName],
     })
 
     return result.rowCount || 0
@@ -74,22 +63,14 @@ export class MigrationAdminStorePg {
     return result.rows
   }
 
-  async deleteTenantJobs(tenantId: string, queueName: string, limit: number): Promise<number> {
+  async deleteTenantJobs(tenantId: string, queueName: string): Promise<number> {
     const result = await this.query({
       text: `
-        WITH jobs_to_delete AS (
-          SELECT id
-          FROM ${this.jobTable}
-          WHERE data->'tenant'->>'ref' = $1
-            AND name = $2
-          ORDER BY created_on DESC
-          LIMIT $3
-        )
-        DELETE FROM ${this.jobTable} AS job
-        USING jobs_to_delete
-        WHERE job.id = jobs_to_delete.id
+        DELETE FROM ${this.jobTable}
+        WHERE data->'tenant'->>'ref' = $1
+          AND name = $2
       `,
-      values: [tenantId, queueName, limit],
+      values: [tenantId, queueName],
     })
 
     return result.rowCount || 0
@@ -114,8 +95,6 @@ export class MigrationAdminStorePg {
   private query<T extends QueryResultRow = QueryResultRow>(
     statement: Parameters<PgExecutor['query']>[0]
   ) {
-    return this.db.query<T>(statement, {
-      signal: AbortSignal.timeout(multitenantDatabaseQueryTimeout),
-    })
+    return this.db.query<T>(statement)
   }
 }

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -113,7 +113,8 @@ export async function* listTenantsToMigrate(signal: AbortSignal) {
       migrationVersion,
       lastCursor,
       [TenantMigrationStatus.FAILED, TenantMigrationStatus.FAILED_STALE],
-      200
+      200,
+      signal
     )
 
     if (data.length === 0) {
@@ -139,7 +140,8 @@ export async function* listTenantsToResetMigrations(
     const data = await tenantConfigStorePg.listTenantsToResetMigrationsBatch(
       afterMigrations,
       lastCursor,
-      200
+      200,
+      signal
     )
 
     if (data.length === 0) {

--- a/src/internal/database/multitenant-pg.test.ts
+++ b/src/internal/database/multitenant-pg.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { vi } from 'vitest'
 
 type MultitenantPgModule = typeof import('./multitenant-pg')
@@ -249,8 +250,8 @@ function mockPgModule(): void {
 }
 
 function createMockPgClient(): MockPgClient {
-  return {
+  return Object.assign(new EventEmitter(), {
     query: vi.fn(async () => ({ rows: [] })),
     release: vi.fn(),
-  }
+  }) as unknown as MockPgClient
 }

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -1,6 +1,9 @@
 import { logger, logSchema } from '@internal/monitoring'
 import { EventEmitter } from 'events'
 import { DatabaseError, Pool as PgPool, type Pool, type PoolClient } from 'pg'
+// Production cancel requests use this pg internals class; the test spies on
+// the same class to keep cancellation pending without opening real sockets.
+import PgConnection from 'pg/lib/connection'
 import { vi } from 'vitest'
 import {
   getPgCancelConnectionTarget,
@@ -53,10 +56,10 @@ function createDatabaseError(code: string | undefined, message = 'database error
 
 async function expectQueryErrorRelease(error: Error): Promise<ReturnType<typeof vi.fn>> {
   const release = vi.fn()
-  const client = {
+  const client = Object.assign(new EventEmitter(), {
     query: vi.fn().mockRejectedValue(error),
     release,
-  } as unknown as PoolClient
+  }) as unknown as PoolClient
   const pool = {
     connect: vi.fn().mockResolvedValue(client),
   } as unknown as Pool
@@ -245,6 +248,140 @@ describe('getPgCancelConnectionTarget', () => {
 })
 
 describe('PgPoolExecutor', () => {
+  it('tracks checked-out client errors during direct queries', async () => {
+    const socketError = new Error('socket reset')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(async () => {
+        expect(client.listenerCount('error')).toBe(1)
+        client.emit('error', socketError)
+        return { rows: [] }
+      }),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.query('SELECT 1')).rejects.toBe(socketError)
+
+    expect(client.release).toHaveBeenCalledWith(socketError)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
+  it('throws tracked checked-out client errors over concurrent direct query errors', async () => {
+    const socketError = new Error('socket reset')
+    const queryError = new Error('benign query error')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(async () => {
+        expect(client.listenerCount('error')).toBe(1)
+        client.emit('error', socketError)
+        throw queryError
+      }),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.query('SELECT 1')).rejects.toBe(socketError)
+
+    expect(client.release).toHaveBeenCalledWith(socketError)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
+  it('keeps checked-out client error listeners attached through direct query release', async () => {
+    const releaseError = new Error('socket reset during release')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(() => {
+        expect(client.listenerCount('error')).toBe(1)
+        client.emit('error', releaseError)
+      }),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.query('SELECT 1')).resolves.toEqual({ rows: [] })
+
+    expect(client.release).toHaveBeenCalledWith(undefined)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
+  it('disposes tracked checked-out client errors before throwing from transaction queries', async () => {
+    const socketError = new Error('socket reset')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockImplementationOnce(async () => {
+          expect(client.listenerCount('error')).toBe(1)
+          client.emit('error', socketError)
+          return { rows: [] }
+        })
+        .mockResolvedValueOnce({ rows: [] }),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    const transaction = await executor.beginTransaction()
+    await expect(transaction.query('SELECT 1')).rejects.toBe(socketError)
+
+    expect(client.release).toHaveBeenCalledWith(socketError)
+    await expect(transaction.rollback()).resolves.toBeUndefined()
+    expect(client.query).toHaveBeenCalledTimes(2)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
+  it('does not release twice when BEGIN disposes the transaction client', async () => {
+    const socketError = new Error('socket reset during begin')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(async () => {
+        expect(client.listenerCount('error')).toBe(1)
+        client.emit('error', socketError)
+        return { rows: [] }
+      }),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.beginTransaction()).rejects.toBe(socketError)
+
+    expect(client.release).toHaveBeenCalledTimes(1)
+    expect(client.release).toHaveBeenCalledWith(socketError)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
+  it('keeps checked-out client error listeners attached through transaction release', async () => {
+    const releaseError = new Error('socket reset during transaction release')
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(() => {
+        expect(client.listenerCount('error')).toBe(1)
+        client.emit('error', releaseError)
+      }),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    const transaction = await executor.beginTransaction()
+
+    await expect(transaction.commit()).resolves.toBeUndefined()
+    expect(client.release).toHaveBeenCalledWith(undefined)
+    expect(client.listenerCount('error')).toBe(0)
+  })
+
   it('returns clients to the pool after regular SQL errors', async () => {
     for (const code of ['42P01', '23505', '23503', '42501', '22P02', '42703']) {
       const error = createDatabaseError(code)
@@ -274,6 +411,124 @@ describe('PgPoolExecutor', () => {
     const protocolErrorRelease = await expectQueryErrorRelease(protocolError)
 
     expect(protocolErrorRelease).toHaveBeenCalledWith(protocolError)
+  })
+
+  it('maps pg-pool connection timeouts during query checkout to DatabaseTimeout', async () => {
+    const timeoutError = new Error('Connection terminated due to connection timeout')
+    const pool = {
+      connect: vi.fn().mockRejectedValue(timeoutError),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.query('SELECT 1')).rejects.toMatchObject({
+      code: 'DatabaseTimeout',
+      originalError: timeoutError,
+    })
+  })
+
+  it('rejects pre-aborted queries before checking out a client', async () => {
+    const signal = AbortSignal.abort()
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    await expect(executor.query('SELECT 1', { signal })).rejects.toMatchObject({
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+      message: 'Query was aborted',
+    })
+    expect(pool.connect).not.toHaveBeenCalled()
+  })
+
+  it('rejects aborted queries without waiting for the pg query to settle', async () => {
+    const controller = new AbortController()
+    const release = vi.fn()
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(() => {
+        controller.abort()
+        return new Promise(() => undefined)
+      }),
+      release,
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    const result = await Promise.race([
+      executor.query('SELECT pg_sleep(999)', { signal: controller.signal }).then(
+        () => ({ status: 'resolved' as const }),
+        (error) => ({ status: 'rejected' as const, error })
+      ),
+      waitForDrainCheck().then(() => ({ status: 'pending' as const })),
+    ])
+
+    expect(result).toMatchObject({
+      status: 'rejected',
+      error: {
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+        message: 'Query was aborted',
+      },
+    })
+    expect(release).toHaveBeenCalledWith(expect.objectContaining({ name: 'AbortError' }))
+  })
+
+  it('rejects aborted queries immediately while cancel is still pending', async () => {
+    vi.useFakeTimers()
+    const connectSpy = vi.spyOn(PgConnection.prototype, 'connect').mockImplementation(() => true)
+    const endSpy = vi.spyOn(PgConnection.prototype, 'end').mockImplementation(() => undefined)
+    const controller = new AbortController()
+    const release = vi.fn()
+    const client = Object.assign(new EventEmitter(), {
+      processID: 123,
+      secretKey: 456,
+      host: 'db.example.test',
+      port: 5432,
+      query: vi.fn(() => {
+        controller.abort()
+        return new Promise(() => undefined)
+      }),
+      release,
+    }) as unknown as PoolClient & EventEmitter
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+    const settled = vi.fn()
+    const queryPromise = executor.query('SELECT pg_sleep(999)', { signal: controller.signal }).then(
+      () => settled('resolved'),
+      (error) => settled('rejected', error)
+    )
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(settled).toHaveBeenCalledWith(
+        'rejected',
+        expect.objectContaining({
+          name: 'AbortError',
+          code: 'ABORT_ERR',
+          message: 'Query was aborted',
+        })
+      )
+      expect(release).toHaveBeenCalledWith(expect.objectContaining({ name: 'AbortError' }))
+      expect(connectSpy).toHaveBeenCalled()
+      expect(endSpy).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(endSpy).toHaveBeenCalled()
+      await queryPromise
+    } finally {
+      connectSpy.mockRestore()
+      endSpy.mockRestore()
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -308,6 +563,30 @@ describe('PgTransaction', () => {
     )
     expect(client.query).toHaveBeenCalledTimes(1)
     expect(client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes the transaction client after an aborted query without queueing rollback', async () => {
+    const controller = new AbortController()
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(() => {
+        controller.abort()
+        return new Promise(() => undefined)
+      }),
+      release: vi.fn(),
+    }) as unknown as PoolClient & EventEmitter
+    const transaction = new PgTransaction(client)
+
+    await expect(
+      transaction.query('SELECT pg_sleep(999)', { signal: controller.signal })
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+      message: 'Query was aborted',
+    })
+
+    expect(client.release).toHaveBeenCalledWith(expect.objectContaining({ name: 'AbortError' }))
+    await transaction.rollback()
+    expect(client.query).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -406,6 +685,21 @@ describe('PgTenantConnection', () => {
 
   it('maps pg-pool acquisition timeouts to DatabaseTimeout', async () => {
     const timeoutError = new Error('timeout exceeded when trying to connect')
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction: vi.fn().mockRejectedValue(timeoutError),
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(pool, createPoolStrategySettings())
+
+    await expect(connection.transaction()).rejects.toMatchObject({
+      code: 'DatabaseTimeout',
+      originalError: timeoutError,
+    })
+  })
+
+  it('maps pg-pool connection-terminated acquisition timeouts to DatabaseTimeout', async () => {
+    const timeoutError = new Error('Connection terminated due to connection timeout')
     const pool = {
       acquire: vi.fn().mockReturnValue({
         beginTransaction: vi.fn().mockRejectedValue(timeoutError),

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -298,6 +298,53 @@ export class PgPoolManager extends PoolManager<PgPoolStrategy> {
   }
 }
 
+class PgClientErrorTracker {
+  private clientError?: Error
+
+  constructor(private readonly client: PoolClient) {
+    this.client.on('error', this.onError)
+  }
+
+  get error(): Error | undefined {
+    return this.clientError
+  }
+
+  throwIfErrored(): void {
+    if (this.clientError) {
+      throw this.clientError
+    }
+  }
+
+  releaseErrorForQuery(error: unknown): Error | undefined {
+    if (this.clientError) {
+      return this.clientError
+    }
+
+    if (shouldDisposeClient(error)) {
+      return ensureError(error)
+    }
+
+    return undefined
+  }
+
+  releaseErrorForFinalizer(error: unknown): Error {
+    return this.clientError ?? ensureError(error)
+  }
+
+  detach(): void {
+    this.client.off('error', this.onError)
+  }
+
+  private readonly onError = (error: unknown): void => {
+    const normalizedError = ensureError(error)
+    markClientDisposable(normalizedError)
+
+    if (!this.clientError) {
+      this.clientError = normalizedError
+    }
+  }
+}
+
 export class PgPoolExecutor implements PgTransactionalExecutor {
   constructor(private readonly pool: Pool) {}
 
@@ -305,30 +352,68 @@ export class PgPoolExecutor implements PgTransactionalExecutor {
     statement: string | PgStatement,
     options?: PgQueryArgument
   ): Promise<QueryResult<T>> {
-    const client = await this.pool.connect()
+    assertValidSignal(getQuerySignal(options))
+
+    let client: PoolClient | undefined
+    let clientErrorTracker: PgClientErrorTracker | undefined
     let releaseError: Error | undefined
 
     try {
-      return await runPgQuery<T>(client, statement, options)
+      client = await this.pool.connect()
+      clientErrorTracker = new PgClientErrorTracker(client)
+      const result = await runPgQuery<T>(client, statement, options)
+      clientErrorTracker.throwIfErrored()
+      return result
     } catch (e) {
-      if (shouldDisposeClient(e)) {
-        releaseError = e instanceof Error ? e : new Error(String(e))
+      if (!client) {
+        if (isConnectionTimeoutError(e)) {
+          throw ERRORS.DatabaseTimeout(e)
+        }
+
+        throw e
       }
-      throw e
+
+      releaseError = clientErrorTracker?.releaseErrorForQuery(e)
+      throw releaseError ?? e
     } finally {
-      client.release(releaseError)
+      if (client && clientErrorTracker) {
+        const trackedError = clientErrorTracker.error
+        try {
+          client.release(releaseError ?? trackedError)
+        } finally {
+          clientErrorTracker.detach()
+        }
+      }
     }
   }
 
   async beginTransaction(options?: TransactionOptions): Promise<PgTransaction> {
-    const client = await this.pool.connect()
-    const transaction = new PgTransaction(client)
+    let client: PoolClient
+    try {
+      client = await this.pool.connect()
+    } catch (e) {
+      if (isConnectionTimeoutError(e)) {
+        throw ERRORS.DatabaseTimeout(e)
+      }
+
+      throw e
+    }
+
+    const clientErrorTracker = new PgClientErrorTracker(client)
+    const transaction = new PgTransaction(client, clientErrorTracker)
 
     try {
       await transaction.query(buildBeginStatement(options))
       return transaction
     } catch (e) {
-      client.release(e instanceof Error ? e : new Error(String(e)))
+      if (!transaction.isCompleted()) {
+        const releaseError = clientErrorTracker.releaseErrorForFinalizer(e)
+        try {
+          client.release(releaseError)
+        } finally {
+          clientErrorTracker.detach()
+        }
+      }
       throw e
     }
   }
@@ -337,7 +422,10 @@ export class PgPoolExecutor implements PgTransactionalExecutor {
 export class PgTransaction implements PgExecutor {
   private completed = false
 
-  constructor(private readonly client: PoolClient) {}
+  constructor(
+    private readonly client: PoolClient,
+    private readonly clientErrorTracker?: PgClientErrorTracker
+  ) {}
 
   isCompleted(): boolean {
     return this.completed
@@ -351,7 +439,21 @@ export class PgTransaction implements PgExecutor {
       throw new Error('Cannot query a completed transaction')
     }
 
-    return runPgQuery<T>(this.client, statement, options)
+    try {
+      const result = await runPgQuery<T>(this.client, statement, options)
+      this.clientErrorTracker?.throwIfErrored()
+      return result
+    } catch (e) {
+      const releaseError =
+        this.clientErrorTracker?.releaseErrorForQuery(e) ??
+        (shouldDisposeClient(e) ? ensureError(e) : undefined)
+      if (releaseError) {
+        this.completed = true
+        this.release(releaseError)
+        throw releaseError
+      }
+      throw e
+    }
   }
 
   async commit(): Promise<void> {
@@ -362,14 +464,15 @@ export class PgTransaction implements PgExecutor {
     let releaseError: Error | undefined
     try {
       await runPgQuery(this.client, 'COMMIT')
+      this.clientErrorTracker?.throwIfErrored()
     } catch (e) {
       // A failed transaction finalizer leaves cleanup state uncertain, so release
       // with the error even for recoverable SQLSTATEs such as 40001 at COMMIT.
-      releaseError = e instanceof Error ? e : new Error(String(e))
+      releaseError = this.clientErrorTracker?.releaseErrorForFinalizer(e) ?? ensureError(e)
       throw e
     } finally {
       this.completed = true
-      this.client.release(releaseError)
+      this.release(releaseError)
     }
   }
 
@@ -381,14 +484,24 @@ export class PgTransaction implements PgExecutor {
     let releaseError: Error | undefined
     try {
       await runPgQuery(this.client, 'ROLLBACK')
+      this.clientErrorTracker?.throwIfErrored()
     } catch (e) {
       // A failed transaction finalizer leaves cleanup state uncertain, so release
       // with the error even for recoverable SQLSTATEs.
-      releaseError = e instanceof Error ? e : new Error(String(e))
+      releaseError = this.clientErrorTracker?.releaseErrorForFinalizer(e) ?? ensureError(e)
       throw e
     } finally {
       this.completed = true
-      this.client.release(releaseError)
+      this.release(releaseError)
+    }
+  }
+
+  private release(releaseError?: Error): void {
+    const trackedError = this.clientErrorTracker?.error
+    try {
+      this.client.release(releaseError ?? trackedError)
+    } finally {
+      this.clientErrorTracker?.detach()
     }
   }
 }
@@ -589,6 +702,10 @@ function createDisposedTenantConnectionError(): Error {
   return new Error('Cannot use a disposed PgTenantConnection')
 }
 
+function ensureError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
 export function createAbortError(): Error & { code: string } {
   const error = new Error('Query was aborted') as Error & { code: string }
   error.name = 'AbortError'
@@ -607,16 +724,29 @@ async function runPgQuery<T extends QueryResultRow = QueryResultRow>(
   const query = normalizeStatement(statement, Array.isArray(options) ? options : undefined)
   let aborted = false
   let cancelPromise: Promise<void> | undefined
+  let rejectAbort: ((error: Error) => void) | undefined
+  const abortPromise = signal
+    ? new Promise<never>((_, reject) => {
+        rejectAbort = reject
+      })
+    : undefined
+
+  const rejectWithAbortError = () => {
+    rejectAbort?.(createAbortError())
+    rejectAbort = undefined
+  }
 
   const onAbort = () => {
     aborted = true
     cancelPromise = cancelPgQuery(client).catch(() => undefined)
+    rejectWithAbortError()
   }
 
   signal?.addEventListener('abort', onAbort, { once: true })
 
   try {
-    const result = await client.query<T>(query.text, query.values)
+    const queryPromise = client.query<T>(query.text, query.values)
+    const result = await (abortPromise ? Promise.race([queryPromise, abortPromise]) : queryPromise)
 
     if (aborted) {
       throw createAbortError()
@@ -625,7 +755,7 @@ async function runPgQuery<T extends QueryResultRow = QueryResultRow>(
     return result
   } catch (e) {
     if (aborted) {
-      await cancelPromise
+      void cancelPromise
       throw createAbortError()
     }
 
@@ -658,6 +788,10 @@ function assertValidSignal(signal?: AbortSignal): void {
   if (signal.aborted) {
     throw createAbortError()
   }
+}
+
+function getQuerySignal(options?: PgQueryArgument): AbortSignal | undefined {
+  return Array.isArray(options) ? undefined : options?.signal
 }
 
 function buildBeginStatement(options?: TransactionOptions): string {
@@ -707,7 +841,8 @@ function isConnectionTimeoutError(error: unknown): error is Error {
   return (
     error instanceof Error &&
     (error.message === 'timeout expired' ||
-      error.message === 'timeout exceeded when trying to connect')
+      error.message === 'timeout exceeded when trying to connect' ||
+      error.message === 'Connection terminated due to connection timeout')
   )
 }
 

--- a/src/internal/database/tenant-store-pg.test.ts
+++ b/src/internal/database/tenant-store-pg.test.ts
@@ -70,4 +70,21 @@ describe('TenantConfigStorePg', () => {
     expect(statement.text).toContain('WHERE id = $3')
     expect(statement.values).toEqual(['postgres://tenant', 10, 'tenant-id'])
   })
+
+  it('uses the caller signal without adding an internal timeout for migration listing', async () => {
+    const { query, store } = createTenantStore()
+    const signal = new AbortController().signal
+
+    await store.listTenantsToMigrateBatch('storage-schema', 0, ['FAILED'], 200, signal)
+
+    expect(query).toHaveBeenCalledWith(expect.anything(), { signal })
+  })
+
+  it('does not add an internal timeout for reset migration listing', async () => {
+    const { query, store } = createTenantStore()
+
+    await store.listTenantsToResetMigrationsBatch(['storage-schema'], 0, 200)
+
+    expect(query).toHaveBeenCalledWith(expect.anything())
+  })
 })

--- a/src/internal/database/tenant-store-pg.test.ts
+++ b/src/internal/database/tenant-store-pg.test.ts
@@ -1,3 +1,4 @@
+import { spyOnAbortSignalAny, spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 import type { PgExecutor, PgStatement } from './pg-connection'
 import { TenantConfigStorePg } from './tenant-store-pg'
 
@@ -71,20 +72,79 @@ describe('TenantConfigStorePg', () => {
     expect(statement.values).toEqual(['postgres://tenant', 10, 'tenant-id'])
   })
 
-  it('uses the caller signal without adding an internal timeout for migration listing', async () => {
+  it('adds the default internal timeout to normal tenant queries', async () => {
+    const { query, store } = createTenantStore()
+    const { timeoutSignal, timeoutSpy } = spyOnAbortSignalTimeout()
+
+    await store.findById('tenant-id')
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Number))
+    expect(query).toHaveBeenCalledWith(expect.anything(), { signal: timeoutSignal })
+  })
+
+  it('combines the caller signal with a migration listing timeout', async () => {
     const { query, store } = createTenantStore()
     const signal = new AbortController().signal
+    const { timeoutSignal, timeoutSpy } = spyOnAbortSignalTimeout()
+    const { anySignal, anySpy } = spyOnAbortSignalAny()
 
     await store.listTenantsToMigrateBatch('storage-schema', 0, ['FAILED'], 200, signal)
 
-    expect(query).toHaveBeenCalledWith(expect.anything(), { signal })
+    expect(timeoutSpy).toHaveBeenCalledWith(60_000)
+    expect(anySpy).toHaveBeenCalledWith([signal, timeoutSignal])
+    expect(query).toHaveBeenCalledWith(expect.anything(), { signal: anySignal })
   })
 
-  it('does not add an internal timeout for reset migration listing', async () => {
+  it('adds a timeout for reset migration listing without a caller signal', async () => {
     const { query, store } = createTenantStore()
+    const { timeoutSignal, timeoutSpy } = spyOnAbortSignalTimeout()
 
     await store.listTenantsToResetMigrationsBatch(['storage-schema'], 0, 200)
 
-    expect(query).toHaveBeenCalledWith(expect.anything())
+    expect(timeoutSpy).toHaveBeenCalledWith(60_000)
+    expect(query).toHaveBeenCalledWith(expect.anything(), { signal: timeoutSignal })
+  })
+
+  it('allows internal timeout to be disabled with timeoutMs zero', async () => {
+    const { query, store } = createTenantStore()
+    const signal = new AbortController().signal
+    const { timeoutSpy } = spyOnAbortSignalTimeout()
+
+    await (
+      store as unknown as {
+        query(
+          statement: PgStatement,
+          options: { signal: AbortSignal; timeoutMs: number }
+        ): Promise<unknown>
+      }
+    ).query({ text: 'SELECT 1' }, { signal, timeoutMs: 0 })
+
+    expect(timeoutSpy).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith(expect.anything(), { signal })
+  })
+
+  it('does not shorten migration listing timeout below the configured tenant query timeout', async () => {
+    vi.resetModules()
+    const configModule = await import('../../config')
+    configModule.getConfig({ reload: true })
+    configModule.mergeConfig({ multitenantDatabaseQueryTimeout: 120_000 })
+    const { TenantConfigStorePg: ConfiguredTenantConfigStorePg } = await import('./tenant-store-pg')
+    const query = vi.fn().mockResolvedValue({
+      rows: [],
+      rowCount: 1,
+    })
+    const store = new ConfiguredTenantConfigStorePg({ query } as unknown as PgExecutor)
+    const { timeoutSignal, timeoutSpy } = spyOnAbortSignalTimeout()
+
+    try {
+      await store.listTenantsToResetMigrationsBatch(['storage-schema'], 0, 200)
+
+      expect(timeoutSpy).toHaveBeenCalledWith(120_000)
+      expect(query).toHaveBeenCalledWith(expect.anything(), { signal: timeoutSignal })
+    } finally {
+      vi.resetModules()
+      const resetConfigModule = await import('../../config')
+      resetConfigModule.getConfig({ reload: true })
+    }
   })
 })

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -5,6 +5,11 @@ import { quoteIdentifier } from './sql'
 
 const { multitenantDatabaseQueryTimeout } = getConfig()
 const QUOTED_ID_COLUMN = quoteIdentifier('id')
+const MIN_MIGRATION_LIST_QUERY_TIMEOUT_MS = 60_000
+const MIGRATION_LIST_QUERY_TIMEOUT_MS = Math.max(
+  MIN_MIGRATION_LIST_QUERY_TIMEOUT_MS,
+  multitenantDatabaseQueryTimeout
+)
 
 export interface TenantConfigRow {
   id: string
@@ -69,6 +74,16 @@ type TenantWritableColumn = (typeof tenantWritableColumns)[number]
 export type TenantConfigRowInput = Partial<Pick<TenantConfigRow, TenantWritableColumn>>
 export type TenantCursorRow = Pick<TenantConfigRow, 'id' | 'cursor_id'> & { cursor_id: number }
 
+interface TenantQueryOptions {
+  db?: PgExecutor
+  signal?: AbortSignal
+  /**
+   * Positive values add an internal timeout. Zero or negative values disable
+   * the internal timeout and use only the caller signal, if provided.
+   */
+  timeoutMs?: number
+}
+
 export class TenantConfigStorePg {
   constructor(private db: PgExecutor) {}
 
@@ -108,7 +123,7 @@ export class TenantConfigStorePg {
         `,
         values,
       },
-      db
+      { db }
     )
   }
 
@@ -134,7 +149,7 @@ export class TenantConfigStorePg {
         `,
         values,
       },
-      db
+      { db }
     )
   }
 
@@ -162,7 +177,7 @@ export class TenantConfigStorePg {
         `,
         values: [...values, tenantId],
       },
-      db
+      { db }
     )
 
     return result.rowCount || 0
@@ -221,7 +236,7 @@ export class TenantConfigStorePg {
     batchSize: number,
     signal?: AbortSignal
   ): Promise<TenantCursorRow[]> {
-    const result = await this.queryWithoutInternalTimeout<TenantCursorRow>(
+    const result = await this.query<TenantCursorRow>(
       {
         text: `
           SELECT id, cursor_id
@@ -239,7 +254,7 @@ export class TenantConfigStorePg {
         `,
         values: [lastCursor, migrationVersion, failedStatuses, batchSize],
       },
-      signal
+      { signal, timeoutMs: MIGRATION_LIST_QUERY_TIMEOUT_MS }
     )
 
     return result.rows
@@ -255,7 +270,7 @@ export class TenantConfigStorePg {
       return []
     }
 
-    const result = await this.queryWithoutInternalTimeout<TenantCursorRow>(
+    const result = await this.query<TenantCursorRow>(
       {
         text: `
           SELECT id, cursor_id
@@ -267,7 +282,7 @@ export class TenantConfigStorePg {
         `,
         values: [lastCursor, migrationVersions, batchSize],
       },
-      signal
+      { signal, timeoutMs: MIGRATION_LIST_QUERY_TIMEOUT_MS }
     )
 
     return result.rows
@@ -275,18 +290,17 @@ export class TenantConfigStorePg {
 
   private query<T extends QueryResultRow = QueryResultRow>(
     statement: Parameters<PgExecutor['query']>[0],
-    db: PgExecutor = this.db
+    options: TenantQueryOptions = {}
   ) {
-    return db.query<T>(statement, {
-      signal: AbortSignal.timeout(multitenantDatabaseQueryTimeout),
-    })
-  }
+    const db = options.db ?? this.db
+    const timeoutMs = options.timeoutMs ?? multitenantDatabaseQueryTimeout
+    const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined
+    const signal =
+      options.signal && timeoutSignal
+        ? AbortSignal.any([options.signal, timeoutSignal])
+        : (options.signal ?? timeoutSignal)
 
-  private queryWithoutInternalTimeout<T extends QueryResultRow = QueryResultRow>(
-    statement: Parameters<PgExecutor['query']>[0],
-    signal?: AbortSignal
-  ) {
-    return signal ? this.db.query<T>(statement, { signal }) : this.db.query<T>(statement)
+    return signal ? db.query<T>(statement, { signal }) : db.query<T>(statement)
   }
 }
 

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -218,25 +218,29 @@ export class TenantConfigStorePg {
     migrationVersion: string,
     lastCursor: number,
     failedStatuses: string[],
-    batchSize: number
+    batchSize: number,
+    signal?: AbortSignal
   ): Promise<TenantCursorRow[]> {
-    const result = await this.query<TenantCursorRow>({
-      text: `
-        SELECT id, cursor_id
-        FROM tenants
-        WHERE cursor_id > $1
-          AND (
-            (
-              migrations_version != $2
-              AND migrations_status != ALL($3::text[])
+    const result = await this.queryWithoutInternalTimeout<TenantCursorRow>(
+      {
+        text: `
+          SELECT id, cursor_id
+          FROM tenants
+          WHERE cursor_id > $1
+            AND (
+              (
+                migrations_version != $2
+                AND migrations_status != ALL($3::text[])
+              )
+              OR migrations_status IS NULL
             )
-            OR migrations_status IS NULL
-          )
-        ORDER BY cursor_id ASC
-        LIMIT $4
-      `,
-      values: [lastCursor, migrationVersion, failedStatuses, batchSize],
-    })
+          ORDER BY cursor_id ASC
+          LIMIT $4
+        `,
+        values: [lastCursor, migrationVersion, failedStatuses, batchSize],
+      },
+      signal
+    )
 
     return result.rows
   }
@@ -244,23 +248,27 @@ export class TenantConfigStorePg {
   async listTenantsToResetMigrationsBatch(
     migrationVersions: string[],
     lastCursor: number,
-    batchSize: number
+    batchSize: number,
+    signal?: AbortSignal
   ): Promise<TenantCursorRow[]> {
     if (migrationVersions.length === 0) {
       return []
     }
 
-    const result = await this.query<TenantCursorRow>({
-      text: `
-        SELECT id, cursor_id
-        FROM tenants
-        WHERE cursor_id > $1
-          AND migrations_version = ANY($2::text[])
-        ORDER BY cursor_id ASC
-        LIMIT $3
-      `,
-      values: [lastCursor, migrationVersions, batchSize],
-    })
+    const result = await this.queryWithoutInternalTimeout<TenantCursorRow>(
+      {
+        text: `
+          SELECT id, cursor_id
+          FROM tenants
+          WHERE cursor_id > $1
+            AND migrations_version = ANY($2::text[])
+          ORDER BY cursor_id ASC
+          LIMIT $3
+        `,
+        values: [lastCursor, migrationVersions, batchSize],
+      },
+      signal
+    )
 
     return result.rows
   }
@@ -272,6 +280,13 @@ export class TenantConfigStorePg {
     return db.query<T>(statement, {
       signal: AbortSignal.timeout(multitenantDatabaseQueryTimeout),
     })
+  }
+
+  private queryWithoutInternalTimeout<T extends QueryResultRow = QueryResultRow>(
+    statement: Parameters<PgExecutor['query']>[0],
+    signal?: AbortSignal
+  ) {
+    return signal ? this.db.query<T>(statement, { signal }) : this.db.query<T>(statement)
   }
 }
 

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -18,7 +18,7 @@ import {
   JwksConfig,
   JwksConfigKey,
   JwksConfigKeyOCT,
-  normalizeDatabasePoolMode,
+  normalizeDatabasePoolModeForRead,
 } from '../../config'
 import { decrypt } from '../auth'
 import { JWKSManager, JWKSManagerStorePg } from '../auth/jwks'
@@ -93,6 +93,7 @@ const {
   icebergEnabled,
   vectorEnabled,
   databaseMaxConnections,
+  databasePoolMode,
 } = getConfig()
 
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
@@ -249,7 +250,7 @@ export async function getTenantConfig(
       anonKey: decrypt(anon_key),
       databaseUrl: decrypt(database_url),
       databasePoolUrl: database_pool_url ? decrypt(database_pool_url) : undefined,
-      databasePoolMode: normalizeDatabasePoolMode(database_pool_mode),
+      databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
       fileSizeLimit: Number(file_size_limit),
       jwtSecret,
       jwks: jwks ? { keys: jwks.keys ?? [] } : jwks,

--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -1,5 +1,6 @@
 import type { Storage } from '@storage/storage'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 
 type CdnConfig = {
   cdnPurgeEndpointURL?: string
@@ -38,8 +39,7 @@ describe('CdnCacheManager', () => {
   it('sends a purge request for an existing object', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
     vi.stubGlobal('fetch', fetchMock)
-    const timeoutSignal = new AbortController().signal
-    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+    const { timeoutSignal, timeoutSpy } = spyOnAbortSignalTimeout()
 
     const { CdnCacheManager } = await importCdnCacheManager({
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',

--- a/src/storage/protocols/iceberg/catalog/reconciler.test.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.test.ts
@@ -1,0 +1,46 @@
+import { IcebergCatalogReconciler } from './reconciler'
+import type { RestCatalogClient } from './rest-catalog-client'
+
+function createReconciler() {
+  return new IcebergCatalogReconciler({} as RestCatalogClient) as unknown as {
+    findCatalogByName: (
+      tnx: { query: ReturnType<typeof vi.fn> },
+      tenantId: string,
+      catalogName: string
+    ) => Promise<unknown>
+    findFirstCatalog: (
+      tnx: { query: ReturnType<typeof vi.fn> },
+      tenantId: string
+    ) => Promise<unknown>
+  }
+}
+
+function getLastStatement(query: ReturnType<typeof vi.fn>): string {
+  const [statement] = query.mock.calls.at(-1) || []
+
+  if (!statement || typeof statement === 'string') {
+    throw new Error('Expected a PgStatement query')
+  }
+
+  return String((statement as { text: string }).text)
+}
+
+describe('IcebergCatalogReconciler', () => {
+  it('ignores soft-deleted catalogs when finding an upstream orphan catalog by name', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] })
+    const reconciler = createReconciler()
+
+    await reconciler.findCatalogByName({ query }, 'tenant-id', 'catalog-name')
+
+    expect(getLastStatement(query)).toContain('deleted_at IS NULL')
+  })
+
+  it('ignores soft-deleted catalogs when falling back to the first tenant catalog', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] })
+    const reconciler = createReconciler()
+
+    await reconciler.findFirstCatalog({ query }, 'tenant-id')
+
+    expect(getLastStatement(query)).toContain('deleted_at IS NULL')
+  })
+})

--- a/src/storage/protocols/iceberg/catalog/reconciler.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.ts
@@ -287,6 +287,7 @@ export class IcebergCatalogReconciler {
         FROM iceberg_catalogs
         WHERE tenant_id = $1
           AND name = $2
+          AND deleted_at IS NULL
         LIMIT 1
       `,
       values: [tenantId, catalogName],
@@ -304,6 +305,7 @@ export class IcebergCatalogReconciler {
         SELECT id, name
         FROM iceberg_catalogs
         WHERE tenant_id = $1
+          AND deleted_at IS NULL
         LIMIT 1
       `,
       values: [tenantId],

--- a/src/storage/protocols/iceberg/catalog/rest-catalog-client.test.ts
+++ b/src/storage/protocols/iceberg/catalog/rest-catalog-client.test.ts
@@ -2,6 +2,7 @@ import { ErrorCode, type StorageBackendError } from '@internal/errors'
 import type { SignRequestOptions } from 'aws-sigv4-sign'
 import JSONBigint from 'json-bigint'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spyOnAbortSignalTimeout } from '../../../../test/utils/abort-signal'
 
 const mockSignRequest = vi.fn()
 vi.mock('aws-sigv4-sign', () => ({
@@ -22,12 +23,6 @@ type TestableRestCatalogClient = {
     data?: unknown
     headers?: Record<string, string>
   }): Promise<T>
-}
-
-function spyOnAbortSignalTimeout() {
-  const timeoutSignal = new AbortController().signal
-  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
-  return { timeoutSignal, timeoutSpy }
 }
 
 describe('RestCatalogClient request pipeline', () => {

--- a/src/storage/protocols/vector/adapter/pgvector/index.ts
+++ b/src/storage/protocols/vector/adapter/pgvector/index.ts
@@ -385,14 +385,6 @@ export class PgVectorStore implements VectorStore {
     return resolveRootPgExecutor(this.executor)
   }
 
-  private tableCapabilityCacheKey(db: PgTransactionalExecutor | PgTransaction): object {
-    if (db instanceof PgTransaction) {
-      return db
-    }
-
-    return tableCapabilityCacheKey(this.rootDb())
-  }
-
   async createVectorIndex(command: CreateIndexCommandInput): Promise<CreateIndexCommandOutput> {
     if (!command.indexName || !command.vectorBucketName) {
       throw ERRORS.MissingParameter('indexName/vectorBucketName')
@@ -502,7 +494,7 @@ export class PgVectorStore implements VectorStore {
         const serializedRows = JSON.stringify([...rows].sort((a, b) => a.key.localeCompare(b.key)))
         const table = tableName(bucket, index)
         const qualified = qualifiedTableName(table)
-        const capabilityCacheKey = this.tableCapabilityCacheKey(db)
+        const capabilityCacheKey = tableCapabilityCacheKey(db)
         const capability = await resolveTableCapability(db, table, capabilityCacheKey)
 
         if (capability.requiresManualUpsert) {
@@ -618,7 +610,7 @@ export class PgVectorStore implements VectorStore {
     params: unknown[],
     topK: number
   ): Promise<{ rows: unknown[] }> {
-    const capability = await resolveTableCapability(db, table, this.tableCapabilityCacheKey(db))
+    const capability = await resolveTableCapability(db, table, tableCapabilityCacheKey(db))
     if (!capability.requiresExactQueryScan) {
       return withPgTransaction(db, async (trx): Promise<{ rows: unknown[] }> => {
         await trx.query({

--- a/src/storage/protocols/vector/adapter/pgvector/index.ts
+++ b/src/storage/protocols/vector/adapter/pgvector/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-sdk/client-s3vectors'
 import {
   PgExecutor,
+  PgTenantConnection,
   PgTransaction,
   PgTransactionalExecutor,
   quoteIdentifier,
@@ -151,6 +152,14 @@ function tableCapabilityCache(db: object): Map<string, Promise<PgVectorTableCapa
   return cache
 }
 
+function tableCapabilityCacheKey(db: PgTransactionalExecutor | PgTransaction): object {
+  if (db instanceof PgTenantConnection) {
+    return db.pool
+  }
+
+  return db
+}
+
 function capabilityForAccessMethod(accessMethod: unknown): PgVectorTableCapability {
   if (typeof accessMethod !== 'string') {
     return UNKNOWN_TABLE_CAPABILITY
@@ -165,9 +174,10 @@ function forgetTableCapability(db: object, table: string): void {
 
 async function resolveTableCapability(
   db: PgExecutor,
-  table: string
+  table: string,
+  cacheKey: object = tableCapabilityCacheKey(db as PgTransactionalExecutor | PgTransaction)
 ): Promise<PgVectorTableCapability> {
-  const cache = tableCapabilityCache(db)
+  const cache = tableCapabilityCache(cacheKey)
   let capability = cache.get(table)
   if (capability) {
     return capability
@@ -375,6 +385,14 @@ export class PgVectorStore implements VectorStore {
     return resolveRootPgExecutor(this.executor)
   }
 
+  private tableCapabilityCacheKey(db: PgTransactionalExecutor | PgTransaction): object {
+    if (db instanceof PgTransaction) {
+      return db
+    }
+
+    return tableCapabilityCacheKey(this.rootDb())
+  }
+
   async createVectorIndex(command: CreateIndexCommandInput): Promise<CreateIndexCommandOutput> {
     if (!command.indexName || !command.vectorBucketName) {
       throw ERRORS.MissingParameter('indexName/vectorBucketName')
@@ -427,8 +445,8 @@ export class PgVectorStore implements VectorStore {
             USING hnsw (embedding ${choice.opClass})
           `)
         })
-        forgetTableCapability(db, table)
-        forgetTableCapability(this.rootDb(), table)
+        forgetTableCapability(tableCapabilityCacheKey(db), table)
+        forgetTableCapability(tableCapabilityCacheKey(this.rootDb()), table)
         // Prime the metric cache so subsequent queryVectors don't need a
         // round-trip lookup to pick the right distance operator. The two
         // names are validated non-empty at the top of this method.
@@ -450,8 +468,8 @@ export class PgVectorStore implements VectorStore {
       async () => {
         const db = this.db()
         await db.query(`DROP TABLE IF EXISTS ${qualifiedTableName(table)}`)
-        forgetTableCapability(db, table)
-        forgetTableCapability(this.rootDb(), table)
+        forgetTableCapability(tableCapabilityCacheKey(db), table)
+        forgetTableCapability(tableCapabilityCacheKey(this.rootDb()), table)
         metricCache.delete(metricCacheKey(bucket, index))
         return { $metadata: {} } as DeleteIndexCommandOutput
       },
@@ -484,7 +502,8 @@ export class PgVectorStore implements VectorStore {
         const serializedRows = JSON.stringify([...rows].sort((a, b) => a.key.localeCompare(b.key)))
         const table = tableName(bucket, index)
         const qualified = qualifiedTableName(table)
-        const capability = await resolveTableCapability(db, table)
+        const capabilityCacheKey = this.tableCapabilityCacheKey(db)
+        const capability = await resolveTableCapability(db, table, capabilityCacheKey)
 
         if (capability.requiresManualUpsert) {
           await this.putVectorsManually(db, qualified, serializedRows)
@@ -509,8 +528,8 @@ export class PgVectorStore implements VectorStore {
             throw e
           }
 
-          forgetTableCapability(db, table)
-          const refreshedCapability = await resolveTableCapability(db, table)
+          forgetTableCapability(capabilityCacheKey, table)
+          const refreshedCapability = await resolveTableCapability(db, table, capabilityCacheKey)
           if (!refreshedCapability.requiresManualUpsert) {
             throw e
           }
@@ -599,7 +618,7 @@ export class PgVectorStore implements VectorStore {
     params: unknown[],
     topK: number
   ): Promise<{ rows: unknown[] }> {
-    const capability = await resolveTableCapability(db, table)
+    const capability = await resolveTableCapability(db, table, this.tableCapabilityCacheKey(db))
     if (!capability.requiresExactQueryScan) {
       return withPgTransaction(db, async (trx): Promise<{ rows: unknown[] }> => {
         await trx.query({

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -2,6 +2,7 @@ import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import type { FastifyRequest } from 'fastify'
 import { Readable } from 'stream'
+import { spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 import type { StorageBackendAdapter } from '../backend'
 
 const EXHAUSTED_RETRY_BACKOFF_MS = 50 + 100 + 200 + 400 + 800
@@ -779,8 +780,7 @@ describe('ImageRenderer fetch client', () => {
       )
       const mockAgent = mockUndici.getMockAgent()
       const pool = mockAgent.get('https://imgproxy.example.test')
-      const timeoutSignal = new AbortController().signal
-      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+      const { timeoutSpy } = spyOnAbortSignalTimeout()
 
       for (let retry = 0; retry < 5; retry += 1) {
         pool

--- a/src/test/admin-migrations.test.ts
+++ b/src/test/admin-migrations.test.ts
@@ -16,7 +16,11 @@ import { DBMigration } from '@internal/database/migrations'
 import { randomUUID } from 'crypto'
 import type { FastifyInstance } from 'fastify'
 import { mergeConfig } from '../config'
-import { closeMultitenantPg, multitenantPgExecutor } from '../internal/database'
+import {
+  closeMultitenantPg,
+  MIGRATION_ADMIN_JOB_LIMIT,
+  multitenantPgExecutor,
+} from '../internal/database'
 import { PG_BOSS_SCHEMA, Queue } from '../internal/queue/queue'
 import { RunMigrationsOnTenants } from '../storage/events/migrations/run-migrations'
 import { createAdminApp } from './common'
@@ -54,15 +58,30 @@ type JobRow = {
 async function insertJobs(jobs: JobRow | JobRow[]) {
   const rows = Array.isArray(jobs) ? jobs : [jobs]
 
-  for (const job of rows) {
-    await multitenantPgExecutor.query({
-      text: `
-        INSERT INTO ${pgBossJobTable} (id, name, state, created_on, data)
-        VALUES ($1, $2, $3, COALESCE($4, now()), $5)
-      `,
-      values: [job.id, job.name, job.state, job.created_on, job.data],
-    })
+  if (rows.length === 0) {
+    return
   }
+
+  await multitenantPgExecutor.query({
+    text: `
+      INSERT INTO ${pgBossJobTable} (id, name, state, created_on, data)
+      SELECT id, name, state, COALESCE(created_on, now()), data
+      FROM unnest(
+        $1::uuid[],
+        $2::text[],
+        $3::text[],
+        $4::timestamptz[],
+        $5::jsonb[]
+      ) AS input(id, name, state, created_on, data)
+    `,
+    values: [
+      rows.map((job) => job.id),
+      rows.map((job) => job.name),
+      rows.map((job) => job.state),
+      rows.map((job) => job.created_on || null),
+      rows.map((job) => JSON.stringify(job.data)),
+    ],
+  })
 }
 
 async function deleteJobs(jobIds: string[]) {
@@ -425,6 +444,7 @@ describe('Admin migrations routes', () => {
     const otherTenantId = `admin-migrations-other-${randomUUID().slice(0, 8)}`
     const olderJobId = trackJobId(randomUUID())
     const newerJobId = trackJobId(randomUUID())
+    const extraTenantJobIds = Array.from({ length: 99 }, () => trackJobId(randomUUID()))
     const otherTenantJobId = trackJobId(randomUUID())
     const wrongQueueJobId = trackJobId(randomUUID())
 
@@ -456,6 +476,18 @@ describe('Admin migrations routes', () => {
           tenantId: jobTenantId,
         },
       },
+      ...extraTenantJobIds.map((id) => ({
+        id,
+        name: RunMigrationsOnTenants.getQueueName(),
+        state: 'active',
+        created_on: new Date('2026-03-25T09:00:00.000Z'),
+        data: {
+          tenant: {
+            ref: jobTenantId,
+          },
+          tenantId: jobTenantId,
+        },
+      })),
       {
         id: otherTenantJobId,
         name: RunMigrationsOnTenants.getQueueName(),
@@ -488,8 +520,8 @@ describe('Admin migrations routes', () => {
 
     expect(response.statusCode).toBe(200)
     const body = JSON.parse(response.body)
-    expect(body).toHaveLength(2)
-    expect(body).toEqual([
+    expect(body).toHaveLength(2 + extraTenantJobIds.length)
+    expect(body.slice(0, 2)).toEqual([
       expect.objectContaining({
         id: newerJobId,
         name: RunMigrationsOnTenants.getQueueName(),
@@ -635,7 +667,9 @@ describe('Admin migrations routes', () => {
   test('deletes only tenant migration jobs from the current queue', async () => {
     const tenantWithJobsId = `admin-migrations-delete-${randomUUID().slice(0, 8)}`
     const otherTenantId = `admin-migrations-delete-other-${randomUUID().slice(0, 8)}`
-    const matchingJobId = trackJobId(randomUUID())
+    const matchingJobIds = Array.from({ length: MIGRATION_ADMIN_JOB_LIMIT + 1 }, () =>
+      trackJobId(randomUUID())
+    )
     const otherTenantJobId = trackJobId(randomUUID())
     const wrongQueueJobId = trackJobId(randomUUID())
 
@@ -643,8 +677,8 @@ describe('Admin migrations routes', () => {
     await createTenant(otherTenantId)
 
     await insertJobs([
-      {
-        id: matchingJobId,
+      ...matchingJobIds.map((id) => ({
+        id,
         name: RunMigrationsOnTenants.getQueueName(),
         state: 'active',
         data: {
@@ -653,7 +687,7 @@ describe('Admin migrations routes', () => {
           },
           tenantId: tenantWithJobsId,
         },
-      },
+      })),
       {
         id: otherTenantJobId,
         name: RunMigrationsOnTenants.getQueueName(),
@@ -685,10 +719,19 @@ describe('Admin migrations routes', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(JSON.parse(response.body)).toBe(1)
+    expect(JSON.parse(response.body)).toBe(MIGRATION_ADMIN_JOB_LIMIT)
+
+    const secondResponse = await adminApp.inject({
+      method: 'DELETE',
+      url: `/tenants/${tenantWithJobsId}/migrations/jobs`,
+      headers,
+    })
+
+    expect(secondResponse.statusCode).toBe(200)
+    expect(JSON.parse(secondResponse.body)).toBe(1)
 
     const rows = await getJobs<{ id: string; name: string }>('id, name', [
-      matchingJobId,
+      ...matchingJobIds,
       otherTenantJobId,
       wrongQueueJobId,
     ])

--- a/src/test/pgvector-adapter.test.ts
+++ b/src/test/pgvector-adapter.test.ts
@@ -1,4 +1,4 @@
-import { PgPoolExecutor, PgTransaction } from '@internal/database'
+import { PgPoolExecutor, PgTenantConnection, PgTransaction } from '@internal/database'
 import { PgVectorStore } from '@storage/protocols/vector'
 import { Pool as PgPool, type PoolClient, type QueryResult } from 'pg'
 import { afterAll, beforeAll, describe, expect, it, type Mock, vi } from 'vitest'
@@ -74,6 +74,24 @@ function createMockExecutor(raw: RawQueryMock, transaction?: Mock) {
       return createMockPgTransaction(transactionRaw)
     },
   } as never
+}
+
+function createMockTenantConnection(raw: RawQueryMock, sharedPool: object): PgTenantConnection {
+  return new PgTenantConnection(
+    Object.assign(sharedPool, {
+      acquire: () => createMockExecutor(raw),
+      destroy: vi.fn(),
+      getPoolStats: vi.fn(),
+      rebalance: vi.fn(),
+    }) as never,
+    {
+      tenantId: 'tenant-a',
+      dbUrl: 'postgres://tenant-a',
+      maxConnections: 2,
+      user: { jwt: 'jwt', payload: { role: 'authenticated' } },
+      superUser: { jwt: 'service', payload: { role: 'service_role' } },
+    } as never
+  )
 }
 
 function createManualUpsertDb(
@@ -822,6 +840,33 @@ describe('PgVectorStore (real pgvector)', () => {
     ).rejects.toThrow('different vector dimensions')
 
     expect(transaction).not.toHaveBeenCalled()
+    expect(raw.mock.calls.filter(([sql]) => isTableAccessMethodLookup(sql))).toHaveLength(1)
+  })
+
+  it('reuses table capability cache across tenant request connections sharing a pool', async () => {
+    const raw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const sharedPool = {}
+
+    const firstStore = new PgVectorStore(createMockTenantConnection(raw, sharedPool))
+    const secondStore = new PgVectorStore(createMockTenantConnection(raw, sharedPool))
+
+    await firstStore.putVectors({
+      vectorBucketName: bucket,
+      indexName: index,
+      vectors: [{ key: 'a', data: { float32: [1, 0] } }],
+    })
+    await secondStore.putVectors({
+      vectorBucketName: bucket,
+      indexName: index,
+      vectors: [{ key: 'b', data: { float32: [0, 1] } }],
+    })
+
     expect(raw.mock.calls.filter(([sql]) => isTableAccessMethodLookup(sql))).toHaveLength(1)
   })
 

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -281,6 +281,120 @@ describe('Tenant configs', () => {
     expect(response.statusCode).toBe(400)
   })
 
+  test('Tolerates invalid legacy database pool mode rows on tenant reads', async () => {
+    const createResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/abc`,
+      payload,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(createResponse.statusCode).toBe(201)
+
+    await multitenantPgExecutor.query({
+      text: 'UPDATE tenants SET database_pool_mode = $1 WHERE id = $2',
+      values: ['garbage', 'abc'],
+    })
+    deleteTenantConfig('abc')
+
+    const getResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/abc`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(getResponse.statusCode).toBe(200)
+
+    const listResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(listResponse.statusCode).toBe(200)
+    await expect(getTenantConfig('abc')).resolves.toMatchObject({
+      databasePoolMode: undefined,
+    })
+  })
+
+  test('Preserves legacy stored recycle pool mode as single-use on tenant reads', async () => {
+    const createResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/abc`,
+      payload,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(createResponse.statusCode).toBe(201)
+
+    await multitenantPgExecutor.query({
+      text: 'UPDATE tenants SET database_pool_mode = $1 WHERE id = $2',
+      values: ['recycle', 'abc'],
+    })
+    deleteTenantConfig('abc')
+
+    const getResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/abc`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(getResponse.statusCode).toBe(200)
+    expect(JSON.parse(getResponse.body)).toEqual({
+      ...payload,
+      databasePoolMode: 'single_use',
+    })
+
+    await expect(getTenantConfig('abc')).resolves.toMatchObject({
+      databasePoolMode: 'single_use',
+    })
+  })
+
+  test('PATCH refreshes local tenant config changes before the notify cache path', async () => {
+    const createResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/abc`,
+      payload: {
+        ...payload,
+        databasePoolMode: 'recycled',
+      },
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(createResponse.statusCode).toBe(201)
+
+    await getTenantConfig('abc')
+    const destroySpy = vi
+      .spyOn(PgTenantConnection.poolManager, 'destroy')
+      .mockResolvedValue(undefined)
+
+    try {
+      const response = await adminApp.inject({
+        method: 'PATCH',
+        url: `/tenants/abc`,
+        payload: {
+          databasePoolUrl: 'postgres://pool.example.test/postgres',
+        },
+        headers: {
+          apikey: process.env.ADMIN_API_KEYS,
+        },
+      })
+      expect(response.statusCode).toBe(204)
+
+      await vi.waitFor(() => {
+        expect(destroySpy).toHaveBeenCalledWith('abc')
+      })
+    } finally {
+      destroySpy.mockRestore()
+    }
+  })
+
   test('Get tenant config omits sensitive data when ADMIN_RETURN_TENANT_SENSITIVE_DATA is false', async () => {
     await adminApp.inject({
       method: 'POST',

--- a/src/test/utils/abort-signal.ts
+++ b/src/test/utils/abort-signal.ts
@@ -1,0 +1,17 @@
+import { onTestFinished, vi } from 'vitest'
+
+export function spyOnAbortSignalTimeout() {
+  const timeoutSignal = new AbortController().signal
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal)
+  onTestFinished(() => timeoutSpy.mockRestore())
+
+  return { timeoutSignal, timeoutSpy }
+}
+
+export function spyOnAbortSignalAny() {
+  const anySignal = new AbortController().signal
+  const anySpy = vi.spyOn(AbortSignal, 'any').mockReturnValue(anySignal)
+  onTestFinished(() => anySpy.mockRestore())
+
+  return { anySignal, anySpy }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Missed a pool in fix #1144 and registered knex error listener on checked-out client.

## What is the new behavior?

crash:
 * track checked-out pg client errors to prevent socket level failures from crashing
 * add error handler for single-tenant pgvector pool for idle connections

compat/hardening/improvements:
 * map connection timeout correctly
 * reject pre-aborted query signals before checkout
 * release tx client on abort instead of queueing rollback
 * normalize invalid/legacy pool mode on read
 * trigger replace/rebalance after admin tenant writes (old bug)
 * increase admin migration job cleanup limit to 2000
 * restore keep fleet migration on caller abort timeout
 * filter soft-deleted iceberg catalog during reconcile
 * reuse table capability probes for pgvector

## Additional context

Related to #1096
Related to #1144
