### PR TITLE
feat: Added separate Database application.

### DIFF
--- a/acceptance/scripts/run-managed-watt-local.ts
+++ b/acceptance/scripts/run-managed-watt-local.ts
@@ -2,29 +2,39 @@ import { type ChildProcess, spawn } from 'node:child_process'
 import fs from 'node:fs'
 import { createServer, type Server as HttpServer } from 'node:http'
 import path from 'node:path'
-import process from 'node:process'
+import { RuntimeApiClient } from '@platformatic/control'
 import dotenv from 'dotenv'
 
-// Snapshot before loading .env.acceptance so server config only comes from .env.test/.env.
 const inheritedEnv = { ...process.env }
 loadAcceptanceEnvFile()
 
 const args = process.argv.slice(2)
-const profile = readArg('profile') ?? acceptanceEnv('ACCEPTANCE_PROFILE') ?? 'smoke'
+const profile = readArg('profile') ?? acceptanceEnv('ACCEPTANCE_PROFILE') ?? 'core'
 const serverEnv = loadServerEnvFiles(inheritedEnv)
 configureManagedLocalQueueEnv(serverEnv)
+serverEnv.LOG_LEVEL = serverEnv.LOG_LEVEL || 'info'
+serverEnv.NODE_ENV = 'test'
+serverEnv.UPLOAD_FILE_SIZE_LIMIT = serverEnv.UPLOAD_FILE_SIZE_LIMIT || '524288000'
+serverEnv.WORKERS_NUM = serverEnv.WORKERS_NUM || '2'
+serverEnv.PLT_MANAGEMENT_API = serverEnv.PLT_MANAGEMENT_API || 'true'
+serverEnv.WATT_HEALTH_ENABLED = serverEnv.WATT_HEALTH_ENABLED || 'false'
+
 const serverPort = serverEnv.SERVER_PORT || serverEnv.PORT || '5000'
 const baseUrl = acceptanceEnv('ACCEPTANCE_BASE_URL') ?? `http://127.0.0.1:${serverPort}`
 const serverIsMultitenant = isMultitenantServer(serverEnv)
 const acceptanceRunEnv: NodeJS.ProcessEnv = {
   ...process.env,
   ACCEPTANCE_BASE_URL: baseUrl,
-  ACCEPTANCE_DATABASE_WATT: 'false',
+  ACCEPTANCE_DATABASE_WATT: 'true',
   ACCEPTANCE_PROFILE: profile,
+  ACCEPTANCE_SERVICE_KEY: acceptanceEnv('ACCEPTANCE_SERVICE_KEY') ?? serverEnv.SERVICE_KEY,
+  ACCEPTANCE_S3_ACCESS_KEY_ID:
+    acceptanceEnv('ACCEPTANCE_S3_ACCESS_KEY_ID') ?? serverEnv.S3_PROTOCOL_ACCESS_KEY_ID,
   ACCEPTANCE_S3_ENDPOINT: acceptanceEnv('ACCEPTANCE_S3_ENDPOINT') ?? `${baseUrl}/s3`,
+  ACCEPTANCE_S3_SECRET_ACCESS_KEY:
+    acceptanceEnv('ACCEPTANCE_S3_SECRET_ACCESS_KEY') ?? serverEnv.S3_PROTOCOL_ACCESS_KEY_SECRET,
+  ACCEPTANCE_TUS_ENDPOINT: `${baseUrl}/upload/resumable`,
   STORAGE_BACKEND: acceptanceEnv('STORAGE_BACKEND') ?? serverEnv.STORAGE_BACKEND,
-  ACCEPTANCE_TUS_ENDPOINT:
-    acceptanceEnv('ACCEPTANCE_TUS_ENDPOINT') ?? `${baseUrl}/upload/resumable`,
 }
 
 let server: ChildProcess | undefined
@@ -35,6 +45,37 @@ main().catch((error) => {
   console.error(error)
   process.exit(1)
 })
+
+async function waitForWattApplication(applicationId: string, timeoutMs: number) {
+  const client = new RuntimeApiClient()
+  const started = Date.now()
+  let lastError: unknown
+
+  try {
+    while (Date.now() - started < timeoutMs) {
+      try {
+        const runtime = await client.getMatchingRuntime()
+        const application = await client.getRuntimeApplications(runtime.pid).then(({ applications }) => {
+          return applications.find((application) => application.id === applicationId)
+        })
+
+        if (application?.status === 'started') {
+          return
+        }
+
+        lastError = new Error(`Application ${applicationId} status is ${application?.status ?? 'unknown'}`)
+      } catch (error) {
+        lastError = error
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  } finally {
+    await client.close()
+  }
+
+  throw new Error(`Timed out waiting for Watt application ${applicationId}: ${String(lastError)}`)
+}
 
 async function main() {
   try {
@@ -49,15 +90,19 @@ async function main() {
       serverEnv.CDN_PURGE_ENDPOINT_URL = purge.url
     }
 
-    server = spawn(localBin('tsx'), ['src/start/server.ts'], {
+    await run('npm', ['run', 'build'], serverEnv)
+
+    server = spawn(localBin('wattpm'), ['start'], {
       detached: process.platform !== 'win32',
       env: serverEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    prefixOutput(server.stdout, '[storage] ')
-    prefixOutput(server.stderr, '[storage] ')
+    prefixOutput(server.stdout, '[watt] ')
+    prefixOutput(server.stderr, '[watt] ')
 
     await waitForStatus(`${baseUrl}/status`, 60_000)
+    await waitForWattApplication('storage', 60_000)
+    await waitForWattApplication('database', 60_000)
 
     if (serverIsMultitenant) {
       provisionedS3Credential = await provisionLocalMultitenantTenant(serverEnv)
@@ -71,7 +116,7 @@ async function main() {
       acceptanceRunEnv.ACCEPTANCE_ADMIN_URL = ''
       acceptanceRunEnv.ACCEPTANCE_ADMIN_API_KEY = ''
       process.stderr.write(
-        '[acceptance] disabled admin acceptance for managed single-tenant server\n'
+        '[acceptance] disabled admin acceptance for managed single-tenant Watt server\n'
       )
     }
 
@@ -276,22 +321,6 @@ function closeHttpServer(server: HttpServer): Promise<void> {
   })
 }
 
-function resolveInfraRestartScript() {
-  const script = acceptanceEnv('ACCEPTANCE_INFRA_RESTART_SCRIPT') ?? 'infra:restart:ci'
-  const allowed = new Set([
-    'infra:restart:ci',
-    'infra:restart:ci:multigres',
-    'infra:restart:ci:oriole',
-    'infra:restart:ci:oriole:pgvector',
-  ])
-
-  if (!allowed.has(script)) {
-    throw new Error(`Unsupported ACCEPTANCE_INFRA_RESTART_SCRIPT: ${script}`)
-  }
-
-  return script
-}
-
 function requiredEnv(env: NodeJS.ProcessEnv, name: string, fallbackName?: string): string {
   const value = env[name] || (fallbackName ? env[fallbackName] : undefined)
 
@@ -350,6 +379,17 @@ function parseJson<T>(text: string): T | undefined {
   return JSON.parse(text) as T
 }
 
+function resolveInfraRestartScript() {
+  const script = acceptanceEnv('ACCEPTANCE_INFRA_RESTART_SCRIPT') ?? 'infra:restart:ci'
+  const allowed = new Set(['infra:restart:ci', 'infra:restart:ci:oriole'])
+
+  if (!allowed.has(script)) {
+    throw new Error(`Unsupported ACCEPTANCE_INFRA_RESTART_SCRIPT: ${script}`)
+  }
+
+  return script
+}
+
 function run(cmd: string, runArgs: string[], runEnv: NodeJS.ProcessEnv): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command(cmd), runArgs, {
@@ -395,84 +435,22 @@ async function waitForStatus(url: string, timeoutMs: number) {
 }
 
 async function stopServer(child: ChildProcess) {
-  if (hasExited(child)) {
+  if (child.exitCode !== null || child.signalCode !== null) {
     return
   }
 
-  if (process.platform === 'win32') {
-    const exitedAfterKill = waitForExit(child, 5_000)
-    child.kill()
-
-    if (!(await exitedAfterKill)) {
-      process.stderr.write('[storage] server did not exit after kill\n')
-    }
-    return
-  }
-
-  const exitedAfterTerminate = waitForExit(child, 5_000)
-  killProcessTree(child, 'SIGTERM')
-
-  if (await exitedAfterTerminate) {
-    return
-  }
-
-  process.stderr.write('[storage] server did not exit after SIGTERM; sending SIGKILL\n')
-
-  const exitedAfterKill = waitForExit(child, 2_000)
-  killProcessTree(child, 'SIGKILL')
-
-  if (!(await exitedAfterKill)) {
-    process.stderr.write('[storage] server did not exit after SIGKILL\n')
-  }
-}
-
-function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
-  if (hasExited(child)) {
-    return Promise.resolve(true)
-  }
-
-  return new Promise((resolve) => {
-    let timer: NodeJS.Timeout
-
-    function cleanup() {
-      clearTimeout(timer)
-      child.off('exit', onExit)
-    }
-
-    function onExit() {
-      cleanup()
-      resolve(true)
-    }
-
-    child.once('exit', onExit)
-    timer = setTimeout(() => {
-      cleanup()
-      resolve(hasExited(child))
-    }, timeoutMs)
-  })
-}
-
-function hasExited(child: ChildProcess): boolean {
-  return child.exitCode !== null || child.signalCode !== null
-}
-
-function killProcessTree(child: ChildProcess, signal: NodeJS.Signals) {
   if (process.platform === 'win32' || !child.pid) {
-    child.kill(signal)
+    child.kill()
     return
   }
 
   try {
-    process.kill(-child.pid, signal)
+    process.kill(-child.pid, 'SIGTERM')
   } catch (error) {
-    if (!isNoSuchProcessError(error)) {
+    if (!(typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH')) {
       throw error
     }
   }
-}
-
-function isNoSuchProcessError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH'
 }
 
 function readArg(name: string) {
@@ -517,16 +495,13 @@ function acceptanceEnv(name: string): string | undefined {
 
 function loadAcceptanceEnvFile() {
   const acceptanceEnvPath = process.env.ACCEPTANCE_ENV_FILE ?? '.env.acceptance'
-
   dotenv.config({ path: path.resolve(acceptanceEnvPath), override: false })
 }
 
 function loadServerEnvFiles(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env = { ...baseEnv }
-
   loadEnvFileInto(env, '.env.test')
   loadEnvFileInto(env, '.env')
-
   return env
 }
 

--- a/acceptance/specs/database-watt.test.ts
+++ b/acceptance/specs/database-watt.test.ts
@@ -1,14 +1,16 @@
 import { randomUUID } from 'node:crypto'
-import { describeAcceptance, encodePathSegments, getAcceptanceConfig } from '../support/config'
-import { createRestClient } from '../support/http'
-import {
-  cleanupRestResources,
-  createRestBucket,
-  requireServiceKey,
-  uniqueBucketName,
-  uniqueObjectKey,
-  uploadRestObject,
-} from '../support/resources'
+import { setupLoopbackMessaging } from '@platformatic/runtime'
+import dotenv from 'dotenv'
+import { describeAcceptance, getAcceptanceConfig } from '../support/config'
+import { uniqueBucketName } from '../support/resources'
+
+dotenv.config({ path: '.env.test', override: false })
+dotenv.config({ path: '.env', override: false })
+
+type ApplicationContext = {
+  close: () => Promise<void>
+  isBackgroundApplication: boolean
+}
 
 type DatabaseWattStats = {
   acquire: number
@@ -40,6 +42,10 @@ type QueryRowsResponse = {
   rows: Array<{ value: number }>
 }
 
+type BucketRowsResponse = {
+  rows: BucketResponse[]
+}
+
 type LockResponse = {
   lockId: string
 }
@@ -48,16 +54,29 @@ type ErrorResponse = {
   code: string
   destination?: string
   message: string
+  sqlState?: string
 }
 
 const describeDatabaseWattAcceptance = process.env.ACCEPTANCE_DATABASE_WATT === 'true' ? describeAcceptance : describe.skip
+let app: ApplicationContext | undefined
+let messaging: ReturnType<typeof setupLoopbackMessaging> | undefined
+
+async function createDatabaseWattApp(): Promise<ApplicationContext> {
+  const moduleUrl = new URL('../../src/database/index.ts', import.meta.url).href
+  const databaseApp = await import(moduleUrl)
+  return databaseApp.create()
+}
 
 function testDestination(): string {
   return process.env.ACCEPTANCE_TENANT_ID || process.env.TENANT_ID || 'default'
 }
 
 function sendDatabaseMessage<T = unknown>(message: string, payload: unknown): Promise<T> {
-  return sendWattMessage<T>('database', message, payload)
+  if (!messaging) {
+    throw new Error('Database Watt loopback messaging is not initialized')
+  }
+
+  return messaging.send('database', message, payload) as Promise<T>
 }
 
 function isDatabaseError(result: unknown): result is ErrorResponse {
@@ -87,6 +106,75 @@ async function queryDatabaseWatt(destination = testDestination()): Promise<Query
     requestId: randomUUID(),
     sql: 'SELECT 1 as value',
   })
+}
+
+async function cleanupBucket(bucketName: string, destination = testDestination()): Promise<void> {
+  const tx = await beginTransaction(destination)
+
+  try {
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: `SELECT set_config('storage.allow_delete_query', 'true', true)`,
+      })
+    )
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: 'DELETE FROM storage.buckets WHERE id = $1',
+        values: [bucketName],
+      })
+    )
+    await checkedResult(sendDatabaseMessage('database.commitTransaction', { lockId: tx.lockId }))
+  } catch (error) {
+    await sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }).catch(() => undefined)
+    throw error
+  }
+}
+
+async function getBucket(bucketName: string, destination = testDestination()): Promise<BucketResponse | undefined> {
+  const result = await checkedResult<BucketRowsResponse>(
+    sendDatabaseMessage('database.query', {
+      destination,
+      requestId: randomUUID(),
+      sql: 'SELECT id, name, public FROM storage.buckets WHERE id = $1',
+      values: [bucketName],
+    })
+  )
+
+  return result.rows[0]
+}
+
+async function insertBucket(bucketName: string, destination = testDestination()): Promise<unknown> {
+  return sendDatabaseMessage('database.query', {
+    destination,
+    requestId: randomUUID(),
+    sql: `INSERT INTO storage.buckets (id, name, owner, public) VALUES ($1, $1, $2, false)`,
+    values: [bucketName, randomUUID()],
+  })
+}
+
+async function commitBucketDatabaseWatt(): Promise<{ bucketName: string }> {
+  const bucketName = uniqueBucketName('dbwatt-commit')
+  const tx = await beginTransaction()
+
+  try {
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: `INSERT INTO storage.buckets (id, name, owner, public) VALUES ($1, $1, $2, false)`,
+        values: [bucketName, randomUUID()],
+      })
+    )
+    await checkedResult(sendDatabaseMessage('database.commitTransaction', { lockId: tx.lockId }))
+    return { bucketName }
+  } catch (error) {
+    await sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }).catch(() => undefined)
+    throw error
+  }
 }
 
 async function masterTransaction(): Promise<{ value: number | undefined }> {
@@ -224,15 +312,28 @@ async function resetDatabaseWattStats(): Promise<void> {
 }
 
 describeDatabaseWattAcceptance(
-  'Database Watt E2E',
+  'Database Watt PostgreSQL integration',
   {
     destructive: true,
     profiles: ['core'],
   },
   () => {
-    it('executes stateless queries in the Database Watt worker', async () => {
-      await resetDatabaseWattStats()
+    beforeAll(async () => {
+      messaging = setupLoopbackMessaging('database-watt-acceptance')
+      app = await createDatabaseWattApp()
+    })
 
+    beforeEach(async () => {
+      await resetDatabaseWattStats()
+    })
+
+    afterAll(async () => {
+      await app?.close()
+      app = undefined
+      messaging = undefined
+    })
+
+    it('executes stateless queries in the Database Watt worker', async () => {
       const response = await queryDatabaseWatt()
       const stats = await getDatabaseWattStats()
 
@@ -248,7 +349,6 @@ describeDatabaseWattAcceptance(
         return
       }
 
-      await resetDatabaseWattStats()
       const response = await queryDatabaseWatt('master')
       const stats = await getDatabaseWattStats()
 
@@ -264,7 +364,6 @@ describeDatabaseWattAcceptance(
         return
       }
 
-      await resetDatabaseWattStats()
       const response = await masterTransaction()
       const stats = await getDatabaseWattStats()
 
@@ -274,56 +373,38 @@ describeDatabaseWattAcceptance(
       expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
     })
 
-    it('commits REST object changes through Database Watt transactions', async () => {
-      const client = createRestClient()
-      const token = requireServiceKey()
-      const bucketName = uniqueBucketName('dbwatt-commit')
-      const objectKey = uniqueObjectKey('dbwatt-commit')
-      await resetDatabaseWattStats()
-
+    it('commits bucket changes through Database Watt transactions', async () => {
+      let bucketName: string | undefined
       try {
-        await createRestBucket(bucketName, { isPublic: false })
-        await uploadRestObject(bucketName, objectKey, 'database-watt-commit')
-
-        const read = await client.request('GET', `/object/${bucketName}/${encodePathSegments(objectKey)}`, {
-          expectedStatus: 200,
-          token,
-        })
+        const committed = await commitBucketDatabaseWatt()
+        bucketName = committed.bucketName
+        const bucket = await getBucket(bucketName)
         const stats = await getDatabaseWattStats()
 
-        expect(read.body).toBe('database-watt-commit')
+        expect(bucket).toMatchObject({ id: bucketName, name: bucketName, public: false })
         expect(stats.beginTransaction).toBeGreaterThanOrEqual(1)
         expect(stats.lockedQuery).toBeGreaterThanOrEqual(1)
         expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
       } finally {
-        await cleanupRestResources(bucketName, [objectKey], client)
+        if (bucketName) {
+          await cleanupBucket(bucketName)
+        }
       }
     })
 
     it('rolls back failed transaction work and leaves no partial bucket state', async () => {
-      const client = createRestClient()
-      const token = requireServiceKey()
-      await resetDatabaseWattStats()
-
       const rollback = await rollbackDatabaseWatt()
       const bucketName = rollback.bucketName
       expect(bucketName).toBeTruthy()
 
-      const lookup = await client.request('GET', `/bucket/${bucketName}`, {
-        expectedStatus: 400,
-        token,
-      })
+      const bucket = await getBucket(bucketName)
       const stats = await getDatabaseWattStats()
 
-      expect(lookup.status).toBe(400)
+      expect(bucket).toBeUndefined()
       expect(stats.rollbackTransaction).toBeGreaterThanOrEqual(1)
     })
 
     it('preserves nested savepoint semantics in Database Watt transactions', async () => {
-      const client = createRestClient()
-      const token = requireServiceKey()
-      await resetDatabaseWattStats()
-
       const savepoint = await savepointDatabaseWatt()
       const outerBucket = savepoint.outerBucket
       const innerBucket = savepoint.innerBucket
@@ -332,56 +413,37 @@ describeDatabaseWattAcceptance(
         expect(outerBucket).toBeTruthy()
         expect(innerBucket).toBeTruthy()
 
-        const outer = await client.request<BucketResponse>('GET', `/bucket/${outerBucket}`, {
-          expectedStatus: 200,
-          token,
-        })
-        const inner = await client.request('GET', `/bucket/${innerBucket}`, {
-          expectedStatus: 400,
-          token,
-        })
+        const outer = await getBucket(outerBucket)
+        const inner = await getBucket(innerBucket)
         const stats = await getDatabaseWattStats()
 
-        expect(outer.json?.id).toBe(outerBucket)
-        expect(inner.status).toBe(400)
+        expect(outer?.id).toBe(outerBucket)
+        expect(inner).toBeUndefined()
         expect(stats.lockedQuery).toBeGreaterThanOrEqual(3)
         expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
       } finally {
         if (outerBucket) {
-          await cleanupRestResources(outerBucket, [], client)
+          await cleanupBucket(outerBucket)
         }
       }
     })
 
-    it('preserves storage error mapping when Database Watt returns PostgreSQL errors', async () => {
-      const client = createRestClient()
-      const token = requireServiceKey()
+    it('preserves PostgreSQL error mapping when Database Watt returns PostgreSQL errors', async () => {
       const bucketName = uniqueBucketName('dbwatt-error')
-      await resetDatabaseWattStats()
 
       try {
-        await createRestBucket(bucketName, { isPublic: false })
-        const duplicate = await client.request('POST', '/bucket', {
-          body: {
-            id: bucketName,
-            name: bucketName,
-            public: false,
-          },
-          expectedStatus: 400,
-          token,
-        })
+        await checkedResult(insertBucket(bucketName))
+        const duplicate = await insertBucket(bucketName) as ErrorResponse
         const stats = await getDatabaseWattStats()
 
-        expect(duplicate.status).toBe(400)
-        expect(stats.lockedQuery).toBeGreaterThanOrEqual(1)
+        expect(duplicate).toMatchObject({ code: 'POSTGRES_ERROR', sqlState: '23505' })
+        expect(stats.query).toBeGreaterThanOrEqual(2)
       } finally {
-        await cleanupRestResources(bucketName, [], client)
+        await cleanupBucket(bucketName)
       }
     })
 
     it('translates request aborts into Database Watt cancellation', async () => {
-      await resetDatabaseWattStats()
-
       const response = await sleepDatabaseWatt()
       const stats = await getDatabaseWattStats()
 
@@ -397,7 +459,6 @@ describeDatabaseWattAcceptance(
         return
       }
 
-      await resetDatabaseWattStats()
       const response = await missingDestinationDatabaseWatt()
 
       expect(response).toMatchObject({ code: 'DESTINATION_UNKNOWN' })
@@ -405,8 +466,6 @@ describeDatabaseWattAcceptance(
     })
 
     it('handles concurrent Database Watt query load', async () => {
-      await resetDatabaseWattStats()
-
       const response = await concurrentQueriesDatabaseWatt()
       const stats = await getDatabaseWattStats()
 
@@ -416,8 +475,6 @@ describeDatabaseWattAcceptance(
 
     it('exercises multitenant destination resolution when the target is multitenant', async () => {
       const config = getAcceptanceConfig()
-      const client = createRestClient()
-      const token = requireServiceKey(config)
       const bucketName = uniqueBucketName('dbwatt-tenant')
 
       if (!config.tenantId) {
@@ -425,19 +482,15 @@ describeDatabaseWattAcceptance(
         return
       }
 
-      await resetDatabaseWattStats()
       try {
-        await createRestBucket(bucketName, { isPublic: false })
-        const bucket = await client.request<BucketResponse>('GET', `/bucket/${bucketName}`, {
-          expectedStatus: 200,
-          token,
-        })
+        await checkedResult(insertBucket(bucketName, config.tenantId))
+        const bucket = await getBucket(bucketName, config.tenantId)
         const stats = await getDatabaseWattStats()
 
-        expect(bucket.json?.id).toBe(bucketName)
-        expect(stats.beginTransaction).toBeGreaterThanOrEqual(1)
+        expect(bucket?.id).toBe(bucketName)
+        expect(stats.query).toBeGreaterThanOrEqual(2)
       } finally {
-        await cleanupRestResources(bucketName, [], client)
+        await cleanupBucket(bucketName, config.tenantId)
       }
     })
   }

--- a/acceptance/specs/database-watt.test.ts
+++ b/acceptance/specs/database-watt.test.ts
@@ -1,0 +1,444 @@
+import { randomUUID } from 'node:crypto'
+import { describeAcceptance, encodePathSegments, getAcceptanceConfig } from '../support/config'
+import { createRestClient } from '../support/http'
+import {
+  cleanupRestResources,
+  createRestBucket,
+  requireServiceKey,
+  uniqueBucketName,
+  uniqueObjectKey,
+  uploadRestObject,
+} from '../support/resources'
+
+type DatabaseWattStats = {
+  acquire: number
+  beginTransaction: number
+  cancel: number
+  commitTransaction: number
+  lockedQuery: number
+  query: number
+  release: number
+  rollbackTransaction: number
+}
+
+type BucketResponse = {
+  id: string
+  name: string
+  public: boolean
+}
+
+type RollbackResponse = {
+  bucketName: string
+}
+
+type SavepointResponse = {
+  innerBucket: string
+  outerBucket: string
+}
+
+type QueryRowsResponse = {
+  rows: Array<{ value: number }>
+}
+
+type LockResponse = {
+  lockId: string
+}
+
+type ErrorResponse = {
+  code: string
+  destination?: string
+  message: string
+}
+
+const describeDatabaseWattAcceptance = process.env.ACCEPTANCE_DATABASE_WATT === 'true' ? describeAcceptance : describe.skip
+
+function testDestination(): string {
+  return process.env.ACCEPTANCE_TENANT_ID || process.env.TENANT_ID || 'default'
+}
+
+function sendDatabaseMessage<T = unknown>(message: string, payload: unknown): Promise<T> {
+  return sendWattMessage<T>('database', message, payload)
+}
+
+function isDatabaseError(result: unknown): result is ErrorResponse {
+  return typeof result === 'object' && result !== null && 'code' in result && 'message' in result
+}
+
+async function checkedResult<T = unknown>(resultPromise: Promise<unknown>): Promise<T> {
+  const result = await resultPromise
+  if (isDatabaseError(result)) {
+    throw new Error(result.message)
+  }
+  return result as T
+}
+
+async function beginTransaction(destination = testDestination()): Promise<LockResponse> {
+  return checkedResult(
+    sendDatabaseMessage('database.beginTransaction', {
+      destination,
+      requestId: randomUUID(),
+    })
+  )
+}
+
+async function queryDatabaseWatt(destination = testDestination()): Promise<QueryRowsResponse> {
+  return sendDatabaseMessage('database.query', {
+    destination,
+    requestId: randomUUID(),
+    sql: 'SELECT 1 as value',
+  })
+}
+
+async function masterTransaction(): Promise<{ value: number | undefined }> {
+  const tx = await beginTransaction('master')
+
+  try {
+    const result = await checkedResult<QueryRowsResponse>(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: 'SELECT 1 as value',
+      })
+    )
+    await checkedResult(sendDatabaseMessage('database.commitTransaction', { lockId: tx.lockId }))
+    return { value: result.rows[0]?.value }
+  } catch (error) {
+    await sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }).catch(() => undefined)
+    throw error
+  }
+}
+
+async function rollbackDatabaseWatt(): Promise<RollbackResponse> {
+  const bucketName = `db-watt-rollback-${Date.now()}`
+  const tx = await beginTransaction()
+
+  try {
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: `INSERT INTO storage.buckets (id, name, owner, public) VALUES ($1, $1, $2, false)`,
+        values: [bucketName, randomUUID()],
+      })
+    )
+    await checkedResult(sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }))
+    return { bucketName }
+  } catch (error) {
+    await sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }).catch(() => undefined)
+    throw error
+  }
+}
+
+async function savepointDatabaseWatt(): Promise<SavepointResponse> {
+  const innerBucket = `db-watt-savepoint-inner-${Date.now()}`
+  const outerBucket = `db-watt-savepoint-outer-${Date.now()}`
+  const tx = await beginTransaction()
+
+  try {
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: `INSERT INTO storage.buckets (id, name, owner, public) VALUES ($1, $1, $2, false)`,
+        values: [outerBucket, randomUUID()],
+      })
+    )
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: 'SAVEPOINT database_watt_acceptance',
+      })
+    )
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: `INSERT INTO storage.buckets (id, name, owner, public) VALUES ($1, $1, $2, false)`,
+        values: [innerBucket, randomUUID()],
+      })
+    )
+    await checkedResult(
+      sendDatabaseMessage('database.lockedQuery', {
+        lockId: tx.lockId,
+        requestId: randomUUID(),
+        sql: 'ROLLBACK TO SAVEPOINT database_watt_acceptance',
+      })
+    )
+    await checkedResult(sendDatabaseMessage('database.commitTransaction', { lockId: tx.lockId }))
+    return { innerBucket, outerBucket }
+  } catch (error) {
+    await sendDatabaseMessage('database.rollbackTransaction', { lockId: tx.lockId }).catch(() => undefined)
+    throw error
+  }
+}
+
+async function sleepDatabaseWatt(): Promise<ErrorResponse> {
+  const requestId = randomUUID()
+  const query = sendDatabaseMessage<ErrorResponse>('database.query', {
+    destination: testDestination(),
+    requestId,
+    sql: 'SELECT pg_sleep(10)',
+  })
+
+  setTimeout(() => {
+    sendDatabaseMessage('database.cancel', { requestId }).catch(() => undefined)
+  }, 50).unref()
+
+  return query
+}
+
+async function missingDestinationDatabaseWatt(): Promise<ErrorResponse> {
+  return sendDatabaseMessage('database.query', {
+    destination: `missing-${randomUUID()}`,
+    requestId: randomUUID(),
+    sql: 'SELECT 1',
+  })
+}
+
+async function concurrentQueriesDatabaseWatt(): Promise<{ count: number }> {
+  const results = await Promise.all(
+    Array.from({ length: 5 }, () =>
+      sendDatabaseMessage<QueryRowsResponse | ErrorResponse>('database.query', {
+        destination: testDestination(),
+        requestId: randomUUID(),
+        sql: 'SELECT 1 as value',
+      })
+    )
+  )
+  const error = results.find(isDatabaseError)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return { count: results.length }
+}
+
+async function getDatabaseWattStats(): Promise<DatabaseWattStats> {
+  return sendDatabaseMessage('database.test.stats', {})
+}
+
+async function resetDatabaseWattStats(): Promise<void> {
+  await sendDatabaseMessage('database.test.resetStats', {})
+}
+
+describeDatabaseWattAcceptance(
+  'Database Watt E2E',
+  {
+    destructive: true,
+    profiles: ['core'],
+  },
+  () => {
+    it('executes stateless queries in the Database Watt worker', async () => {
+      await resetDatabaseWattStats()
+
+      const response = await queryDatabaseWatt()
+      const stats = await getDatabaseWattStats()
+
+      expect(response.rows[0]).toEqual({ value: 1 })
+      expect(stats.query).toBeGreaterThanOrEqual(1)
+    })
+
+    it('executes master database queries through Database Watt', async () => {
+      const config = getAcceptanceConfig()
+
+      if (!config.tenantId) {
+        expect(config.tenantId).toBeUndefined()
+        return
+      }
+
+      await resetDatabaseWattStats()
+      const response = await queryDatabaseWatt('master')
+      const stats = await getDatabaseWattStats()
+
+      expect(response.rows[0]).toEqual({ value: 1 })
+      expect(stats.query).toBeGreaterThanOrEqual(1)
+    })
+
+    it('executes master database transactions through Database Watt', async () => {
+      const config = getAcceptanceConfig()
+
+      if (!config.tenantId) {
+        expect(config.tenantId).toBeUndefined()
+        return
+      }
+
+      await resetDatabaseWattStats()
+      const response = await masterTransaction()
+      const stats = await getDatabaseWattStats()
+
+      expect(response).toEqual({ value: 1 })
+      expect(stats.beginTransaction).toBeGreaterThanOrEqual(1)
+      expect(stats.lockedQuery).toBeGreaterThanOrEqual(1)
+      expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
+    })
+
+    it('commits REST object changes through Database Watt transactions', async () => {
+      const client = createRestClient()
+      const token = requireServiceKey()
+      const bucketName = uniqueBucketName('dbwatt-commit')
+      const objectKey = uniqueObjectKey('dbwatt-commit')
+      await resetDatabaseWattStats()
+
+      try {
+        await createRestBucket(bucketName, { isPublic: false })
+        await uploadRestObject(bucketName, objectKey, 'database-watt-commit')
+
+        const read = await client.request('GET', `/object/${bucketName}/${encodePathSegments(objectKey)}`, {
+          expectedStatus: 200,
+          token,
+        })
+        const stats = await getDatabaseWattStats()
+
+        expect(read.body).toBe('database-watt-commit')
+        expect(stats.beginTransaction).toBeGreaterThanOrEqual(1)
+        expect(stats.lockedQuery).toBeGreaterThanOrEqual(1)
+        expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
+      } finally {
+        await cleanupRestResources(bucketName, [objectKey], client)
+      }
+    })
+
+    it('rolls back failed transaction work and leaves no partial bucket state', async () => {
+      const client = createRestClient()
+      const token = requireServiceKey()
+      await resetDatabaseWattStats()
+
+      const rollback = await rollbackDatabaseWatt()
+      const bucketName = rollback.bucketName
+      expect(bucketName).toBeTruthy()
+
+      const lookup = await client.request('GET', `/bucket/${bucketName}`, {
+        expectedStatus: 400,
+        token,
+      })
+      const stats = await getDatabaseWattStats()
+
+      expect(lookup.status).toBe(400)
+      expect(stats.rollbackTransaction).toBeGreaterThanOrEqual(1)
+    })
+
+    it('preserves nested savepoint semantics in Database Watt transactions', async () => {
+      const client = createRestClient()
+      const token = requireServiceKey()
+      await resetDatabaseWattStats()
+
+      const savepoint = await savepointDatabaseWatt()
+      const outerBucket = savepoint.outerBucket
+      const innerBucket = savepoint.innerBucket
+
+      try {
+        expect(outerBucket).toBeTruthy()
+        expect(innerBucket).toBeTruthy()
+
+        const outer = await client.request<BucketResponse>('GET', `/bucket/${outerBucket}`, {
+          expectedStatus: 200,
+          token,
+        })
+        const inner = await client.request('GET', `/bucket/${innerBucket}`, {
+          expectedStatus: 400,
+          token,
+        })
+        const stats = await getDatabaseWattStats()
+
+        expect(outer.json?.id).toBe(outerBucket)
+        expect(inner.status).toBe(400)
+        expect(stats.lockedQuery).toBeGreaterThanOrEqual(3)
+        expect(stats.commitTransaction).toBeGreaterThanOrEqual(1)
+      } finally {
+        if (outerBucket) {
+          await cleanupRestResources(outerBucket, [], client)
+        }
+      }
+    })
+
+    it('preserves storage error mapping when Database Watt returns PostgreSQL errors', async () => {
+      const client = createRestClient()
+      const token = requireServiceKey()
+      const bucketName = uniqueBucketName('dbwatt-error')
+      await resetDatabaseWattStats()
+
+      try {
+        await createRestBucket(bucketName, { isPublic: false })
+        const duplicate = await client.request('POST', '/bucket', {
+          body: {
+            id: bucketName,
+            name: bucketName,
+            public: false,
+          },
+          expectedStatus: 400,
+          token,
+        })
+        const stats = await getDatabaseWattStats()
+
+        expect(duplicate.status).toBe(400)
+        expect(stats.lockedQuery).toBeGreaterThanOrEqual(1)
+      } finally {
+        await cleanupRestResources(bucketName, [], client)
+      }
+    })
+
+    it('translates request aborts into Database Watt cancellation', async () => {
+      await resetDatabaseWattStats()
+
+      const response = await sleepDatabaseWatt()
+      const stats = await getDatabaseWattStats()
+
+      expect(response).toMatchObject({ code: expect.any(String) })
+      expect(stats.cancel).toBeGreaterThanOrEqual(1)
+    })
+
+    it('returns typed destination errors through the Database Watt worker', async () => {
+      const config = getAcceptanceConfig()
+
+      if (!config.tenantId) {
+        expect(config.tenantId).toBeUndefined()
+        return
+      }
+
+      await resetDatabaseWattStats()
+      const response = await missingDestinationDatabaseWatt()
+
+      expect(response).toMatchObject({ code: 'DESTINATION_UNKNOWN' })
+      expect(response.destination).toEqual(expect.stringMatching(/^missing-/))
+    })
+
+    it('handles concurrent Database Watt query load', async () => {
+      await resetDatabaseWattStats()
+
+      const response = await concurrentQueriesDatabaseWatt()
+      const stats = await getDatabaseWattStats()
+
+      expect(response).toEqual({ count: 5 })
+      expect(stats.query).toBeGreaterThanOrEqual(5)
+    })
+
+    it('exercises multitenant destination resolution when the target is multitenant', async () => {
+      const config = getAcceptanceConfig()
+      const client = createRestClient()
+      const token = requireServiceKey(config)
+      const bucketName = uniqueBucketName('dbwatt-tenant')
+
+      if (!config.tenantId) {
+        expect(config.tenantId).toBeUndefined()
+        return
+      }
+
+      await resetDatabaseWattStats()
+      try {
+        await createRestBucket(bucketName, { isPublic: false })
+        const bucket = await client.request<BucketResponse>('GET', `/bucket/${bucketName}`, {
+          expectedStatus: 200,
+          token,
+        })
+        const stats = await getDatabaseWattStats()
+
+        expect(bucket.json?.id).toBe(bucketName)
+        expect(stats.beginTransaction).toBeGreaterThanOrEqual(1)
+      } finally {
+        await cleanupRestResources(bucketName, [], client)
+      }
+    })
+  }
+)

