### PR TITLE
fix: drop single_use pool mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -48,7 +48,8 @@ DATABASE_SEARCH_PATH=
 
 DATABASE_APPLICATION_NAME="Supabase Storage API"
 
-## When DATABASE_POOL_URL is SET the following params are ignored
+## When DATABASE_POOL_URL is set, these params still control
+## the local pg.Pool that Storage keeps open to the pooler.
 DATABASE_MAX_CONNECTIONS=20
 DATABASE_FREE_POOL_AFTER_INACTIVITY=60000
 DATABASE_POOL_DRAIN_TIMEOUT=30000

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,7 +6,6 @@ const CONFIG_ENV_KEYS = [
   'TENANT_POOL_CACHE_TTL_MS',
   'TENANT_POOL_CACHE_HIT_LOG_SAMPLE_RATE',
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
-  'DATABASE_POOL_MODE',
   'DATABASE_POOL_DRAIN_TIMEOUT',
 ] as const
 
@@ -57,29 +56,6 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheHitLogSampleRate).toBe(0)
     expect(config.tenantPoolCacheMissLogSampleRate).toBe(0)
     expect(config.databasePoolDrainTimeout).toBe(30_000)
-  })
-
-  test('falls back to recycled pool mode for invalid DATABASE_POOL_MODE env values', async () => {
-    setConfigEnv({
-      DATABASE_POOL_MODE: 'garbage',
-    })
-
-    const { getConfig } = await import('./config')
-    const config = getConfig({ reload: true })
-
-    expect(config.databasePoolMode).toBe('recycled')
-  })
-
-  test('preserves legacy tenant-row recycle semantics on read', async () => {
-    const { normalizeDatabasePoolModeForRead } = await import('./config')
-
-    expect(normalizeDatabasePoolModeForRead('recycle')).toBe('single_use')
-  })
-
-  test('falls back for invalid tenant-row pool mode values on read', async () => {
-    const { normalizeDatabasePoolModeForRead } = await import('./config')
-
-    expect(normalizeDatabasePoolModeForRead('garbage', 'recycled')).toBe('recycled')
   })
 
   test('parses database pool drain timeout in milliseconds', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,6 @@ import { SignJWT } from 'jose'
 export type StorageBackendType = 'file' | 's3'
 export type VectorBucketProvider = 's3' | 'pgvector'
 export type IcebergCatalogAuthType = 'sigv4' | 'token'
-export type DatabasePoolMode = 'single_use' | 'recycled'
 export type DatabaseEngine = 'postgres' | 'multigres'
 const DEFAULT_S3_UPLOAD_PART_SIZE = 16 * 1024 * 1024
 const MIN_S3_UPLOAD_PART_SIZE = 5 * 1024 * 1024
@@ -105,7 +104,6 @@ type StorageConfigType = {
   databaseSSLRootCert?: string
   databaseEngine: DatabaseEngine
   databasePoolURL?: string
-  databasePoolMode?: DatabasePoolMode
   databaseMaxConnections: number
   databaseFreePoolAfterInactivity: number
   databasePoolDrainTimeout: number
@@ -250,59 +248,6 @@ function getConfigFromEnv(key: string, fallbackEnv?: string): string {
   return value
 }
 
-export function normalizeDatabasePoolMode(
-  mode: string | null | undefined
-): DatabasePoolMode | null | undefined {
-  if (mode === null || mode === undefined) {
-    return mode
-  }
-
-  if (mode === '') {
-    return undefined
-  }
-
-  if (mode === 'single_use') {
-    return 'single_use'
-  }
-
-  if (mode === 'recycled' || mode === 'recycle') {
-    return 'recycled'
-  }
-
-  throw new Error(`Invalid database pool mode "${mode}". Expected "single_use" or "recycled".`)
-}
-
-export function normalizeDatabasePoolModeForRead(
-  mode: string | null | undefined,
-  fallback?: DatabasePoolMode
-): DatabasePoolMode | null | undefined {
-  if (mode === null) {
-    return null
-  }
-
-  if (mode === undefined || mode === '') {
-    return undefined
-  }
-
-  if (mode === 'single_use' || mode === 'recycled') {
-    return mode
-  }
-
-  if (mode === 'recycle') {
-    return 'single_use'
-  }
-
-  return fallback
-}
-
-function normalizeDatabasePoolModeFromEnv(mode: string | undefined): DatabasePoolMode | undefined {
-  try {
-    return normalizeDatabasePoolMode(mode) ?? undefined
-  } catch {
-    return 'recycled'
-  }
-}
-
 export function normalizeDatabaseEngine(engine: string | null | undefined): DatabaseEngine {
   if (engine === null || engine === undefined || engine === '') {
     return 'postgres'
@@ -329,16 +274,7 @@ export function setEnvPaths(paths: string[]) {
 }
 
 export function mergeConfig(newConfig: Partial<StorageConfigType>) {
-  const normalizedConfig = { ...newConfig } as Partial<StorageConfigType> & {
-    databasePoolMode?: string | null
-  }
-
-  if ('databasePoolMode' in normalizedConfig) {
-    normalizedConfig.databasePoolMode =
-      normalizeDatabasePoolMode(normalizedConfig.databasePoolMode) ?? undefined
-  }
-
-  config = { ...config, ...(normalizedConfig as Required<StorageConfigType>) }
+  config = { ...config, ...(newConfig as Required<StorageConfigType>) }
 }
 
 export function getConfig(options?: { reload?: boolean }): StorageConfigType {
@@ -524,9 +460,6 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     databaseEngine: normalizeDatabaseEngine(getOptionalConfigFromEnv('DATABASE_ENGINE')),
     databaseURL: getOptionalIfMultitenantConfigFromEnv('DATABASE_URL') || '',
     databasePoolURL: getOptionalConfigFromEnv('DATABASE_POOL_URL') || '',
-    databasePoolMode: normalizeDatabasePoolModeFromEnv(
-      getOptionalConfigFromEnv('DATABASE_POOL_MODE')
-    ),
     databaseMaxConnections: parseInt(
       getOptionalConfigFromEnv('DATABASE_MAX_CONNECTIONS') || '20',
       10

--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -1,0 +1,93 @@
+import Fastify from 'fastify'
+import { vi } from 'vitest'
+
+async function loadDbSuperUserPlugin() {
+  vi.resetModules()
+
+  const requestDb = {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    setAbortSignal: vi.fn(),
+  }
+  const getPostgresConnection = vi.fn().mockResolvedValue(requestDb)
+  const getServiceKeyUser = vi.fn().mockResolvedValue({
+    jwt: 'service-jwt',
+    payload: {
+      role: 'service_role',
+    },
+  })
+
+  vi.doMock('@internal/database', () => {
+    return {
+      getPostgresConnection,
+      getServiceKeyUser,
+      getTenantConfig: vi.fn(),
+      PgTenantConnection: class {},
+    }
+  })
+
+  vi.doMock('@internal/database/migrations', () => {
+    return {
+      areMigrationsUpToDate: vi.fn(),
+      DBMigration: {},
+      lastLocalMigrationName: vi.fn().mockResolvedValue('initialmigration'),
+      progressiveMigrations: {
+        addTenant: vi.fn(),
+      },
+      runMigrationsOnTenant: vi.fn(),
+      updateTenantMigrationsState: vi.fn(),
+    }
+  })
+
+  const configModule = await import('../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({
+    isMultitenant: false,
+  })
+
+  const { dbSuperUser } = await import('./db')
+
+  return {
+    dbSuperUser,
+    getPostgresConnection,
+  }
+}
+
+describe('dbSuperUser plugin', () => {
+  afterEach(() => {
+    vi.doUnmock('@internal/database')
+    vi.doUnmock('@internal/database/migrations')
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('does not forward route-level maxConnections into shared tenant pool settings', async () => {
+    const { dbSuperUser, getPostgresConnection } = await loadDbSuperUserPlugin()
+    const app = Fastify()
+
+    app.decorateRequest('tenantId')
+    app.addHook('onRequest', async (request) => {
+      request.tenantId = 'tenant-id'
+    })
+    const legacyOptions = { disableHostCheck: true, maxConnections: 5 } as unknown as {
+      disableHostCheck: boolean
+    }
+    await app.register(dbSuperUser, legacyOptions)
+    app.get('/test', async () => ({ ok: true }))
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: {
+          'x-forwarded-host': 'tenant.local.test',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(getPostgresConnection).toHaveBeenCalledTimes(1)
+      expect(getPostgresConnection.mock.calls[0][0]).not.toHaveProperty('maxConnections')
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -80,7 +80,6 @@ export const db = fastifyPlugin(
 
 interface DbSuperUserPluginOptions {
   disableHostCheck?: boolean
-  maxConnections?: number
 }
 
 export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
@@ -100,7 +99,6 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
         method: request.method,
         headers: request.headers,
         disableHostCheck: opts.disableHostCheck,
-        maxConnections: opts.maxConnections,
         operation: () => request.operation?.type,
       })
 

--- a/src/http/routes/admin/objects.ts
+++ b/src/http/routes/admin/objects.ts
@@ -75,7 +75,6 @@ export default async function routes(fastify: FastifyInstance) {
   registerApiKeyAuth(fastify)
   fastify.register(dbSuperUser, {
     disableHostCheck: true,
-    maxConnections: 5,
   })
   fastify.register(storage)
 

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -25,12 +25,7 @@ import { PG_BOSS_SCHEMA } from '@internal/queue'
 import { RunMigrationsOnTenants } from '@storage/events'
 import { FastifyInstance, RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import {
-  getConfig,
-  JwksConfigKey,
-  normalizeDatabasePoolMode,
-  normalizeDatabasePoolModeForRead,
-} from '../../../config'
+import { getConfig, JwksConfigKey } from '../../../config'
 import { dbSuperUser, storage } from '../../plugins'
 import { registerApiKeyAuth } from '../../plugins/apikey'
 import { registerJsonParserAllowingEmptyBody } from '../../plugins/empty-json-body'
@@ -42,11 +37,6 @@ const patchSchema = {
       anonKey: { type: 'string' },
       databaseUrl: { type: 'string' },
       databasePoolUrl: { type: 'string', nullable: true },
-      databasePoolMode: {
-        type: 'string',
-        enum: ['single_use', 'recycled', 'recycle', null],
-        nullable: true,
-      },
       maxConnections: { type: 'number' },
       jwks: { type: 'object', nullable: true },
       fileSizeLimit: { type: 'number' },
@@ -126,7 +116,6 @@ interface tenantDBInterface {
   anon_key: string
   database_url: string
   database_pool_url?: string | null
-  database_pool_mode?: string | null
   max_connections?: number
   jwt_secret: string
   jwks: { keys?: JwksConfigKey[] } | null
@@ -146,13 +135,8 @@ interface tenantDBInterface {
   disable_events?: string[] | null
 }
 
-const {
-  dbMigrationFreezeAt,
-  icebergEnabled,
-  vectorEnabled,
-  adminReturnTenantSensitiveData,
-  databasePoolMode,
-} = getConfig()
+const { dbMigrationFreezeAt, icebergEnabled, vectorEnabled, adminReturnTenantSensitiveData } =
+  getConfig()
 const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 const tenantConfigStorePg = new TenantConfigStorePg(multitenantPgExecutor)
 const migrationAdminStorePg = new MigrationAdminStorePg(multitenantPgExecutor, PG_BOSS_SCHEMA)
@@ -278,7 +262,6 @@ export default async function routes(fastify: FastifyInstance) {
         anon_key,
         database_url,
         database_pool_url,
-        database_pool_mode,
         max_connections,
         file_size_limit,
         jwt_secret,
@@ -311,7 +294,6 @@ export default async function routes(fastify: FastifyInstance) {
               serviceKey: decrypt(service_key),
             }
           : {}),
-        databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
         migrationVersion: migrations_version,
@@ -357,7 +339,6 @@ export default async function routes(fastify: FastifyInstance) {
         anon_key,
         database_url,
         database_pool_url,
-        database_pool_mode,
         max_connections,
         file_size_limit,
         jwt_secret,
@@ -398,7 +379,6 @@ export default async function routes(fastify: FastifyInstance) {
               serviceKey: decrypt(service_key),
             }
           : {}),
-        databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
         capabilities,
@@ -441,7 +421,6 @@ export default async function routes(fastify: FastifyInstance) {
       const {
         anonKey,
         databaseUrl,
-        databasePoolMode,
         fileSizeLimit,
         jwtSecret,
         jwks,
@@ -458,7 +437,6 @@ export default async function routes(fastify: FastifyInstance) {
         anon_key: encrypt(anonKey),
         database_url: encrypt(databaseUrl),
         database_pool_url: databasePoolUrl ? encrypt(databasePoolUrl) : undefined,
-        database_pool_mode: normalizeDatabasePoolMode(databasePoolMode),
         max_connections: maxConnections ? Number(maxConnections) : undefined,
         file_size_limit: fileSizeLimit,
         jwt_secret: encrypt(jwtSecret),
@@ -513,7 +491,6 @@ export default async function routes(fastify: FastifyInstance) {
         serviceKey,
         features,
         databasePoolUrl,
-        databasePoolMode,
         maxConnections,
         tracingMode,
         disableEvents,
@@ -528,7 +505,6 @@ export default async function routes(fastify: FastifyInstance) {
           : databasePoolUrl === null
             ? null
             : undefined,
-        database_pool_mode: normalizeDatabasePoolMode(databasePoolMode),
         max_connections: maxConnections ? Number(maxConnections) : undefined,
         file_size_limit: fileSizeLimit,
         jwt_secret: jwtSecret !== undefined ? encrypt(jwtSecret) : undefined,
@@ -586,7 +562,6 @@ export default async function routes(fastify: FastifyInstance) {
         serviceKey,
         features,
         databasePoolUrl,
-        databasePoolMode,
         maxConnections,
         tracingMode,
         disableEvents,
@@ -631,10 +606,6 @@ export default async function routes(fastify: FastifyInstance) {
 
       if (maxConnections) {
         tenantInfo.max_connections = Number(maxConnections)
-      }
-
-      if (databasePoolMode !== undefined) {
-        tenantInfo.database_pool_mode = normalizeDatabasePoolMode(databasePoolMode)
       }
 
       if (tracingMode) {

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -8,7 +8,6 @@ import { getTenantConfig } from './tenant'
 interface ConnectionOptions {
   host: string
   tenantId: string
-  maxConnections?: number
   headers?: Record<string, string | undefined | string[]>
   method?: string
   path?: string
@@ -45,13 +44,11 @@ async function getDbSettings(
     databaseURL,
     databaseMaxConnections,
     requestXForwardedHostRegExp,
-    databasePoolMode,
   } = getConfig()
 
   let dbUrl = databasePoolURL || databaseURL
   let maxConnections = databaseMaxConnections
   let isExternalPool = Boolean(databasePoolURL)
-  let isSingleUse = !databasePoolMode || databasePoolMode === 'single_use'
 
   if (isMultitenant) {
     if (!tenantId) {
@@ -75,13 +72,11 @@ async function getDbSettings(
     dbUrl = tenant.databasePoolUrl || tenant.databaseUrl
     isExternalPool = Boolean(tenant.databasePoolUrl)
     maxConnections = tenant.maxConnections ?? maxConnections
-    isSingleUse = tenant.databasePoolMode ? tenant.databasePoolMode === 'single_use' : isSingleUse
   }
 
   return {
     dbUrl,
     isExternalPool,
     maxConnections,
-    isSingleUse,
   }
 }

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -591,7 +591,7 @@ describe('PgTransaction', () => {
 })
 
 describe('PgTenantConnection', () => {
-  it('rejects pool acquisition after disposal', async () => {
+  it('rejects connection use after disposal without destroying the retained pool', async () => {
     const pool = {
       acquire: vi.fn(),
       destroy: vi.fn().mockResolvedValue(undefined),
@@ -600,7 +600,6 @@ describe('PgTenantConnection', () => {
       pool,
       createPoolStrategySettings({
         isExternalPool: true,
-        isSingleUse: true,
       })
     )
 
@@ -613,29 +612,6 @@ describe('PgTenantConnection', () => {
       'Cannot use a disposed PgTenantConnection'
     )
     await expect(connection.transaction()).rejects.toThrow(
-      'Cannot use a disposed PgTenantConnection'
-    )
-    expect(() => connection.asSuperUser()).toThrow('Cannot use a disposed PgTenantConnection')
-    expect(pool.acquire).not.toHaveBeenCalled()
-    expect(pool.destroy).toHaveBeenCalledTimes(1)
-  })
-
-  it('rejects cacheable connection use after disposal without destroying the retained pool', async () => {
-    const pool = {
-      acquire: vi.fn(),
-      destroy: vi.fn().mockResolvedValue(undefined),
-    } as unknown as PgPoolStrategy
-    const connection = new PgTenantConnection(
-      pool,
-      createPoolStrategySettings({
-        isExternalPool: false,
-        isSingleUse: false,
-      })
-    )
-
-    await connection.dispose()
-
-    await expect(connection.query('SELECT 1')).rejects.toThrow(
       'Cannot use a disposed PgTenantConnection'
     )
     expect(() => connection.asSuperUser()).toThrow('Cannot use a disposed PgTenantConnection')
@@ -658,7 +634,6 @@ describe('PgTenantConnection', () => {
       pool,
       createPoolStrategySettings({
         isExternalPool: true,
-        isSingleUse: true,
       })
     )
 
@@ -677,7 +652,7 @@ describe('PgTenantConnection', () => {
       })
       expect(pool.acquire).toHaveBeenCalledTimes(1)
       expect(beginTransaction).toHaveBeenCalledTimes(1)
-      expect(pool.destroy).toHaveBeenCalledTimes(1)
+      expect(pool.destroy).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -152,7 +152,6 @@ export class PgPoolStrategy {
   }
 
   protected getSettings() {
-    const isSingleUseExternalPool = this.options.isSingleUse && this.options.isExternalPool
     const numWorkers = Math.max(this.options.numWorkers ?? 1, 1)
     const clusterSize = this.options.clusterSize || 0
     let maxConnection = this.options.maxConnections || databaseMaxConnections
@@ -162,13 +161,9 @@ export class PgPoolStrategy {
       maxConnection = Math.ceil(maxConnection / divisor) || 1
     }
 
-    if (isSingleUseExternalPool) {
-      maxConnection = 1
-    }
-
     return {
       ...this.options,
-      idleTimeoutMillis: isSingleUseExternalPool ? 100 : databaseFreePoolAfterInactivity,
+      idleTimeoutMillis: databaseFreePoolAfterInactivity,
       maxConnections: maxConnection,
       searchPath: this.options.isExternalPool ? undefined : searchPath,
     }
@@ -530,11 +525,6 @@ export class PgTenantConnection {
 
   dispose() {
     this.disposed = true
-
-    if (this.options.isSingleUse && this.options.isExternalPool) {
-      return this.pool.destroy()
-    }
-
     return Promise.resolve()
   }
 

--- a/src/internal/database/pool.test.ts
+++ b/src/internal/database/pool.test.ts
@@ -316,9 +316,7 @@ describe('PoolManager cache lifecycle', () => {
       outcome: 'miss',
       sampleRate: 1,
       sampleWeight: 1,
-      isCacheable: true,
       isExternalPool: false,
-      isSingleUse: false,
     })
     const expectedHitLog = expect.objectContaining({
       type: poolModule.TENANT_POOL_CACHE_LOOKUP_LOG_TYPE,
@@ -328,9 +326,7 @@ describe('PoolManager cache lifecycle', () => {
       outcome: 'hit',
       sampleRate: 1,
       sampleWeight: 1,
-      isCacheable: true,
       isExternalPool: false,
-      isSingleUse: false,
     })
 
     expect(second).toBe(first)
@@ -414,7 +410,7 @@ describe('PoolManager cache lifecycle', () => {
     await poolManager.destroyAll()
   })
 
-  test('logs sampled single-use external pool cache misses without a cached pool', async () => {
+  test('logs sampled external pool cache misses', async () => {
     const poolModule = await loadPoolModule(10_000, undefined, {
       tenantPoolCacheMissLogSampleRate: 1,
     })
@@ -435,18 +431,15 @@ describe('PoolManager cache lifecycle', () => {
     const expectedMissLog = expect.objectContaining({
       type: poolModule.TENANT_POOL_CACHE_LOOKUP_LOG_TYPE,
       cache: TENANT_POOL_CACHE_NAME,
-      tenantId: 'tenant-single-use-external-log',
-      project: 'tenant-single-use-external-log',
+      tenantId: 'tenant-external-pool-log',
+      project: 'tenant-external-pool-log',
       outcome: 'miss',
       sampleRate: 1,
       sampleWeight: 1,
-      isCacheable: false,
       isExternalPool: true,
-      isSingleUse: true,
     })
-    const pool = poolManager.getPool({
-      ...createPoolSettings('tenant-single-use-external-log'),
-      isSingleUse: true,
+    poolManager.getPool({
+      ...createPoolSettings('tenant-external-pool-log'),
       isExternalPool: true,
     })
 
@@ -456,7 +449,6 @@ describe('PoolManager cache lifecycle', () => {
       )
     ).toEqual([[expectedMissLog, poolModule.TENANT_POOL_CACHE_LOOKUP_LOG_MESSAGE]])
 
-    await pool.destroy()
     await poolManager.destroyAll()
   })
 
@@ -547,7 +539,7 @@ describe('PoolManager cache lifecycle', () => {
     expect(poolManager.created[1].destroy).toHaveBeenCalledTimes(1)
   })
 
-  test('records pool cache misses for single-use external pools without cached pools', async () => {
+  test('caches external pools across lookups and records miss then hit', async () => {
     const poolModule = await loadPoolModule(10_000)
     const metricsModule = await import('@internal/monitoring/metrics')
     const addSpy = vi.spyOn(metricsModule.cacheRequestsTotal, 'add')
@@ -564,58 +556,23 @@ describe('PoolManager cache lifecycle', () => {
 
     const poolManager = new TestPoolManager()
     const settings = {
-      ...createPoolSettings('tenant-single-use-external'),
-      isSingleUse: true,
+      ...createPoolSettings('tenant-external-pool-cache'),
       isExternalPool: true,
     }
 
     const first = poolManager.getPool(settings)
     const second = poolManager.getPool(settings)
 
-    expect(second).not.toBe(first)
-    expect(poolManager.created).toHaveLength(2)
+    expect(second).toBe(first)
+    expect(poolManager.created).toHaveLength(1)
     expect(
       addSpy.mock.calls.filter(([, attrs]) => {
         return attrs && typeof attrs === 'object' && attrs.cache === TENANT_POOL_CACHE_NAME
       })
     ).toEqual([
       [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'miss' }],
-      [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'miss' }],
+      [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }],
     ])
-
-    await Promise.all([first.destroy(), second.destroy()])
-    await poolManager.destroyAll()
-  })
-
-  test('reuses cached pools for single-use external requests and records a hit', async () => {
-    const poolModule = await loadPoolModule(10_000)
-    const metricsModule = await import('@internal/monitoring/metrics')
-    const addSpy = vi.spyOn(metricsModule.cacheRequestsTotal, 'add')
-
-    class TestPoolManager extends poolModule.PoolManager {
-      created: TestPool[] = []
-
-      protected newPool(_settings: TenantConnectionOptions): PoolStrategy {
-        const pool = createTestPool()
-        this.created.push(pool)
-        return pool
-      }
-    }
-
-    const poolManager = new TestPoolManager()
-    const tenantId = 'tenant-single-use-external-reuses-cache'
-    const cachedPool = poolManager.getPool(createPoolSettings(tenantId))
-    addSpy.mockClear()
-
-    const reusedPool = poolManager.getPool({
-      ...createPoolSettings(tenantId),
-      isSingleUse: true,
-      isExternalPool: true,
-    })
-
-    expect(reusedPool).toBe(cachedPool)
-    expect(poolManager.created).toHaveLength(1)
-    expect(addSpy.mock.calls).toEqual([[1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }]])
 
     await poolManager.destroyAll()
   })

--- a/src/internal/database/pool.ts
+++ b/src/internal/database/pool.ts
@@ -27,7 +27,6 @@ export interface TenantConnectionOptions {
   tenantId: string
   dbUrl: string
   isExternalPool?: boolean
-  isSingleUse?: boolean
   idleTimeoutMillis?: number
   reapIntervalMillis?: number
   maxConnections: number
@@ -111,11 +110,10 @@ function recordTenantPoolCacheRequest(outcome: CacheLookupOutcome): void {
 
 function recordTenantPoolCacheLookup(
   settings: TenantConnectionOptions,
-  isCacheable: boolean,
   outcome: CacheLookupOutcome
 ): void {
   recordTenantPoolCacheRequest(outcome)
-  logTenantPoolCacheLookup(settings, isCacheable, outcome)
+  logTenantPoolCacheLookup(settings, outcome)
 }
 
 function shouldLogTenantPoolCacheLookup(sampleRate: number): boolean {
@@ -124,7 +122,6 @@ function shouldLogTenantPoolCacheLookup(sampleRate: number): boolean {
 
 function logTenantPoolCacheLookup(
   settings: TenantConnectionOptions,
-  isCacheable: boolean,
   outcome: CacheLookupOutcome
 ): void {
   const sampleRate =
@@ -142,9 +139,7 @@ function logTenantPoolCacheLookup(
     outcome,
     sampleRate,
     sampleWeight: 1 / sampleRate,
-    isCacheable,
     isExternalPool: Boolean(settings.isExternalPool),
-    isSingleUse: Boolean(settings.isSingleUse),
   }
 
   logSchema.info(logger, TENANT_POOL_CACHE_LOOKUP_LOG_MESSAGE, log)
@@ -266,16 +261,11 @@ export abstract class PoolManager<TPool extends PoolStrategy = PoolStrategy> {
   }
 
   getPool(settings: TenantConnectionOptions): TPool {
-    const isCacheable = (settings.isSingleUse && !settings.isExternalPool) || !settings.isSingleUse
     const { value: existingPool, outcome } = tenantPools.getWithOutcome(settings.tenantId)
-    recordTenantPoolCacheLookup(settings, isCacheable, outcome)
+    recordTenantPoolCacheLookup(settings, outcome)
 
     if (existingPool) {
       return existingPool as TPool
-    }
-
-    if (!isCacheable) {
-      return this.newPool({ ...settings, numWorkers: this.numWorkers })
     }
 
     const newPool = this.newPool({ ...settings, numWorkers: this.numWorkers })

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -16,7 +16,6 @@ export interface TenantConfigRow {
   anon_key: string
   database_url: string
   database_pool_url?: string | null
-  database_pool_mode?: string | null
   max_connections?: number | null
   jwt_secret: string
   jwks?: { keys?: JwksConfigKey[] } | null
@@ -47,7 +46,6 @@ const tenantWritableColumns = [
   'anon_key',
   'database_url',
   'database_pool_url',
-  'database_pool_mode',
   'max_connections',
   'jwt_secret',
   'jwks',

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -12,14 +12,7 @@ import {
 } from '@storage/protocols/s3/credentials'
 import { JWTPayload } from 'jose'
 import objectSizeOf from 'object-sizeof'
-import {
-  type DatabasePoolMode,
-  getConfig,
-  JwksConfig,
-  JwksConfigKey,
-  JwksConfigKeyOCT,
-  normalizeDatabasePoolModeForRead,
-} from '../../config'
+import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
 import { decrypt } from '../auth'
 import { JWKSManager, JWKSManagerStorePg } from '../auth/jwks'
 import { createMutexByKey } from '../concurrency'
@@ -33,7 +26,6 @@ interface TenantConfig {
   anonKey?: string
   databaseUrl: string
   databasePoolUrl?: string
-  databasePoolMode?: DatabasePoolMode | null
   maxConnections?: number
   fileSizeLimit: number
   features: Features
@@ -93,7 +85,6 @@ const {
   icebergEnabled,
   vectorEnabled,
   databaseMaxConnections,
-  databasePoolMode,
 } = getConfig()
 
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
@@ -219,7 +210,6 @@ export async function getTenantConfig(
     const {
       anon_key,
       database_url,
-      database_pool_mode,
       file_size_limit,
       jwt_secret,
       jwks,
@@ -250,7 +240,6 @@ export async function getTenantConfig(
       anonKey: decrypt(anon_key),
       databaseUrl: decrypt(database_url),
       databasePoolUrl: database_pool_url ? decrypt(database_pool_url) : undefined,
-      databasePoolMode: normalizeDatabasePoolModeForRead(database_pool_mode, databasePoolMode),
       fileSizeLimit: Number(file_size_limit),
       jwtSecret,
       jwks: jwks ? { keys: jwks.keys ?? [] } : jwks,
@@ -441,12 +430,7 @@ export async function onTenantConfigChange(cacheKey: string) {
   try {
     const newConfig = await getTenantConfig(cacheKey, { recordMetrics: false })
 
-    // 1. Pool mode flipped recycled → single_use: tear down the long-lived pool.
-    if (newConfig.databasePoolMode === 'single_use' && oldConfig.databasePoolMode === 'recycled') {
-      return destroyTenantPool(cacheKey)
-    }
-
-    // 2. DB endpoint changed: the cached pool's connection string is stale, and
+    // 1. DB endpoint changed: the cached pool's connection string is stale, and
     //    so are its open sockets. Hard destroy so the next request rebuilds
     //    against the new endpoint.
     if (
@@ -456,7 +440,7 @@ export async function onTenantConfigChange(cacheKey: string) {
       return destroyTenantPool(cacheKey)
     }
 
-    // 3. Max connections changed: endpoint is fine, only the budget moved.
+    // 2. Max connections changed: endpoint is fine, only the budget moved.
     //    Rebalance the cached pg pool in place so new acquire attempts observe
     //    the new budget while in-flight queries keep their checked-out clients.
     if (

--- a/src/test/pg-connection.test.ts
+++ b/src/test/pg-connection.test.ts
@@ -210,7 +210,6 @@ describe('Pg database foundation', () => {
     const settings = createConnectionSettings(superUser, {
       tenantId: 'pg-foundation-cacheable',
       isExternalPool: false,
-      isSingleUse: false,
     })
 
     const first = await PgTenantConnection.create(settings)
@@ -227,26 +226,31 @@ describe('Pg database foundation', () => {
     )
   })
 
-  it('does not cache single-use external pg tenant pools and dispose closes them', async () => {
+  it('caches external pg tenant pools and dispose keeps them open for reuse', async () => {
     const superUser = await getServiceKeyUser(tenantId)
     const settings = createConnectionSettings(superUser, {
-      tenantId: 'pg-foundation-single-use',
+      tenantId: 'pg-foundation-external-pool',
       isExternalPool: true,
-      isSingleUse: true,
     })
 
     const first = await PgTenantConnection.create(settings)
     const second = await PgTenantConnection.create(settings)
 
-    expect(second.pool).not.toBe(first.pool)
+    expect(second.pool).toBe(first.pool)
 
     await first.pool.acquire().query('SELECT 1')
     expect(first.pool.getPoolStats()).not.toBeNull()
 
     await first.dispose()
-    expect(first.pool.getPoolStats()).toBeNull()
+    expect(first.pool.getPoolStats()).not.toBeNull()
+    await expect(first.query('SELECT 1')).rejects.toThrow(
+      'Cannot use a disposed PgTenantConnection'
+    )
 
+    // The shared pool stays usable for connections that were not disposed.
+    await second.pool.acquire().query('SELECT 1')
     await second.dispose()
+    await PgTenantConnection.poolManager.destroy('pg-foundation-external-pool')
   })
 
   it('creates pg tenant connections through the shared database settings factory', async () => {

--- a/src/test/query-abort-signal.test.ts
+++ b/src/test/query-abort-signal.test.ts
@@ -24,7 +24,6 @@ describe('Query Abort Signal', () => {
 
     const pool: TestPool = poolManager.getPool({
       tenantId,
-      isSingleUse: true,
       isExternalPool: true,
       maxConnections: 1,
       dbUrl: databasePoolURL || databaseURL,

--- a/src/test/tenant-pg-store-runtime.test.ts
+++ b/src/test/tenant-pg-store-runtime.test.ts
@@ -177,7 +177,6 @@ describe('pg store runtime selection', () => {
       url: `/tenants/${tenantId}`,
       payload: {
         databasePoolUrl: 'postgres://tenant-pool-db',
-        databasePoolMode: 'single_use',
         maxConnections: 3,
         fileSizeLimit: 1234,
         features: {
@@ -196,7 +195,6 @@ describe('pg store runtime selection', () => {
     await expect(getTenantConfig(tenantId)).resolves.toMatchObject({
       databaseUrl: createPayload.databaseUrl,
       databasePoolUrl: 'postgres://tenant-pool-db',
-      databasePoolMode: 'single_use',
       fileSizeLimit: 1234,
       maxConnections: 3,
       disableEvents: ['ObjectCreated:*'],

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -31,7 +31,6 @@ const migrationVersion = Object.entries(DBMigration).sort(([_, a], [__, b]) => b
 
 const payload = {
   anonKey: 'a',
-  databasePoolMode: null,
   databaseUrl: 'b',
   databasePoolUrl: 'v',
   maxConnections: 12,
@@ -74,7 +73,6 @@ const payload = {
 
 const payload2 = {
   anonKey: 'e',
-  databasePoolMode: null,
   databaseUrl: 'f',
   databasePoolUrl: 'm',
   maxConnections: 14,
@@ -233,13 +231,13 @@ describe('Tenant configs', () => {
     await expect(getFeatures('abc')).resolves.toEqual(payload.features)
   })
 
-  test('Normalizes legacy database pool mode alias on tenant writes', async () => {
+  test('Ignores legacy database pool mode fields on tenant writes', async () => {
     const response = await adminApp.inject({
       method: 'POST',
       url: `/tenants/abc`,
       payload: {
         ...payload,
-        databasePoolMode: 'recycle',
+        databasePoolMode: 'single_use',
       },
       headers: {
         apikey: process.env.ADMIN_API_KEYS,
@@ -255,114 +253,14 @@ describe('Tenant configs', () => {
       },
     })
     expect(getResponse.statusCode).toBe(200)
-    expect(JSON.parse(getResponse.body)).toEqual({
-      ...payload,
-      databasePoolMode: 'recycled',
-    })
-
-    await expect(getTenantConfig('abc')).resolves.toMatchObject({
-      databasePoolMode: 'recycled',
-    })
-  })
-
-  test('Rejects invalid database pool mode values', async () => {
-    const response = await adminApp.inject({
-      method: 'POST',
-      url: `/tenants/abc`,
-      payload: {
-        ...payload,
-        databasePoolMode: 'invalid',
-      },
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-
-    expect(response.statusCode).toBe(400)
-  })
-
-  test('Tolerates invalid legacy database pool mode rows on tenant reads', async () => {
-    const createResponse = await adminApp.inject({
-      method: 'POST',
-      url: `/tenants/abc`,
-      payload,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-    expect(createResponse.statusCode).toBe(201)
-
-    await multitenantPgExecutor.query({
-      text: 'UPDATE tenants SET database_pool_mode = $1 WHERE id = $2',
-      values: ['garbage', 'abc'],
-    })
-    deleteTenantConfig('abc')
-
-    const getResponse = await adminApp.inject({
-      method: 'GET',
-      url: `/tenants/abc`,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-    expect(getResponse.statusCode).toBe(200)
-
-    const listResponse = await adminApp.inject({
-      method: 'GET',
-      url: `/tenants`,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-    expect(listResponse.statusCode).toBe(200)
-    await expect(getTenantConfig('abc')).resolves.toMatchObject({
-      databasePoolMode: undefined,
-    })
-  })
-
-  test('Preserves legacy stored recycle pool mode as single-use on tenant reads', async () => {
-    const createResponse = await adminApp.inject({
-      method: 'POST',
-      url: `/tenants/abc`,
-      payload,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-    expect(createResponse.statusCode).toBe(201)
-
-    await multitenantPgExecutor.query({
-      text: 'UPDATE tenants SET database_pool_mode = $1 WHERE id = $2',
-      values: ['recycle', 'abc'],
-    })
-    deleteTenantConfig('abc')
-
-    const getResponse = await adminApp.inject({
-      method: 'GET',
-      url: `/tenants/abc`,
-      headers: {
-        apikey: process.env.ADMIN_API_KEYS,
-      },
-    })
-    expect(getResponse.statusCode).toBe(200)
-    expect(JSON.parse(getResponse.body)).toEqual({
-      ...payload,
-      databasePoolMode: 'single_use',
-    })
-
-    await expect(getTenantConfig('abc')).resolves.toMatchObject({
-      databasePoolMode: 'single_use',
-    })
+    expect(JSON.parse(getResponse.body)).toEqual(payload)
   })
 
   test('PATCH refreshes local tenant config changes before the notify cache path', async () => {
     const createResponse = await adminApp.inject({
       method: 'POST',
       url: `/tenants/abc`,
-      payload: {
-        ...payload,
-        databasePoolMode: 'recycled',
-      },
+      payload,
       headers: {
         apikey: process.env.ADMIN_API_KEYS,
       },
@@ -690,7 +588,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://tenant'),
-      database_pool_mode: 'recycled',
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1015,7 +912,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://tenant'),
-      database_pool_mode: null,
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1069,7 +965,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://tenant'),
-      database_pool_mode: 'recycled',
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1123,7 +1018,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://old-host'),
-      database_pool_mode: 'recycled',
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1177,7 +1071,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://tenant'),
-      database_pool_mode: 'recycled',
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1231,7 +1124,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://old-host'),
-      database_pool_mode: 'recycled',
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,
@@ -1288,7 +1180,6 @@ describe('Tenant configs', () => {
     const encryptedTenant = {
       anon_key: encrypt('anon'),
       database_url: encrypt('postgres://tenant'),
-      database_pool_mode: null,
       file_size_limit: 1,
       jwt_secret: encrypt('jwt-secret'),
       jwks: null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix & performance

## What is the current behavior?

There is a legacy pool mode (single use) which creates a pool for every request that's expensive. Recycle was introduced but not all tenants were migrated proactively. If there is no update on tenant, they still continue using this mode. 

## What is the new behavior?

Drop single use mode. Drop admin read/write functionality of mode by always using recycled mode. Drop route level connection setting because it poisons the cache depending on the order of creation.

## Additional context

No migrations yet. Column can be dropped later on.
