### PR TITLE
fix: map wrapped slowdown error and enrich its context

### DIFF
--- a/src/http/error-handler.test.ts
+++ b/src/http/error-handler.test.ts
@@ -1,5 +1,7 @@
 import { ErrorCode } from '@internal/errors'
+import { DBError } from '@storage/database/errors'
 import Fastify from 'fastify'
+import { DatabaseError } from 'pg'
 import { setErrorHandler } from './error-handler'
 
 describe('setErrorHandler', () => {
@@ -67,4 +69,62 @@ describe('setErrorHandler', () => {
       await app.close()
     }
   })
+
+  it('maps wrapped database slowdown errors to 429', async () => {
+    const app = Fastify()
+    setErrorHandler(app)
+
+    app.get('/wrapped-slowdown', async () => {
+      throw DBError.fromDBError(
+        createPgError('08P01', 'no more connections allowed (max_client_conn)')
+      )
+    })
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/wrapped-slowdown',
+      })
+
+      expect(response.statusCode).toBe(429)
+      expect(response.json()).toMatchObject({
+        statusCode: '429',
+        code: ErrorCode.SlowDown,
+        error: 'too_many_connections',
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('keeps wrapped non-slowdown connection errors as database errors', async () => {
+    const app = Fastify()
+    setErrorHandler(app)
+
+    app.get('/wrapped-protocol-error', async () => {
+      throw DBError.fromDBError(createPgError('08P01', 'received invalid response: 58'))
+    })
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/wrapped-protocol-error',
+      })
+
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toMatchObject({
+        statusCode: '500',
+        code: ErrorCode.DatabaseError,
+        error: ErrorCode.DatabaseError,
+      })
+    } finally {
+      await app.close()
+    }
+  })
 })
+
+function createPgError(code: string, message: string): DatabaseError {
+  const error = new DatabaseError(message, message.length, 'error')
+  error.code = code
+  return error
+}

--- a/src/http/routes/s3/error-handler.test.ts
+++ b/src/http/routes/s3/error-handler.test.ts
@@ -1,0 +1,68 @@
+import { ErrorCode } from '@internal/errors'
+import { DBError } from '@storage/database/errors'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { DatabaseError } from 'pg'
+import { vi } from 'vitest'
+import { s3ErrorHandler } from './error-handler'
+
+describe('s3ErrorHandler', () => {
+  it('maps wrapped database slowdown errors to 429', () => {
+    const request = createRequest('/s3/public/object')
+    const reply = createReply()
+
+    s3ErrorHandler(
+      DBError.fromDBError(createPgError('08P01', 'no more connections allowed (max_client_conn)')),
+      request,
+      reply
+    )
+
+    expect(reply.status).toHaveBeenCalledWith(429)
+    expect(reply.send).toHaveBeenCalledWith({
+      Error: {
+        Resource: 'public/object',
+        Code: ErrorCode.SlowDown,
+        Message: 'Too many connections issued to the database',
+      },
+    })
+  })
+
+  it('keeps wrapped non-slowdown connection errors as database errors', () => {
+    const request = createRequest('/s3/public/object')
+    const reply = createReply()
+
+    s3ErrorHandler(
+      DBError.fromDBError(createPgError('08P01', 'received invalid response: 58')),
+      request,
+      reply
+    )
+
+    expect(reply.status).toHaveBeenCalledWith(500)
+    expect(reply.send).toHaveBeenCalledWith({
+      Error: {
+        Resource: 'public/object',
+        Code: ErrorCode.DatabaseError,
+        Message: 'database error, code: 08P01',
+      },
+    })
+  })
+})
+
+function createPgError(code: string, message: string): DatabaseError {
+  const error = new DatabaseError(message, message.length, 'error')
+  error.code = code
+  return error
+}
+
+function createRequest(url: string): FastifyRequest {
+  return { url } as FastifyRequest
+}
+
+function createReply(): FastifyReply {
+  const reply = {
+    status: vi.fn(),
+    send: vi.fn(),
+  }
+  reply.status.mockReturnValue(reply)
+  reply.send.mockReturnValue(reply)
+  return reply as unknown as FastifyReply
+}

