### PR TITLE
ci: add multigres to migration idempotency check

### DIFF
--- a/.github/actions/verify-migration-idempotency/action.yml
+++ b/.github/actions/verify-migration-idempotency/action.yml
@@ -27,8 +27,8 @@ runs:
         [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
         docker compose --project-directory . \
           -f ./.docker/docker-compose-infra.yml $override_arg \
-          exec -T tenant_db \
-          pg_dump -U postgres -d postgres \
+          exec -T -e PGPASSWORD=postgres tenant_db \
+          pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
           --exclude-table-data=storage.migrations \
           --restrict-key=test \
           > before-${{ inputs.label }}.sql
@@ -48,8 +48,8 @@ runs:
         [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
         docker compose --project-directory . \
           -f ./.docker/docker-compose-infra.yml $override_arg \
-          exec -T tenant_db \
-          pg_dump -U postgres -d postgres \
+          exec -T -e PGPASSWORD=postgres tenant_db \
+          pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
           --exclude-table-data=storage.migrations \
           --restrict-key=test \
           > after-${{ inputs.label }}.sql

--- a/.github/actions/verify-migration-idempotency/action.yml
+++ b/.github/actions/verify-migration-idempotency/action.yml
@@ -1,0 +1,61 @@
+name: Verify migration idempotency
+description: >
+  Dump the schema, reset and rerun migrations, dump again, and diff the two
+  dumps to catch non-idempotent migrations.
+
+inputs:
+  override-file:
+    description: docker compose override file selecting the tenant_db engine; omit for vanilla Postgres
+    required: false
+    default: ""
+  label:
+    description: Engine name used in dump filenames and the mismatch message
+    required: true
+  database-url:
+    description: Connection string the idempotency script migrates against
+    default: postgresql://postgres:postgres@127.0.0.1/postgres
+
+runs:
+  using: composite
+  steps:
+    - name: Dump schema before
+      shell: bash
+      env:
+        OVERRIDE_FILE: ${{ inputs.override-file }}
+      run: |
+        override_arg=""
+        [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        docker compose --project-directory . \
+          -f ./.docker/docker-compose-infra.yml $override_arg \
+          exec -T tenant_db \
+          pg_dump -U postgres -d postgres \
+          --exclude-table-data=storage.migrations \
+          --restrict-key=test \
+          > before-${{ inputs.label }}.sql
+
+    - name: Reset and rerun migrations
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+      run: npm run migration:test-idempotency
+
+    - name: Dump schema after
+      shell: bash
+      env:
+        OVERRIDE_FILE: ${{ inputs.override-file }}
+      run: |
+        override_arg=""
+        [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        docker compose --project-directory . \
+          -f ./.docker/docker-compose-infra.yml $override_arg \
+          exec -T tenant_db \
+          pg_dump -U postgres -d postgres \
+          --exclude-table-data=storage.migrations \
+          --restrict-key=test \
+          > after-${{ inputs.label }}.sql
+
+    - name: Diff schemas
+      shell: bash
+      run: |
+        diff before-${{ inputs.label }}.sql after-${{ inputs.label }}.sql \
+          || (echo '${{ inputs.label }} schema mismatch!'; exit 1)

--- a/.github/actions/verify-migration-idempotency/action.yml
+++ b/.github/actions/verify-migration-idempotency/action.yml
@@ -14,6 +14,14 @@ inputs:
   database-url:
     description: Connection string the idempotency script migrates against
     default: postgresql://postgres:postgres@127.0.0.1/postgres
+  additional-exclude-table-data:
+    description: >
+      Space-separated list of extra schema.table entries to exclude from data
+      diffing, on top of storage.migrations. Use this for engine-internal
+      tables whose data legitimately changes between dumps regardless of
+      migration idempotency (e.g. multigres.heartbeat).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -22,14 +30,19 @@ runs:
       shell: bash
       env:
         OVERRIDE_FILE: ${{ inputs.override-file }}
+        EXTRA_EXCLUDES: ${{ inputs.additional-exclude-table-data }}
       run: |
         override_arg=""
         [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        exclude_args=(--exclude-table-data=storage.migrations)
+        for t in $EXTRA_EXCLUDES; do
+          exclude_args+=("--exclude-table-data=$t")
+        done
         docker compose --project-directory . \
           -f ./.docker/docker-compose-infra.yml $override_arg \
           exec -T -e PGPASSWORD=postgres tenant_db \
           pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
-          --exclude-table-data=storage.migrations \
+          "${exclude_args[@]}" \
           --restrict-key=test \
           > before-${{ inputs.label }}.sql
 
@@ -43,14 +56,19 @@ runs:
       shell: bash
       env:
         OVERRIDE_FILE: ${{ inputs.override-file }}
+        EXTRA_EXCLUDES: ${{ inputs.additional-exclude-table-data }}
       run: |
         override_arg=""
         [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        exclude_args=(--exclude-table-data=storage.migrations)
+        for t in $EXTRA_EXCLUDES; do
+          exclude_args+=("--exclude-table-data=$t")
+        done
         docker compose --project-directory . \
           -f ./.docker/docker-compose-infra.yml $override_arg \
           exec -T -e PGPASSWORD=postgres tenant_db \
           pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
-          --exclude-table-data=storage.migrations \
+          "${exclude_args[@]}" \
           --restrict-key=test \
           > after-${{ inputs.label }}.sql
 

--- a/.github/actions/verify-migration-idempotency/action.yml
+++ b/.github/actions/verify-migration-idempotency/action.yml
@@ -32,14 +32,14 @@ runs:
         OVERRIDE_FILE: ${{ inputs.override-file }}
         EXTRA_EXCLUDES: ${{ inputs.additional-exclude-table-data }}
       run: |
-        override_arg=""
-        [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        compose_files=(-f ./.docker/docker-compose-infra.yml)
+        [ -n "$OVERRIDE_FILE" ] && compose_files+=(-f "$OVERRIDE_FILE")
         exclude_args=(--exclude-table-data=storage.migrations)
         for t in $EXTRA_EXCLUDES; do
           exclude_args+=("--exclude-table-data=$t")
         done
         docker compose --project-directory . \
-          -f ./.docker/docker-compose-infra.yml $override_arg \
+          "${compose_files[@]}" \
           exec -T -e PGPASSWORD=postgres tenant_db \
           pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
           "${exclude_args[@]}" \
@@ -58,14 +58,14 @@ runs:
         OVERRIDE_FILE: ${{ inputs.override-file }}
         EXTRA_EXCLUDES: ${{ inputs.additional-exclude-table-data }}
       run: |
-        override_arg=""
-        [ -n "$OVERRIDE_FILE" ] && override_arg="-f $OVERRIDE_FILE"
+        compose_files=(-f ./.docker/docker-compose-infra.yml)
+        [ -n "$OVERRIDE_FILE" ] && compose_files+=(-f "$OVERRIDE_FILE")
         exclude_args=(--exclude-table-data=storage.migrations)
         for t in $EXTRA_EXCLUDES; do
           exclude_args+=("--exclude-table-data=$t")
         done
         docker compose --project-directory . \
-          -f ./.docker/docker-compose-infra.yml $override_arg \
+          "${compose_files[@]}" \
           exec -T -e PGPASSWORD=postgres tenant_db \
           pg_dump -h 127.0.0.1 -p 5432 -U postgres -d postgres \
           "${exclude_args[@]}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,22 +82,9 @@ jobs:
           fail-on-error: false
         continue-on-error: true
       - name: Verify migration idempotency
-        env: &migration_idempotency_env
-          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1/postgres
-        run: |
-          pg_dump "$DATABASE_URL" \
-            --exclude-table-data=storage.migrations \
-            --restrict-key=test \
-            > before.sql
-
-          npm run migration:test-idempotency
-
-          pg_dump "$DATABASE_URL" \
-            --exclude-table-data=storage.migrations \
-            --restrict-key=test \
-            > after.sql
-
-          diff before.sql after.sql || (echo 'Schema mismatch!'; exit 1)
+        uses: ./.github/actions/verify-migration-idempotency
+        with:
+          label: postgres
 
   test_oriole:
     name: Test / OrioleDB
@@ -117,29 +104,10 @@ jobs:
           mkdir -p data && chmod -R 777 data && \
           npm run test:oriole:ci
       - name: Verify OrioleDB migration idempotency
-        env: *migration_idempotency_env
-        run: |
-          docker compose --project-directory . \
-            -f ./.docker/docker-compose-infra.yml \
-            -f ./.docker/docker-compose-infra-oriole-override.yml \
-            exec -T tenant_db \
-            pg_dump -U postgres -d postgres \
-            --exclude-table-data=storage.migrations \
-            --restrict-key=test \
-            > before-oriole.sql
-
-          npm run migration:test-idempotency
-
-          docker compose --project-directory . \
-            -f ./.docker/docker-compose-infra.yml \
-            -f ./.docker/docker-compose-infra-oriole-override.yml \
-            exec -T tenant_db \
-            pg_dump -U postgres -d postgres \
-            --exclude-table-data=storage.migrations \
-            --restrict-key=test \
-            > after-oriole.sql
-
-          diff before-oriole.sql after-oriole.sql || (echo 'Oriole schema mismatch!'; exit 1)
+        uses: ./.github/actions/verify-migration-idempotency
+        with:
+          override-file: ./.docker/docker-compose-infra-oriole-override.yml
+          label: oriole
 
   test_multigres:
     name: Test / Multigres
@@ -160,6 +128,11 @@ jobs:
         run: |
           mkdir -p data && chmod -R 777 data && \
           npm run test:multigres:ci
+      - name: Verify Multigres migration idempotency
+        uses: ./.github/actions/verify-migration-idempotency
+        with:
+          override-file: ./.docker/docker-compose-infra-multigres-override.yml
+          label: multigres
 
   coveralls_finish:
     name: Coveralls / Finalize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           override-file: ./.docker/docker-compose-infra-multigres-override.yml
           label: multigres
+          additional-exclude-table-data: multigres.heartbeat
 
   coveralls_finish:
     name: Coveralls / Finalize


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now that multigres supports pg dump we can include it in the migrations idempotency check

## What is the current behavior?

Currently multigres step doesn't include this check because it did not support pg dump

## What is the new behavior?

Now we have multigres also do the migration idempotency check. I have extracted this step into it's own common action so we can reuse it across steps. This centralizes the logic in one spot.

## Additional context


