### PR TITLE
fix: make cache metrics cheaper

### DIFF
--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -1,6 +1,6 @@
 import { JWT_CACHE_NAME } from '@internal/cache'
 import { ErrorCode } from '@internal/errors'
-import { cacheRequestsTotal } from '@internal/monitoring/metrics'
+import * as metrics from '@internal/monitoring/metrics'
 import * as crypto from 'crypto'
 import { SignJWT } from 'jose'
 import { vi } from 'vitest'
@@ -268,11 +268,11 @@ describe('JWT', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
 
-      const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+      const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
       const secret = crypto.randomBytes(32).toString('base64url')
       const token = await signJWT({ sub: 'cached-user' }, secret, 2)
 
-      addSpy.mockClear()
+      recordSpy.mockClear()
 
       await expect(verifyJWTWithCache(token, secret)).resolves.toMatchObject({
         sub: 'cached-user',
@@ -281,9 +281,9 @@ describe('JWT', () => {
         sub: 'cached-user',
       })
 
-      expect(addSpy.mock.calls).toEqual([
-        [1, { cache: JWT_CACHE_NAME, outcome: 'miss' }],
-        [1, { cache: JWT_CACHE_NAME, outcome: 'hit' }],
+      expect(recordSpy.mock.calls).toEqual([
+        [JWT_CACHE_NAME, 'miss'],
+        [JWT_CACHE_NAME, 'hit'],
       ])
 
       vi.advanceTimersByTime(2200)
@@ -292,20 +292,20 @@ describe('JWT', () => {
     })
 
     test('it should not reuse cached JWT verifications when the secret changes', async () => {
-      const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+      const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
       const secret = crypto.randomBytes(32).toString('base64url')
       const token = await signJWT({ sub: 'cached-user' }, secret, 2)
 
-      addSpy.mockClear()
+      recordSpy.mockClear()
 
       await expect(verifyJWTWithCache(token, secret)).resolves.toMatchObject({
         sub: 'cached-user',
       })
       await expect(verifyJWTWithCache(token, 'definitely-the-wrong-secret')).rejects.toThrow()
 
-      expect(addSpy.mock.calls).toEqual([
-        [1, { cache: JWT_CACHE_NAME, outcome: 'miss' }],
-        [1, { cache: JWT_CACHE_NAME, outcome: 'miss' }],
+      expect(recordSpy.mock.calls).toEqual([
+        [JWT_CACHE_NAME, 'miss'],
+        [JWT_CACHE_NAME, 'miss'],
       ])
     })
 
@@ -363,13 +363,11 @@ describe('JWT', () => {
       }))
 
       try {
-        const { cacheRequestsTotal: isolatedCacheRequestsTotal } = await import(
-          '@internal/monitoring/metrics'
-        )
+        const isolatedMetrics = await import('@internal/monitoring/metrics')
         const { verifyJWTWithCache: isolatedVerifyJWTWithCache } = await import('./jwt')
-        const addSpy = vi.spyOn(isolatedCacheRequestsTotal, 'add')
+        const recordSpy = vi.spyOn(isolatedMetrics, 'recordCacheRequest')
 
-        addSpy.mockClear()
+        recordSpy.mockClear()
 
         await expect(isolatedVerifyJWTWithCache(token, secret)).resolves.toMatchObject({
           sub: 'cached-user',
@@ -385,10 +383,10 @@ describe('JWT', () => {
         })
 
         expect(jwtVerifyMock).toHaveBeenCalledTimes(2)
-        expect(addSpy.mock.calls).toEqual([
-          [1, { cache: JWT_CACHE_NAME, outcome: 'miss' }],
-          [1, { cache: JWT_CACHE_NAME, outcome: 'miss' }],
-          [1, { cache: JWT_CACHE_NAME, outcome: 'hit' }],
+        expect(recordSpy.mock.calls).toEqual([
+          [JWT_CACHE_NAME, 'miss'],
+          [JWT_CACHE_NAME, 'miss'],
+          [JWT_CACHE_NAME, 'hit'],
         ])
       } finally {
         vi.doUnmock('jose')

--- a/src/internal/cache/adapter.ts
+++ b/src/internal/cache/adapter.ts
@@ -2,7 +2,8 @@ export type CacheLookupOptions = {
   recordMetrics?: boolean
 }
 
-export type CacheLookupOutcome = 'hit' | 'miss' | 'stale'
+export const CACHE_LOOKUP_OUTCOMES = ['hit', 'miss', 'stale'] as const
+export type CacheLookupOutcome = (typeof CACHE_LOOKUP_OUTCOMES)[number]
 
 export type CacheLookupResult<V> = {
   value: V | undefined

--- a/src/internal/cache/monitoring.test.ts
+++ b/src/internal/cache/monitoring.test.ts
@@ -4,14 +4,7 @@ import {
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_CONFIG_CACHE_NAME,
 } from '@internal/cache'
-import {
-  cacheEntries,
-  cacheEvictionsTotal,
-  cacheRequestsTotal,
-  cacheSizeBytes,
-  meter,
-  setMetricsEnabled,
-} from '@internal/monitoring/metrics'
+import * as metrics from '@internal/monitoring/metrics'
 import { vi } from 'vitest'
 import { monitorCache } from './monitoring'
 
@@ -33,7 +26,7 @@ describe('cache telemetry helpers', () => {
   })
 
   test('records cache hits and misses', () => {
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {
       max: 2,
     })
@@ -43,18 +36,12 @@ describe('cache telemetry helpers', () => {
     expect(cache.get('hit')).toEqual({ ok: true })
     expect(cache.get('miss')).toBeUndefined()
 
-    expect(addSpy).toHaveBeenNthCalledWith(1, 1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'hit',
-    })
-    expect(addSpy).toHaveBeenNthCalledWith(2, 1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'miss',
-    })
+    expect(recordSpy).toHaveBeenNthCalledWith(1, TENANT_CONFIG_CACHE_NAME, 'hit')
+    expect(recordSpy).toHaveBeenNthCalledWith(2, TENANT_CONFIG_CACHE_NAME, 'miss')
   })
 
   test('can read without recording cache request metrics', () => {
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {
       max: 2,
     })
@@ -64,11 +51,11 @@ describe('cache telemetry helpers', () => {
     expect(cache.get('hit', { recordMetrics: false })).toEqual({ ok: true })
     expect(cache.get('miss', { recordMetrics: false })).toBeUndefined()
 
-    expect(addSpy).not.toHaveBeenCalled()
+    expect(recordSpy).not.toHaveBeenCalled()
   })
 
   test('records stale cache reads when allowStale is enabled', () => {
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {
       max: 2,
       ttl: 10,
@@ -82,14 +69,11 @@ describe('cache telemetry helpers', () => {
     vi.advanceTimersByTime(11)
 
     expect(cache.get('stale')).toEqual({ ok: true })
-    expect(addSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'stale',
-    })
+    expect(recordSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME, 'stale')
   })
 
   test('records evictions', () => {
-    const evictionSpy = vi.spyOn(cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metrics, 'recordCacheEviction')
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {
       max: 1,
     })
@@ -97,16 +81,11 @@ describe('cache telemetry helpers', () => {
     cache.set('first', { ok: true })
     cache.set('second', { ok: false })
 
-    expect(evictionSpy.mock.calls).toContainEqual([
-      1,
-      {
-        cache: TENANT_CONFIG_CACHE_NAME,
-      },
-    ])
+    expect(evictionSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME)
   })
 
   test('records ttl cache hits and misses', () => {
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createTtlCache(TENANT_CONFIG_CACHE_NAME, {
       max: 2,
       ttl: 1000,
@@ -117,18 +96,12 @@ describe('cache telemetry helpers', () => {
     expect(cache.get('hit')).toEqual({ ok: true })
     expect(cache.get('miss')).toBeUndefined()
 
-    expect(addSpy).toHaveBeenNthCalledWith(1, 1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'hit',
-    })
-    expect(addSpy).toHaveBeenNthCalledWith(2, 1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'miss',
-    })
+    expect(recordSpy).toHaveBeenNthCalledWith(1, TENANT_CONFIG_CACHE_NAME, 'hit')
+    expect(recordSpy).toHaveBeenNthCalledWith(2, TENANT_CONFIG_CACHE_NAME, 'miss')
   })
 
   test('records ttl cache evictions', () => {
-    const evictionSpy = vi.spyOn(cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metrics, 'recordCacheEviction')
     const cache = createTtlCache(TENANT_CONFIG_CACHE_NAME, {
       max: 1,
       ttl: 1000,
@@ -137,13 +110,11 @@ describe('cache telemetry helpers', () => {
     cache.set('first', { ok: true })
     cache.set('second', { ok: false })
 
-    expect(evictionSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-    })
+    expect(evictionSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME)
   })
 
   test('chains caller disposeAfter after recording evictions', () => {
-    const evictionSpy = vi.spyOn(cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metrics, 'recordCacheEviction')
     const disposeAfter = vi.fn()
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {
       max: 1,
@@ -153,9 +124,7 @@ describe('cache telemetry helpers', () => {
     cache.set('first', { ok: true })
     cache.set('second', { ok: false })
 
-    expect(evictionSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-    })
+    expect(evictionSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME)
     expect(disposeAfter).toHaveBeenCalledWith({ ok: true }, 'first', 'evict')
     expect(evictionSpy.mock.invocationCallOrder[0]).toBeLessThan(
       disposeAfter.mock.invocationCallOrder[0]
@@ -195,7 +164,7 @@ describe('cache telemetry helpers', () => {
   })
 
   test('purges stale entries before reporting occupancy metrics', () => {
-    const addBatchObservableCallbackSpy = vi.spyOn(meter, 'addBatchObservableCallback')
+    const addBatchObservableCallbackSpy = vi.spyOn(metrics.meter, 'addBatchObservableCallback')
     let batchObserver: ((observer: { observe: (...args: unknown[]) => void }) => void) | undefined
 
     addBatchObservableCallbackSpy.mockImplementation((callback) => {
@@ -223,16 +192,16 @@ describe('cache telemetry helpers', () => {
     batchObserver?.({ observe: observeSpy })
 
     expect(cache.getStats()).toEqual({ entries: 0, sizeBytes: 0 })
-    expect(observeSpy).toHaveBeenCalledWith(cacheEntries, 0, {
+    expect(observeSpy).toHaveBeenCalledWith(metrics.cacheEntries, 0, {
       cache: TENANT_CONFIG_CACHE_NAME,
     })
-    expect(observeSpy).toHaveBeenCalledWith(cacheSizeBytes, 0, {
+    expect(observeSpy).toHaveBeenCalledWith(metrics.cacheSizeBytes, 0, {
       cache: TENANT_CONFIG_CACHE_NAME,
     })
   })
 
   test('skips stale purges when occupancy gauges are disabled', () => {
-    const addBatchObservableCallbackSpy = vi.spyOn(meter, 'addBatchObservableCallback')
+    const addBatchObservableCallbackSpy = vi.spyOn(metrics.meter, 'addBatchObservableCallback')
     let batchObserver: ((observer: { observe: (...args: unknown[]) => void }) => void) | undefined
 
     addBatchObservableCallbackSpy.mockImplementation((callback) => {
@@ -252,7 +221,7 @@ describe('cache telemetry helpers', () => {
     monitorCache(TENANT_CONFIG_CACHE_NAME, cache, { purgeStale })
 
     try {
-      setMetricsEnabled([
+      metrics.setMetricsEnabled([
         { name: 'cache_entries', enabled: false },
         { name: 'cache_size_bytes', enabled: false },
       ])
@@ -264,7 +233,7 @@ describe('cache telemetry helpers', () => {
       expect(cache.getStats).not.toHaveBeenCalled()
       expect(observeSpy).not.toHaveBeenCalled()
     } finally {
-      setMetricsEnabled([
+      metrics.setMetricsEnabled([
         { name: 'cache_entries', enabled: true },
         { name: 'cache_size_bytes', enabled: true },
       ])
@@ -274,7 +243,7 @@ describe('cache telemetry helpers', () => {
   test('records stale ttl cache reads before timer cleanup', () => {
     vi.useRealTimers()
 
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createTtlCache(TENANT_CONFIG_CACHE_NAME, {
       max: 2,
       ttl: 10,
@@ -284,16 +253,13 @@ describe('cache telemetry helpers', () => {
     busyWaitMs(20)
 
     expect(cache.get('stale')).toEqual({ ok: true })
-    expect(addSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_CONFIG_CACHE_NAME,
-      outcome: 'stale',
-    })
+    expect(recordSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME, 'stale')
   })
 
   test('purges stale ttl entries before reporting occupancy metrics', () => {
     vi.useRealTimers()
 
-    const addBatchObservableCallbackSpy = vi.spyOn(meter, 'addBatchObservableCallback')
+    const addBatchObservableCallbackSpy = vi.spyOn(metrics.meter, 'addBatchObservableCallback')
     let batchObserver: ((observer: { observe: (...args: unknown[]) => void }) => void) | undefined
 
     addBatchObservableCallbackSpy.mockImplementation((callback) => {
@@ -314,17 +280,20 @@ describe('cache telemetry helpers', () => {
     batchObserver?.({ observe: observeSpy })
 
     expect(cache.getStats()).toEqual({ entries: 0, sizeBytes: 0 })
-    expect(observeSpy).toHaveBeenCalledWith(cacheEntries, 0, {
+    expect(observeSpy).toHaveBeenCalledWith(metrics.cacheEntries, 0, {
       cache: TENANT_CONFIG_CACHE_NAME,
     })
-    expect(observeSpy).toHaveBeenCalledWith(cacheSizeBytes, 0, {
+    expect(observeSpy).toHaveBeenCalledWith(metrics.cacheSizeBytes, 0, {
       cache: TENANT_CONFIG_CACHE_NAME,
     })
   })
 
   test('dispose unregisters occupancy callbacks and tears down wrapped caches', () => {
-    const addBatchObservableCallbackSpy = vi.spyOn(meter, 'addBatchObservableCallback')
-    const removeBatchObservableCallbackSpy = vi.spyOn(meter, 'removeBatchObservableCallback')
+    const addBatchObservableCallbackSpy = vi.spyOn(metrics.meter, 'addBatchObservableCallback')
+    const removeBatchObservableCallbackSpy = vi.spyOn(
+      metrics.meter,
+      'removeBatchObservableCallback'
+    )
     const cache = {
       delete: vi.fn().mockReturnValue(false),
       dispose: vi.fn(),
@@ -336,8 +305,8 @@ describe('cache telemetry helpers', () => {
 
     const monitoredCache = monitorCache(TENANT_CONFIG_CACHE_NAME, cache)
     const [callback, observables] = addBatchObservableCallbackSpy.mock.calls.at(-1) as [
-      Parameters<typeof meter.addBatchObservableCallback>[0],
-      Parameters<typeof meter.addBatchObservableCallback>[1],
+      Parameters<typeof metrics.meter.addBatchObservableCallback>[0],
+      Parameters<typeof metrics.meter.addBatchObservableCallback>[1],
     ]
 
     monitoredCache.dispose()

--- a/src/internal/cache/monitoring.ts
+++ b/src/internal/cache/monitoring.ts
@@ -1,10 +1,10 @@
 import {
   cacheEntries,
-  cacheEvictionsTotal,
-  cacheRequestsTotal,
   cacheSizeBytes,
   isMetricEnabled,
   meter,
+  recordCacheEviction,
+  recordCacheRequest,
 } from '@internal/monitoring/metrics'
 import { Attributes, BatchObservableCallback, Observable } from '@opentelemetry/api'
 import { CacheLookupOptions, Disposable, DisposableCache, OutcomeAwareCache } from './adapter'
@@ -27,13 +27,6 @@ function isDisposable(value: unknown): value is Disposable {
   )
 }
 
-function cacheAttrs(
-  cache: CacheName,
-  attrs?: Record<string, string | number | boolean>
-): Attributes {
-  return attrs ? { cache, ...attrs } : { cache }
-}
-
 export function withCacheEvictionMetrics<K, V, R extends string>(
   cacheName: CacheName,
   dispose?: CacheDisposeHandler<K, V, R>
@@ -42,7 +35,7 @@ export function withCacheEvictionMetrics<K, V, R extends string>(
     // Track capacity-pressure evictions only.
     // TTL expiry/removal reasons are excluded on purpose.
     if (reason === 'evict') {
-      cacheEvictionsTotal.add(1, cacheAttrs(cacheName))
+      recordCacheEviction(cacheName)
     }
 
     dispose?.(value, key, reason)
@@ -51,6 +44,7 @@ export function withCacheEvictionMetrics<K, V, R extends string>(
 
 class MonitoredCache<K, V, SetOptions = undefined> implements DisposableCache<K, V, SetOptions> {
   private disposed = false
+  private readonly cacheAttributes: Attributes
   private readonly observeOccupancy: BatchObservableCallback = (observer) => {
     const cacheEntriesEnabled = isMetricEnabled('cache_entries')
     const cacheSizeBytesEnabled = isMetricEnabled('cache_size_bytes')
@@ -61,14 +55,13 @@ class MonitoredCache<K, V, SetOptions = undefined> implements DisposableCache<K,
 
     this.options?.purgeStale?.()
     const stats = this.cache.getStats()
-    const attrs = cacheAttrs(this.name)
 
     if (cacheEntriesEnabled) {
-      observer.observe(cacheEntries, stats.entries, attrs)
+      observer.observe(cacheEntries, stats.entries, this.cacheAttributes)
     }
 
     if (cacheSizeBytesEnabled) {
-      observer.observe(cacheSizeBytes, stats.sizeBytes, attrs)
+      observer.observe(cacheSizeBytes, stats.sizeBytes, this.cacheAttributes)
     }
   }
 
@@ -77,6 +70,7 @@ class MonitoredCache<K, V, SetOptions = undefined> implements DisposableCache<K,
     private readonly cache: OutcomeAwareCache<K, V, SetOptions>,
     private readonly options?: MonitorCacheOptions
   ) {
+    this.cacheAttributes = { cache: name }
     meter.addBatchObservableCallback(this.observeOccupancy, CACHE_OCCUPANCY_OBSERVABLES)
   }
 
@@ -86,7 +80,7 @@ class MonitoredCache<K, V, SetOptions = undefined> implements DisposableCache<K,
     }
 
     const { value, outcome } = this.cache.getWithOutcome(key)
-    cacheRequestsTotal.add(1, cacheAttrs(this.name, { outcome }))
+    recordCacheRequest(this.name, outcome)
 
     return value
   }

--- a/src/internal/database/pool.test.ts
+++ b/src/internal/database/pool.test.ts
@@ -226,7 +226,7 @@ describe('PoolManager cache lifecycle', () => {
   test('records logical pool cache misses and hits', async () => {
     const poolModule = await loadPoolModule(10_000)
     const metricsModule = await import('@internal/monitoring/metrics')
-    const addSpy = vi.spyOn(metricsModule.cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metricsModule, 'recordCacheRequest')
 
     class TestPoolManager extends poolModule.PoolManager {
       created: TestPool[] = []
@@ -246,10 +246,10 @@ describe('PoolManager cache lifecycle', () => {
 
     expect(second).toBe(first)
     expect(poolManager.created).toHaveLength(1)
-    expect(addSpy.mock.calls).toEqual(
+    expect(recordSpy.mock.calls).toEqual(
       expect.arrayContaining([
-        [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'miss' }],
-        [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }],
+        [TENANT_POOL_CACHE_NAME, 'miss'],
+        [TENANT_POOL_CACHE_NAME, 'hit'],
       ])
     )
 
@@ -455,7 +455,7 @@ describe('PoolManager cache lifecycle', () => {
   test('records pool cache evictions when inactivity ttl removes cached pools', async () => {
     const poolModule = await loadPoolModule(20)
     const metricsModule = await import('@internal/monitoring/metrics')
-    const evictionSpy = vi.spyOn(metricsModule.cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metricsModule, 'recordCacheEviction')
 
     class TestPoolManager extends poolModule.PoolManager {
       created: TestPool[] = []
@@ -472,9 +472,7 @@ describe('PoolManager cache lifecycle', () => {
 
     await vi.advanceTimersByTimeAsync(40)
 
-    expect(evictionSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_POOL_CACHE_NAME,
-    })
+    expect(evictionSpy).toHaveBeenCalledWith(TENANT_POOL_CACHE_NAME)
     expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
 
     await poolManager.destroyAll()
@@ -483,7 +481,7 @@ describe('PoolManager cache lifecycle', () => {
   test('records pool cache evictions when capacity removes cached pools', async () => {
     const poolModule = await loadPoolModule(10_000, 1)
     const metricsModule = await import('@internal/monitoring/metrics')
-    const evictionSpy = vi.spyOn(metricsModule.cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metricsModule, 'recordCacheEviction')
 
     class TestPoolManager extends poolModule.PoolManager {
       created: TestPool[] = []
@@ -499,9 +497,7 @@ describe('PoolManager cache lifecycle', () => {
     poolManager.getPool(createPoolSettings('tenant-cache-capacity-eviction-a'))
     poolManager.getPool(createPoolSettings('tenant-cache-capacity-eviction-b'))
 
-    expect(evictionSpy).toHaveBeenCalledWith(1, {
-      cache: TENANT_POOL_CACHE_NAME,
-    })
+    expect(evictionSpy).toHaveBeenCalledWith(TENANT_POOL_CACHE_NAME)
     expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
 
     await poolManager.destroyAll()
@@ -510,7 +506,7 @@ describe('PoolManager cache lifecycle', () => {
   test('does not record pool cache evictions for explicit destroys', async () => {
     const poolModule = await loadPoolModule(10_000)
     const metricsModule = await import('@internal/monitoring/metrics')
-    const evictionSpy = vi.spyOn(metricsModule.cacheEvictionsTotal, 'add')
+    const evictionSpy = vi.spyOn(metricsModule, 'recordCacheEviction')
 
     class TestPoolManager extends poolModule.PoolManager {
       created: TestPool[] = []
@@ -529,12 +525,7 @@ describe('PoolManager cache lifecycle', () => {
     await poolManager.destroy('tenant-cache-explicit-destroy-a')
     await poolManager.destroyAll()
 
-    expect(evictionSpy.mock.calls).not.toContainEqual([
-      1,
-      {
-        cache: TENANT_POOL_CACHE_NAME,
-      },
-    ])
+    expect(evictionSpy).not.toHaveBeenCalledWith(TENANT_POOL_CACHE_NAME)
     expect(poolManager.created[0].destroy).toHaveBeenCalledTimes(1)
     expect(poolManager.created[1].destroy).toHaveBeenCalledTimes(1)
   })
@@ -542,7 +533,7 @@ describe('PoolManager cache lifecycle', () => {
   test('caches external pools across lookups and records miss then hit', async () => {
     const poolModule = await loadPoolModule(10_000)
     const metricsModule = await import('@internal/monitoring/metrics')
-    const addSpy = vi.spyOn(metricsModule.cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metricsModule, 'recordCacheRequest')
 
     class TestPoolManager extends poolModule.PoolManager {
       created: TestPool[] = []
@@ -565,13 +556,9 @@ describe('PoolManager cache lifecycle', () => {
 
     expect(second).toBe(first)
     expect(poolManager.created).toHaveLength(1)
-    expect(
-      addSpy.mock.calls.filter(([, attrs]) => {
-        return attrs && typeof attrs === 'object' && attrs.cache === TENANT_POOL_CACHE_NAME
-      })
-    ).toEqual([
-      [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'miss' }],
-      [1, { cache: TENANT_POOL_CACHE_NAME, outcome: 'hit' }],
+    expect(recordSpy.mock.calls.filter(([cache]) => cache === TENANT_POOL_CACHE_NAME)).toEqual([
+      [TENANT_POOL_CACHE_NAME, 'miss'],
+      [TENANT_POOL_CACHE_NAME, 'hit'],
     ])
 
     await poolManager.destroyAll()

--- a/src/internal/database/pool.ts
+++ b/src/internal/database/pool.ts
@@ -1,13 +1,13 @@
 import { type CacheLookupOutcome, createTtlCache, TENANT_POOL_CACHE_NAME } from '@internal/cache'
 import { logger, logSchema } from '@internal/monitoring'
 import {
-  cacheEvictionsTotal,
-  cacheRequestsTotal,
   dbActiveConnection,
   dbActivePool,
   dbInUseConnection,
   isMetricEnabled,
   meter,
+  recordCacheEviction,
+  recordCacheRequest,
 } from '@internal/monitoring/metrics'
 import { JWTPayload } from 'jose'
 import { getConfig } from '../../config'
@@ -95,17 +95,12 @@ async function destroyPoolSafely(pool: PoolStrategy): Promise<void> {
 function recordTenantPoolCacheEviction(reason: string): void {
   // Explicit destroy paths are filtered before this helper is called.
   if (reason === 'stale' || reason === 'evict' || reason === 'delete') {
-    cacheEvictionsTotal.add(1, {
-      cache: TENANT_POOL_CACHE_NAME,
-    })
+    recordCacheEviction(TENANT_POOL_CACHE_NAME)
   }
 }
 
 function recordTenantPoolCacheRequest(outcome: CacheLookupOutcome): void {
-  cacheRequestsTotal.add(1, {
-    cache: TENANT_POOL_CACHE_NAME,
-    outcome,
-  })
+  recordCacheRequest(TENANT_POOL_CACHE_NAME, outcome)
 }
 
 function recordTenantPoolCacheLookup(

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -1,0 +1,118 @@
+import type { Meter } from '@opentelemetry/api'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+interface CapturedObservable {
+  name: string
+  callback: (observer: {
+    observe: (value: number, attributes?: Record<string, unknown>) => void
+  }) => void
+}
+
+interface CapturedObservation {
+  value: number
+  attributes?: Record<string, unknown>
+}
+
+function createMockMeter(): {
+  meter: Meter
+  invoke: (name: string) => CapturedObservation[]
+} {
+  const observables: CapturedObservable[] = []
+  const noopMetric = {
+    add: vi.fn(),
+    record: vi.fn(),
+  }
+
+  const createObservable = () => (name: string) => ({
+    addCallback(callback: CapturedObservable['callback']) {
+      observables.push({ name, callback })
+    },
+  })
+
+  const meter = {
+    createCounter: vi.fn(() => noopMetric),
+    createGauge: vi.fn(() => noopMetric),
+    createHistogram: vi.fn(() => noopMetric),
+    createObservableCounter: vi.fn(createObservable()),
+    createObservableGauge: vi.fn(createObservable()),
+    createUpDownCounter: vi.fn(() => noopMetric),
+    addBatchObservableCallback: vi.fn(),
+    removeBatchObservableCallback: vi.fn(),
+  } as unknown as Meter
+
+  const invoke = (name: string): CapturedObservation[] => {
+    const observations: CapturedObservation[] = []
+    const observer = {
+      observe: (value: number, attributes?: Record<string, unknown>) => {
+        observations.push({ value, attributes })
+      },
+    }
+
+    for (const observable of observables) {
+      if (observable.name === name) {
+        observable.callback(observer)
+      }
+    }
+
+    return observations
+  }
+
+  return { meter, invoke }
+}
+
+async function importMetricsWithMockMeter() {
+  vi.resetModules()
+
+  const mockMeter = createMockMeter()
+  vi.doMock('@opentelemetry/api', () => ({
+    metrics: {
+      getMeter: vi.fn(() => mockMeter.meter),
+    },
+  }))
+
+  const metricsModule = await import('./metrics')
+  return { metricsModule, mockMeter }
+}
+
+describe('metrics registry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.doUnmock('@opentelemetry/api')
+  })
+
+  test('observes cumulative cache counters with stable attributes even when disabled', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    metricsModule.setMetricsEnabled([
+      { name: 'cache_requests_total', enabled: false },
+      { name: 'cache_evictions_total', enabled: false },
+    ])
+    metricsModule.recordCacheRequest('tenant_config', 'hit')
+    metricsModule.recordCacheRequest('tenant_config', 'hit')
+    metricsModule.recordCacheRequest('tenant_config', 'miss')
+    metricsModule.recordCacheRequest('tenant_pool', 'stale')
+    metricsModule.recordCacheEviction('tenant_config')
+
+    expect(mockMeter.invoke('cache_requests_total')).toEqual([
+      {
+        value: 2,
+        attributes: { cache: 'tenant_config', outcome: 'hit' },
+      },
+      {
+        value: 1,
+        attributes: { cache: 'tenant_config', outcome: 'miss' },
+      },
+      {
+        value: 1,
+        attributes: { cache: 'tenant_pool', outcome: 'stale' },
+      },
+    ])
+
+    expect(mockMeter.invoke('cache_evictions_total')).toEqual([
+      {
+        value: 1,
+        attributes: { cache: 'tenant_config' },
+      },
+    ])
+  })
+})

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,5 +1,6 @@
 import { CACHE_LOOKUP_OUTCOMES, type CacheLookupOutcome } from '@internal/cache/adapter'
-import { Attributes, metrics } from '@opentelemetry/api'
+import type { CacheName } from '@internal/cache/names'
+import { type Attributes, metrics } from '@opentelemetry/api'
 
 // ============================================================================
 // Metric Registry — tracks all metrics for admin API
@@ -112,9 +113,9 @@ type CacheMetricsState = {
   evictionAttributes: Attributes
 }
 
-const cacheMetricsState = new Map<string, CacheMetricsState>()
+const cacheMetricsState = new Map<CacheName, CacheMetricsState>()
 
-function getCacheMetricsState(cache: string): CacheMetricsState {
+function getCacheMetricsState(cache: CacheName): CacheMetricsState {
   let state = cacheMetricsState.get(cache)
   if (!state) {
     state = {
@@ -133,12 +134,12 @@ function getCacheMetricsState(cache: string): CacheMetricsState {
 }
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
-export function recordCacheRequest(cache: string, outcome: CacheLookupOutcome): void {
+export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
   getCacheMetricsState(cache).requests[outcome]++
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
-export function recordCacheEviction(cache: string): void {
+export function recordCacheEviction(cache: CacheName): void {
   getCacheMetricsState(cache).evictions++
 }
 

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,4 +1,5 @@
-import { metrics } from '@opentelemetry/api'
+import { CACHE_LOOKUP_OUTCOMES, type CacheLookupOutcome } from '@internal/cache/adapter'
+import { Attributes, metrics } from '@opentelemetry/api'
 
 // ============================================================================
 // Metric Registry — tracks all metrics for admin API
@@ -97,18 +98,78 @@ export const fileUploadedSuccess = registerMetric('upload_success', 'counter', (
 
 // ============================================================================
 // Cache Metrics
+//
+// These observable counters intentionally do not check `isMetricEnabled()`.
+// With cumulative async OTel instruments, skipping `observe()` after a runtime
+// disable can keep the previous point exported, then jump on re-enable because
+// the in-process tally kept advancing. Drop these metrics at exporter/view
+// configuration if they need to be suppressed entirely.
 // ============================================================================
+type CacheMetricsState = {
+  requests: Record<CacheLookupOutcome, number>
+  requestAttributes: Record<CacheLookupOutcome, Attributes>
+  evictions: number
+  evictionAttributes: Attributes
+}
+
+const cacheMetricsState = new Map<string, CacheMetricsState>()
+
+function getCacheMetricsState(cache: string): CacheMetricsState {
+  let state = cacheMetricsState.get(cache)
+  if (!state) {
+    state = {
+      requests: { hit: 0, miss: 0, stale: 0 },
+      requestAttributes: {
+        hit: { cache, outcome: 'hit' },
+        miss: { cache, outcome: 'miss' },
+        stale: { cache, outcome: 'stale' },
+      },
+      evictions: 0,
+      evictionAttributes: { cache },
+    }
+    cacheMetricsState.set(cache, state)
+  }
+  return state
+}
+
+/** Records a single cache lookup outcome by bumping an in-process tally. */
+export function recordCacheRequest(cache: string, outcome: CacheLookupOutcome): void {
+  getCacheMetricsState(cache).requests[outcome]++
+}
+
+/** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
+export function recordCacheEviction(cache: string): void {
+  getCacheMetricsState(cache).evictions++
+}
+
 export const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () =>
-  meter.createCounter('cache_requests_total', {
+  meter.createObservableCounter('cache_requests_total', {
     description: 'Total cache lookups by cache and outcome',
   })
 )
+cacheRequestsTotal.addCallback((observer) => {
+  for (const state of cacheMetricsState.values()) {
+    for (const outcome of CACHE_LOOKUP_OUTCOMES) {
+      const count = state.requests[outcome]
+      if (count > 0) {
+        observer.observe(count, state.requestAttributes[outcome])
+      }
+    }
+  }
+})
 
 export const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
-  meter.createCounter('cache_evictions_total', {
+  meter.createObservableCounter('cache_evictions_total', {
     description: 'Total cache evictions',
   })
 )
+cacheEvictionsTotal.addCallback((observer) => {
+  for (const state of cacheMetricsState.values()) {
+    if (state.evictions > 0) {
+      observer.observe(state.evictions, state.evictionAttributes)
+    }
+  }
+})
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>
   meter.createObservableGauge('cache_entries', {

--- a/src/test/tenant-jwks.test.ts
+++ b/src/test/tenant-jwks.test.ts
@@ -24,7 +24,7 @@ import {
   jwksManager,
   listenForTenantUpdate,
 } from '@internal/database'
-import { cacheRequestsTotal } from '@internal/monitoring/metrics'
+import * as metrics from '@internal/monitoring/metrics'
 import { PostgresPubSub } from '@internal/pubsub'
 import dotenv from 'dotenv'
 import * as migrate from '../internal/database/migrations/migrate'
@@ -431,7 +431,7 @@ describe('Tenant jwks configs', () => {
 
   test('Config records one cache request per logical lookup', async () => {
     const listActiveSpy = vi.spyOn(jwksManager['storage'], 'listActive')
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const lookupTenantId = 'jwks-cache-metrics-lookup'
     const encryptedJwk = {
       id: 'cache-metrics',
@@ -445,7 +445,7 @@ describe('Tenant jwks configs', () => {
       listActiveSpy.mockImplementation(() => listActiveRequest.promise)
 
       await assertLogicalLookupMetrics({
-        addSpy,
+        recordSpy,
         backendCallSpy: listActiveSpy,
         cacheName: TENANT_JWKS_CACHE_NAME,
         startLookups: () => [
@@ -462,7 +462,7 @@ describe('Tenant jwks configs', () => {
       })
     } finally {
       listActiveSpy.mockRestore()
-      addSpy.mockRestore()
+      recordSpy.mockRestore()
     }
   })
 

--- a/src/test/tenant-s3-credentials.test.ts
+++ b/src/test/tenant-s3-credentials.test.ts
@@ -20,7 +20,7 @@ import {
   multitenantPgExecutor,
   s3CredentialsManager,
 } from '@internal/database'
-import { cacheRequestsTotal } from '@internal/monitoring/metrics'
+import * as metrics from '@internal/monitoring/metrics'
 import { PostgresPubSub } from '@internal/pubsub'
 import dotenv from 'dotenv'
 import objectSizeOf from 'object-sizeof'
@@ -542,7 +542,7 @@ describe('Tenant S3 credentials', () => {
 
   test('Config records one cache request per logical lookup', async () => {
     const getByKeySpy = vi.spyOn(s3CredentialsManager['storage'], 'getOneByAccessKey')
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const lookupTenantId = 's3-cache-metrics-lookup'
     const lookupAccessKey = 's3-cache-metrics-access-key'
     const credentials = {
@@ -560,7 +560,7 @@ describe('Tenant S3 credentials', () => {
       getByKeySpy.mockImplementation(() => credentialsLookup.promise)
 
       await assertLogicalLookupMetrics({
-        addSpy,
+        recordSpy,
         backendCallSpy: getByKeySpy,
         cacheName: TENANT_S3_CREDENTIALS_CACHE_NAME,
         startLookups: () => [
@@ -580,7 +580,7 @@ describe('Tenant S3 credentials', () => {
       })
     } finally {
       getByKeySpy.mockRestore()
-      addSpy.mockRestore()
+      recordSpy.mockRestore()
     }
   })
 })

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -15,7 +15,7 @@ import {
   getTenantConfig,
   onTenantConfigChange,
 } from '@internal/database/tenant'
-import { cacheRequestsTotal } from '@internal/monitoring/metrics'
+import * as metrics from '@internal/monitoring/metrics'
 import dotenv from 'dotenv'
 import * as migrate from '../internal/database/migrations/migrate'
 import { adminApp } from './common'
@@ -1175,7 +1175,7 @@ describe('Tenant configs', () => {
 
   test('Get tenant config records one cache request per logical lookup', async () => {
     const querySpy = vi.spyOn(multitenantPgExecutor, 'query')
-    const addSpy = vi.spyOn(cacheRequestsTotal, 'add')
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const tenantId = 'cache-metrics-lookup'
     const encryptedTenant = {
       anon_key: encrypt('anon'),
@@ -1208,7 +1208,7 @@ describe('Tenant configs', () => {
     try {
       querySpy.mockImplementation(() => tenantQuery.promise)
       await assertLogicalLookupMetrics({
-        addSpy,
+        recordSpy,
         backendCallSpy: querySpy,
         cacheName: TENANT_CONFIG_CACHE_NAME,
         startLookups: () => [
@@ -1226,7 +1226,7 @@ describe('Tenant configs', () => {
     } finally {
       deleteTenantConfig(tenantId)
       querySpy.mockRestore()
-      addSpy.mockRestore()
+      recordSpy.mockRestore()
     }
   })
 })

--- a/src/test/utils/cache-metrics.ts
+++ b/src/test/utils/cache-metrics.ts
@@ -1,14 +1,9 @@
 import type { Mock, MockInstance } from 'vitest'
 
-type CacheMetricAttributes = {
-  cache?: string
-  outcome?: string
-}
-
-type CacheRequestMetricCall = [number, { cache: string; outcome: string }]
+type CacheRequestRecordCall = [string, string]
 
 type AssertLogicalLookupMetricsOptions<T> = {
-  addSpy: MockInstance
+  recordSpy: MockInstance
   backendCallSpy: Mock | MockInstance
   cacheName: string
   startLookups: () => [Promise<T>, Promise<T>, Promise<T>]
@@ -22,24 +17,18 @@ async function waitForImmediate(): Promise<void> {
 }
 
 export function getCacheRequestCalls(
-  addSpy: MockInstance,
+  recordSpy: MockInstance,
   cacheName: string
-): CacheRequestMetricCall[] {
-  return addSpy.mock.calls.filter((call) => {
-    const [, attrs] = call as [number, CacheMetricAttributes | undefined]
-    const metricAttrs = attrs as CacheMetricAttributes | undefined
+): CacheRequestRecordCall[] {
+  return recordSpy.mock.calls.filter((call) => {
+    const [cache, outcome] = call as [unknown, unknown]
 
-    return Boolean(
-      metricAttrs &&
-        typeof metricAttrs === 'object' &&
-        metricAttrs.outcome &&
-        metricAttrs.cache === cacheName
-    )
-  }) as CacheRequestMetricCall[]
+    return cache === cacheName && typeof outcome === 'string'
+  }) as CacheRequestRecordCall[]
 }
 
 export async function assertLogicalLookupMetrics<T>({
-  addSpy,
+  recordSpy,
   backendCallSpy,
   cacheName,
   startLookups,
@@ -48,7 +37,7 @@ export async function assertLogicalLookupMetrics<T>({
   assertCachedHit,
 }: AssertLogicalLookupMetricsOptions<T>): Promise<void> {
   await waitForImmediate()
-  addSpy.mockClear()
+  recordSpy.mockClear()
 
   const lookups = startLookups()
 
@@ -58,12 +47,12 @@ export async function assertLogicalLookupMetrics<T>({
   // Waiters re-check the cache inside
   // the mutex with recordMetrics: false
   // so only these three outer misses are emitted.
-  const misses = [
-    [1, { cache: cacheName, outcome: 'miss' }],
-    [1, { cache: cacheName, outcome: 'miss' }],
-    [1, { cache: cacheName, outcome: 'miss' }],
+  const misses: CacheRequestRecordCall[] = [
+    [cacheName, 'miss'],
+    [cacheName, 'miss'],
+    [cacheName, 'miss'],
   ]
-  expect(getCacheRequestCalls(addSpy, cacheName)).toEqual(misses)
+  expect(getCacheRequestCalls(recordSpy, cacheName)).toEqual(misses)
   expect(backendCallSpy).toHaveBeenCalledTimes(1)
 
   resolveBackend()
@@ -71,12 +60,9 @@ export async function assertLogicalLookupMetrics<T>({
   const results = (await Promise.all(lookups)) as [T, T, T]
   await assertConcurrentResults?.(results)
 
-  expect(getCacheRequestCalls(addSpy, cacheName)).toEqual(misses)
+  expect(getCacheRequestCalls(recordSpy, cacheName)).toEqual(misses)
 
   await assertCachedHit()
 
-  expect(getCacheRequestCalls(addSpy, cacheName)).toEqual([
-    ...misses,
-    [1, { cache: cacheName, outcome: 'hit' }],
-  ])
+  expect(getCacheRequestCalls(recordSpy, cacheName)).toEqual([...misses, [cacheName, 'hit']])
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactoring for performance

## What is the current behavior?

Cache metrics are reported by sync counters which are allocating/hashing for attribute per call in the hot path.

## What is the new behavior?

Refactor them into observable counters backed by in-process integers. Hot operation becomes an integer increment. 

## Additional context

These metrics don't honor metric disabling.