--- a/src/internal/errors/database-error.test.ts
+++ b/src/internal/errors/database-error.test.ts
@@ -1,5 +1,8 @@
 import { DatabaseError } from 'pg'
+import { DBError } from '../../storage/database/errors'
+import { ERRORS } from './codes'
 import { isDatabaseSlowDownError } from './database-error'
+import { StorageBackendError } from './storage-error'
 
 function databaseError(message: string): DatabaseError {
   return new DatabaseError(message, message.length, 'error')
@@ -36,5 +39,25 @@ describe('isDatabaseSlowDownError', () => {
         new Error('server login has been failing, cached error: connect timeout')
       )
     ).toBe(false)
+  })
+
+  it('matches wrapped database errors with slowdown messages', () => {
+    const error = databaseError('no more connections allowed (max_client_conn)')
+    error.code = '08P01'
+
+    expect(isDatabaseSlowDownError(DBError.fromDBError(error))).toBe(true)
+  })
+
+  it('does not match wrapped database errors without slowdown messages', () => {
+    const error = databaseError('received invalid response: 58')
+    error.code = '08P01'
+
+    expect(isDatabaseSlowDownError(DBError.fromDBError(error))).toBe(false)
+  })
+
+  it('does not match storage errors without wrapped database errors', () => {
+    const error = ERRORS.DatabaseError('database error, code: 08P01') as StorageBackendError
+
+    expect(isDatabaseSlowDownError(error)).toBe(false)
   })
 })

--- a/src/internal/errors/database-error.ts
+++ b/src/internal/errors/database-error.ts
@@ -1,16 +1,40 @@
 import { DatabaseError } from 'pg'
+import { StorageBackendError } from './storage-error'
+
+const SLOWDOWN_MESSAGES = [
+  'Authentication error', // supavisor specific
+  'Max client connections reached',
+  'remaining connection slots are reserved for non-replication superuser connections',
+  'no more connections allowed',
+  'sorry, too many clients already',
+  'server login has been failing, try again later',
+  'server login has been failing, cached error',
+]
 
 export function isDatabaseSlowDownError(error: Error): boolean {
-  return (
-    error instanceof DatabaseError &&
-    [
-      'Authentication error', // supavisor specific
-      'Max client connections reached',
-      'remaining connection slots are reserved for non-replication superuser connections',
-      'no more connections allowed',
-      'sorry, too many clients already',
-      'server login has been failing, try again later',
-      'server login has been failing, cached error',
-    ].some((msg) => error.message.includes(msg))
-  )
+  const databaseError = getDatabaseError(error)
+  return Boolean(databaseError && hasDatabaseSlowDownMessage(databaseError.message))
+}
+
+export function hasDatabaseSlowDownMessage(message: string): boolean {
+  for (const slowdownMessage of SLOWDOWN_MESSAGES) {
+    if (message.includes(slowdownMessage)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function getDatabaseError(error: Error): DatabaseError | undefined {
+  if (error instanceof DatabaseError) {
+    return error
+  }
+
+  if (error instanceof StorageBackendError) {
+    const originalError = error.getOriginalError()
+    return originalError instanceof DatabaseError ? originalError : undefined
+  }
+
+  return undefined
 }

--- a/src/storage/database/errors.test.ts
+++ b/src/storage/database/errors.test.ts
@@ -59,6 +59,62 @@ describe('DBError', () => {
       },
     })
   })