--- a/docs/database-watt-postgresql-scope.md
+++ b/docs/database-watt-postgresql-scope.md
@@ -1,0 +1,18 @@
+# Database Watt PostgreSQL Ownership
+
+Database Watt owns runtime PostgreSQL access for storage metadata and multitenant master DB queries when the app runs under Watt.
+
+## Routed Through Database Watt
+
+- Tenant metadata DB access via `getPostgresConnection()` when Watt messaging is available.
+- Multitenant master DB access via `multitenantPgExecutor` when Watt messaging is available.
+
+## Direct PostgreSQL Access That Remains
+
+- Direct PostgreSQL fallback for non-Watt/local mode.
+- Queue/pg-boss access in `src/internal/queue/database.ts`; queues are intentionally out of this migration for now.
+- Migration runner access in `src/internal/database/migrations/migrate.ts`; migrations are intentionally out of scope for Database Watt for now.
+- Tests and seeding utilities.
+- `pg` type/error imports used to preserve existing public interfaces and error mapping.
+
+Any new runtime PostgreSQL access should go through Database Watt unless it is explicitly documented here as an exception.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "devDependencies": {
         "@aws-sdk/s3-presigned-post": "^3.1023.0",
         "@biomejs/biome": "2.5.1",
+        "@platformatic/runtime": "^3.59.0",
         "@types/js-yaml": "^4.0.5",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^24.12.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:integration:coverage": "vitest run --coverage --config vitest.integration.config.ts",
     "acceptance": "tsx acceptance/scripts/run-managed-local.ts",
+    "acceptance:watt": "tsx acceptance/scripts/run-managed-watt-local.ts",
     "acceptance:run": "tsx acceptance/scripts/run.ts",
     "acceptance:typecheck": "tsc -p acceptance/tsconfig.json --noEmit",
     "test": "npm run test:unit && npm run infra:restart && npm run test:dummy-data && npm run test:integration",
@@ -115,6 +116,7 @@
   "devDependencies": {
     "@aws-sdk/s3-presigned-post": "^3.1023.0",
     "@biomejs/biome": "2.5.1",
+    "@platformatic/runtime": "^3.59.0",
     "@types/js-yaml": "^4.0.5",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^24.12.0",

--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -1,13 +1,60 @@
 import { vi } from 'vitest'
 
-const getGlobal = vi.hoisted(() => vi.fn())
 const lastLocalMigrationName = vi.hoisted(() => vi.fn())
 const adminApiKey = 'test-admin-api-key'
 const originalServerAdminApiKeys = process.env.SERVER_ADMIN_API_KEYS
 
-vi.mock('@platformatic/globals', () => ({
-  getGlobal,
-}))
+function mockAdminAppDependencies() {
+  vi.doMock('./config', () => ({
+    getConfig: () => ({
+      adminApiKeys: adminApiKey,
+      prometheusMetricsEnabled: false,
+      version: 'test',
+    }),
+  }))
+  vi.doMock('@internal/monitoring/otel-metrics', () => ({
+    handleMetricsRequest: vi.fn(),
+  }))
+  vi.doMock('./http', () => ({
+    plugins: {
+      adminTenantId: async () => {},
+      logRequest: () => async () => {},
+      registerApiKeyAuth: (fastify: {
+        addHook: (name: string, hook: Function) => void
+      }) => {
+        fastify.addHook(
+          'onRequest',
+          async (
+            request: { headers: Record<string, unknown> },
+            reply: { status: Function }
+          ) => {
+            if (request.headers.apikey !== adminApiKey) {
+              return reply.status(401).send()
+            }
+          }
+        )
+      },
+      requestContext: async () => {},
+      signals: async () => {},
+    },
+    routes: {
+      jwks: async () => {},
+      icebergAdmin: async () => {},
+      metricsConfig: async () => {},
+      migrations: async () => {},
+      objects: async () => {},
+      pprof: async (fastify: { get: Function }) => {
+        fastify.get('/profile', async (_request: unknown, reply: { status: Function }) => {
+          return reply.status(401).send()
+        })
+      },
+      queue: async () => {},
+      s3Credentials: async () => {},
+      tenants: async () => {},
+    },
+    setErrorHandler: vi.fn(),
+  }))
+}
 
 vi.mock('@internal/database/migrations', async () => {
   const actual = await vi.importActual<typeof import('@internal/database/migrations')>(
@@ -20,17 +67,42 @@ vi.mock('@internal/database/migrations', async () => {
 })
 
 async function buildAdminApp() {
-  vi.resetModules()
+  mockAdminAppDependencies()
   const { default: buildAdmin } = await import('./admin-app')
   const app = buildAdmin({})
   await app.ready()
   return app
 }
 
+async function clearWattGlobals() {
+  const { removeGlobals } = await import('@platformatic/globals')
+  removeGlobals(['applicationId', 'workerId', 'messaging'])
+}
+
+async function setWattGlobals() {
+  const { updateGlobals } = await import('@platformatic/globals')
+  updateGlobals({
+    applicationId: 'storage',
+    workerId: 0,
+  })
+}
+
 describe('admin app', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.useRealTimers()
+    vi.resetModules()
+    await clearWattGlobals()
     process.env.SERVER_ADMIN_API_KEYS = adminApiKey
     lastLocalMigrationName.mockResolvedValue('storage-schema')
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await clearWattGlobals()
+    vi.doUnmock('./config')
+    vi.doUnmock('@internal/monitoring/otel-metrics')
+    vi.doUnmock('./http')
+    vi.resetModules()
   })
 
   afterAll(() => {
@@ -42,8 +114,6 @@ describe('admin app', () => {
   })
 
   it('does not register pprof endpoints outside Watt', async () => {
-    getGlobal.mockReturnValue(undefined)
-
     const app = await buildAdminApp()
 
     try {
@@ -59,10 +129,7 @@ describe('admin app', () => {
   })
 
   it('registers pprof endpoints under Watt', async () => {
-    getGlobal.mockReturnValue({
-      applicationId: 'storage',
-      workerId: 0,
-    })
+    await setWattGlobals()
 
     const app = await buildAdminApp()
 
@@ -79,7 +146,6 @@ describe('admin app', () => {
   })
 
   it('returns the stack migration version', async () => {
-    getGlobal.mockReturnValue(undefined)
     lastLocalMigrationName.mockResolvedValue('create-migrations-table')
 
     const app = await buildAdminApp()
@@ -103,8 +169,6 @@ describe('admin app', () => {
   })
 
   it('requires the admin API key for the stack migration version', async () => {
-    getGlobal.mockReturnValue(undefined)
-
     const app = await buildAdminApp()
 
     try {

--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const lastLocalMigrationName = vi.hoisted(() => vi.fn())
 const adminApiKey = 'test-admin-api-key'

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -2,7 +2,7 @@ import fastifySwagger from '@fastify/swagger'
 import fastifySwaggerUi from '@fastify/swagger-ui'
 import { lastLocalMigrationName } from '@internal/database/migrations'
 import { handleMetricsRequest } from '@internal/monitoring/otel-metrics'
-import { getGlobal } from '@platformatic/globals'
+import { hasField } from '@platformatic/globals'
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import { getConfig } from './config'
 import { plugins, routes, setErrorHandler } from './http'
@@ -15,7 +15,7 @@ const { version, prometheusMetricsEnabled } = getConfig()
 
 const build = (opts: buildOpts = {}): FastifyInstance => {
   const app = fastify(opts)
-  const isRunningUnderWatt = typeof getGlobal()?.applicationId === 'string'
+  const isRunningUnderWatt = hasField('applicationId')
 
   if (opts.exposeDocs) {
     app.register(fastifySwagger, {

--- a/src/database/cancellation.ts
+++ b/src/database/cancellation.ts
@@ -1,0 +1,132 @@
+import type { PoolClient } from 'pg'
+import PgConnection from 'pg/lib/connection'
+
+export type CancellableClient = PoolClient & {
+  processID?: number
+  secretKey?: number
+  host?: string | string[]
+  port?: number
+  connectionParameters?: {
+    host?: string | string[]
+    port?: number
+  }
+}
+
+export type InFlightOperation = {
+  client?: CancellableClient
+  lockId?: string
+  cancelled: boolean
+}
+
+export class CancellationRegistry {
+  private readonly operations = new Map<string, InFlightOperation>()
+
+  start(requestId: string | undefined, operation: InFlightOperation): void {
+    if (requestId) {
+      this.operations.set(requestId, operation)
+    }
+  }
+
+  setClient(requestId: string | undefined, client: CancellableClient): void {
+    if (!requestId) {
+      return
+    }
+
+    const operation = this.operations.get(requestId)
+    if (operation) {
+      operation.client = client
+    }
+  }
+
+  finish(requestId: string | undefined): void {
+    if (requestId) {
+      this.operations.delete(requestId)
+    }
+  }
+
+  async cancel(requestId: string, lockId?: string): Promise<{ cancelled: boolean }> {
+    const operation = this.operations.get(requestId)
+    if (!operation) {
+      return { cancelled: false }
+    }
+
+    if (lockId && operation.lockId && operation.lockId !== lockId) {
+      return { cancelled: false }
+    }
+
+    operation.cancelled = true
+    if (operation.client) {
+      await cancelPgQuery(operation.client)
+    }
+
+    return { cancelled: true }
+  }
+}
+
+async function cancelPgQuery(client: CancellableClient): Promise<void> {
+  const processID = client.processID
+  const secretKey = client.secretKey
+
+  if (!processID || !secretKey) {
+    return
+  }
+
+  const cancelConnection = new PgConnection()
+  cancelConnection.unref()
+  const target = getPgCancelConnectionTarget(client)
+
+  return new Promise((resolve) => {
+    let resolved = false
+
+    const done = () => {
+      if (resolved) {
+        return
+      }
+
+      resolved = true
+      clearTimeout(timeout)
+      cancelConnection.end()
+      resolve()
+    }
+
+    const timeout = setTimeout(done, 5_000)
+    timeout.unref()
+
+    cancelConnection.on('error', done)
+    cancelConnection.on('end', done)
+    cancelConnection.on('connect', () => {
+      try {
+        cancelConnection.cancel(processID, secretKey)
+      } catch {
+        done()
+      }
+    })
+
+    if (target.type === 'socket') {
+      cancelConnection.connect(target.path)
+    } else {
+      cancelConnection.connect(target.port, target.host)
+    }
+  })
+}
+
+function getPgCancelConnectionTarget(
+  client: Pick<CancellableClient, 'host' | 'port' | 'connectionParameters'>
+): { type: 'socket'; path: string } | { type: 'tcp'; host: string; port: number } {
+  const rawHost = client.host || client.connectionParameters?.host || 'localhost'
+  const host = Array.isArray(rawHost) ? rawHost[0] || 'localhost' : rawHost
+  const port = client.port || client.connectionParameters?.port || 5432
+
+  if (host.startsWith('/')) {
+    return {
+      type: 'socket',
+      path: `${host}/.s.PGSQL.${port}`,
+    }
+  }
+
+  return {
+    type: 'tcp',
+    host,
+    port,
+  }
+}

--- a/src/database/config.ts
+++ b/src/database/config.ts
@@ -22,6 +22,7 @@ export type DatabaseConfig = {
   maxResultRows: number
   maxSerializedRequestBytes: number
   maxSqlBytes: number
+  poolIsExternal: boolean
   poolConnectionString?: string
   poolMode?: string
   rootCert?: string
@@ -73,6 +74,7 @@ export function readConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig
       10 * 1024 * 1024
     ),
     maxSqlBytes: readPositiveInteger(env.DATABASE_WATT_MAX_SQL_BYTES, 1024 * 1024),
+    poolIsExternal: Boolean(env.DATABASE_POOL_URL),
     poolConnectionString: env.DATABASE_POOL_URL || env.DATABASE_URL,
     poolMode: env.DATABASE_POOL_MODE,
     rootCert: readRootCert(env.DATABASE_SSL_ROOT_CERT),

--- a/src/database/config.ts
+++ b/src/database/config.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs'
+
+export type DatabaseConfig = {
+  applicationName: string
+  acquireTimeoutMs: number
+  connectionTimeoutMs: number
+  destinationAcquireQueueLimit: number
+  destinationMaxConnections: number
+  globalAcquireQueueLimit: number
+  globalMaxConnections: number
+  idlePoolTimeoutMs: number
+  lockIdleTimeoutMs: number
+  lockMaxLifetimeMs: number
+  masterIsExternalPool: boolean
+  masterConnectionString?: string
+  masterMaxConnections: number
+  maxActivePools: number
+  maxOperationNameLength: number
+  maxParameterCount: number
+  maxRequestIdLength: number
+  maxResultBytes: number
+  maxResultRows: number
+  maxSerializedRequestBytes: number
+  maxSqlBytes: number
+  poolConnectionString?: string
+  poolMode?: string
+  rootCert?: string
+  serverStatementTimeoutMs: number
+  shutdownTimeoutMs: number
+}
+
+export function readConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {
+  return {
+    applicationName: env.DATABASE_APPLICATION_NAME || `Supabase Storage Database Watt`,
+    acquireTimeoutMs: readPositiveInteger(env.DATABASE_WATT_ACQUIRE_TIMEOUT, 3_000),
+    connectionTimeoutMs: readPositiveInteger(env.DATABASE_CONNECTION_TIMEOUT, 3_000),
+    destinationAcquireQueueLimit: readPositiveInteger(
+      env.DATABASE_WATT_DESTINATION_ACQUIRE_QUEUE_LIMIT,
+      100
+    ),
+    destinationMaxConnections: readPositiveInteger(
+      env.DATABASE_WATT_DESTINATION_MAX_CONNECTIONS || env.DATABASE_MAX_CONNECTIONS,
+      20
+    ),
+    globalAcquireQueueLimit: readPositiveInteger(env.DATABASE_WATT_GLOBAL_ACQUIRE_QUEUE_LIMIT, 500),
+    globalMaxConnections: readPositiveInteger(
+      env.DATABASE_WATT_GLOBAL_MAX_CONNECTIONS || env.DATABASE_MAX_CONNECTIONS,
+      20
+    ),
+    idlePoolTimeoutMs: readPositiveInteger(
+      env.DATABASE_WATT_POOL_IDLE_TIMEOUT || env.DATABASE_FREE_POOL_AFTER_INACTIVITY,
+      60_000
+    ),
+    lockIdleTimeoutMs: readPositiveInteger(env.DATABASE_WATT_LOCK_IDLE_TIMEOUT, 30_000),
+    lockMaxLifetimeMs: readPositiveInteger(env.DATABASE_WATT_LOCK_MAX_LIFETIME, 120_000),
+    masterConnectionString:
+      isTruthy(env.MULTI_TENANT) || isTruthy(env.IS_MULTITENANT)
+        ? env.DATABASE_MULTITENANT_POOL_URL || env.DATABASE_MULTITENANT_URL
+        : undefined,
+    masterIsExternalPool: Boolean(env.DATABASE_MULTITENANT_POOL_URL),
+    masterMaxConnections: readPositiveInteger(
+      env.DATABASE_MULTITENANT_MAX_CONNECTIONS || env.DATABASE_WATT_MASTER_MAX_CONNECTIONS,
+      10
+    ),
+    maxActivePools: readPositiveInteger(env.DATABASE_WATT_MAX_ACTIVE_POOLS, 1_000),
+    maxOperationNameLength: readPositiveInteger(env.DATABASE_WATT_MAX_OPERATION_NAME_LENGTH, 128),
+    maxParameterCount: readPositiveInteger(env.DATABASE_WATT_MAX_PARAMETER_COUNT, 10_000),
+    maxRequestIdLength: readPositiveInteger(env.DATABASE_WATT_MAX_REQUEST_ID_LENGTH, 128),
+    maxResultBytes: readPositiveInteger(env.DATABASE_WATT_MAX_RESULT_BYTES, 10 * 1024 * 1024),
+    maxResultRows: readPositiveInteger(env.DATABASE_WATT_MAX_RESULT_ROWS, 10_000),
+    maxSerializedRequestBytes: readPositiveInteger(
+      env.DATABASE_WATT_MAX_SERIALIZED_REQUEST_BYTES,
+      10 * 1024 * 1024
+    ),
+    maxSqlBytes: readPositiveInteger(env.DATABASE_WATT_MAX_SQL_BYTES, 1024 * 1024),
+    poolConnectionString: env.DATABASE_POOL_URL || env.DATABASE_URL,
+    poolMode: env.DATABASE_POOL_MODE,
+    rootCert: readRootCert(env.DATABASE_SSL_ROOT_CERT),
+    serverStatementTimeoutMs: readInteger(env.DATABASE_STATEMENT_TIMEOUT, 30_000),
+    shutdownTimeoutMs: readPositiveInteger(env.DATABASE_WATT_SHUTDOWN_TIMEOUT, 10_000),
+  }
+}
+
+function readInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === '') {
+    return fallback
+  }
+
+  const numberValue = Number.parseInt(value, 10)
+  return Number.isFinite(numberValue) ? numberValue : fallback
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  return Math.max(readInteger(value, fallback), 0)
+}
+
+function readRootCert(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  if (value.includes('-----BEGIN CERTIFICATE-----')) {
+    return value
+  }
+
+  return readFileSync(value, 'utf8')
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes'
+}

--- a/src/database/destinations.ts
+++ b/src/database/destinations.ts
@@ -36,7 +36,7 @@ export class DestinationResolver {
     return {
       connectionString,
       id: destination,
-      isExternalPool: Boolean(process.env.DATABASE_POOL_URL),
+      isExternalPool: this.config.poolIsExternal,
       maxConnections: this.config.destinationMaxConnections,
       poolMode: this.config.poolMode,
     }

--- a/src/database/destinations.ts
+++ b/src/database/destinations.ts
@@ -1,0 +1,117 @@
+import { Pool } from 'pg'
+import type { DatabaseConfig } from './config.js'
+import { DatabaseWattError } from './errors.js'
+import { getSslSettings } from './ssl.js'
+import type { DestinationConfig } from './types.js'
+
+type TenantRow = {
+  database_pool_mode?: string | null
+  database_pool_url?: string | null
+  database_url: string
+  max_connections?: number | null
+}
+
+export class DestinationResolver {
+  private masterPool?: Pool
+  private readonly config: DatabaseConfig
+
+  constructor(config: DatabaseConfig) {
+    this.config = config
+  }
+
+  async resolve(destination: string): Promise<DestinationConfig> {
+    if (destination === 'master') {
+      return this.resolveMasterDestination()
+    }
+
+    if (this.config.masterConnectionString) {
+      return this.resolveTenant(destination)
+    }
+
+    const connectionString = this.config.poolConnectionString
+    if (!connectionString) {
+      throw new DatabaseWattError('DESTINATION_UNKNOWN', 'No database connection string configured')
+    }
+
+    return {
+      connectionString,
+      id: destination,
+      isExternalPool: Boolean(process.env.DATABASE_POOL_URL),
+      maxConnections: this.config.destinationMaxConnections,
+      poolMode: this.config.poolMode,
+    }
+  }
+
+  async close(): Promise<void> {
+    const pool = this.masterPool
+    this.masterPool = undefined
+    if (pool) {
+      await pool.end()
+    }
+  }
+
+  private async resolveTenant(destination: string): Promise<DestinationConfig> {
+    const result = await this.getMasterPool().query<TenantRow>(
+      `
+        SELECT database_url, database_pool_url, database_pool_mode, max_connections
+        FROM tenants
+        WHERE id = $1
+        LIMIT 1
+      `,
+      [destination]
+    )
+
+    const tenant = result.rows[0]
+    if (!tenant) {
+      throw new DatabaseWattError('DESTINATION_UNKNOWN', 'Destination is unknown')
+    }
+
+    const connectionString = tenant.database_pool_url || tenant.database_url
+    if (!connectionString) {
+      throw new DatabaseWattError('DESTINATION_UNKNOWN', 'Destination has no database credentials')
+    }
+
+    return {
+      connectionString,
+      id: destination,
+      isExternalPool: Boolean(tenant.database_pool_url),
+      maxConnections: tenant.max_connections || this.config.destinationMaxConnections,
+      poolMode: tenant.database_pool_mode,
+    }
+  }
+
+  private resolveMasterDestination(): DestinationConfig {
+    const connectionString = this.config.masterConnectionString
+    if (!connectionString) {
+      throw new DatabaseWattError('DESTINATION_UNKNOWN', 'No multitenant database configured')
+    }
+
+    return {
+      connectionString,
+      id: 'master',
+      isExternalPool: this.config.masterIsExternalPool,
+      maxConnections: this.config.masterMaxConnections,
+    }
+  }
+
+  private getMasterPool(): Pool {
+    const connectionString = this.config.masterConnectionString
+    if (!connectionString) {
+      throw new DatabaseWattError('DESTINATION_UNKNOWN', 'No multitenant database configured')
+    }
+
+    if (!this.masterPool) {
+      this.masterPool = new Pool({
+        application_name: this.config.applicationName,
+        connectionString,
+        connectionTimeoutMillis: this.config.connectionTimeoutMs,
+        idleTimeoutMillis: this.config.idlePoolTimeoutMs,
+        max: this.config.masterMaxConnections,
+        min: 0,
+        ssl: getSslSettings(connectionString, this.config.rootCert),
+      })
+    }
+
+    return this.masterPool
+  }
+}

--- a/src/database/errors.ts
+++ b/src/database/errors.ts
@@ -1,0 +1,117 @@
+import { DatabaseError } from 'pg'
+
+export type DatabaseErrorCode =
+  | 'POSTGRES_ERROR'
+  | 'DESTINATION_UNKNOWN'
+  | 'CLIENT_TIMEOUT'
+  | 'SERVER_TIMEOUT'
+  | 'CONNECTION_TIMEOUT'
+  | 'ACQUIRE_TIMEOUT'
+  | 'MESSAGING_TIMEOUT'
+  | 'MESSAGING_ERROR'
+  | 'BUSY'
+  | 'RESULT_TOO_LARGE'
+  | 'PROTOCOL_ERROR'
+  | 'SHUTDOWN'
+
+export type DatabaseErrorResponse = {
+  code: DatabaseErrorCode
+  message: string
+  requestId?: string
+  operationName?: string
+  destination?: string
+  lockId?: string
+  sqlState?: string
+  stack?: string
+  connectionDiscarded?: boolean
+}
+
+export type ErrorContext = {
+  requestId?: string
+  operationName?: string
+  destination?: string
+  lockId?: string
+}
+
+export class DatabaseWattError extends Error {
+  readonly code: DatabaseErrorCode
+  readonly connectionDiscarded?: boolean
+  readonly sqlState?: string
+
+  constructor(
+    code: DatabaseErrorCode,
+    message: string,
+    options: { connectionDiscarded?: boolean; cause?: unknown; sqlState?: string } = {}
+  ) {
+    super(message, { cause: options.cause })
+    this.name = 'DatabaseWattError'
+    this.code = code
+    this.connectionDiscarded = options.connectionDiscarded
+    this.sqlState = options.sqlState
+  }
+}
+
+export function toErrorResponse(error: unknown, context: ErrorContext = {}): DatabaseErrorResponse {
+  if (error instanceof DatabaseWattError) {
+    return {
+      code: error.code,
+      message: error.message,
+      requestId: context.requestId,
+      operationName: context.operationName,
+      destination: context.destination,
+      lockId: context.lockId,
+      sqlState: error.sqlState,
+      stack: error.stack,
+      connectionDiscarded: error.connectionDiscarded,
+    }
+  }
+
+  if (error instanceof DatabaseError) {
+    return {
+      code: 'POSTGRES_ERROR',
+      message: error.message,
+      requestId: context.requestId,
+      operationName: context.operationName,
+      destination: context.destination,
+      lockId: context.lockId,
+      sqlState: error.code,
+      stack: error.stack,
+    }
+  }
+
+  if (isConnectionTimeoutError(error)) {
+    const connectionError = error as Error
+    return {
+      code: 'CONNECTION_TIMEOUT',
+      message: connectionError.message,
+      requestId: context.requestId,
+      operationName: context.operationName,
+      destination: context.destination,
+      lockId: context.lockId,
+      stack: connectionError.stack,
+    }
+  }
+
+  const fallback = error instanceof Error ? error : new Error(String(error))
+  return {
+    code: 'MESSAGING_ERROR',
+    message: fallback.message,
+    requestId: context.requestId,
+    operationName: context.operationName,
+    destination: context.destination,
+    lockId: context.lockId,
+    stack: fallback.stack,
+  }
+}
+
+export function isErrorResponse(value: unknown): boolean {
+  return Boolean(value && typeof value === 'object' && 'code' in value && 'message' in value)
+}
+
+function isConnectionTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === 'timeout expired' ||
+      error.message === 'timeout exceeded when trying to connect')
+  )
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,0 +1,346 @@
+import { getMessaging } from '@platformatic/globals'
+import { CancellationRegistry } from './cancellation.js'
+import { readConfig } from './config.js'
+import { DestinationResolver } from './destinations.js'
+import { DatabaseWattError, toErrorResponse } from './errors.js'
+import { LockRegistry } from './locks.js'
+import { registerDatabaseWattMetrics } from './metrics.js'
+import { PoolRegistry, runQuery } from './pools.js'
+import { enforceResultLimits } from './result-limits.js'
+import type {
+  AcquireConnectionRequest,
+  BeginTransactionRequest,
+  CancelRequest,
+  CommitTransactionRequest,
+  LockedQueryRequest,
+  QueryRequest,
+  ReleaseConnectionRequest,
+  RollbackTransactionRequest,
+} from './types.js'
+import {
+  validateCancelRequest,
+  validateLockRequestEnvelope,
+  validateNonLockRequestEnvelope,
+  validateQueryEnvelope,
+} from './validation.js'
+
+export class Application {
+  #config: ReturnType<typeof readConfig>
+  #resolver: DestinationResolver
+  #pools: PoolRegistry
+  #locks: LockRegistry
+  #cancellations: CancellationRegistry
+  #shuttingDown: boolean
+  #stats: Record<string, number>
+
+  constructor() {
+    this.#config = readConfig()
+    this.#resolver = new DestinationResolver(this.#config)
+    this.#pools = new PoolRegistry(this.#config)
+    this.#locks = new LockRegistry(this.#config)
+    this.#cancellations = new CancellationRegistry()
+    this.#shuttingDown = false
+    this.#stats = {
+      acquire: 0,
+      beginTransaction: 0,
+      cancel: 0,
+      commitTransaction: 0,
+      lockedQuery: 0,
+      query: 0,
+      release: 0,
+      rollbackTransaction: 0,  
+    }
+    
+    this.#registerHandlers()
+    registerDatabaseWattMetrics(this.#pools)
+  }
+
+  close(): Promise<void> {      
+    this.#shuttingDown = true
+
+    return this.#withShutdownTimeout(
+      Promise.allSettled([this.#locks.close(), this.#pools.close(), this.#resolver.close()]).then(() => undefined),
+      this.#config.shutdownTimeoutMs
+    )
+  }
+
+  #registerHandlers(): void {
+    const messaging = getMessaging({throwOnMissing: false})
+    
+    if (!messaging) {
+      return
+    }
+
+    messaging.handle('database.query', this.#handleQuery.bind(this))
+    messaging.handle('database.acquire', this.#handleAcquire.bind(this))
+    messaging.handle('database.lockedQuery', this.#handleLockedQuery.bind(this))
+    messaging.handle('database.release', this.#handleRelease.bind(this))
+    messaging.handle('database.beginTransaction', this.#handleBeginTransaction.bind(this))
+    messaging.handle('database.commitTransaction', this.#handleCommitTransaction.bind(this))
+    messaging.handle('database.rollbackTransaction', this.#handleRollbackTransaction.bind(this))
+    messaging.handle('database.cancel', this.#handleCancel.bind(this))
+    messaging.handle('database.test.stats', () => ({ ...this.#stats }))
+    messaging.handle('database.test.resetStats', this.#handleResetStats.bind(this))      
+  }
+
+  async #handleQuery(rawRequest: unknown): Promise<unknown> {
+    this.#stats.query++
+    let request: QueryRequest | undefined
+    let cancellationRequestId: string | undefined
+
+    try {
+      validateNonLockRequestEnvelope(rawRequest, this.#config)
+      validateQueryEnvelope(rawRequest, this.#config)
+      request = rawRequest as QueryRequest
+
+      this.#assertAcceptingWork()
+      const destination = await this.#resolver.resolve(request.destination)
+      this.#cancellations.start(request.requestId, { cancelled: false })
+      cancellationRequestId = request.requestId
+
+      const response = await this.#pools.query(
+        destination,
+        request.sql,
+        request.values,
+        (client) => this.#cancellations.setClient(request?.requestId, client)
+      )
+      return enforceResultLimits(response, this.#config)
+    } catch (error) {
+      return toErrorResponse(error, request ?? undefined)
+    } finally {
+      this.#cancellations.finish(cancellationRequestId)
+    }
+  }
+
+  async #handleAcquire(rawRequest: unknown): Promise<unknown> {
+    this.#stats.acquire++
+    let request: AcquireConnectionRequest | undefined
+
+    try {
+      validateNonLockRequestEnvelope(rawRequest, this.#config)
+      request = rawRequest as AcquireConnectionRequest
+
+      this.#assertAcceptingWork()
+      const destination = await this.#resolver.resolve(request.destination)
+      const client = await this.#pools.acquire(destination)
+      return { lockId: this.#locks.create(destination, client) }
+    } catch (error) {
+      return toErrorResponse(error, request ?? undefined)
+    }
+  }
+
+  async #handleLockedQuery(rawRequest: unknown): Promise<unknown> {
+    this.#stats.lockedQuery++
+    let request: LockedQueryRequest | undefined
+    let context: LockedQueryRequest | (LockedQueryRequest & { destination?: string }) | undefined
+    let cancellationRequestId: string | undefined
+
+    try {
+      validateLockRequestEnvelope(rawRequest, this.#config)
+      validateQueryEnvelope(rawRequest, this.#config)
+      request = rawRequest as LockedQueryRequest
+      context = request
+      context = this.#withLockContext(request)
+
+      this.#assertAcceptingWork()
+      this.#cancellations.start(request.requestId, { cancelled: false, lockId: request.lockId })
+      cancellationRequestId = request.requestId
+
+      this.#cancellations.setClient(request.requestId, this.#locks.getClient(request.lockId))
+      const response = await this.#locks.query(request.lockId, request.sql, request.values)
+      return enforceResultLimits(response, this.#config)
+    } catch (error) {
+      return toErrorResponse(error, context ?? undefined)
+    } finally {
+      this.#cancellations.finish(cancellationRequestId)
+    }
+  }
+
+  async #handleRelease(rawRequest: unknown): Promise<unknown> {
+    this.#stats.release++
+    let request: ReleaseConnectionRequest | undefined
+    let context: ReleaseConnectionRequest | (ReleaseConnectionRequest & { destination?: string }) | undefined
+
+    try {
+      validateLockRequestEnvelope(rawRequest, this.#config)
+      request = rawRequest as ReleaseConnectionRequest
+      context = request
+      context = this.#withLockContext(request)
+
+      await this.#locks.release(request.lockId)
+      return { released: true }
+    } catch (error) {
+      return toErrorResponse(error, context ?? undefined)
+    }
+  }
+
+  async #handleBeginTransaction(rawRequest: unknown): Promise<unknown> {
+    this.#stats.beginTransaction++
+    let request: BeginTransactionRequest | undefined
+
+    try {
+      validateNonLockRequestEnvelope(rawRequest, this.#config)
+      request = rawRequest as BeginTransactionRequest
+
+      this.#assertAcceptingWork()
+      const destination = await this.#resolver.resolve(request.destination)
+      const client = await this.#pools.acquire(destination)
+      let lockId: string | undefined
+
+      try {
+        await runQuery(client, this.#buildBeginStatement(request))
+        if (this.#config.serverStatementTimeoutMs > 0) {
+          await runQuery(client, `SELECT set_config('statement_timeout', $1, true)`, [
+            `${this.#config.serverStatementTimeoutMs}ms`,
+          ])
+        }
+        lockId = this.#locks.create(destination, client, true)
+        return { lockId }
+      } catch (error) {
+        client.release(error instanceof Error ? error : new Error(String(error)))
+        throw error
+      }
+    } catch (error) {
+      return toErrorResponse(error, request ?? undefined)
+    }
+  }
+
+  async #handleCommitTransaction(rawRequest: unknown): Promise<unknown> {
+    this.#stats.commitTransaction++
+    let request: CommitTransactionRequest | undefined
+    let context: CommitTransactionRequest | (CommitTransactionRequest & { destination?: string }) | undefined
+
+    try {
+      validateLockRequestEnvelope(rawRequest, this.#config)
+      request = rawRequest as CommitTransactionRequest
+      context = request
+      context = this.#withLockContext(request)
+
+      await this.#locks.commit(request.lockId)
+      return { committed: true }
+    } catch (error) {
+      return toErrorResponse(error, context ?? undefined)
+    }
+  }
+
+  async #handleRollbackTransaction(rawRequest: unknown): Promise<unknown> {
+    this.#stats.rollbackTransaction++
+    let request: RollbackTransactionRequest | undefined
+    let context: RollbackTransactionRequest | (RollbackTransactionRequest & { destination?: string }) | undefined
+
+    try {
+      validateLockRequestEnvelope(rawRequest, this.#config)
+      request = rawRequest as RollbackTransactionRequest
+      context = request
+      context = this.#withLockContext(request)
+
+      await this.#locks.rollback(request.lockId)
+      return { rolledBack: true }
+    } catch (error) {
+      return toErrorResponse(error, context ?? undefined)
+    }
+  }
+
+  async #handleCancel(rawRequest: unknown): Promise<unknown> {
+    this.#stats.cancel++
+    let request: CancelRequest | undefined
+
+    try {
+      validateCancelRequest(rawRequest)
+      request = rawRequest as CancelRequest
+
+      return this.#cancellations.cancel(request.requestId, request.lockId)
+    } catch (error) {
+      return toErrorResponse(error, request ?? undefined)
+    }
+  }
+
+  #handleResetStats(): { reset: boolean } {
+    for (const key of Object.keys(this.#stats)) {
+      this.#stats[key] = 0
+    }
+
+    return { reset: true }
+  }
+
+  #withLockContext<T extends { lockId: string; operationName?: string; requestId?: string }>(
+    request: T
+  ): T & { destination?: string } {
+    return {
+      ...request,
+      destination: this.#locks.getDestination(request.lockId),
+    }
+  }
+
+  #assertAcceptingWork(): void {
+    if (this.#shuttingDown) {
+      throw new DatabaseWattError('SHUTDOWN', 'Database application is shutting down')
+    }
+  }
+
+  #buildBeginStatement(request: BeginTransactionRequest): string {
+    const modes: string[] = []
+    const isolationLevel = this.#normalizeIsolationLevel(request.isolationLevel)
+
+    if (isolationLevel) {
+      modes.push(`ISOLATION LEVEL ${isolationLevel}`)
+    }
+
+    if (request.readOnly) {
+      modes.push('READ ONLY')
+    }
+
+    if (modes.length === 0) {
+      return 'BEGIN'
+    }
+
+    return `BEGIN ${modes.join(', ')}`
+  }
+
+  #normalizeIsolationLevel(isolationLevel: string | undefined): string | undefined {
+    switch (isolationLevel) {
+      case 'read committed':
+        return 'READ COMMITTED'
+      case 'repeatable read':
+        return 'REPEATABLE READ'
+      case 'serializable':
+        return 'SERIALIZABLE'
+      default:
+        return undefined
+    }
+  }
+
+  async #withShutdownTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeout: NodeJS.Timeout | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(new DatabaseWattError('SHUTDOWN', 'Database application shutdown timed out'))
+      }, timeoutMs)
+      timeout.unref()
+    })
+
+    try {
+      return await Promise.race([promise, timeoutPromise])
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    }
+  }
+}
+
+export interface ApplicationContext {
+  app: Application
+  isBackgroundApplication: boolean
+  close: () => Promise<void>
+}
+
+export function create() {  
+  const app = new Application()
+
+  return {
+    app,
+    isBackgroundApplication: true,
+    close: app.close.bind(app),
+  }
+}

--- a/src/database/locks.ts
+++ b/src/database/locks.ts
@@ -1,0 +1,216 @@
+import { randomBytes } from 'node:crypto'
+import type { PoolClient, QueryResultRow } from 'pg'
+import type { DatabaseConfig } from './config.js'
+import { DatabaseWattError } from './errors.js'
+import { isConnectionStateError, runQuery, toQueryResponse } from './pools.js'
+import type { DestinationConfig, QueryResponse } from './types.js'
+
+type LockRecord = {
+  busy: Promise<unknown>
+  client: PoolClient
+  createdAt: number
+  destination: DestinationConfig
+  inTransaction: boolean
+  lastUsedAt: number
+  lockId: string
+  terminal: boolean
+}
+
+export class LockRegistry {
+  private readonly config: DatabaseConfig
+  private readonly locks = new Map<string, LockRecord>()
+  private readonly cleanupInterval: NodeJS.Timeout
+
+  constructor(config: DatabaseConfig) {
+    this.config = config
+    this.cleanupInterval = setInterval(() => {
+      void this.expireLocks()
+    }, Math.min(config.lockIdleTimeoutMs, config.lockMaxLifetimeMs, 10_000))
+    this.cleanupInterval.unref()
+  }
+
+  create(destination: DestinationConfig, client: PoolClient, inTransaction = false): string {
+    const lockId = randomBytes(32).toString('base64url')
+    const now = Date.now()
+    this.locks.set(lockId, {
+      busy: Promise.resolve(),
+      client,
+      createdAt: now,
+      destination,
+      inTransaction,
+      lastUsedAt: now,
+      lockId,
+      terminal: false,
+    })
+    return lockId
+  }
+
+  getDestination(lockId: string): string | undefined {
+    return this.locks.get(lockId)?.destination.id
+  }
+
+  getClient(lockId: string): PoolClient {
+    return this.getLock(lockId).client
+  }
+
+  async query<T extends QueryResultRow = QueryResultRow>(
+    lockId: string,
+    sql: string,
+    values?: unknown[]
+  ): Promise<QueryResponse<T>> {
+    return this.withLock(lockId, async (lock) => {
+      const result = await runQuery<T>(lock.client, sql, values)
+      return toQueryResponse(result)
+    })
+  }
+
+  async release(lockId: string): Promise<void> {
+    await this.withLock(lockId, async (lock) => {
+      if (lock.inTransaction) {
+        throw new DatabaseWattError('PROTOCOL_ERROR', 'Cannot release a transaction lock')
+      }
+
+      this.remove(lock, undefined)
+    })
+  }
+
+  async markTransaction(lockId: string): Promise<void> {
+    await this.withLock(lockId, async (lock) => {
+      lock.inTransaction = true
+    })
+  }
+
+  async commit(lockId: string): Promise<void> {
+    await this.withLock(lockId, async (lock) => {
+      if (!lock.inTransaction) {
+        throw new DatabaseWattError('PROTOCOL_ERROR', 'Lock is not in a transaction')
+      }
+
+      let releaseError: Error | undefined
+      try {
+        await runQuery(lock.client, 'COMMIT')
+      } catch (error) {
+        releaseError = error instanceof Error ? error : new Error(String(error))
+        throw error
+      } finally {
+        this.remove(lock, releaseError)
+      }
+    })
+  }
+
+  async rollback(lockId: string): Promise<void> {
+    await this.withLock(lockId, async (lock) => {
+      if (!lock.inTransaction) {
+        this.remove(lock, undefined)
+        return
+      }
+
+      let releaseError: Error | undefined
+      try {
+        await runQuery(lock.client, 'ROLLBACK')
+      } catch (error) {
+        releaseError = error instanceof Error ? error : new Error(String(error))
+        throw error
+      } finally {
+        this.remove(lock, releaseError)
+      }
+    })
+  }
+
+  async purge(lockId: string, releaseError?: Error): Promise<void> {
+    const lock = this.locks.get(lockId)
+    if (!lock) {
+      return
+    }
+
+    await lock.busy.catch(() => undefined)
+    this.remove(lock, releaseError)
+  }
+
+  async close(): Promise<void> {
+    clearInterval(this.cleanupInterval)
+    const locks = [...this.locks.values()]
+    this.locks.clear()
+
+    await Promise.allSettled(
+      locks.map(async (lock) => {
+        await lock.busy.catch(() => undefined)
+        if (lock.inTransaction) {
+          await runQuery(lock.client, 'ROLLBACK').catch(() => undefined)
+        }
+        lock.client.release()
+      })
+    )
+  }
+
+  private async withLock<T>(lockId: string, fn: (lock: LockRecord) => Promise<T>): Promise<T> {
+    const lock = this.getLock(lockId)
+    const work = lock.busy.then(async () => {
+      this.assertUsable(lock)
+      lock.lastUsedAt = Date.now()
+
+      try {
+        return await fn(lock)
+      } catch (error) {
+        if (isConnectionStateError(error)) {
+          this.remove(lock, error instanceof Error ? error : new Error(String(error)))
+        }
+        throw error
+      }
+    })
+
+    lock.busy = work.catch(() => undefined)
+    return work
+  }
+
+  private getLock(lockId: string): LockRecord {
+    const lock = this.locks.get(lockId)
+    if (!lock || lock.terminal) {
+      throw new DatabaseWattError('PROTOCOL_ERROR', 'Unknown lock ID')
+    }
+    return lock
+  }
+
+  private assertUsable(lock: LockRecord): void {
+    const now = Date.now()
+    if (now - lock.createdAt > this.config.lockMaxLifetimeMs) {
+      this.remove(lock, new Error('Lock maximum lifetime exceeded'))
+      throw new DatabaseWattError('PROTOCOL_ERROR', 'Unknown lock ID')
+    }
+
+    if (now - lock.lastUsedAt > this.config.lockIdleTimeoutMs) {
+      this.remove(lock, new Error('Lock idle timeout exceeded'))
+      throw new DatabaseWattError('PROTOCOL_ERROR', 'Unknown lock ID')
+    }
+  }
+
+  private remove(lock: LockRecord, releaseError: Error | undefined): void {
+    if (lock.terminal) {
+      return
+    }
+
+    lock.terminal = true
+    this.locks.delete(lock.lockId)
+    lock.client.release(releaseError)
+  }
+
+  private async expireLocks(): Promise<void> {
+    const now = Date.now()
+    const expired = [...this.locks.values()].filter((lock) => {
+      return (
+        now - lock.createdAt > this.config.lockMaxLifetimeMs ||
+        now - lock.lastUsedAt > this.config.lockIdleTimeoutMs
+      )
+    })
+
+    await Promise.allSettled(
+      expired.map(async (lock) => {
+        await lock.busy.catch(() => undefined)
+        if (lock.inTransaction) {
+          await runQuery(lock.client, 'ROLLBACK').catch(() => undefined)
+        }
+        this.remove(lock, undefined)
+      })
+    )
+  }
+}

--- a/src/database/metrics.ts
+++ b/src/database/metrics.ts
@@ -1,0 +1,36 @@
+import { metrics } from '@opentelemetry/api'
+import type { PoolRegistry } from './pools.js'
+
+let registered = false
+
+export function registerDatabaseWattMetrics(pools: PoolRegistry): void {
+  if (registered) {
+    return
+  }
+
+  registered = true
+  const meter = metrics.getMeter('storage-database-watt')
+  const activePools = meter.createObservableGauge('database_watt_active_pools', {
+    description: 'Current number of active Database Watt destination pools',
+  })
+  const totalConnections = meter.createObservableGauge('database_watt_connections', {
+    description: 'Current number of Database Watt PostgreSQL connections',
+  })
+  const inUseConnections = meter.createObservableGauge('database_watt_connections_in_use', {
+    description: 'Current number of Database Watt PostgreSQL connections in use',
+  })
+  const waitingRequests = meter.createObservableGauge('database_watt_waiting_requests', {
+    description: 'Current number of Database Watt requests waiting for PostgreSQL connections',
+  })
+
+  meter.addBatchObservableCallback(
+    (observer) => {
+      const stats = pools.getStats()
+      observer.observe(activePools, stats.pools)
+      observer.observe(totalConnections, stats.totalConnections)
+      observer.observe(inUseConnections, stats.inUseConnections)
+      observer.observe(waitingRequests, stats.waitingRequests)
+    },
+    [activePools, totalConnections, inUseConnections, waitingRequests]
+  )
+}

--- a/src/database/pg-lib-connection.d.ts
+++ b/src/database/pg-lib-connection.d.ts
@@ -1,0 +1,11 @@
+declare module 'pg/lib/connection' {
+  import { EventEmitter } from 'node:events'
+
+  export default class PgConnection extends EventEmitter {
+    cancel(processID: number, secretKey: number): void
+    connect(port: number, host: string): void
+    connect(path: string): void
+    end(): void
+    unref(): void
+  }
+}

--- a/src/database/pools.ts
+++ b/src/database/pools.ts
@@ -21,13 +21,17 @@ export class PoolRegistry {
   private readonly config: DatabaseConfig
   private readonly pools = new Map<string, PoolEntry>()
   private pendingGlobalAcquisitions = 0
+  private cachedStats?: PoolRegistryStats
   private readonly evictionInterval: NodeJS.Timeout
 
   constructor(config: DatabaseConfig) {
     this.config = config
-    this.evictionInterval = setInterval(() => {
-      void this.evictIdlePools()
-    }, Math.max(config.idlePoolTimeoutMs, 1_000))
+    this.evictionInterval = setInterval(
+      () => {
+        void this.evictIdlePools()
+      },
+      Math.max(config.idlePoolTimeoutMs, 1_000)
+    )
     this.evictionInterval.unref()
   }
 
@@ -75,6 +79,10 @@ export class PoolRegistry {
   }
 
   getStats(): PoolRegistryStats {
+    if (this.cachedStats) {
+      return this.cachedStats
+    }
+
     let inUseConnections = 0
     let totalConnections = 0
     let waitingRequests = 0
@@ -85,18 +93,25 @@ export class PoolRegistry {
       waitingRequests += entry.pool.waitingCount
     }
 
-    return {
+    const stats = {
       inUseConnections,
       pools: this.pools.size,
       totalConnections,
       waitingRequests,
     }
+    this.cachedStats = stats
+    queueMicrotask(() => {
+      this.cachedStats = undefined
+    })
+
+    return stats
   }
 
   async close(): Promise<void> {
     clearInterval(this.evictionInterval)
     const pools = [...this.pools.values()].map((entry) => entry.pool)
     this.pools.clear()
+    this.cachedStats = undefined
     await Promise.allSettled(pools.map((pool) => pool.end()))
   }
 
@@ -132,6 +147,7 @@ export class PoolRegistry {
     }
 
     this.pools.set(destination.id, entry)
+    this.cachedStats = undefined
     return entry
   }
 
@@ -166,6 +182,7 @@ export class PoolRegistry {
       }
 
       this.pools.delete(destination)
+      this.cachedStats = undefined
       toEvict.push(entry.pool)
     }
 

--- a/src/database/pools.ts
+++ b/src/database/pools.ts
@@ -1,0 +1,225 @@
+import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from 'pg'
+import type { DatabaseConfig } from './config.js'
+import { DatabaseWattError } from './errors.js'
+import { getSslSettings } from './ssl.js'
+import type { DestinationConfig, QueryResponse } from './types.js'
+
+type PoolEntry = {
+  config: DestinationConfig
+  lastUsedAt: number
+  pool: Pool
+}
+
+export type PoolRegistryStats = {
+  pools: number
+  totalConnections: number
+  inUseConnections: number
+  waitingRequests: number
+}
+
+export class PoolRegistry {
+  private readonly config: DatabaseConfig
+  private readonly pools = new Map<string, PoolEntry>()
+  private pendingGlobalAcquisitions = 0
+  private readonly evictionInterval: NodeJS.Timeout
+
+  constructor(config: DatabaseConfig) {
+    this.config = config
+    this.evictionInterval = setInterval(() => {
+      void this.evictIdlePools()
+    }, Math.max(config.idlePoolTimeoutMs, 1_000))
+    this.evictionInterval.unref()
+  }
+
+  async query<T extends QueryResultRow = QueryResultRow>(
+    destination: DestinationConfig,
+    sql: string,
+    values: unknown[] | undefined,
+    onClient?: (client: PoolClient) => void
+  ): Promise<QueryResponse<T>> {
+    const client = await this.acquire(destination)
+    let releaseError: Error | undefined
+
+    try {
+      onClient?.(client)
+      const result = await runQuery<T>(client, sql, values)
+      return toQueryResponse(result)
+    } catch (error) {
+      if (isConnectionStateError(error)) {
+        releaseError = error instanceof Error ? error : new Error(String(error))
+      }
+      throw error
+    } finally {
+      client.release(releaseError)
+    }
+  }
+
+  async acquire(destination: DestinationConfig): Promise<PoolClient> {
+    const entry = this.getOrCreatePool(destination)
+    this.assertCanAcquire(entry)
+    this.pendingGlobalAcquisitions++
+
+    const timeout = createTimeout(this.config.acquireTimeoutMs)
+    try {
+      return await Promise.race([
+        entry.pool.connect(),
+        timeout.promise.then(() => {
+          throw new DatabaseWattError('ACQUIRE_TIMEOUT', 'Timed out acquiring database connection')
+        }),
+      ])
+    } finally {
+      timeout.clear()
+      this.pendingGlobalAcquisitions--
+      entry.lastUsedAt = Date.now()
+    }
+  }
+
+  getStats(): PoolRegistryStats {
+    let inUseConnections = 0
+    let totalConnections = 0
+    let waitingRequests = 0
+
+    for (const entry of this.pools.values()) {
+      inUseConnections += Math.max(entry.pool.totalCount - entry.pool.idleCount, 0)
+      totalConnections += entry.pool.totalCount
+      waitingRequests += entry.pool.waitingCount
+    }
+
+    return {
+      inUseConnections,
+      pools: this.pools.size,
+      totalConnections,
+      waitingRequests,
+    }
+  }
+
+  async close(): Promise<void> {
+    clearInterval(this.evictionInterval)
+    const pools = [...this.pools.values()].map((entry) => entry.pool)
+    this.pools.clear()
+    await Promise.allSettled(pools.map((pool) => pool.end()))
+  }
+
+  private getOrCreatePool(destination: DestinationConfig): PoolEntry {
+    const existing = this.pools.get(destination.id)
+    if (existing) {
+      existing.lastUsedAt = Date.now()
+      return existing
+    }
+
+    if (this.pools.size >= this.config.maxActivePools) {
+      throw new DatabaseWattError('BUSY', 'Maximum active destination pools reached')
+    }
+
+    const maxConnections = Math.max(
+      Math.min(destination.maxConnections, this.config.destinationMaxConnections),
+      1
+    )
+    const pool = new Pool({
+      application_name: this.config.applicationName,
+      connectionString: destination.connectionString,
+      connectionTimeoutMillis: this.config.connectionTimeoutMs,
+      idleTimeoutMillis: this.config.idlePoolTimeoutMs,
+      max: maxConnections,
+      min: 0,
+      ssl: getSslSettings(destination.connectionString, this.config.rootCert),
+    })
+
+    const entry = {
+      config: destination,
+      lastUsedAt: Date.now(),
+      pool,
+    }
+
+    this.pools.set(destination.id, entry)
+    return entry
+  }
+
+  private assertCanAcquire(entry: PoolEntry): void {
+    const stats = this.getStats()
+
+    if (this.pendingGlobalAcquisitions >= this.config.globalAcquireQueueLimit) {
+      throw new DatabaseWattError('BUSY', 'Global acquisition queue is full')
+    }
+
+    if (entry.pool.waitingCount >= this.config.destinationAcquireQueueLimit) {
+      throw new DatabaseWattError('BUSY', 'Destination acquisition queue is full')
+    }
+
+    const targetHasIdleConnection = entry.pool.idleCount > 0
+    if (!targetHasIdleConnection && stats.totalConnections >= this.config.globalMaxConnections) {
+      throw new DatabaseWattError('BUSY', 'Global connection budget is exhausted')
+    }
+  }
+
+  private async evictIdlePools(): Promise<void> {
+    const now = Date.now()
+    const toEvict: Pool[] = []
+
+    for (const [destination, entry] of this.pools) {
+      if (now - entry.lastUsedAt < this.config.idlePoolTimeoutMs) {
+        continue
+      }
+
+      if (entry.pool.totalCount !== entry.pool.idleCount || entry.pool.waitingCount > 0) {
+        continue
+      }
+
+      this.pools.delete(destination)
+      toEvict.push(entry.pool)
+    }
+
+    await Promise.allSettled(toEvict.map((pool) => pool.end()))
+  }
+}
+
+export async function runQuery<T extends QueryResultRow = QueryResultRow>(
+  client: PoolClient,
+  sql: string,
+  values?: unknown[]
+): Promise<QueryResult<T>> {
+  return client.query<T>(sql, values)
+}
+
+export function toQueryResponse<T extends QueryResultRow = QueryResultRow>(
+  result: QueryResult<T>
+): QueryResponse<T> {
+  return {
+    rows: result.rows,
+    rowCount: result.rowCount || 0,
+  }
+}
+
+export function isConnectionStateError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const code = (error as { code?: string }).code
+  if (typeof code === 'string' && code.startsWith('08')) {
+    return true
+  }
+
+  return (
+    error.message.startsWith('received invalid response:') ||
+    error.message.startsWith('Received unexpected ') ||
+    error.message.startsWith('Unknown authenticationOk message type')
+  )
+}
+
+function createTimeout(timeoutMs: number): { clear: () => void; promise: Promise<void> } {
+  let timeout: NodeJS.Timeout | undefined
+  const promise = new Promise<void>((resolve) => {
+    timeout = setTimeout(resolve, timeoutMs)
+    timeout.unref()
+  })
+
+  return {
+    clear: () => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    },
+    promise,
+  }
+}

--- a/src/database/result-limits.ts
+++ b/src/database/result-limits.ts
@@ -1,0 +1,17 @@
+import { Buffer } from 'node:buffer'
+import type { DatabaseConfig } from './config.js'
+import { DatabaseWattError } from './errors.js'
+import type { QueryResponse } from './types.js'
+
+export function enforceResultLimits<T>(response: QueryResponse<T>, config: DatabaseConfig): QueryResponse<T> {
+  if (response.rows.length > config.maxResultRows) {
+    throw new DatabaseWattError('RESULT_TOO_LARGE', 'Result row limit exceeded')
+  }
+
+  const serializedSize = Buffer.byteLength(JSON.stringify(response))
+  if (serializedSize > config.maxResultBytes) {
+    throw new DatabaseWattError('RESULT_TOO_LARGE', 'Result byte limit exceeded')
+  }
+
+  return response
+}

--- a/src/database/ssl.ts
+++ b/src/database/ssl.ts
@@ -1,0 +1,32 @@
+export function getSslSettings(
+  connectionString: string,
+  rootCert?: string
+): { ca?: string; rejectUnauthorized?: boolean } | false | undefined {
+  const sslMode = getSslMode(connectionString)
+
+  if (sslMode === 'disable') {
+    return false
+  }
+
+  if (rootCert) {
+    return {
+      ca: rootCert,
+    }
+  }
+
+  if (sslMode === 'require' || sslMode === 'prefer') {
+    return {
+      rejectUnauthorized: false,
+    }
+  }
+
+  return undefined
+}
+
+function getSslMode(connectionString: string): string | undefined {
+  try {
+    return new URL(connectionString).searchParams.get('sslmode') || undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/database/ssl.ts
+++ b/src/database/ssl.ts
@@ -1,7 +1,7 @@
 export function getSslSettings(
   connectionString: string,
   rootCert?: string
-): { ca?: string; rejectUnauthorized?: boolean } | false | undefined {
+): { ca?: string; rejectUnauthorized?: boolean } | boolean | undefined {
   const sslMode = getSslMode(connectionString)
 
   if (sslMode === 'disable') {
@@ -14,7 +14,11 @@ export function getSslSettings(
     }
   }
 
-  if (sslMode === 'require' || sslMode === 'prefer') {
+  if (sslMode === 'require') {
+    return true
+  }
+
+  if (sslMode === 'prefer') {
     return {
       rejectUnauthorized: false,
     }

--- a/src/database/tests/cancellation.test.ts
+++ b/src/database/tests/cancellation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CancellationRegistry } from '../cancellation.js'
+
+describe('database cancellation registry', () => {
+  it('tracks missing and completed requests', async () => {
+    const registry = new CancellationRegistry()
+
+    expect(await registry.cancel('missing')).toEqual({ cancelled: false })
+
+    registry.start('req-1', { cancelled: false })
+    registry.finish('req-1')
+
+    expect(await registry.cancel('req-1')).toEqual({ cancelled: false })
+  })
+
+  it('marks an in-flight operation as cancelled', async () => {
+    const registry = new CancellationRegistry()
+    const operation = { cancelled: false, lockId: 'lock-a' }
+
+    registry.start('req-1', operation)
+
+    expect(await registry.cancel('req-1', 'lock-a')).toEqual({ cancelled: true })
+    expect(operation.cancelled).toBe(true)
+  })
+
+  it('does not cancel operations for a different lock', async () => {
+    const registry = new CancellationRegistry()
+    const operation = { cancelled: false, lockId: 'lock-a' }
+
+    registry.start('req-1', operation)
+
+    expect(await registry.cancel('req-1', 'lock-b')).toEqual({ cancelled: false })
+    expect(operation.cancelled).toBe(false)
+  })
+
+  it('sends PostgreSQL cancel when client backend identifiers are present', async () => {
+    vi.resetModules()
+
+    const cancel = vi.fn()
+    const end = vi.fn()
+    const unref = vi.fn()
+    vi.doMock('pg/lib/connection', () => ({
+      default: class MockPgConnection {
+        private callbacks = new Map<string, () => void>()
+        cancel = cancel
+        end = end
+        unref = unref
+        on(event: string, callback: () => void) {
+          this.callbacks.set(event, callback)
+        }
+        connect() {
+          setImmediate(() => {
+            this.callbacks.get('connect')?.()
+            this.callbacks.get('end')?.()
+          })
+        }
+      },
+    }))
+
+    const { CancellationRegistry: MockedCancellationRegistry } = await import('../cancellation.js')
+    const registry = new MockedCancellationRegistry()
+    registry.start('req-1', { cancelled: false })
+    registry.setClient('req-1', {
+      connectionParameters: { host: 'localhost', port: 5432 },
+      processID: 1,
+      secretKey: 2,
+    } as never)
+
+    expect(await registry.cancel('req-1')).toEqual({ cancelled: true })
+    expect(cancel).toHaveBeenCalledWith(1, 2)
+    expect(end).toHaveBeenCalled()
+    vi.doUnmock('pg/lib/connection')
+  })
+})

--- a/src/database/tests/destinations.test.ts
+++ b/src/database/tests/destinations.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { readConfig } from '../config.js'
+import { DestinationResolver } from '../destinations.js'
+
+describe('database destination resolution', () => {
+  it('derives single-tenant external pool state from parsed config', async () => {
+    const resolver = new DestinationResolver(
+      readConfig({
+        DATABASE_POOL_URL: 'postgres://pooler',
+      })
+    )
+
+    const destination = await resolver.resolve('default')
+
+    expect(destination).toMatchObject({
+      connectionString: 'postgres://pooler',
+      isExternalPool: true,
+    })
+  })
+})

--- a/src/database/tests/errors.test.ts
+++ b/src/database/tests/errors.test.ts
@@ -1,0 +1,45 @@
+import { DatabaseError } from 'pg'
+import { describe, expect, it } from 'vitest'
+import { DatabaseWattError, isErrorResponse, toErrorResponse } from '../errors.js'
+
+describe('database error contract', () => {
+  it('serializes DatabaseWattError with safe context', () => {
+    const response = toErrorResponse(new DatabaseWattError('BUSY', 'queue full'), {
+      destination: 'tenant-a',
+      operationName: 'op',
+      requestId: 'req-1',
+    })
+
+    expect(response).toMatchObject({
+      code: 'BUSY',
+      destination: 'tenant-a',
+      message: 'queue full',
+      operationName: 'op',
+      requestId: 'req-1',
+    })
+  })
+
+  it('maps PostgreSQL errors to POSTGRES_ERROR and SQLSTATE', () => {
+    const error = new DatabaseError('duplicate key', 1, 'error')
+    error.code = '23505'
+
+    const response = toErrorResponse(error, { lockId: 'lock-a' })
+
+    expect(response).toMatchObject({
+      code: 'POSTGRES_ERROR',
+      lockId: 'lock-a',
+      message: 'duplicate key',
+      sqlState: '23505',
+    })
+  })
+
+  it('maps unknown errors to MESSAGING_ERROR', () => {
+    const response = toErrorResponse(new Error('transport failed'))
+
+    expect(response).toMatchObject({
+      code: 'MESSAGING_ERROR',
+      message: 'transport failed',
+    })
+    expect(isErrorResponse(response)).toBe(true)
+  })
+})

--- a/src/database/tests/index.test.ts
+++ b/src/database/tests/index.test.ts
@@ -1,0 +1,304 @@
+import { setupLoopbackMessaging } from '@platformatic/runtime'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DatabaseErrorResponse } from '../errors.js'
+import type { ApplicationContext } from '../index.js'
+
+type Handler = (data: unknown) => Promise<unknown>
+
+type MockClient = {
+  queries: Array<{ sql: string; values?: unknown[] }>
+  query: ReturnType<typeof vi.fn>
+  release: ReturnType<typeof vi.fn>
+}
+
+type MockedEnvironment = {
+  app: ApplicationContext,
+  messaging: ReturnType<typeof setupLoopbackMessaging>
+  clients: MockClient[]
+  pools: Array<{ config: Record<string, unknown>; ended: boolean; queries: Array<{ sql: string; values?: unknown[] }> }>
+}
+
+function createMockClient(rows: unknown[]): MockClient {
+  const client: MockClient = {
+    queries: [],
+    query: vi.fn(async (sql: string, values?: unknown[]) => {
+      client.queries.push({ sql, values })
+      return { rowCount: rows.length, rows }
+    }),
+    release: vi.fn(),
+  }
+
+  return client
+}
+
+async function loadApp(options: {
+  env?: Record<string, string>
+  queryRows?: unknown[]
+  tenantRows?: unknown[]
+} = {}): Promise<MockedEnvironment> {
+  vi.resetModules()
+
+  const handlers = new Map<string, Handler>()
+  const clients: MockClient[] = []
+  const pools: MockedEnvironment['pools'] = []
+  const queryRows = options.queryRows || [{ ok: true }]
+  const tenantRows = options.tenantRows || []
+
+  process.env = {
+    ...originalEnv,
+    DATABASE_URL: 'postgres://single-tenant',
+    ...options.env,
+  }
+
+  vi.doMock('pg', () => {
+    class MockDatabaseError extends Error {
+      code?: string
+      constructor(message: string) {
+        super(message)
+      }
+    }
+
+    class MockPool {
+      totalCount = 0
+      idleCount = 0
+      waitingCount = 0
+      ended = false
+      queries: Array<{ sql: string; values?: unknown[] }> = []
+      config: Record<string, unknown>
+
+      constructor(config: Record<string, unknown>) {
+        this.config = config
+        pools.push(this)
+      }
+
+      async query(sql: string, values?: unknown[]) {
+        this.queries.push({ sql, values })
+        return { rowCount: tenantRows.length, rows: tenantRows }
+      }
+
+      async connect() {
+        this.totalCount++
+        const client = createMockClient(queryRows)
+        clients.push(client)
+        return client
+      }
+
+      async end() {
+        this.ended = true
+      }
+    }
+
+    return {
+      DatabaseError: MockDatabaseError,
+      Pool: MockPool,
+      default: { types: { setTypeParser: vi.fn() } },
+    }
+  })
+
+  vi.doMock('pg/lib/connection', () => ({
+    default: class MockPgConnection {},
+  }))
+
+  // We need dynamic import due to the mocking of PostgreSQL modules above
+  const {create} = await import('../index.js')
+
+  const messaging = setupLoopbackMessaging('db')
+  const app = create()
+  return { app, messaging, clients, pools }
+}
+
+const originalEnv = { ...process.env }
+
+afterEach(async () => {
+  vi.doUnmock('pg')
+  vi.doUnmock('pg/lib/connection')
+  vi.resetModules()
+  process.env = { ...originalEnv }
+})
+
+describe('database Watt application messaging handlers', () => {
+  it('registers prefixed handlers and exposes no server', async () => {
+    const { app } = await loadApp()
+
+    expect(app.isBackgroundApplication).toBe(true)    
+  })
+
+  it('executes stateless queries against the single-tenant destination', async () => {
+    const { messaging, clients } = await loadApp()
+
+    const response = await messaging.send('foo', 'database.query', {
+      destination: 'default',
+      requestId: 'req-1',
+      sql: 'SELECT 1',
+      values: [1],
+    })
+
+    expect(response).toEqual({ rowCount: 1, rows: [{ ok: true }] })
+    expect(clients[0].query).toHaveBeenCalledWith('SELECT 1', [1])
+    expect(clients[0].release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('returns validation errors from malformed requests', async () => {
+    const { messaging } = await loadApp()
+
+    const response = (await messaging.send('database', 'database.query', {
+      destination: '',
+      sql: 'SELECT 1',
+    })) as DatabaseErrorResponse
+
+    expect(response).toMatchObject({
+      code: 'PROTOCOL_ERROR',
+      message: 'destination must be a non-empty string',
+    })
+  })
+
+  it('enforces result limits in handlers', async () => {
+    const { messaging } = await loadApp({
+      env: { DATABASE_WATT_MAX_RESULT_ROWS: '1' },
+      queryRows: [{ id: 1 }, { id: 2 }],
+    })
+
+    const response = (await messaging.send('database', 'database.query', {
+      destination: 'default',
+      sql: 'SELECT 1',
+    })) as DatabaseErrorResponse
+
+    expect(response).toMatchObject({
+      code: 'RESULT_TOO_LARGE',
+      message: 'Result row limit exceeded',
+    })
+    expect(response).not.toHaveProperty('rows')
+  })
+
+  it('acquires and releases pinned connections', async () => {
+    const { clients, messaging } = await loadApp()
+
+    const acquire = (await messaging.send('database', 'database.acquire', {
+      destination: 'default',
+    })) as { lockId: string }
+
+    expect(acquire.lockId).toBeTruthy()
+
+    const release = await messaging.send('database', 'database.release', { lockId: acquire.lockId })
+
+    expect(release).toEqual({ released: true })
+    expect(clients[0].release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('runs transaction lifecycle on one pinned connection', async () => {
+    const { clients, messaging } = await loadApp()
+
+    const begin = (await messaging.send('database', 'database.beginTransaction', {
+      destination: 'default',
+      isolationLevel: 'serializable',
+      readOnly: true,
+    })) as { lockId: string }
+
+    expect(begin.lockId).toBeTruthy()
+
+    await messaging.send('database', 'database.lockedQuery', {
+      lockId: begin.lockId,
+      sql: 'SELECT 1',
+    })
+    const commit = await messaging.send('database', 'database.commitTransaction', { lockId: begin.lockId })
+
+    expect(commit).toEqual({ committed: true })
+    expect(clients[0].queries.map((query) => query.sql)).toEqual([
+      'BEGIN ISOLATION LEVEL SERIALIZABLE, READ ONLY',
+      `SELECT set_config('statement_timeout', $1, true)`,
+      'SELECT 1',
+      'COMMIT',
+    ])
+    expect(clients[0].release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('resolves multitenant destinations through the master pool', async () => {
+    const { clients, messaging, pools } = await loadApp({
+      env: { DATABASE_MULTITENANT_URL: 'postgres://master', MULTI_TENANT: 'true' },
+      tenantRows: [{ database_url: 'postgres://tenant-db', max_connections: 4 }],
+    })
+
+    const response = await messaging.send('database', 'database.query', {
+      destination: 'tenant-a',
+      sql: 'SELECT 1',
+    })
+
+    expect(response).toEqual({ rowCount: 1, rows: [{ ok: true }] })
+    expect(pools[0].queries[0]).toMatchObject({
+      values: ['tenant-a'],
+    })
+    expect(clients[0].query).toHaveBeenCalledWith('SELECT 1', undefined)
+  })
+
+  it('resolves the reserved master destination directly to the master database', async () => {
+    const { clients, messaging, pools } = await loadApp({
+      env: { DATABASE_MULTITENANT_URL: 'postgres://master', MULTI_TENANT: 'true' },
+    })
+
+    const response = await messaging.send('database', 'database.query', {
+      destination: 'master',
+      sql: 'SELECT 1',
+    })
+
+    expect(response).toEqual({ rowCount: 1, rows: [{ ok: true }] })
+    expect(pools[0].config).toMatchObject({ connectionString: 'postgres://master' })
+    expect(pools[0].queries).toHaveLength(0)
+    expect(clients[0].query).toHaveBeenCalledWith('SELECT 1', undefined)
+  })
+
+  it('returns DESTINATION_UNKNOWN for the master destination without master config', async () => {
+    const { messaging } = await loadApp({
+      env: { DATABASE_MULTITENANT_URL: '', MULTI_TENANT: 'true' },
+    })
+
+    const response = (await messaging.send('database', 'database.query', {
+      destination: 'master',
+      sql: 'SELECT 1',
+    })) as DatabaseErrorResponse
+
+    expect(response).toMatchObject({
+      code: 'DESTINATION_UNKNOWN',
+      destination: 'master',
+    })
+  })
+
+  it('returns DESTINATION_UNKNOWN for missing tenants', async () => {
+    const { messaging } = await loadApp({
+      env: { DATABASE_MULTITENANT_URL: 'postgres://master', MULTI_TENANT: 'true' },
+      tenantRows: [],
+    })
+
+    const response = (await messaging.send('database', 'database.query', {
+      destination: 'missing',
+      sql: 'SELECT 1',
+    })) as DatabaseErrorResponse
+
+    expect(response).toMatchObject({
+      code: 'DESTINATION_UNKNOWN',
+      destination: 'missing',
+    })
+  })
+
+  it('closes pools and rejects new work after shutdown starts', async () => {
+    const { app, messaging, pools } = await loadApp()
+
+    await messaging.send('database', 'database.query', {
+      destination: 'default',
+      sql: 'SELECT 1',
+    })
+    await app.close()
+
+    const response = (await messaging.send('database', 'database.query', {
+      destination: 'default',
+      sql: 'SELECT 1',
+    })) as DatabaseErrorResponse
+
+    expect(pools[0].ended).toBe(true)
+    expect(response).toMatchObject({
+      code: 'SHUTDOWN',
+      message: 'Database application is shutting down',
+    })
+  })
+})
+
+

--- a/src/database/tests/index.test.ts
+++ b/src/database/tests/index.test.ts
@@ -3,8 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DatabaseErrorResponse } from '../errors.js'
 import type { ApplicationContext } from '../index.js'
 
-type Handler = (data: unknown) => Promise<unknown>
-
 type MockClient = {
   queries: Array<{ sql: string; values?: unknown[] }>
   query: ReturnType<typeof vi.fn>
@@ -12,10 +10,14 @@ type MockClient = {
 }
 
 type MockedEnvironment = {
-  app: ApplicationContext,
+  app: ApplicationContext
   messaging: ReturnType<typeof setupLoopbackMessaging>
   clients: MockClient[]
-  pools: Array<{ config: Record<string, unknown>; ended: boolean; queries: Array<{ sql: string; values?: unknown[] }> }>
+  pools: Array<{
+    config: Record<string, unknown>
+    ended: boolean
+    queries: Array<{ sql: string; values?: unknown[] }>
+  }>
 }
 
 function createMockClient(rows: unknown[]): MockClient {
@@ -31,14 +33,11 @@ function createMockClient(rows: unknown[]): MockClient {
   return client
 }
 
-async function loadApp(options: {
-  env?: Record<string, string>
-  queryRows?: unknown[]
-  tenantRows?: unknown[]
-} = {}): Promise<MockedEnvironment> {
+async function loadApp(
+  options: { env?: Record<string, string>; queryRows?: unknown[]; tenantRows?: unknown[] } = {}
+): Promise<MockedEnvironment> {
   vi.resetModules()
 
-  const handlers = new Map<string, Handler>()
   const clients: MockClient[] = []
   const pools: MockedEnvironment['pools'] = []
   const queryRows = options.queryRows || [{ ok: true }]
@@ -100,7 +99,7 @@ async function loadApp(options: {
   }))
 
   // We need dynamic import due to the mocking of PostgreSQL modules above
-  const {create} = await import('../index.js')
+  const { create } = await import('../index.js')
 
   const messaging = setupLoopbackMessaging('db')
   const app = create()
@@ -120,7 +119,7 @@ describe('database Watt application messaging handlers', () => {
   it('registers prefixed handlers and exposes no server', async () => {
     const { app } = await loadApp()
 
-    expect(app.isBackgroundApplication).toBe(true)    
+    expect(app.isBackgroundApplication).toBe(true)
   })
 
   it('executes stateless queries against the single-tenant destination', async () => {
@@ -136,6 +135,19 @@ describe('database Watt application messaging handlers', () => {
     expect(response).toEqual({ rowCount: 1, rows: [{ ok: true }] })
     expect(clients[0].query).toHaveBeenCalledWith('SELECT 1', [1])
     expect(clients[0].release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('marks single-tenant DATABASE_POOL_URL destinations as external pools', async () => {
+    const { messaging, pools } = await loadApp({
+      env: { DATABASE_POOL_URL: 'postgres://pooler' },
+    })
+
+    await messaging.send('database', 'database.query', {
+      destination: 'default',
+      sql: 'SELECT 1',
+    })
+
+    expect(pools[0].config).toMatchObject({ connectionString: 'postgres://pooler' })
   })
 
   it('returns validation errors from malformed requests', async () => {
@@ -200,7 +212,9 @@ describe('database Watt application messaging handlers', () => {
       lockId: begin.lockId,
       sql: 'SELECT 1',
     })
-    const commit = await messaging.send('database', 'database.commitTransaction', { lockId: begin.lockId })
+    const commit = await messaging.send('database', 'database.commitTransaction', {
+      lockId: begin.lockId,
+    })
 
     expect(commit).toEqual({ committed: true })
     expect(clients[0].queries.map((query) => query.sql)).toEqual([
@@ -300,5 +314,3 @@ describe('database Watt application messaging handlers', () => {
     })
   })
 })
-
-

--- a/src/database/tests/locks.test.ts
+++ b/src/database/tests/locks.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readConfig } from '../config.js'
+import { DatabaseWattError } from '../errors.js'
+import { LockRegistry } from '../locks.js'
+import type { DestinationConfig } from '../types.js'
+
+type FakeClient = {
+  query: ReturnType<typeof vi.fn>
+  release: ReturnType<typeof vi.fn>
+}
+
+function createDestination(): DestinationConfig {
+  return {
+    connectionString: 'postgres://example',
+    id: 'tenant-a',
+    isExternalPool: false,
+    maxConnections: 10,
+  }
+}
+
+function createClient(): FakeClient {
+  return {
+    query: vi.fn().mockResolvedValue({ rowCount: 1, rows: [{ ok: true }] }),
+    release: vi.fn(),
+  }
+}
+
+describe('database lock registry', () => {
+  it('runs locked queries on the pinned client', async () => {
+    const locks = new LockRegistry(readConfig())
+    const client = createClient()
+    const lockId = locks.create(createDestination(), client as never)
+
+    const result = await locks.query(lockId, 'SELECT 1', [1])
+
+    expect(result).toEqual({ rowCount: 1, rows: [{ ok: true }] })
+    expect(client.query).toHaveBeenCalledWith('SELECT 1', [1])
+    expect(client.release).not.toHaveBeenCalled()
+
+    await locks.release(lockId)
+    expect(client.release).toHaveBeenCalledTimes(1)
+    await locks.close()
+  })
+
+  it('rejects reuse after release', async () => {
+    const locks = new LockRegistry(readConfig())
+    const client = createClient()
+    const lockId = locks.create(createDestination(), client as never)
+
+    await locks.release(lockId)
+
+    await expect(locks.query(lockId, 'SELECT 1')).rejects.toMatchObject({
+      code: 'PROTOCOL_ERROR',
+      message: 'Unknown lock ID',
+    })
+    await locks.close()
+  })
+
+  it('does not release transaction locks through release()', async () => {
+    const locks = new LockRegistry(readConfig())
+    const client = createClient()
+    const lockId = locks.create(createDestination(), client as never, true)
+
+    await expect(locks.release(lockId)).rejects.toBeInstanceOf(DatabaseWattError)
+    expect(client.release).not.toHaveBeenCalled()
+
+    await locks.rollback(lockId)
+    expect(client.query).toHaveBeenCalledWith('ROLLBACK', undefined)
+    expect(client.release).toHaveBeenCalledTimes(1)
+    await locks.close()
+  })
+
+  it('commits transactions and removes terminal locks', async () => {
+    const locks = new LockRegistry(readConfig())
+    const client = createClient()
+    const lockId = locks.create(createDestination(), client as never, true)
+
+    await locks.commit(lockId)
+
+    expect(client.query).toHaveBeenCalledWith('COMMIT', undefined)
+    expect(client.release).toHaveBeenCalledTimes(1)
+    await expect(locks.rollback(lockId)).rejects.toMatchObject({ code: 'PROTOCOL_ERROR' })
+    await locks.close()
+  })
+
+  it('serializes lock-bound work for the same lock', async () => {
+    const locks = new LockRegistry(readConfig())
+    const client = createClient()
+    const order: string[] = []
+    let releaseFirstQuery!: () => void
+
+    client.query.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          order.push('first-start')
+          releaseFirstQuery = () => {
+            order.push('first-end')
+            resolve({ rowCount: 1, rows: [] })
+          }
+        })
+    )
+    client.query.mockImplementationOnce(async () => {
+      order.push('second-start')
+      return { rowCount: 1, rows: [] }
+    })
+
+    const lockId = locks.create(createDestination(), client as never)
+    const first = locks.query(lockId, 'SELECT 1')
+    const second = locks.query(lockId, 'SELECT 2')
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(order).toEqual(['first-start'])
+
+    releaseFirstQuery()
+    await Promise.all([first, second])
+
+    expect(order).toEqual(['first-start', 'first-end', 'second-start'])
+    await locks.release(lockId)
+    await locks.close()
+  })
+})

--- a/src/database/tests/result-limits.test.ts
+++ b/src/database/tests/result-limits.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readConfig } from '../config.js'
+import { DatabaseWattError } from '../errors.js'
+import { enforceResultLimits } from '../result-limits.js'
+
+describe('database result limits', () => {
+  it('returns bounded results unchanged', () => {
+    const config = readConfig({ DATABASE_WATT_MAX_RESULT_ROWS: '2', DATABASE_WATT_MAX_RESULT_BYTES: '1000' })
+    const result = { rowCount: 1, rows: [{ id: 1 }] }
+
+    expect(enforceResultLimits(result, config)).toBe(result)
+  })
+
+  it('rejects row limits without returning partial rows', () => {
+    const config = readConfig({ DATABASE_WATT_MAX_RESULT_ROWS: '1', DATABASE_WATT_MAX_RESULT_BYTES: '1000' })
+
+    expect(() => enforceResultLimits({ rowCount: 2, rows: [{ id: 1 }, { id: 2 }] }, config)).toThrow(
+      DatabaseWattError
+    )
+  })
+
+  it('rejects byte limits', () => {
+    const config = readConfig({ DATABASE_WATT_MAX_RESULT_ROWS: '10', DATABASE_WATT_MAX_RESULT_BYTES: '20' })
+
+    expect(() => enforceResultLimits({ rowCount: 1, rows: [{ value: 'x'.repeat(100) }] }, config)).toThrow(
+      /byte limit/
+    )
+  })
+})

--- a/src/database/tests/ssl.test.ts
+++ b/src/database/tests/ssl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { getSslSettings } from '../ssl.js'
+
+describe('database SSL settings', () => {
+  it('disables SSL when sslmode=disable', () => {
+    expect(getSslSettings('postgres://user:pass@localhost/db?sslmode=disable')).toBe(false)
+  })
+
+  it('uses certificate verification for sslmode=require without a root cert', () => {
+    expect(getSslSettings('postgres://user:pass@localhost/db?sslmode=require')).toBe(true)
+  })
+
+  it('uses the configured root certificate when present', () => {
+    expect(getSslSettings('postgres://user:pass@localhost/db?sslmode=require', '<cert>')).toEqual({
+      ca: '<cert>',
+    })
+  })
+
+  it('keeps sslmode=prefer compatible with poolers that use self-signed certificates', () => {
+    expect(getSslSettings('postgres://user:pass@localhost/db?sslmode=prefer')).toEqual({
+      rejectUnauthorized: false,
+    })
+  })
+})

--- a/src/database/tests/validation.test.ts
+++ b/src/database/tests/validation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { readConfig } from '../config.js'
+import { DatabaseWattError } from '../errors.js'
+import {
+  validateCancelRequest,
+  validateLockRequestEnvelope,
+  validateNonLockRequestEnvelope,
+  validateQueryEnvelope,
+} from '../validation.js'
+
+describe('database request validation', () => {
+  const config = readConfig({
+    DATABASE_WATT_MAX_OPERATION_NAME_LENGTH: '8',
+    DATABASE_WATT_MAX_PARAMETER_COUNT: '2',
+    DATABASE_WATT_MAX_REQUEST_ID_LENGTH: '8',
+    DATABASE_WATT_MAX_SERIALIZED_REQUEST_BYTES: '200',
+    DATABASE_WATT_MAX_SQL_BYTES: '10',
+  })
+
+  it('accepts valid stateless query envelopes', () => {
+    const request = {
+      destination: 'tenant-a',
+      operationName: 'select',
+      requestId: 'req-1',
+      sql: 'SELECT 1',
+      values: [1],
+    }
+
+    expect(() => validateNonLockRequestEnvelope(request, config)).not.toThrow()
+    expect(() => validateQueryEnvelope(request, config)).not.toThrow()
+  })
+
+  it('rejects missing destinations before query execution', () => {
+    expect(() => validateNonLockRequestEnvelope({ sql: 'SELECT 1' }, config)).toThrow(
+      DatabaseWattError
+    )
+  })
+
+  it('rejects missing lock identifiers for lock-bound requests', () => {
+    expect(() => validateLockRequestEnvelope({ sql: 'SELECT 1' }, config)).toThrow(
+      /lockId/
+    )
+  })
+
+  it('rejects invalid SQL and parameter payloads', () => {
+    expect(() => validateQueryEnvelope({ sql: 1 }, config)).toThrow(/sql/)
+    expect(() => validateQueryEnvelope({ sql: 'SELECT 1', values: 'bad' }, config)).toThrow(
+      /values/
+    )
+    expect(() => validateQueryEnvelope({ sql: 'SELECT 1', values: [1, 2, 3] }, config)).toThrow(
+      /maxParameterCount/
+    )
+    expect(() => validateQueryEnvelope({ sql: 'SELECT 1234567890' }, config)).toThrow(
+      /maxSqlBytes/
+    )
+  })
+
+  it('bounds metadata and serialized request size', () => {
+    expect(() =>
+      validateNonLockRequestEnvelope({ destination: 'a', requestId: 'too-long-request-id' }, config)
+    ).toThrow(/requestId/)
+
+    expect(() =>
+      validateNonLockRequestEnvelope({ destination: 'a', operationName: 'too-long-operation' }, config)
+    ).toThrow(/operationName/)
+
+    expect(() =>
+      validateNonLockRequestEnvelope({ destination: 'a', padding: 'x'.repeat(500) }, config)
+    ).toThrow(/maxSerializedRequestBytes/)
+  })
+
+  it('validates cancellation requests', () => {
+    expect(() => validateCancelRequest({ requestId: 'req-1' })).not.toThrow()
+    expect(() => validateCancelRequest({})).toThrow(/requestId/)
+  })
+})

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,0 +1,60 @@
+export type WireRequestMeta = {
+  requestId?: string
+  operationName?: string
+}
+
+export type QueryRequest = WireRequestMeta & {
+  destination: string
+  sql: string
+  values?: unknown[]
+}
+
+export type AcquireConnectionRequest = WireRequestMeta & {
+  destination: string
+}
+
+export type AcquireConnectionResponse = {
+  lockId: string
+}
+
+export type LockedQueryRequest = WireRequestMeta & {
+  lockId: string
+  sql: string
+  values?: unknown[]
+}
+
+export type ReleaseConnectionRequest = WireRequestMeta & {
+  lockId: string
+}
+
+export type BeginTransactionRequest = WireRequestMeta & {
+  destination: string
+  isolationLevel?: 'read committed' | 'repeatable read' | 'serializable'
+  readOnly?: boolean
+}
+
+export type CommitTransactionRequest = WireRequestMeta & {
+  lockId: string
+}
+
+export type RollbackTransactionRequest = WireRequestMeta & {
+  lockId: string
+}
+
+export type CancelRequest = {
+  requestId: string
+  lockId?: string
+}
+
+export type QueryResponse<T = unknown> = {
+  rows: T[]
+  rowCount: number
+}
+
+export type DestinationConfig = {
+  connectionString: string
+  id: string
+  isExternalPool: boolean
+  maxConnections: number
+  poolMode?: string | null
+}

--- a/src/database/validation.ts
+++ b/src/database/validation.ts
@@ -1,0 +1,85 @@
+import { Buffer } from 'node:buffer'
+import type { DatabaseConfig } from './config.js'
+import { DatabaseWattError } from './errors.js'
+
+export function validateNonLockRequestEnvelope(
+  request: unknown,
+  config: DatabaseConfig
+): void {
+  validateBaseEnvelope(request, config)
+  const destination = (request as { destination?: unknown }).destination
+  if (typeof destination !== 'string' || destination.length === 0) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'destination must be a non-empty string')
+  }
+}
+
+export function validateLockRequestEnvelope(
+  request: unknown,
+  config: DatabaseConfig
+): void {
+  validateBaseEnvelope(request, config)
+  const lockId = (request as { lockId?: unknown }).lockId
+  if (typeof lockId !== 'string' || lockId.length === 0) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'lockId must be a non-empty string')
+  }
+}
+
+export function validateQueryEnvelope(
+  request: unknown,
+  config: DatabaseConfig
+): void {
+  const sql = (request as { sql?: unknown }).sql
+  const values = (request as { values?: unknown }).values
+
+  if (typeof sql !== 'string') {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'sql must be a string')
+  }
+
+  if (Buffer.byteLength(sql) > config.maxSqlBytes) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'sql exceeds maxSqlBytes')
+  }
+
+  if (values !== undefined && !Array.isArray(values)) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'values must be an array when present')
+  }
+
+  if (Array.isArray(values) && values.length > config.maxParameterCount) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'values exceeds maxParameterCount')
+  }
+}
+
+export function validateCancelRequest(request: unknown): void {
+  if (!request || typeof request !== 'object') {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'request must be an object')
+  }
+
+  const requestId = (request as { requestId?: unknown }).requestId
+  if (typeof requestId !== 'string' || requestId.length === 0) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'requestId must be a non-empty string')
+  }
+}
+
+function validateBaseEnvelope(request: unknown, config: DatabaseConfig): void {
+  if (!request || typeof request !== 'object') {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'request must be an object')
+  }
+
+  const serializedSize = Buffer.byteLength(JSON.stringify(request))
+  if (serializedSize > config.maxSerializedRequestBytes) {
+    throw new DatabaseWattError('PROTOCOL_ERROR', 'request exceeds maxSerializedRequestBytes')
+  }
+
+  const requestId = (request as { requestId?: unknown }).requestId
+  if (requestId !== undefined) {
+    if (typeof requestId !== 'string' || requestId.length > config.maxRequestIdLength) {
+      throw new DatabaseWattError('PROTOCOL_ERROR', 'requestId is invalid')
+    }
+  }
+
+  const operationName = (request as { operationName?: unknown }).operationName
+  if (operationName !== undefined) {
+    if (typeof operationName !== 'string' || operationName.length > config.maxOperationNameLength) {
+      throw new DatabaseWattError('PROTOCOL_ERROR', 'operationName is invalid')
+    }
+  }
+}

--- a/src/internal/database/client.test.ts
+++ b/src/internal/database/client.test.ts
@@ -1,0 +1,141 @@
+import { removeGlobals, updateGlobals } from '@platformatic/globals'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type LoadClientOptions = {
+  isMultitenant?: boolean
+  hasWattMessaging?: boolean
+  disableHostCheck?: boolean
+}
+
+afterEach(() => {
+  vi.doUnmock('@internal/cluster')
+  vi.doUnmock('@internal/errors')
+  vi.doUnmock('../../config')
+  vi.doUnmock('./pg-connection')
+  vi.doUnmock('./tenant')
+  vi.doUnmock('./watt-connection')
+  vi.resetModules()  
+  removeGlobals(['messaging'])
+})
+
+describe('database connection client', () => {
+  it('uses Database Watt when messaging is available', async () => {
+    const { client, getTenantConfig, getWattPostgresConnection, wattConnection } = await loadClient({
+      hasWattMessaging: true,
+    })
+
+    const connection = await client.getPostgresConnection(createConnectionOptions())
+
+    expect(connection).toBe(wattConnection)
+    expect(getTenantConfig).not.toHaveBeenCalled()
+    expect(getWattPostgresConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dbUrl: '',
+        isExternalPool: false,
+        isSingleUse: false,
+        maxConnections: 20,
+        tenantId: 'tenant-a',
+      })
+    )
+  })
+
+  it('falls back to direct PostgreSQL when Watt messaging is unavailable', async () => {
+    const { client, getTenantConfig, pgConnection, pgCreate } = await loadClient({
+      hasWattMessaging: false,
+    })
+
+    const connection = await client.getPostgresConnection(createConnectionOptions())
+
+    expect(connection).toBe(pgConnection)
+    expect(getTenantConfig).toHaveBeenCalledWith('tenant-a')
+    expect(pgCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterSize: 3,
+        dbUrl: 'postgres://tenant-db',
+        maxConnections: 7,
+      })
+    )
+  })
+
+  it('validates multitenant forwarded host before routing to Database Watt', async () => {
+    const { client, getWattPostgresConnection } = await loadClient({
+      hasWattMessaging: true,
+      isMultitenant: true,
+    })
+
+    await expect(
+      client.getPostgresConnection(
+        createConnectionOptions({ host: 'evil.example.test', disableHostCheck: false })
+      )
+    ).rejects.toThrow('X-Forwarded-Host header does not match regular expression')
+
+    expect(getWattPostgresConnection).not.toHaveBeenCalled()
+  })
+})
+
+async function loadClient(options: LoadClientOptions = {}) {
+  vi.resetModules()
+
+  const getTenantConfig = vi.fn(async () => ({
+    databasePoolMode: 'transaction',
+    databasePoolUrl: undefined,
+    databaseUrl: 'postgres://tenant-db',
+    maxConnections: 7,
+  }))
+  const pgConnection = { kind: 'pg-connection' }
+  const wattConnection = { kind: 'watt-connection' }
+  const pgCreate = vi.fn(async () => pgConnection)
+  const getWattPostgresConnection = vi.fn(async () => wattConnection)
+
+  vi.doMock('@internal/cluster', () => ({ Cluster: { size: 3 } }))
+  vi.doMock('@internal/errors', () => ({
+    ERRORS: {
+      InvalidTenantId: () => new Error('Invalid tenant id'),
+      InvalidXForwardedHeader: (message: string) => new Error(message),
+    },
+  }))
+  vi.doMock('../../config', () => ({
+    getConfig: () => ({
+      databaseMaxConnections: 20,
+      databasePoolMode: 'transaction',
+      databasePoolURL: undefined,
+      databaseURL: 'postgres://default-db',
+      isMultitenant: options.isMultitenant ?? true,
+      requestXForwardedHostRegExp: '^tenant-[a-z]+\\.example\\.test$',
+    }),
+    normalizeDatabasePoolMode: (value: string | undefined) => value,
+  }))
+  vi.doMock('./pg-connection', () => ({
+    PgTenantConnection: { create: pgCreate },
+  }))
+  vi.doMock('./tenant', () => ({ getTenantConfig }))
+  vi.doMock('./watt-connection', () => ({
+    getWattPostgresConnection,    
+  }))
+
+  if(options.hasWattMessaging) {
+    updateGlobals({ messaging: {} as unknown as any })
+  } else {
+    removeGlobals(['messaging'])
+  }
+
+  const client = await import('./client')
+  return { client, getTenantConfig, getWattPostgresConnection, pgConnection, pgCreate, wattConnection }
+}
+
+function createConnectionOptions(overrides: Partial<Parameters<typeof import('./client').getPostgresConnection>[0]> = {}) {
+  return {
+    disableHostCheck: true,
+    host: 'tenant-a.example.test',
+    superUser: {
+      jwt: 'service-jwt',
+      payload: { role: 'service_role' },
+    },
+    tenantId: 'tenant-a',
+    user: {
+      jwt: 'user-jwt',
+      payload: { role: 'authenticated' },
+    },
+    ...overrides,
+  }
+}

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -1,10 +1,12 @@
 import { Cluster } from '@internal/cluster'
 import { ERRORS } from '@internal/errors'
 import { getXForwardedHostRegExp } from '@internal/http/x-forwarded-host'
+import { hasField } from '@platformatic/globals'
 import { getConfig } from '../../config'
 import { PgTenantConnection } from './pg-connection'
 import { User } from './pool'
 import { getTenantConfig } from './tenant'
+import { getWattPostgresConnection } from './watt-connection'
 
 const xForwardedHostRegExp = getXForwardedHostRegExp()
 
@@ -18,6 +20,7 @@ interface ConnectionOptions {
   superUser: User
   disableHostCheck?: boolean
   operation?: () => string | undefined
+  maxConnections?: number
 }
 
 export async function getPgPostgresConnection(
@@ -34,7 +37,52 @@ export async function getPgPostgresConnection(
   })
 }
 
-export const getPostgresConnection = getPgPostgresConnection
+function validateConnectionOptions(options: ConnectionOptions): void {
+  const { isMultitenant, requestXForwardedHostRegExp } = getConfig()
+
+  if (!isMultitenant) {
+    return
+  }
+
+  if (!options.tenantId) {
+    throw ERRORS.InvalidTenantId()
+  }
+
+  if (!requestXForwardedHostRegExp || options.disableHostCheck) {
+    return
+  }
+
+  const xForwardedHost = options.host
+
+  if (typeof xForwardedHost !== 'string') {
+    throw ERRORS.InvalidXForwardedHeader('X-Forwarded-Host header is not a string')
+  }
+
+  if (!new RegExp(requestXForwardedHostRegExp).test(xForwardedHost)) {
+    throw ERRORS.InvalidXForwardedHeader(
+      'X-Forwarded-Host header does not match regular expression'
+    )
+  }
+}
+
+export async function getPostgresConnection(
+  options: ConnectionOptions
+): Promise<PgTenantConnection> {
+  if (!hasField('messaging')) {
+    return getPgPostgresConnection(options)
+  }
+
+  validateConnectionOptions(options)
+  const { databaseMaxConnections } = getConfig()
+
+  return getWattPostgresConnection({
+    ...options,
+    dbUrl: '',
+    isExternalPool: false,
+    isSingleUse: false,
+    maxConnections: options.maxConnections ?? databaseMaxConnections,
+  })
+}
 
 async function getDbSettings(
   tenantId: string,

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -1,5 +1,6 @@
 import { ERRORS } from '@internal/errors'
 import { ResetMigrationsOnTenant, RunMigrationsOnTenants } from '@storage/events'
+// Database migrations intentionally keep direct pg access outside Database Watt for now.
 import { Client, ClientConfig } from 'pg'
 import { MigrationError } from 'postgres-migrations'
 import { runMigration } from 'postgres-migrations/dist/run-migration'

--- a/src/internal/database/multitenant-pg.test.ts
+++ b/src/internal/database/multitenant-pg.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { vi } from 'vitest'
+import { afterEach, describe, it, vi } from 'vitest'
 
 type MultitenantPgModule = typeof import('./multitenant-pg')
 type MockPgPoolOptions = {
@@ -17,14 +17,30 @@ type MockPgPool = {
   connect: () => Promise<MockPgClient>
   end: () => Promise<void>
 }
+type MockWattQuery = {
+  destination: string
+  statement: unknown
+}
 
 let createdPools: MockPgPool[] = []
+let wattQueries: MockWattQuery[] = []
+const originalEnv = { ...process.env }
 
 async function loadMultitenantPgModule(
-  configOverrides: Record<string, unknown> = {}
+  configOverrides: Record<string, unknown> = {},
+  options: { hasWattMessaging?: boolean } = {}
 ): Promise<MultitenantPgModule> {
   vi.resetModules()
+  process.env = { ...originalEnv, MULTI_TENANT: 'true' }
   mockPgModule()
+  mockWattConnectionModule()
+  const globals = await import('@platformatic/globals')
+
+  if (options.hasWattMessaging) {
+    globals.updateGlobals({ messaging: {} as unknown as never })
+  } else {
+    globals.removeGlobals(['messaging'])
+  }
 
   const configModule = await import('../../config')
   configModule.getConfig({ reload: true })
@@ -46,7 +62,9 @@ describe('multitenant pg pool', () => {
     await loadedModule?.closeMultitenantPg()
     loadedModule = undefined
     vi.doUnmock('pg')
+    vi.doUnmock('./watt-connection')
     vi.resetModules()
+    process.env = { ...originalEnv }
   })
 
   it('does not pass DATABASE_SSL_ROOT_CERT into the shared multitenant pool config', async () => {
@@ -195,6 +213,36 @@ describe('multitenant pg pool', () => {
     expect('getMultitenantPgPool' in loadedModule).toBe(false)
     expect('getMultitenantPgPoolConfig' in loadedModule).toBe(false)
   })
+
+  it('uses Database Watt for master queries when messaging is available', async () => {
+    loadedModule = await loadMultitenantPgModule({}, { hasWattMessaging: true })
+
+    await runQuery(loadedModule)
+
+    expect(createdPools).toHaveLength(0)
+    expect(wattQueries).toEqual([
+      {
+        destination: 'master',
+        statement: 'select 1',
+      },
+    ])
+  })
+
+  it('uses Database Watt for master transactions when messaging is available', async () => {
+    loadedModule = await loadMultitenantPgModule({}, { hasWattMessaging: true })
+
+    const tx = await loadedModule.multitenantPgExecutor.beginTransaction()
+    await tx.query('select 1')
+    await tx.commit()
+
+    expect(createdPools).toHaveLength(0)
+    expect(wattQueries).toEqual([
+      {
+        destination: 'master',
+        statement: 'select 1',
+      },
+    ])
+  })
 })
 
 async function runQuery(module: MultitenantPgModule): Promise<void> {
@@ -245,6 +293,37 @@ function mockPgModule(): void {
         Pool: MockPool,
         types,
       },
+    }
+  })
+}
+
+function mockWattConnectionModule(): void {
+  wattQueries = []
+
+  vi.doMock('./watt-connection', () => {
+    class MockDatabaseWattPgExecutor {
+      constructor(private readonly destination: string) {}
+
+      async query(statement: unknown) {
+        wattQueries.push({ destination: this.destination, statement })
+        return { rowCount: 0, rows: [] }
+      }
+
+      async beginTransaction() {
+        return {
+          commit: vi.fn(async () => undefined),
+          isCompleted: vi.fn(() => false),
+          query: vi.fn(async (statement: unknown) => {
+            wattQueries.push({ destination: this.destination, statement })
+            return { rowCount: 0, rows: [] }
+          }),
+          rollback: vi.fn(async () => undefined),
+        }
+      }
+    }
+
+    return {
+      DatabaseWattPgExecutor: MockDatabaseWattPgExecutor,
     }
   })
 }

--- a/src/internal/database/multitenant-pg.ts
+++ b/src/internal/database/multitenant-pg.ts
@@ -1,7 +1,9 @@
 import { logger, logSchema } from '@internal/monitoring'
+import { hasField } from '@platformatic/globals'
 import { Pool, PoolConfig } from 'pg'
 import { getConfig } from '../../config'
 import { attachPgPoolErrorHandler, PgPoolExecutor, PgTransactionalExecutor } from './pg-connection'
+import { DatabaseWattPgExecutor } from './watt-connection'
 
 function buildMultitenantPgPoolConfig(config: ReturnType<typeof getConfig>): PoolConfig {
   const {
@@ -148,13 +150,16 @@ function getPoolConfigSignature(config: PoolConfig): string {
 }
 
 const multitenantPgPoolOwner = new MultitenantPgPoolOwner()
+const multitenantWattExecutor = new DatabaseWattPgExecutor('master', () => 'multitenant-pg')
 
 export const multitenantPgExecutor: PgTransactionalExecutor = {
   async query(statement, options) {
-    return multitenantPgPoolOwner.getExecutor().query(statement, options)
+    const executor = hasField('messaging') ? multitenantWattExecutor : multitenantPgPoolOwner.getExecutor()
+    return executor.query(statement, options)
   },
   async beginTransaction(options) {
-    return multitenantPgPoolOwner.getExecutor().beginTransaction(options)
+    const executor = hasField('messaging') ? multitenantWattExecutor : multitenantPgPoolOwner.getExecutor()
+    return executor.beginTransaction(options)
   },
 }
 

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -97,6 +97,23 @@ interface PgPoolErrorContext {
   project?: string
 }
 
+export interface PgTransactionLike extends PgExecutor {
+  isCompleted(): boolean
+  commit(): Promise<void>
+  rollback(): Promise<void>
+}
+
+export interface PgTenantConnectionLike extends PgExecutor {
+  readonly role: string
+  dispose(): Promise<void>
+  setAbortSignal(signal: AbortSignal): void
+  getAbortSignal(): AbortSignal | undefined
+  beginTransaction(options?: TransactionOptions): Promise<PgTransactionLike>
+  asSuperUser(): PgTenantConnectionLike
+  transaction(opts?: TransactionOptions): Promise<PgTransactionLike>
+  setScope(tnx: PgExecutor): Promise<void>
+}
+
 type PgClientWithCancel = PoolClient & {
   processID?: number
   secretKey?: number
@@ -471,7 +488,7 @@ export class PgPoolExecutor implements PgTransactionalExecutor {
   }
 }
 
-export class PgTransaction implements PgExecutor {
+export class PgTransaction implements PgTransactionLike {
   private completed = false
   private statementTimeoutMs?: number
 
@@ -610,7 +627,7 @@ export class PgTransaction implements PgExecutor {
   }
 }
 
-export class PgTenantConnection {
+export class PgTenantConnection implements PgTenantConnectionLike {
   static poolManager = new PgPoolManager()
   public readonly role: string
   private abortSignal?: AbortSignal

--- a/src/internal/database/watt-connection.test.ts
+++ b/src/internal/database/watt-connection.test.ts
@@ -1,0 +1,218 @@
+import { removeGlobals, updateGlobals } from '@platformatic/globals'
+import { describe, expect, it } from 'vitest'
+import type { TenantConnectionOptions } from './pool'
+import {
+  DatabaseWattPgExecutor,
+  getWattPostgresConnection,
+} from './watt-connection'
+
+type SentWattMessage = {
+  application: string
+  data: Record<string, unknown>
+  message: string
+}
+
+function installWattMessagingMock(
+  responses: Record<string, unknown> = {}
+): { sent: SentWattMessage[] } {
+  const sent: SentWattMessage[] = []
+
+  updateGlobals({
+    messaging: {
+      send: vi.fn(async (application: string, message: string, data: Record<string, unknown>) => {
+        sent.push({ application, data, message })
+        const response = responses[message]
+        return response instanceof Promise ? response : response
+      }),
+    } as unknown as any
+  })
+
+  return { sent }
+}
+
+afterEach(() => {
+  removeGlobals(['messaging'])
+})
+
+describe('Watt PostgreSQL connection adapter', () => {
+  it('sends stateless queries through Database Watt messaging', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.query': { rowCount: 1, rows: [{ id: 1 }] },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    const result = await connection.query<{ id: number }>({ text: 'SELECT $1::int as id', values: [1] })
+
+    expect(result.rows).toEqual([{ id: 1 }])
+    expect(result.rowCount).toBe(1)
+    expect(sent[0]).toMatchObject({
+      application: 'database',
+      message: 'database.query',
+      data: {
+        destination: 'tenant-a',
+        operationName: 'operation-a',
+        sql: 'SELECT $1::int as id',
+        values: [1],
+      },
+    })
+    expect(sent[0].data.requestId).toEqual(expect.any(String))
+  })
+
+  it('runs transaction lifecycle through lock-bound messages', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.beginTransaction': { lockId: 'lock-a' },
+      'database.lockedQuery': { rowCount: 1, rows: [{ ok: true }] },
+      'database.commitTransaction': { committed: true },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    const tx = await connection.transaction({ isolation: 'serializable', readOnly: true })
+    const result = await tx.query('SELECT 1')
+    await tx.commit()
+
+    expect(result.rows).toEqual([{ ok: true }])
+    expect(sent.map((message) => message.message)).toEqual([
+      'database.beginTransaction',
+      'database.lockedQuery',
+      'database.commitTransaction',
+    ])
+    expect(sent[0].data).toMatchObject({
+      destination: 'tenant-a',
+      isolationLevel: 'serializable',
+      readOnly: true,
+    })
+    expect(sent[1].data).toMatchObject({ lockId: 'lock-a', sql: 'SELECT 1' })
+    expect(tx.isCompleted()).toBe(true)
+  })
+
+  it('rolls back transactions through Database Watt messaging', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.beginTransaction': { lockId: 'lock-a' },
+      'database.rollbackTransaction': { rolledBack: true },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    const tx = await connection.transaction()
+    await tx.rollback()
+
+    expect(sent.map((message) => message.message)).toEqual([
+      'database.beginTransaction',
+      'database.rollbackTransaction',
+    ])
+    expect(tx.isCompleted()).toBe(true)
+  })
+
+  it('maps PostgreSQL error responses back to pg DatabaseError', async () => {
+    installWattMessagingMock({
+      'database.query': {
+        code: 'POSTGRES_ERROR',
+        message: 'duplicate key value violates unique constraint',
+        sqlState: '23505',
+      },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    await expect(connection.query('INSERT')).rejects.toMatchObject({
+      code: '23505',
+      message: 'duplicate key value violates unique constraint',
+    })
+  })
+
+  it('sends explicit cancellation when an AbortSignal fires', async () => {
+    let resolveQuery!: (value: unknown) => void
+    const { sent } = installWattMessagingMock({
+      'database.query':
+        new Promise((resolve) => {
+          resolveQuery = resolve
+        }),
+      'database.cancel': { cancelled: true },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+    const controller = new AbortController()
+
+    const query = connection.query('SELECT pg_sleep(10)', { signal: controller.signal })
+    controller.abort()
+
+    await expect(query).rejects.toMatchObject({ name: 'AbortError', code: 'ABORT_ERR' })
+    resolveQuery({ rowCount: 0, rows: [] })
+
+    expect(sent.map((message) => message.message)).toEqual(['database.query', 'database.cancel'])
+    expect(sent[1].data.requestId).toBe(sent[0].data.requestId)
+  })
+
+  it('creates superuser connections with service role credentials', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.query': { rowCount: 1, rows: [] },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    await connection.asSuperUser().query('SELECT 1')
+
+    expect(sent[0].data.destination).toBe('tenant-a')
+    expect(connection.asSuperUser().role).toBe('service_role')
+  })
+
+  it('sends master executor queries through Database Watt messaging', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.query': { rowCount: 1, rows: [{ id: 'master' }] },
+    })
+    const executor = new DatabaseWattPgExecutor('master', () => 'master-operation')
+
+    const result = await executor.query<{ id: string }>('SELECT current_database()')
+
+    expect(result.rows).toEqual([{ id: 'master' }])
+    expect(sent[0]).toMatchObject({
+      application: 'database',
+      message: 'database.query',
+      data: {
+        destination: 'master',
+        operationName: 'master-operation',
+        sql: 'SELECT current_database()',
+      },
+    })
+  })
+
+  it('runs master executor transactions through Database Watt messaging', async () => {
+    const { sent } = installWattMessagingMock({
+      'database.beginTransaction': { lockId: 'master-lock' },
+      'database.lockedQuery': { rowCount: 1, rows: [{ ok: true }] },
+      'database.commitTransaction': { committed: true },
+    })
+    const executor = new DatabaseWattPgExecutor('master')
+
+    const tx = await executor.beginTransaction({ isolation: 'serializable', readOnly: true })
+    await tx.query('SELECT 1')
+    await tx.commit()
+
+    expect(sent.map((message) => message.message)).toEqual([
+      'database.beginTransaction',
+      'database.lockedQuery',
+      'database.commitTransaction',
+    ])
+    expect(sent[0].data).toMatchObject({
+      destination: 'master',
+      isolationLevel: 'serializable',
+      readOnly: true,
+    })
+    expect(sent[1].data).toMatchObject({ lockId: 'master-lock', sql: 'SELECT 1' })
+  })
+})
+
+function createConnectionOptions(): TenantConnectionOptions {
+  return {
+    dbUrl: '',
+    isExternalPool: false,
+    isSingleUse: false,
+    maxConnections: 10,
+    operation: () => 'operation-a',
+    superUser: {
+      jwt: 'service-jwt',
+      payload: { role: 'service_role' },
+    },
+    tenantId: 'tenant-a',
+    user: {
+      jwt: 'user-jwt',
+      payload: { role: 'authenticated' },
+    },
+  }
+}

--- a/src/internal/database/watt-connection.test.ts
+++ b/src/internal/database/watt-connection.test.ts
@@ -1,10 +1,7 @@
 import { removeGlobals, updateGlobals } from '@platformatic/globals'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { TenantConnectionOptions } from './pool'
-import {
-  DatabaseWattPgExecutor,
-  getWattPostgresConnection,
-} from './watt-connection'
+import { DatabaseWattPgExecutor, getWattPostgresConnection } from './watt-connection'
 
 type SentWattMessage = {
   application: string
@@ -12,19 +9,21 @@ type SentWattMessage = {
   message: string
 }
 
-function installWattMessagingMock(
-  responses: Record<string, unknown> = {}
-): { sent: SentWattMessage[] } {
+function installWattMessagingMock(responses: Record<string, unknown> = {}): {
+  sent: SentWattMessage[]
+} {
   const sent: SentWattMessage[] = []
 
   updateGlobals({
     messaging: {
+      handle: vi.fn(),
+      notify: vi.fn(),
       send: vi.fn(async (application: string, message: string, data: Record<string, unknown>) => {
         sent.push({ application, data, message })
         const response = responses[message]
         return response instanceof Promise ? response : response
       }),
-    } as unknown as any
+    },
   })
 
   return { sent }
@@ -41,7 +40,10 @@ describe('Watt PostgreSQL connection adapter', () => {
     })
     const connection = await getWattPostgresConnection(createConnectionOptions())
 
-    const result = await connection.query<{ id: number }>({ text: 'SELECT $1::int as id', values: [1] })
+    const result = await connection.query<{ id: number }>({
+      text: 'SELECT $1::int as id',
+      values: [1],
+    })
 
     expect(result.rows).toEqual([{ id: 1 }])
     expect(result.rowCount).toBe(1)
@@ -118,13 +120,42 @@ describe('Watt PostgreSQL connection adapter', () => {
     })
   })
 
+  it('preserves timeout response codes on pg DatabaseError', async () => {
+    installWattMessagingMock({
+      'database.query': {
+        code: 'ACQUIRE_TIMEOUT',
+        message: 'Timed out acquiring database connection',
+      },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    await expect(connection.query('SELECT 1')).rejects.toMatchObject({
+      code: 'ACQUIRE_TIMEOUT',
+      message: 'Timed out acquiring database connection',
+    })
+  })
+
+  it('maps server timeouts to PostgreSQL query-canceled SQLSTATE', async () => {
+    installWattMessagingMock({
+      'database.query': {
+        code: 'SERVER_TIMEOUT',
+        message: 'canceling statement due to statement timeout',
+      },
+    })
+    const connection = await getWattPostgresConnection(createConnectionOptions())
+
+    await expect(connection.query('SELECT pg_sleep(10)')).rejects.toMatchObject({
+      code: '57014',
+      message: 'canceling statement due to statement timeout',
+    })
+  })
+
   it('sends explicit cancellation when an AbortSignal fires', async () => {
     let resolveQuery!: (value: unknown) => void
     const { sent } = installWattMessagingMock({
-      'database.query':
-        new Promise((resolve) => {
-          resolveQuery = resolve
-        }),
+      'database.query': new Promise((resolve) => {
+        resolveQuery = resolve
+      }),
       'database.cancel': { cancelled: true },
     })
     const connection = await getWattPostgresConnection(createConnectionOptions())

--- a/src/internal/database/watt-connection.ts
+++ b/src/internal/database/watt-connection.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from 'node:crypto'
 import { getMessaging } from '@platformatic/globals'
 import { TransactionOptions } from '@storage/database'
-import { randomUUID } from 'node:crypto'
 import { DatabaseError, QueryResult, QueryResultRow } from 'pg'
 import {
   PgExecutor,
@@ -170,10 +170,7 @@ class WattPgTransaction implements PgTransactionLike {
   private readonly lockId: string
   private readonly operation?: () => string | undefined
 
-  constructor(
-    lockId: string,
-    operation?: () => string | undefined
-  ) {
+  constructor(lockId: string, operation?: () => string | undefined) {
     this.lockId = lockId
     this.operation = operation
   }
@@ -280,7 +277,9 @@ async function sendDatabaseMessage<T>(
         return
       }
 
-      void getMessaging().send(databaseApplicationId, 'database.cancel', { requestId, lockId }).catch(() => undefined)
+      void getMessaging()
+        .send(databaseApplicationId, 'database.cancel', { requestId, lockId })
+        .catch(() => undefined)
       reject(createAbortError())
     }
 
@@ -352,7 +351,7 @@ function toDatabaseError(response: DatabaseErrorResponse): Error {
     response.code === 'MESSAGING_TIMEOUT'
   ) {
     const error = new DatabaseError(response.message, 0, 'error')
-    error.code = response.code === 'SERVER_TIMEOUT' ? '57014' : undefined
+    error.code = response.code === 'SERVER_TIMEOUT' ? '57014' : response.code
     error.stack = response.stack
     return error
   }

--- a/src/internal/database/watt-connection.ts
+++ b/src/internal/database/watt-connection.ts
@@ -1,0 +1,382 @@
+import { getMessaging } from '@platformatic/globals'
+import { TransactionOptions } from '@storage/database'
+import { randomUUID } from 'node:crypto'
+import { DatabaseError, QueryResult, QueryResultRow } from 'pg'
+import {
+  PgExecutor,
+  PgQueryOptions,
+  PgStatement,
+  PgTenantConnection,
+  PgTenantConnectionLike,
+  PgTransaction,
+  PgTransactionalExecutor,
+  PgTransactionLike,
+} from './pg-connection'
+import { searchPath, TenantConnectionOptions } from './pool'
+
+type DatabaseErrorResponse = {
+  code: string
+  message: string
+  requestId?: string
+  operationName?: string
+  destination?: string
+  lockId?: string
+  sqlState?: string
+  stack?: string
+  connectionDiscarded?: boolean
+}
+
+type QueryResponse<T extends QueryResultRow = QueryResultRow> = {
+  rows: T[]
+  rowCount: number
+}
+
+type PgQueryArgument = PgQueryOptions | unknown[]
+
+const databaseApplicationId = 'database'
+
+export async function getWattPostgresConnection(
+  options: TenantConnectionOptions
+): Promise<PgTenantConnection> {
+  return new WattPgTenantConnection(options) as unknown as PgTenantConnection
+}
+
+class WattPgTenantConnection implements PgTenantConnectionLike {
+  readonly role: string
+  private readonly executor: DatabaseWattPgExecutor
+  private wattAbortSignal?: AbortSignal
+
+  constructor(private readonly options: TenantConnectionOptions) {
+    this.role = options.user.payload.role || 'anon'
+    this.executor = new DatabaseWattPgExecutor(options.tenantId, options.operation)
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  setAbortSignal(signal: AbortSignal): void {
+    this.wattAbortSignal = signal
+  }
+
+  getAbortSignal(): AbortSignal | undefined {
+    return this.wattAbortSignal
+  }
+
+  async query<T extends QueryResultRow = QueryResultRow>(
+    statement: string | PgStatement,
+    options?: PgQueryArgument
+  ): Promise<QueryResult<T>> {
+    return this.executor.query<T>(statement, mergeSignalOptions(options, this.wattAbortSignal))
+  }
+
+  async beginTransaction(options?: TransactionOptions): Promise<PgTransactionLike> {
+    return this.executor.beginTransaction(options)
+  }
+
+  asSuperUser(): PgTenantConnection {
+    const connection = new WattPgTenantConnection({
+      ...this.options,
+      user: this.options.superUser,
+    })
+
+    if (this.wattAbortSignal) {
+      connection.setAbortSignal(this.wattAbortSignal)
+    }
+
+    return connection as unknown as PgTenantConnection
+  }
+
+  async transaction(opts?: TransactionOptions): Promise<PgTransaction> {
+    return this.beginTransaction(opts) as Promise<PgTransaction>
+  }
+
+  async setScope(tnx: PgExecutor): Promise<void> {
+    const headers = JSON.stringify(this.options.headers || {})
+    await tnx.query({
+      text: `
+        SELECT
+          set_config('role', $1, true),
+          set_config('request.jwt.claim.role', $2, true),
+          set_config('request.jwt', $3, true),
+          set_config('request.jwt.claim.sub', $4, true),
+          set_config('request.jwt.claims', $5, true),
+          set_config('request.headers', $6, true),
+          set_config('request.method', $7, true),
+          set_config('request.path', $8, true),
+          set_config('storage.operation', $9, true),
+          set_config('storage.allow_delete_query', 'true', true),
+          set_config('search_path', $10, true);
+      `,
+      values: [
+        this.role,
+        this.role,
+        this.options.user.jwt || '',
+        this.options.user.payload.sub || '',
+        JSON.stringify(this.options.user.payload),
+        headers,
+        this.options.method || '',
+        this.options.path || '',
+        this.options.operation?.() || '',
+        searchPath.join(','),
+      ],
+    })
+  }
+}
+
+export class DatabaseWattPgExecutor implements PgTransactionalExecutor {
+  private readonly destination: string
+  private readonly operation?: () => string | undefined
+
+  constructor(destination: string, operation?: () => string | undefined) {
+    this.destination = destination
+    this.operation = operation
+  }
+
+  async query<T extends QueryResultRow = QueryResultRow>(
+    statement: string | PgStatement,
+    options?: PgQueryArgument
+  ): Promise<QueryResult<T>> {
+    const query = normalizeStatement(statement, Array.isArray(options) ? options : undefined)
+    const signal = Array.isArray(options) ? undefined : options?.signal
+    const response = await sendDatabaseMessage<QueryResponse<T>>(
+      'database.query',
+      {
+        destination: this.destination,
+        operationName: this.operation?.(),
+        sql: query.text,
+        values: query.values,
+      },
+      signal
+    )
+
+    return toPgQueryResult(response)
+  }
+
+  async beginTransaction(options?: TransactionOptions): Promise<PgTransaction> {
+    const response = await sendDatabaseMessage<{ lockId: string }>('database.beginTransaction', {
+      destination: this.destination,
+      isolationLevel: options?.isolation,
+      operationName: this.operation?.(),
+      readOnly: options?.readOnly,
+    })
+
+    return new WattPgTransaction(response.lockId, this.operation) as unknown as PgTransaction
+  }
+}
+
+class WattPgTransaction implements PgTransactionLike {
+  private wattCompleted = false
+  private readonly lockId: string
+  private readonly operation?: () => string | undefined
+
+  constructor(
+    lockId: string,
+    operation?: () => string | undefined
+  ) {
+    this.lockId = lockId
+    this.operation = operation
+  }
+
+  isCompleted(): boolean {
+    return this.wattCompleted
+  }
+
+  async query<T extends QueryResultRow = QueryResultRow>(
+    statement: string | PgStatement,
+    options?: PgQueryArgument
+  ): Promise<QueryResult<T>> {
+    if (this.wattCompleted) {
+      throw new Error('Cannot query a completed transaction')
+    }
+
+    const query = normalizeStatement(statement, Array.isArray(options) ? options : undefined)
+    const signal = Array.isArray(options) ? undefined : options?.signal
+    const response = await sendDatabaseMessage<QueryResponse<T>>(
+      'database.lockedQuery',
+      {
+        lockId: this.lockId,
+        operationName: this.operation?.(),
+        sql: query.text,
+        values: query.values,
+      },
+      signal,
+      this.lockId
+    )
+
+    return toPgQueryResult(response)
+  }
+
+  async commit(): Promise<void> {
+    if (this.wattCompleted) {
+      return
+    }
+
+    try {
+      await sendDatabaseMessage('database.commitTransaction', { lockId: this.lockId })
+    } finally {
+      this.wattCompleted = true
+    }
+  }
+
+  async rollback(): Promise<void> {
+    if (this.wattCompleted) {
+      return
+    }
+
+    try {
+      await sendDatabaseMessage('database.rollbackTransaction', { lockId: this.lockId })
+    } finally {
+      this.wattCompleted = true
+    }
+  }
+}
+
+function normalizeStatement(statement: string | PgStatement, values?: unknown[]): PgStatement {
+  if (typeof statement === 'string') {
+    return { text: statement, values }
+  }
+
+  return statement
+}
+
+function mergeSignalOptions(
+  options: PgQueryArgument | undefined,
+  signal: AbortSignal | undefined
+): PgQueryArgument | undefined {
+  if (!signal || Array.isArray(options)) {
+    return options
+  }
+
+  return {
+    ...options,
+    signal: options?.signal || signal,
+  }
+}
+
+async function sendDatabaseMessage<T>(
+  message: string,
+  data: Record<string, unknown>,
+  signal?: AbortSignal,
+  lockId?: string
+): Promise<T> {
+  assertValidSignal(signal)
+
+  const requestId = typeof data.requestId === 'string' ? data.requestId : randomUUID()
+  const payload = { ...data, requestId }
+  const request = getMessaging().send(databaseApplicationId, message, payload)
+
+  if (!signal) {
+    const response = await request
+    return parseDatabaseMessageResponse<T>(response)
+  }
+
+  let abortListener: (() => void) | undefined
+  let settled = false
+
+  const abortPromise = new Promise<never>((_, reject) => {
+    abortListener = () => {
+      if (settled) {
+        return
+      }
+
+      void getMessaging().send(databaseApplicationId, 'database.cancel', { requestId, lockId }).catch(() => undefined)
+      reject(createAbortError())
+    }
+
+    signal.addEventListener('abort', abortListener, { once: true })
+  })
+
+  try {
+    const response = await Promise.race([request, abortPromise])
+    return parseDatabaseMessageResponse<T>(response)
+  } finally {
+    settled = true
+    if (abortListener) {
+      signal.removeEventListener('abort', abortListener)
+    }
+  }
+}
+
+function parseDatabaseMessageResponse<T>(response: unknown): T {
+  if (isDatabaseErrorResponse(response)) {
+    throw toDatabaseError(response)
+  }
+
+  return response as T
+}
+
+function assertValidSignal(signal?: AbortSignal): void {
+  if (!signal) {
+    return
+  }
+
+  if (!(signal instanceof AbortSignal)) {
+    throw new Error('Expected signal to be an instance of AbortSignal')
+  }
+
+  if (signal.aborted) {
+    throw createAbortError()
+  }
+}
+
+function createAbortError(): Error & { code: string } {
+  const error = new Error('Query was aborted') as Error & { code: string }
+  error.name = 'AbortError'
+  error.code = 'ABORT_ERR'
+  return error
+}
+
+function isDatabaseErrorResponse(response: unknown): response is DatabaseErrorResponse {
+  return Boolean(
+    response &&
+      typeof response === 'object' &&
+      typeof (response as { code?: unknown }).code === 'string' &&
+      typeof (response as { message?: unknown }).message === 'string'
+  )
+}
+
+function toDatabaseError(response: DatabaseErrorResponse): Error {
+  if (response.code === 'POSTGRES_ERROR') {
+    const error = new DatabaseError(response.message, 0, 'error')
+    error.code = response.sqlState
+    error.stack = response.stack
+    return error
+  }
+
+  if (
+    response.code === 'CLIENT_TIMEOUT' ||
+    response.code === 'SERVER_TIMEOUT' ||
+    response.code === 'CONNECTION_TIMEOUT' ||
+    response.code === 'ACQUIRE_TIMEOUT' ||
+    response.code === 'MESSAGING_TIMEOUT'
+  ) {
+    const error = new DatabaseError(response.message, 0, 'error')
+    error.code = response.code === 'SERVER_TIMEOUT' ? '57014' : undefined
+    error.stack = response.stack
+    return error
+  }
+
+  const error = new Error(response.message) as Error & {
+    code?: string
+    databaseCode?: string
+    databaseResponse?: DatabaseErrorResponse
+  }
+  error.code = response.code
+  error.databaseCode = response.code
+  error.databaseResponse = response
+  error.stack = response.stack
+  return error
+}
+
+function toPgQueryResult<T extends QueryResultRow = QueryResultRow>(
+  response: QueryResponse<T>
+): QueryResult<T> {
+  return {
+    command: '',
+    fields: [],
+    oid: 0,
+    rowCount: response.rowCount,
+    rows: response.rows,
+  }
+}

--- a/watt.database.json
+++ b/watt.database.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.56.0.json",
+  "node": {
+    "main": "./dist/database/index.js",
+    "hasServer": false
+  }
+}

--- a/watt.json
+++ b/watt.json
@@ -1,24 +1,33 @@
 {
-  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.52.0.json",
-  "node": {
-    "main": "./dist/start/server.js"
+  "$schema": "https://schemas.platformatic.dev/@platformatic/runtime/3.56.0.json",
+  "entrypoint": "storage",
+  "exitOnUnhandledErrors": false,
+  "workers": "{WORKERS_NUM}",
+  "logger": {
+    "level": "{LOG_LEVEL}"
   },
-  "runtime": {
-    "exitOnUnhandledErrors": false,
-    "workers": "{WORKERS_NUM}",
-    "logger": {
-      "level": "{LOG_LEVEL}"
+  "health": {
+    "enabled": "{WATT_HEALTH_ENABLED}",
+    "maxELU": "{WATT_HEALTH_MAX_ELU}",
+    "gracePeriod": "{WATT_HEALTH_GRACE_PERIOD}",
+    "maxUnhealthyChecks": "{WATT_HEALTH_MAX_UNHEALTHY_CHECKS}",
+    "interval": "{WATT_HEALTH_INTERVAL}"
+  },
+  "managementApi": "{PLT_MANAGEMENT_API}",
+  "applications": [
+    {
+      "id": "storage",
+      "path": ".",
+      "config": "watt.storage.json"
     },
-    "health": {
-      "enabled": "{WATT_HEALTH_ENABLED}",
-      "maxELU": "{WATT_HEALTH_MAX_ELU}",
-      "gracePeriod": "{WATT_HEALTH_GRACE_PERIOD}",
-      "maxUnhealthyChecks": "{WATT_HEALTH_MAX_UNHEALTHY_CHECKS}",
-      "interval": "{WATT_HEALTH_INTERVAL}"
-    },
-    "management": {
-      "operations": ["getWorkers"]
-    },
-    "managementApi": "{PLT_MANAGEMENT_API}"
+    {
+      "id": "database",
+      "path": ".",
+      "config": "watt.database.json",
+      "workers": 1
+    }
+  ],
+  "management": {
+    "operations": ["getWorkers"]
   }
 }

--- a/watt.storage.json
+++ b/watt.storage.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/node/3.56.0.json",
+  "node": {
+    "main": "./dist/start/server.js",
+    "disableBuildInDevelopment": true
+  }
+}


### PR DESCRIPTION
This PR adds a separate Watt `database` application and routes PostgreSQL operations through Platformatic messaging when Watt messaging is available.

Main areas:

1. Database Watt app
2. Storage-to-database messaging integration
3. Watt runtime config and acceptance coverage

**Review Order**

1. `watt.json`
2. `watt.database.json`
3. `src/database/index.ts`
4. `src/database/pools.ts`
5. `src/database/locks.ts`
6. `src/internal/database/client.ts`
7. `src/internal/database/watt-connection.ts`
8. `acceptance/specs/database-watt.test.ts`

**High-Risk Areas**

1. `WattPgTenantConnection` and `WattPgTransaction` are cast to `PgTenantConnection`/`PgTransaction`, not actual instances. Review any `instanceof PgTransaction` usage.
2. `toPgQueryResult()` returns empty `command`, `fields`, and `oid`: `src/internal/database/watt-connection.ts:372`. Any caller relying on those fields may regress.
3. Pool global budget checks may race under concurrent acquisition: `src/database/pools.ts:138`.
4. Acquire timeout races `pool.connect()`: `src/database/pools.ts:57`. Verify no delayed client leak.
5. `beginTransaction` validation does not appear to validate `isolationLevel`/`readOnly`: `src/database/validation.ts:5`.
6. Error responses carry stack traces across messaging: `src/internal/database/watt-connection.ts:339`. Confirm this is acceptable.
7. `watt.json` uses schema/runtime `3.56.0`, while `package.json` still has `platformatic` and `wattpm` at `^3.52.0`: `package.json:109`.

**Manual Review Focus**

Check these behaviors carefully:

1. Single-tenant Watt DB routing.
2. Multitenant tenant resolution.
3. Transaction commit, rollback, and savepoint behavior.
4. Query cancellation during long-running SQL.
5. Duplicate-key/Postgres error SQLSTATE mapping.
6. Pool exhaustion and acquire timeout behavior.
7. Vector operations, because transaction compatibility is a likely risk area.
8. Shutdown while a transaction/query is active.