+
+  test('curates metadata to query, code, and pgMessage for connection-class errors', () => {
+    const error = createPgError('08P01', 'no more connections allowed (max_client_conn)')
+    error.severity = 'FATAL'
+    error.schema = 'storage'
+    error.table = 'objects'
+    error.column = 'name'
+    error.dataType = 'text'
+    error.constraint = 'objects_bucket_id_name_key'
+    error.routine = 'pooler_error'
+    error.detail = 'Key (bucket_id, name)=(public, secret.txt) already exists.'
+    error.hint = 'try again later'
+
+    const mapped = DBError.fromDBError(error, 'SELECT * FROM storage.objects')
+
+    expect(mapped).toMatchObject({ code: 'DatabaseError', originalError: error })
+    expect(mapped.metadata).toEqual({
+      query: 'SELECT * FROM storage.objects',
+      code: '08P01',
+      pgMessage: 'no more connections allowed (max_client_conn)',
+    })
+  })
+
+  test('does not include pg messages for input-echoing errors', () => {
+    const error = createPgError(
+      '22P02',
+      'invalid input syntax for type uuid: "attacker-controlled-value"'
+    )
+    error.severity = 'ERROR'
+    error.detail = 'Value "attacker-controlled-value" is not a uuid.'
+    error.hint = 'Check the id parameter.'
+
+    const mapped = DBError.fromDBError(error, 'SELECT * FROM storage.objects')
+
+    expect(mapped).toMatchObject({ code: 'InvalidParameter' })
+    expect(mapped.metadata).toEqual({
+      query: 'SELECT * FROM storage.objects',
+      code: '22P02',
+    })
+    expect(mapped.message).toContain('attacker-controlled-value')
+  })
+
+  test('does not include row values from duplicate-key details in metadata', () => {
+    const error = createPgError('23505', 'duplicate key value violates unique constraint')
+    error.severity = 'ERROR'
+    error.detail = 'Key (bucket_id, name)=(public, secret.txt) already exists.'
+    error.hint = 'try a different object name'
+
+    const mapped = DBError.fromDBError(error, 'INSERT INTO storage.objects')
+
+    expect(mapped).toMatchObject({ code: 'ResourceAlreadyExists' })
+    expect(mapped.metadata).toEqual({
+      query: 'INSERT INTO storage.objects',
+      code: '23505',
+    })
+  })
 })
 
 function createPgError(code: string, message: string): DatabaseError {

--- a/src/storage/database/errors.ts
+++ b/src/storage/database/errors.ts
@@ -1,5 +1,11 @@
 import { ERRORS, RenderableError, StorageBackendError, StorageErrorOptions } from '@internal/errors'
+import { hasDatabaseSlowDownMessage } from '@internal/errors/database-error'
 import { DatabaseError } from 'pg'
+
+export interface PgErrorContext {
+  query?: string
+  queryName?: string
+}
 
 export class DBError extends StorageBackendError implements RenderableError {
   constructor(options: StorageErrorOptions) {
@@ -7,7 +13,7 @@ export class DBError extends StorageBackendError implements RenderableError {
     Object.setPrototypeOf(this, DBError.prototype)
   }
 
-  static fromDBError(pgError: DatabaseError, query?: string) {
+  static fromDBError(pgError: DatabaseError, context?: string | PgErrorContext) {
     switch (pgError.code) {
       case '42501':
         return ERRORS.AccessDenied(
@@ -15,75 +21,49 @@ export class DBError extends StorageBackendError implements RenderableError {
             ? 'new row violates row-level security policy'
             : pgError.message,
           pgError
-        ).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        ).withMetadata(pgErrorMetadata(pgError, context))
       case '23505':
-        return ERRORS.ResourceAlreadyExists(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.ResourceAlreadyExists(pgError).withMetadata(pgErrorMetadata(pgError, context))
       case '23503':
-        return ERRORS.RelatedResourceNotFound(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.RelatedResourceNotFound(pgError).withMetadata(
+          pgErrorMetadata(pgError, context)
+        )
       case '55P03':
       case 'resource_locked':
-        return ERRORS.ResourceLocked(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.ResourceLocked(pgError).withMetadata(pgErrorMetadata(pgError, context))
       case '57014':
-        return ERRORS.DatabaseTimeout(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.DatabaseTimeout(pgError).withMetadata(pgErrorMetadata(pgError, context))
       case '25006':
-        return ERRORS.DatabaseReadOnly(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.DatabaseReadOnly(pgError).withMetadata(pgErrorMetadata(pgError, context))
       case '25P02':
-        return ERRORS.DatabaseTransactionAborted(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.DatabaseTransactionAborted(pgError).withMetadata(
+          pgErrorMetadata(pgError, context)
+        )
       case '42P17':
-        return ERRORS.InvalidObjectDefinition(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.InvalidObjectDefinition(pgError).withMetadata(
+          pgErrorMetadata(pgError, context)
+        )
       case '22P02':
         return ERRORS.InvalidParameter('value', {
           error: pgError,
           message: pgError.message || 'Invalid value format or type conversion failed',
-        }).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        }).withMetadata(pgErrorMetadata(pgError, context))
       case '42703':
       case '42P01':
-        return ERRORS.DatabaseSchemaMismatch(pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.DatabaseSchemaMismatch(pgError).withMetadata(
+          pgErrorMetadata(pgError, context)
+        )
       default:
-        return ERRORS.DatabaseError(`database error, code: ${pgError.code}`, pgError).withMetadata({
-          query,
-          code: pgError.code,
-        })
+        return ERRORS.DatabaseError(`database error, code: ${pgError.code}`, pgError).withMetadata(
+          pgErrorMetadata(pgError, context)
+        )
     }
   }
 }
 
 export function mapPgTransactionAbortedError(error: unknown, query?: string): unknown {
   if (isPgTransactionAbortedError(error)) {
-    return ERRORS.DatabaseTransactionAborted(error).withMetadata({
-      query,
-      code: error.code,
-    })
+    return ERRORS.DatabaseTransactionAborted(error).withMetadata(pgErrorMetadata(error, query))
   }
 
   return error
@@ -91,4 +71,35 @@ export function mapPgTransactionAbortedError(error: unknown, query?: string): un
 
 function isPgTransactionAbortedError(error: unknown): error is DatabaseError {
   return error instanceof DatabaseError && error.code === '25P02'
+}
+
+function pgErrorMetadata(
+  pgError: DatabaseError,
+  context?: string | PgErrorContext
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {}
+
+  if (typeof context === 'string') {
+    setIfPresent(metadata, 'query', context)
+  } else if (context) {
+    setIfPresent(metadata, 'query', context.query)
+    setIfPresent(metadata, 'queryName', context.queryName)
+  }
+
+  setIfPresent(metadata, 'code', pgError.code)
+  if (shouldIncludePgMessage(pgError)) {
+    setIfPresent(metadata, 'pgMessage', pgError.message)
+  }
+
+  return metadata
+}
+
+function shouldIncludePgMessage(pgError: DatabaseError): boolean {
+  return Boolean(pgError.code?.startsWith('08') || hasDatabaseSlowDownMessage(pgError.message))
+}
+
+function setIfPresent(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (value !== undefined && value !== '') {
+    target[key] = value
+  }
 }

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -1,11 +1,23 @@
 import { PgTenantConnection } from '@internal/database'
+import { normalizeRawError } from '@internal/errors'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
+import { DatabaseError } from 'pg'
 import { vi } from 'vitest'
 import { escapeLike, StoragePgDB } from './pg'
 
 class TestStoragePgDB extends StoragePgDB {
   runMetricProbe(): Promise<string> {
     return this.runUnscopedQuery('MetricWithoutTenantAttribute', async () => 'ok')
+  }
+
+  runErrorMappingProbe(): Promise<unknown> {
+    return this.runQuery('FindBucketById', (db) => {
+      return this.query(db, 'SELECT * FROM storage.buckets WHERE id = $1')
+    })
+  }
+
+  runUnscopedErrorMappingProbe(): Promise<string> {
+    return this.runUnscopedQuery('CreateS3KeysTempTable', async () => 'ok')
   }
 }
 
@@ -51,3 +63,157 @@ describe('StoragePgDB metrics', () => {
     }
   })
 })
+
+describe('StoragePgDB error mapping', () => {
+  test('preserves query name for pg errors thrown by inner SQL statements', async () => {
+    const error = createPgError('08P01', 'no more connections allowed (max_client_conn)')
+    error.severity = 'FATAL'
+    error.routine = 'pooler_error'
+    const transaction = {
+      commit: vi.fn(),
+      rollback: vi.fn(),
+      isCompleted: vi.fn().mockReturnValue(false),
+      query: vi.fn().mockRejectedValue(error),
+    }
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      transaction: vi.fn().mockResolvedValue(transaction),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new TestStoragePgDB(connection, {
+      tenantId: 'tenant-with-protocol-error',
+      host: 'localhost',
+    })
+
+    const mappedError = await storage.runErrorMappingProbe().catch((error) => error)
+
+    expect(mappedError).toMatchObject({
+      code: 'DatabaseError',
+      message: 'database error, code: 08P01',
+      originalError: error,
+      metadata: {
+        code: '08P01',
+        pgMessage: 'no more connections allowed (max_client_conn)',
+        query: 'SELECT * FROM storage.buckets WHERE id = $1',
+        queryName: 'FindBucketById',
+      },
+    })
+    // severity/routine are set on the pg error but must not be duplicated into metadata.
+    expect(JSON.parse(normalizeRawError(mappedError, 'info').raw).metadata).toEqual({
+      code: '08P01',
+      pgMessage: 'no more connections allowed (max_client_conn)',
+      query: 'SELECT * FROM storage.buckets WHERE id = $1',
+      queryName: 'FindBucketById',
+    })
+  })
+
+  test('preserves query name for pg errors thrown while starting the transaction', async () => {
+    const error = createPgError('08P01', 'no more connections allowed (max_client_conn)')
+    error.severity = 'FATAL'
+    error.routine = 'pooler_error'
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      transaction: vi.fn().mockRejectedValue(error),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new TestStoragePgDB(connection, {
+      tenantId: 'tenant-with-transaction-setup-error',
+      host: 'localhost',
+    })
+
+    const mappedError = await storage.runErrorMappingProbe().catch((error) => error)
+
+    expect(mappedError).toMatchObject({
+      code: 'DatabaseError',
+      message: 'database error, code: 08P01',
+      originalError: error,
+      metadata: {
+        code: '08P01',
+        pgMessage: 'no more connections allowed (max_client_conn)',
+        queryName: 'FindBucketById',
+      },
+    })
+    expect(JSON.parse(normalizeRawError(mappedError, 'info').raw).metadata).toEqual({
+      code: '08P01',
+      pgMessage: 'no more connections allowed (max_client_conn)',
+      queryName: 'FindBucketById',
+    })
+  })
+
+  test('preserves query name for pg errors thrown while acquiring an unscoped executor', async () => {
+    const error = createPgError('08006', 'connection failure')
+    error.severity = 'FATAL'
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      pool: {
+        acquire: vi.fn(() => {
+          throw error
+        }),
+      },
+    } as unknown as PgTenantConnection
+    const storage = new TestStoragePgDB(connection, {
+      tenantId: 'tenant-with-unscoped-acquire-error',
+      host: 'localhost',
+    })
+
+    const mappedError = await storage.runUnscopedErrorMappingProbe().catch((error) => error)
+
+    expect(mappedError).toMatchObject({
+      code: 'DatabaseError',
+      originalError: error,
+      metadata: {
+        code: '08006',
+        pgMessage: 'connection failure',
+        queryName: 'CreateS3KeysTempTable',
+      },
+    })
+    expect(JSON.parse(normalizeRawError(mappedError, 'info').raw).metadata).toEqual({
+      code: '08006',
+      pgMessage: 'connection failure',
+      queryName: 'CreateS3KeysTempTable',
+    })
+  })
+
+  test('passes through non-pg errors from transaction setup', async () => {
+    const error = new Error('connection setup failed before pg error mapping')
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      transaction: vi.fn().mockRejectedValue(error),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new TestStoragePgDB(connection, {
+      tenantId: 'tenant-with-non-pg-error',
+      host: 'localhost',
+    })
+
+    await expect(storage.runErrorMappingProbe()).rejects.toBe(error)
+  })
+
+  test('does not attach query name to non-pg storage errors from transaction setup', async () => {
+    // transaction() resolving without a handle makes runQuery throw
+    // ERRORS.InternalError('Could not create transaction') — a StorageBackendError
+    // whose originalError is not a pg error, so the gate must leave it untouched.
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      transaction: vi.fn().mockResolvedValue(undefined),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new TestStoragePgDB(connection, {
+      tenantId: 'tenant-with-missing-transaction-handle',
+      host: 'localhost',
+    })
+
+    const mappedError = await storage.runErrorMappingProbe().catch((error) => error)
+
+    expect(mappedError).toMatchObject({
+      code: 'InternalError',
+      metadata: expect.not.objectContaining({ queryName: expect.anything() }),
+    })
+  })
+})
+
+function createPgError(code: string, message: string): DatabaseError {
+  const error = new DatabaseError(message, message.length, 'error')
+  error.code = code
+  return error
+}

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -8,7 +8,7 @@ import {
   quoteQualifiedIdentifier,
 } from '@internal/database'
 import { DBMigration, tenantHasMigrations } from '@internal/database/migrations'
-import { ERRORS, ErrorCode, isStorageError } from '@internal/errors'
+import { ERRORS, ErrorCode, isStorageError, StorageBackendError } from '@internal/errors'
 import { hashStringToInt } from '@internal/hashing'
 import { logger, logSchema } from '@internal/monitoring'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
@@ -26,7 +26,7 @@ import {
   SearchObjectOption,
   TransactionOptions,
 } from './adapter'
-import { DBError, mapPgTransactionAbortedError } from './errors'
+import { DBError, mapPgTransactionAbortedError, PgErrorContext } from './errors'
 
 const { databaseEngine, isMultitenant } = getConfig()
 // Scanner cache tables are unlogged scratch tables, not session temp tables.
@@ -1808,7 +1808,7 @@ export class StoragePgDB implements Database {
           })
         }
       }
-      throw mapPgError(e)
+      throw mapPgErrorWithQueryName(e, queryName)
     } finally {
       try {
         if (!savepoint && differentScopes) {
@@ -1861,7 +1861,7 @@ export class StoragePgDB implements Database {
     try {
       return await fn(this.connection.pool.acquire(), abortSignal)
     } catch (e) {
-      throw mapPgError(e)
+      throw mapPgErrorWithQueryName(e, queryName)
     } finally {
       recordDuration()
     }
@@ -1999,9 +1999,28 @@ function objectLockClause(filters?: FindObjectFilters): string {
   return filters?.noWait ? `${lock} NOWAIT` : lock
 }
 
-function mapPgError(error: unknown, query?: string): unknown {
+function mapPgError(error: unknown, context?: string | PgErrorContext): unknown {
   if (error instanceof DatabaseError) {
-    return DBError.fromDBError(error, query)
+    return DBError.fromDBError(error, context)
+  }
+
+  return error
+}
+
+function mapPgErrorWithQueryName(error: unknown, queryName: string): unknown {
+  return ensurePgErrorQueryName(mapPgError(error), queryName)
+}
+
+function ensurePgErrorQueryName(error: unknown, queryName: string): unknown {
+  if (!(error instanceof StorageBackendError) || !(error.originalError instanceof DatabaseError)) {
+    return error
+  }
+
+  const metadata = error.metadata
+  if (!metadata) {
+    error.metadata = { queryName }
+  } else if (metadata.queryName === undefined) {
+    metadata.queryName = queryName
   }
 
   return error


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and related improvement

## What is the current behavior?

Slowdown error only recognizes `pg.DatabaseError` but error is wrapped so it's missed in mapping and returns 500.

## What is the new behavior?

Mapper unwraps when it contains `pg.DatabaseError` and correctly maps to 429.
`pg.DatabaseError.message` isn't enumerable so actual cause was missed but it's added as pgMessage into metadata and limited to protocol or slowdown errors to prevent sensitive information leaking.

## Additional context

`queryName` is better attached to pg errors. 
Slowdown errors are hoisted as a module level const to prevent allocation, which allocated previously on every error.