### PR TITLE
fix: cheaper counter metrics

### DIFF
--- a/src/http/plugins/metrics.test.ts
+++ b/src/http/plugins/metrics.test.ts
@@ -5,8 +5,7 @@ import { httpMetrics } from './metrics'
 describe('httpMetrics plugin', () => {
   it('records HTTP metric attributes without tenant id labels', async () => {
     const app = Fastify()
-    const durationSpy = vi.spyOn(monitoringMetrics.httpRequestDuration, 'record')
-    const httpSizesSpy = vi.spyOn(monitoringMetrics, 'recordHttpSizes')
+    const httpMetricsSpy = vi.spyOn(monitoringMetrics, 'recordHttpRequestMetrics')
 
     app.decorateRequest('tenantId', 'tenant-a')
     await app.register(httpMetrics())
@@ -28,25 +27,16 @@ describe('httpMetrics plugin', () => {
 
       expect(response.statusCode).toBe(200)
 
-      const expectedAttributes = {
-        method: 'POST',
-        operation: 'unknown',
-        status_code: '200',
-      }
-
-      expect(durationSpy).toHaveBeenCalledWith(expect.any(Number), expectedAttributes)
-      expect(httpSizesSpy).toHaveBeenCalledWith(7, 2, expectedAttributes)
+      expect(httpMetricsSpy).toHaveBeenCalledWith(expect.any(Number), 7, 2, 'POST', 'unknown', 200)
     } finally {
-      durationSpy.mockRestore()
-      httpSizesSpy.mockRestore()
+      httpMetricsSpy.mockRestore()
       await app.close()
     }
   })
 
   it('ignores malformed request content-length headers', async () => {
     const app = Fastify()
-    const durationSpy = vi.spyOn(monitoringMetrics.httpRequestDuration, 'record')
-    const httpSizesSpy = vi.spyOn(monitoringMetrics, 'recordHttpSizes')
+    const httpMetricsSpy = vi.spyOn(monitoringMetrics, 'recordHttpRequestMetrics')
 
     await app.register(httpMetrics())
     app.post('/objects/:bucket', async (_request, reply) => {
@@ -66,19 +56,16 @@ describe('httpMetrics plugin', () => {
       })
 
       expect(response.statusCode).toBe(200)
-      expect(durationSpy).toHaveBeenCalled()
-      expect(httpSizesSpy).toHaveBeenCalledWith(
+      expect(httpMetricsSpy).toHaveBeenCalledWith(
+        expect.any(Number),
         undefined,
         2,
-        expect.objectContaining({
-          method: 'POST',
-          operation: 'unknown',
-          status_code: '200',
-        })
+        'POST',
+        'unknown',
+        200
       )
     } finally {
-      durationSpy.mockRestore()
-      httpSizesSpy.mockRestore()
+      httpMetricsSpy.mockRestore()
       await app.close()
     }
   })

--- a/src/http/plugins/metrics.test.ts
+++ b/src/http/plugins/metrics.test.ts
@@ -1,17 +1,12 @@
-import {
-  httpRequestDuration,
-  httpRequestSizeBytes,
-  httpResponseSizeBytes,
-} from '@internal/monitoring/metrics'
+import * as monitoringMetrics from '@internal/monitoring/metrics'
 import Fastify from 'fastify'
 import { httpMetrics } from './metrics'
 
 describe('httpMetrics plugin', () => {
   it('records HTTP metric attributes without tenant id labels', async () => {
     const app = Fastify()
-    const durationSpy = vi.spyOn(httpRequestDuration, 'record')
-    const requestSizeSpy = vi.spyOn(httpRequestSizeBytes, 'add')
-    const responseSizeSpy = vi.spyOn(httpResponseSizeBytes, 'add')
+    const durationSpy = vi.spyOn(monitoringMetrics.httpRequestDuration, 'record')
+    const httpSizesSpy = vi.spyOn(monitoringMetrics, 'recordHttpSizes')
 
     app.decorateRequest('tenantId', 'tenant-a')
     await app.register(httpMetrics())
@@ -40,12 +35,50 @@ describe('httpMetrics plugin', () => {
       }
 
       expect(durationSpy).toHaveBeenCalledWith(expect.any(Number), expectedAttributes)
-      expect(requestSizeSpy).toHaveBeenCalledWith(7, expectedAttributes)
-      expect(responseSizeSpy).toHaveBeenCalledWith(2, expectedAttributes)
+      expect(httpSizesSpy).toHaveBeenCalledWith(7, 2, expectedAttributes)
     } finally {
       durationSpy.mockRestore()
-      requestSizeSpy.mockRestore()
-      responseSizeSpy.mockRestore()
+      httpSizesSpy.mockRestore()
+      await app.close()
+    }
+  })
+
+  it('ignores malformed request content-length headers', async () => {
+    const app = Fastify()
+    const durationSpy = vi.spyOn(monitoringMetrics.httpRequestDuration, 'record')
+    const httpSizesSpy = vi.spyOn(monitoringMetrics, 'recordHttpSizes')
+
+    await app.register(httpMetrics())
+    app.post('/objects/:bucket', async (_request, reply) => {
+      reply.header('content-length', 'nope')
+      return 'ok'
+    })
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/objects/bucket-a',
+        headers: {
+          'content-length': 'not-a-size',
+          'content-type': 'text/plain',
+        },
+        payload: 'payload',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(durationSpy).toHaveBeenCalled()
+      expect(httpSizesSpy).toHaveBeenCalledWith(
+        undefined,
+        2,
+        expect.objectContaining({
+          method: 'POST',
+          operation: 'unknown',
+          status_code: '200',
+        })
+      )
+    } finally {
+      durationSpy.mockRestore()
+      httpSizesSpy.mockRestore()
       await app.close()
     }
   })

--- a/src/http/plugins/metrics.ts
+++ b/src/http/plugins/metrics.ts
@@ -1,13 +1,21 @@
-import {
-  httpRequestDuration,
-  httpRequestSizeBytes,
-  httpResponseSizeBytes,
-} from '@internal/monitoring/metrics'
+import { httpRequestDuration, recordHttpSizes } from '@internal/monitoring/metrics'
 import { handleMetricsRequest } from '@internal/monitoring/otel-metrics'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig } from '../../config'
 
 const { prometheusMetricsEnabled } = getConfig()
+
+function parseMetricSizeHeader(value: number | string | string[] | undefined): number | undefined {
+  let size: number | undefined
+
+  if (typeof value === 'number') {
+    size = value
+  } else if (typeof value === 'string') {
+    size = parseInt(value, 10)
+  }
+
+  return typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : undefined
+}
 
 interface MetricsOptions {
   enabledEndpoint?: boolean
@@ -91,25 +99,14 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
 
         // Record request size from content-length header
         const requestContentLength = request.headers['content-length']
-        if (requestContentLength) {
-          const requestSize = parseInt(requestContentLength, 10)
-          if (!isNaN(requestSize) && requestSize > 0) {
-            httpRequestSizeBytes.add(requestSize, attributes)
-          }
-        }
+        const requestSize = parseMetricSizeHeader(requestContentLength)
 
         // Record response size from content-length header
         const responseContentLength = reply.getHeader('content-length')
-        if (responseContentLength) {
-          const responseSize =
-            typeof responseContentLength === 'string'
-              ? parseInt(responseContentLength, 10)
-              : typeof responseContentLength === 'number'
-                ? responseContentLength
-                : 0
-          if (!isNaN(responseSize) && responseSize > 0) {
-            httpResponseSizeBytes.add(responseSize, attributes)
-          }
+        const responseSize = parseMetricSizeHeader(responseContentLength)
+
+        if (requestSize !== undefined || responseSize !== undefined) {
+          recordHttpSizes(requestSize, responseSize, attributes)
         }
       })
     },

--- a/src/http/plugins/metrics.ts
+++ b/src/http/plugins/metrics.ts
@@ -1,4 +1,4 @@
-import { httpRequestDuration, recordHttpSizes } from '@internal/monitoring/metrics'
+import { recordHttpRequestMetrics } from '@internal/monitoring/metrics'
 import { handleMetricsRequest } from '@internal/monitoring/otel-metrics'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig } from '../../config'
@@ -87,15 +87,8 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
         const durationNs = endTime - startTime
         const durationSeconds = Number(durationNs) / 1e9
 
-        const attributes = {
-          method: request.method,
-          operation:
-            request.operation?.type || request.routeOptions?.config?.operation?.type || 'unknown',
-          status_code: `${reply.statusCode}`,
-        }
-
-        // Record duration (histogram count replaces httpRequestsTotal)
-        httpRequestDuration.record(durationSeconds, attributes)
+        const operation =
+          request.operation?.type || request.routeOptions?.config?.operation?.type || 'unknown'
 
         // Record request size from content-length header
         const requestContentLength = request.headers['content-length']
@@ -105,9 +98,14 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
         const responseContentLength = reply.getHeader('content-length')
         const responseSize = parseMetricSizeHeader(responseContentLength)
 
-        if (requestSize !== undefined || responseSize !== undefined) {
-          recordHttpSizes(requestSize, responseSize, attributes)
-        }
+        recordHttpRequestMetrics(
+          durationSeconds,
+          requestSize,
+          responseSize,
+          request.method,
+          operation,
+          reply.statusCode
+        )
       })
     },
     { name: 'http-metrics' }

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -61,7 +61,7 @@ interface UploadState {
 }
 
 /** A representative two-counter group keyed by a plain string, mirroring the upload metrics. */
-function createUploadGroup(meter: Meter) {
+function createUploadGroup(meter: Meter, maxStates = 10) {
   const createState = vi.fn(
     (uploadType: string): UploadState => ({
       started: 0,
@@ -73,6 +73,7 @@ function createUploadGroup(meter: Meter) {
   const group = createBatchObservableCounterGroup({
     meter,
     registerMetric,
+    maxStates,
     counters: {
       started: { name: 'upload_started', description: 'Total uploads started' },
       success: { name: 'upload_success', description: 'Total successful uploads' },
@@ -111,6 +112,7 @@ describe('createBatchObservableCounterGroup', () => {
     createBatchObservableCounterGroup({
       meter: meter.meter,
       registerMetric,
+      maxStates: 10,
       counters: {
         bytes: { name: 'request_bytes', description: 'bytes in', unit: 'bytes' },
         count: { name: 'request_total', description: 'requests' },
@@ -149,6 +151,7 @@ describe('createBatchObservableCounterGroup', () => {
     const group = createBatchObservableCounterGroup({
       meter: meter.meter,
       registerMetric,
+      maxStates: 10,
       counters: { total: { name: 'http_total', description: 'requests' } },
       getKey: (input: { method: string; status: string }) => `${input.method}\x00${input.status}`,
       createState,
@@ -176,11 +179,16 @@ describe('createBatchObservableCounterGroup', () => {
     group.state('standard').success += 1
     group.state('multipart').started += 1
 
-    expect(meter.collect()).toEqual([
-      { name: 'upload_started', value: 2, attributes: { uploadType: 'standard' } },
-      { name: 'upload_success', value: 1, attributes: { uploadType: 'standard' } },
-      { name: 'upload_started', value: 1, attributes: { uploadType: 'multipart' } },
-    ])
+    const observations = meter.collect()
+
+    expect(observations).toHaveLength(3)
+    expect(observations).toEqual(
+      expect.arrayContaining([
+        { name: 'upload_started', value: 2, attributes: { uploadType: 'standard' } },
+        { name: 'upload_success', value: 1, attributes: { uploadType: 'standard' } },
+        { name: 'upload_started', value: 1, attributes: { uploadType: 'multipart' } },
+      ])
+    )
   })
 
   test('collect() omits series the observe callback guards out', () => {
@@ -192,5 +200,52 @@ describe('createBatchObservableCounterGroup', () => {
     expect(meter.collect()).toEqual([
       { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
     ])
+  })
+
+  test('evicts least recently used states once maxStates is reached', () => {
+    const meter = createFakeMeter()
+    const { group, createState } = createUploadGroup(meter.meter, 2)
+
+    group.state('standard').started += 1
+    group.state('multipart').started += 1
+    group.state('standard').success += 1
+    group.state('resumable').started += 1
+
+    const observations = meter.collect()
+
+    expect(createState).toHaveBeenCalledTimes(3)
+    expect(observations).toHaveLength(3)
+    expect(observations).toEqual(
+      expect.arrayContaining([
+        { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
+        { name: 'upload_success', value: 1, attributes: { uploadType: 'standard' } },
+        { name: 'upload_started', value: 1, attributes: { uploadType: 'resumable' } },
+      ])
+    )
+    expect(
+      observations.some((observation) => observation.attributes?.uploadType === 'multipart')
+    ).toBe(false)
+
+    const recreated = group.state('multipart')
+
+    expect(recreated.started).toBe(0)
+    expect(recreated.success).toBe(0)
+    expect(createState).toHaveBeenCalledTimes(4)
+  })
+
+  test('requires a positive maxStates cap', () => {
+    const meter = createFakeMeter()
+
+    expect(() =>
+      createBatchObservableCounterGroup({
+        meter: meter.meter,
+        registerMetric,
+        maxStates: 0,
+        counters: { total: { name: 'http_total', description: 'requests' } },
+        getKey: (key: string) => key,
+        createState: () => ({ count: 0 }),
+        observe: () => undefined,
+      })
+    ).toThrow('maxStates must be a positive integer')
   })
 })

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -1,0 +1,196 @@
+import type { Attributes, BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createBatchObservableCounterGroup } from './batch-observable-counter'
+
+interface Observation {
+  name: string
+  value: number
+  attributes?: Attributes
+}
+
+type CounterOptions = { description?: string; unit?: string }
+
+/**
+ * Minimal in-memory `Meter` stand-in. The factory only touches
+ * `createObservableCounter` and `addBatchObservableCallback`, so the fake can be
+ * tiny — and because the factory takes its dependencies by injection, no module
+ * mocking is required.
+ */
+function createFakeMeter() {
+  const counterNames = new Map<Observable, string>()
+  const createdCounters: { name: string; options?: CounterOptions }[] = []
+  const batchCallbacks: { callback: BatchObservableCallback; observables: Observable[] }[] = []
+
+  const meter = {
+    createObservableCounter: vi.fn((name: string, options?: CounterOptions) => {
+      const observable = { name } as unknown as Observable
+      counterNames.set(observable, name)
+      createdCounters.push({ name, options })
+      return observable
+    }),
+    addBatchObservableCallback: vi.fn(
+      (callback: BatchObservableCallback, observables: Observable[]) => {
+        batchCallbacks.push({ callback, observables })
+      }
+    ),
+  } as unknown as Meter
+
+  /** Runs every registered batch callback and returns the resulting observations in order. */
+  const collect = (): Observation[] => {
+    const observations: Observation[] = []
+    for (const { callback } of batchCallbacks) {
+      void callback({
+        observe: (observable, value, attributes) => {
+          observations.push({ name: counterNames.get(observable) as string, value, attributes })
+        },
+      })
+    }
+    return observations
+  }
+
+  return { meter, createdCounters, batchCallbacks, collect }
+}
+
+const registerMetric = <T>(_name: string, _type: 'counter', factory: () => T): T => factory()
+
+interface UploadState {
+  started: number
+  success: number
+  attributes: Attributes
+}
+
+/** A representative two-counter group keyed by a plain string, mirroring the upload metrics. */
+function createUploadGroup(meter: Meter) {
+  const createState = vi.fn(
+    (uploadType: string): UploadState => ({
+      started: 0,
+      success: 0,
+      attributes: { uploadType },
+    })
+  )
+
+  const group = createBatchObservableCounterGroup({
+    meter,
+    registerMetric,
+    counters: {
+      started: { name: 'upload_started', description: 'Total uploads started' },
+      success: { name: 'upload_success', description: 'Total successful uploads' },
+    },
+    getKey: (uploadType: string) => uploadType,
+    createState,
+    observe: (observer, counters, state: UploadState) => {
+      if (state.started > 0) {
+        observer.observe(counters.started, state.started, state.attributes)
+      }
+      if (state.success > 0) {
+        observer.observe(counters.success, state.success, state.attributes)
+      }
+    },
+  })
+
+  return { group, createState }
+}
+
+describe('createBatchObservableCounterGroup', () => {
+  test('registers one observable counter per config and a single batch callback over all of them', () => {
+    const meter = createFakeMeter()
+    createUploadGroup(meter.meter)
+
+    expect(meter.createdCounters.map((counter) => counter.name)).toEqual([
+      'upload_started',
+      'upload_success',
+    ])
+    expect(meter.batchCallbacks).toHaveLength(1)
+    expect(meter.batchCallbacks[0].observables).toHaveLength(2)
+  })
+
+  test('forwards description and unit to each counter, omitting unit when absent', () => {
+    const meter = createFakeMeter()
+
+    createBatchObservableCounterGroup({
+      meter: meter.meter,
+      registerMetric,
+      counters: {
+        bytes: { name: 'request_bytes', description: 'bytes in', unit: 'bytes' },
+        count: { name: 'request_total', description: 'requests' },
+      },
+      getKey: (key: string) => key,
+      createState: (key: string) => ({ key }),
+      observe: () => undefined,
+    })
+
+    expect(meter.createdCounters).toEqual([
+      { name: 'request_bytes', options: { description: 'bytes in', unit: 'bytes' } },
+      { name: 'request_total', options: { description: 'requests' } },
+    ])
+  })
+
+  test('state() creates one tally per derived key and reuses it for equal keys', () => {
+    const meter = createFakeMeter()
+    const { group, createState } = createUploadGroup(meter.meter)
+
+    const first = group.state('standard')
+    const second = group.state('standard')
+    const other = group.state('multipart')
+
+    expect(second).toBe(first)
+    expect(other).not.toBe(first)
+    expect(createState).toHaveBeenCalledTimes(2)
+  })
+
+  test('dedups by derived key even when inputs are different objects', () => {
+    const meter = createFakeMeter()
+    const createState = vi.fn((input: { method: string; status: string }) => ({
+      count: 0,
+      attributes: { method: input.method, status: input.status } as Attributes,
+    }))
+
+    const group = createBatchObservableCounterGroup({
+      meter: meter.meter,
+      registerMetric,
+      counters: { total: { name: 'http_total', description: 'requests' } },
+      getKey: (input: { method: string; status: string }) => `${input.method}\x00${input.status}`,
+      createState,
+      observe: (observer, counters, state) => {
+        if (state.count > 0) {
+          observer.observe(counters.total, state.count, state.attributes)
+        }
+      },
+    })
+
+    group.state({ method: 'GET', status: '200' }).count++
+    group.state({ method: 'GET', status: '200' }).count++
+
+    expect(createState).toHaveBeenCalledTimes(1)
+    expect(meter.collect()).toEqual([
+      { name: 'http_total', value: 2, attributes: { method: 'GET', status: '200' } },
+    ])
+  })
+
+  test('collect() observes each state once and routes every series to its counter', () => {
+    const meter = createFakeMeter()
+    const { group } = createUploadGroup(meter.meter)
+
+    group.state('standard').started += 2
+    group.state('standard').success += 1
+    group.state('multipart').started += 1
+
+    expect(meter.collect()).toEqual([
+      { name: 'upload_started', value: 2, attributes: { uploadType: 'standard' } },
+      { name: 'upload_success', value: 1, attributes: { uploadType: 'standard' } },
+      { name: 'upload_started', value: 1, attributes: { uploadType: 'multipart' } },
+    ])
+  })
+
+  test('collect() omits series the observe callback guards out', () => {
+    const meter = createFakeMeter()
+    const { group } = createUploadGroup(meter.meter)
+
+    group.state('standard').started += 1
+
+    expect(meter.collect()).toEqual([
+      { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
+    ])
+  })
+})

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -1,7 +1,10 @@
 import type { Attributes, BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
 import { describe, expect, test, vi } from 'vitest'
 
-import { createBatchObservableCounterGroup } from './batch-observable-counter'
+import {
+  createBatchObservableCounterGroup,
+  SAFE_COUNTER_THRESHOLD,
+} from './batch-observable-counter'
 
 interface Observation {
   name: string
@@ -191,6 +194,36 @@ describe('createBatchObservableCounterGroup', () => {
 
     expect(meter.collect()).toEqual([
       { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
+    ])
+  })
+
+  test('add() increments flat counter state without an update object', () => {
+    const meter = createFakeMeter()
+    const { group, createState } = createUploadGroup(meter.meter)
+
+    group.add('standard', 'started')
+    group.add('standard', 'success', 2)
+    group.add('standard', 'started', 0)
+    group.add('standard', 'success', Number.NaN)
+
+    expect(createState).toHaveBeenCalledTimes(1)
+    expect(meter.collect()).toEqual(
+      expect.arrayContaining([
+        { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
+        { name: 'upload_success', value: 2, attributes: { uploadType: 'standard' } },
+      ])
+    )
+  })
+
+  test('add() keeps flat counters below the safe threshold', () => {
+    const meter = createFakeMeter()
+    const { group } = createUploadGroup(meter.meter)
+
+    group.add('standard', 'started', SAFE_COUNTER_THRESHOLD - 1)
+    group.add('standard', 'started', 2)
+
+    expect(meter.collect()).toEqual([
+      { name: 'upload_started', value: 2, attributes: { uploadType: 'standard' } },
     ])
   })
 

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import {
   createBatchObservableCounterGroup,
+  type ObservableCounterSeries,
   SAFE_COUNTER_THRESHOLD,
 } from './batch-observable-counter'
 
@@ -14,12 +15,6 @@ interface Observation {
 
 type CounterOptions = { description?: string; unit?: string }
 
-/**
- * Minimal in-memory `Meter` stand-in. The factory only touches
- * `createObservableCounter` and `addBatchObservableCallback`, so the fake can be
- * tiny — and because the factory takes its dependencies by injection, no module
- * mocking is required.
- */
 function createFakeMeter() {
   const counterNames = new Map<Observable, string>()
   const createdCounters: { name: string; options?: CounterOptions }[] = []
@@ -58,18 +53,16 @@ function createFakeMeter() {
 const registerMetric = <T>(_name: string, _type: 'counter', factory: () => T): T => factory()
 
 interface UploadState {
-  started: number
-  success: number
-  attributes: Attributes
+  started: ObservableCounterSeries
+  success: ObservableCounterSeries
 }
 
 /** A representative two-counter group keyed by a plain string, mirroring the upload metrics. */
 function createUploadGroup(meter: Meter, maxStates = 10) {
   const createState = vi.fn(
     (uploadType: string): UploadState => ({
-      started: 0,
-      success: 0,
-      attributes: { uploadType },
+      started: { count: 0, attributes: { uploadType } },
+      success: { count: 0, attributes: { uploadType } },
     })
   )
 
@@ -170,9 +163,9 @@ describe('createBatchObservableCounterGroup', () => {
     const meter = createFakeMeter()
     const { group } = createUploadGroup(meter.meter)
 
-    group.state('standard').started += 2
-    group.state('standard').success += 1
-    group.state('multipart').started += 1
+    group.state('standard').started.count += 2
+    group.state('standard').success.count += 1
+    group.state('multipart').started.count += 1
 
     const observations = meter.collect()
 
@@ -190,21 +183,21 @@ describe('createBatchObservableCounterGroup', () => {
     const meter = createFakeMeter()
     const { group } = createUploadGroup(meter.meter)
 
-    group.state('standard').started += 1
+    group.state('standard').started.count += 1
 
     expect(meter.collect()).toEqual([
       { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
     ])
   })
 
-  test('add() increments flat counter state without an update object', () => {
+  test('generated counter methods increment counter series without an update object', () => {
     const meter = createFakeMeter()
     const { group, createState } = createUploadGroup(meter.meter)
 
-    group.add('standard', 'started')
-    group.add('standard', 'success', 2)
-    group.add('standard', 'started', 0)
-    group.add('standard', 'success', Number.NaN)
+    group.addStarted('standard')
+    group.addSuccess('standard', 2)
+    group.addStarted('standard', 0)
+    group.addSuccess('standard', Number.NaN)
 
     expect(createState).toHaveBeenCalledTimes(1)
     expect(meter.collect()).toEqual(
@@ -219,7 +212,7 @@ describe('createBatchObservableCounterGroup', () => {
     const meter = createFakeMeter()
     const { group } = createUploadGroup(meter.meter)
 
-    group.add('standard', 'started', SAFE_COUNTER_THRESHOLD - 1)
+    group.addStarted('standard', SAFE_COUNTER_THRESHOLD - 1)
     group.add('standard', 'started', 2)
 
     expect(meter.collect()).toEqual([
@@ -231,7 +224,7 @@ describe('createBatchObservableCounterGroup', () => {
     ])
   })
 
-  test('allows a custom observer for non-flat state shapes', () => {
+  test('generated counter methods increment nested counter maps', () => {
     const meter = createFakeMeter()
     const group = createBatchObservableCounterGroup({
       meter: meter.meter,
@@ -247,33 +240,13 @@ describe('createBatchObservableCounterGroup', () => {
           hit: { count: 0, attributes: { cache, outcome: 'hit' } as Attributes },
           miss: { count: 0, attributes: { cache, outcome: 'miss' } as Attributes },
         },
-        evictions: 0,
-        evictionAttributes: { cache } as Attributes,
+        evictions: { count: 0, attributes: { cache } as Attributes },
       }),
-      observe: (observer, counters, state) => {
-        if (state.requests.hit.count > 0) {
-          observer.observe(
-            counters.requests,
-            state.requests.hit.count,
-            state.requests.hit.attributes
-          )
-        }
-        if (state.requests.miss.count > 0) {
-          observer.observe(
-            counters.requests,
-            state.requests.miss.count,
-            state.requests.miss.attributes
-          )
-        }
-        if (state.evictions > 0) {
-          observer.observe(counters.evictions, state.evictions, state.evictionAttributes)
-        }
-      },
     })
 
-    group.state('metadata').requests.hit.count += 1
-    group.state('metadata').requests.miss.count += 2
-    group.state('metadata').evictions += 1
+    group.addRequests('metadata', 'hit')
+    group.addRequests('metadata', 'miss', 2)
+    group.addEvictions('metadata')
 
     expect(meter.collect()).toEqual([
       {
@@ -294,10 +267,10 @@ describe('createBatchObservableCounterGroup', () => {
     const meter = createFakeMeter()
     const { group, createState } = createUploadGroup(meter.meter, 2)
 
-    group.state('standard').started += 1
-    group.state('multipart').started += 1
-    group.state('standard').success += 1
-    group.state('resumable').started += 1
+    group.state('standard').started.count += 1
+    group.state('multipart').started.count += 1
+    group.state('standard').success.count += 1
+    group.state('resumable').started.count += 1
 
     const observations = meter.collect()
 
@@ -316,8 +289,8 @@ describe('createBatchObservableCounterGroup', () => {
 
     const recreated = group.state('multipart')
 
-    expect(recreated.started).toBe(0)
-    expect(recreated.success).toBe(0)
+    expect(recreated.started.count).toBe(0)
+    expect(recreated.success.count).toBe(0)
     expect(createState).toHaveBeenCalledTimes(4)
   })
 

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -80,14 +80,6 @@ function createUploadGroup(meter: Meter, maxStates = 10) {
     },
     getKey: (uploadType: string) => uploadType,
     createState,
-    observe: (observer, counters, state: UploadState) => {
-      if (state.started > 0) {
-        observer.observe(counters.started, state.started, state.attributes)
-      }
-      if (state.success > 0) {
-        observer.observe(counters.success, state.success, state.attributes)
-      }
-    },
   })
 
   return { group, createState }
@@ -171,7 +163,7 @@ describe('createBatchObservableCounterGroup', () => {
     ])
   })
 
-  test('collect() observes each state once and routes every series to its counter', () => {
+  test('default observer collects each state once and routes every series to its counter', () => {
     const meter = createFakeMeter()
     const { group } = createUploadGroup(meter.meter)
 
@@ -191,7 +183,7 @@ describe('createBatchObservableCounterGroup', () => {
     )
   })
 
-  test('collect() omits series the observe callback guards out', () => {
+  test('default observer omits zero-value series', () => {
     const meter = createFakeMeter()
     const { group } = createUploadGroup(meter.meter)
 
@@ -199,6 +191,65 @@ describe('createBatchObservableCounterGroup', () => {
 
     expect(meter.collect()).toEqual([
       { name: 'upload_started', value: 1, attributes: { uploadType: 'standard' } },
+    ])
+  })
+
+  test('allows a custom observer for non-flat state shapes', () => {
+    const meter = createFakeMeter()
+    const group = createBatchObservableCounterGroup({
+      meter: meter.meter,
+      registerMetric,
+      maxStates: 10,
+      counters: {
+        requests: { name: 'cache_requests_total', description: 'cache requests' },
+        evictions: { name: 'cache_evictions_total', description: 'cache evictions' },
+      },
+      getKey: (cache: string) => cache,
+      createState: (cache: string) => ({
+        requests: {
+          hit: { count: 0, attributes: { cache, outcome: 'hit' } as Attributes },
+          miss: { count: 0, attributes: { cache, outcome: 'miss' } as Attributes },
+        },
+        evictions: 0,
+        evictionAttributes: { cache } as Attributes,
+      }),
+      observe: (observer, counters, state) => {
+        if (state.requests.hit.count > 0) {
+          observer.observe(
+            counters.requests,
+            state.requests.hit.count,
+            state.requests.hit.attributes
+          )
+        }
+        if (state.requests.miss.count > 0) {
+          observer.observe(
+            counters.requests,
+            state.requests.miss.count,
+            state.requests.miss.attributes
+          )
+        }
+        if (state.evictions > 0) {
+          observer.observe(counters.evictions, state.evictions, state.evictionAttributes)
+        }
+      },
+    })
+
+    group.state('metadata').requests.hit.count += 1
+    group.state('metadata').requests.miss.count += 2
+    group.state('metadata').evictions += 1
+
+    expect(meter.collect()).toEqual([
+      {
+        name: 'cache_requests_total',
+        value: 1,
+        attributes: { cache: 'metadata', outcome: 'hit' },
+      },
+      {
+        name: 'cache_requests_total',
+        value: 2,
+        attributes: { cache: 'metadata', outcome: 'miss' },
+      },
+      { name: 'cache_evictions_total', value: 1, attributes: { cache: 'metadata' } },
     ])
   })
 

--- a/src/internal/monitoring/counter/batch-observable-counter.test.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.test.ts
@@ -223,7 +223,11 @@ describe('createBatchObservableCounterGroup', () => {
     group.add('standard', 'started', 2)
 
     expect(meter.collect()).toEqual([
-      { name: 'upload_started', value: 2, attributes: { uploadType: 'standard' } },
+      {
+        name: 'upload_started',
+        value: SAFE_COUNTER_THRESHOLD,
+        attributes: { uploadType: 'standard' },
+      },
     ])
   })
 

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -65,7 +65,7 @@ export function safeAddCounter(current: number, amount: number): number {
     next >= SAFE_COUNTER_THRESHOLD ||
     !Number.isSafeInteger(next)
   ) {
-    return Math.min(amount, SAFE_COUNTER_THRESHOLD)
+    return SAFE_COUNTER_THRESHOLD
   }
 
   return next

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -1,0 +1,71 @@
+import type { BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
+
+type BatchObservableObserver = Parameters<BatchObservableCallback>[0]
+
+type RegisterCounterMetric = <T>(name: string, type: 'counter', factory: () => T) => T
+
+type ObservableCounterConfig = {
+  name: string
+  description: string
+  unit?: string
+}
+
+type BatchObservableCounterGroup<TInput, TState> = {
+  /** Returns the mutable tally for `input`, creating it on first use. */
+  state(input: TInput): TState
+}
+
+export function createBatchObservableCounterGroup<
+  TCounter extends string,
+  TInput,
+  TKey,
+  TState,
+>(options: {
+  meter: Meter
+  registerMetric: RegisterCounterMetric
+  counters: Record<TCounter, ObservableCounterConfig>
+  getKey(input: TInput): TKey
+  createState(input: TInput): TState
+  observe(
+    observer: BatchObservableObserver,
+    counters: Record<TCounter, Observable>,
+    state: TState
+  ): void
+}): BatchObservableCounterGroup<TInput, TState> {
+  const states = new Map<TKey, TState>()
+  const counterKeys = Object.keys(options.counters) as TCounter[]
+  const counters = {} as Record<TCounter, Observable>
+
+  for (const counterKey of counterKeys) {
+    const config = options.counters[counterKey]
+    counters[counterKey] = options.registerMetric(config.name, 'counter', () =>
+      options.meter.createObservableCounter(
+        config.name,
+        config.unit
+          ? { description: config.description, unit: config.unit }
+          : { description: config.description }
+      )
+    )
+  }
+
+  options.meter.addBatchObservableCallback(
+    (observer) => {
+      states.forEach((state) => options.observe(observer, counters, state))
+    },
+    counterKeys.map((counterKey) => counters[counterKey])
+  )
+
+  return {
+    state(input) {
+      const key = options.getKey(input)
+      let state = states.get(key)
+
+      if (!state) {
+        state = options.createState(input)
+        states.set(key, state)
+      }
+
+      return state
+    },
+  }
+}

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -1,4 +1,4 @@
-import type { BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
+import type { Attributes, BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
 import { LRUCache } from 'lru-cache'
 
 type BatchObservableObserver = Parameters<BatchObservableCallback>[0]
@@ -11,29 +11,85 @@ type ObservableCounterConfig = {
   unit?: string
 }
 
+type DefaultObservableCounterState<TCounter extends string> = Record<TCounter, number> & {
+  attributes: Attributes
+}
+
 type BatchObservableCounterGroup<TInput, TState> = {
   /** Returns the mutable tally for `input`, creating it on first use. */
   state(input: TInput): TState
 }
 
-export function createBatchObservableCounterGroup<
+type BatchObservableCounterGroupOptions<
   TCounter extends string,
   TInput,
   TKey extends {},
   TState extends {},
->(options: {
+> = {
   meter: Meter
   registerMetric: RegisterCounterMetric
   counters: Record<TCounter, ObservableCounterConfig>
   maxStates: number
   getKey(input: TInput): TKey
   createState(input: TInput): TState
+}
+
+type CustomObservableCounterGroupOptions<
+  TCounter extends string,
+  TInput,
+  TKey extends {},
+  TState extends {},
+> = BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState> & {
   observe(
     observer: BatchObservableObserver,
     counters: Record<TCounter, Observable>,
     state: TState
   ): void
-}): BatchObservableCounterGroup<TInput, TState> {
+}
+
+function observeDefaultCounters<TCounter extends string>(
+  observer: BatchObservableObserver,
+  counters: Record<TCounter, Observable>,
+  counterKeys: TCounter[],
+  state: DefaultObservableCounterState<TCounter>
+): void {
+  for (const counterKey of counterKeys) {
+    const value = state[counterKey]
+
+    if (value > 0) {
+      observer.observe(counters[counterKey], value, state.attributes)
+    }
+  }
+}
+
+export function createBatchObservableCounterGroup<
+  TCounter extends string,
+  TInput,
+  TKey extends {},
+  TState extends DefaultObservableCounterState<TCounter>,
+>(
+  options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState>
+): BatchObservableCounterGroup<TInput, TState>
+
+export function createBatchObservableCounterGroup<
+  TCounter extends string,
+  TInput,
+  TKey extends {},
+  TState extends {},
+>(
+  options: CustomObservableCounterGroupOptions<TCounter, TInput, TKey, TState>
+): BatchObservableCounterGroup<TInput, TState>
+
+export function createBatchObservableCounterGroup<
+  TCounter extends string,
+  TInput,
+  TKey extends {},
+  TState extends {},
+>(
+  options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState> & {
+    observe?: CustomObservableCounterGroupOptions<TCounter, TInput, TKey, TState>['observe']
+  }
+): BatchObservableCounterGroup<TInput, TState> {
   if (!Number.isInteger(options.maxStates) || options.maxStates < 1) {
     throw new Error('maxStates must be a positive integer')
   }
@@ -54,9 +110,19 @@ export function createBatchObservableCounterGroup<
     )
   }
 
+  const observe =
+    options.observe ??
+    ((observer: BatchObservableObserver, counters: Record<TCounter, Observable>, state: TState) =>
+      observeDefaultCounters(
+        observer,
+        counters,
+        counterKeys,
+        state as unknown as DefaultObservableCounterState<TCounter>
+      ))
+
   options.meter.addBatchObservableCallback(
     (observer) => {
-      states.forEach((state) => options.observe(observer, counters, state))
+      states.forEach((state) => observe(observer, counters, state))
     },
     counterKeys.map((counterKey) => counters[counterKey])
   )

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -11,21 +11,40 @@ type ObservableCounterConfig = {
   unit?: string
 }
 
-type DefaultObservableCounterState<TCounter extends string> = Record<TCounter, number> & {
+type AddCounterMethodName<TCounter extends string> = `add${Capitalize<TCounter>}`
+
+export type ObservableCounterSeries = {
+  count: number
   attributes: Attributes
 }
+
+type CounterDimension<TValue> = TValue extends object
+  ? {
+      [TKey in keyof TValue & string]: TValue[TKey] extends ObservableCounterSeries ? TKey : never
+    }[keyof TValue & string]
+  : never
+
+type AddCounterMethod<TInput, TValue> = TValue extends ObservableCounterSeries
+  ? (input: TInput, amount?: number) => void
+  : CounterDimension<TValue> extends never
+    ? never
+    : (input: TInput, dimension: CounterDimension<TValue>, amount?: number) => void
+
+type AutoAddCounterMethods<
+  TCounter extends string,
+  TInput,
+  TState extends Record<TCounter, unknown>,
+> = {
+  [TKey in TCounter as AddCounterMethod<TInput, TState[TKey]> extends never
+    ? never
+    : AddCounterMethodName<TKey>]: AddCounterMethod<TInput, TState[TKey]>
+}
+
+type ObservableCounterGroupState<TCounter extends string> = Record<TCounter, unknown>
 
 type BatchObservableCounterGroup<TInput, TState> = {
   /** Returns the mutable tally for `input`, creating it on first use. */
   state(input: TInput): TState
-}
-
-type DefaultBatchObservableCounterGroup<
-  TCounter extends string,
-  TInput,
-  TState,
-> = BatchObservableCounterGroup<TInput, TState> & {
-  add(input: TInput, counterKey: TCounter, amount?: number): void
 }
 
 type BatchObservableCounterGroupOptions<
@@ -71,18 +90,55 @@ export function safeAddCounter(current: number, amount: number): number {
   return next
 }
 
-function observeDefaultCounters<TCounter extends string>(
+function isAddableCounterAmount(amount: number): boolean {
+  return Number.isFinite(amount) && amount > 0
+}
+
+function addMethodName(counterKey: string): `add${string}` {
+  return `add${counterKey.charAt(0).toUpperCase()}${counterKey.slice(1)}`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object')
+}
+
+function isObservableCounterState(value: unknown): value is ObservableCounterSeries {
+  return isRecord(value) && typeof value.count === 'number' && isRecord(value.attributes)
+}
+
+function observeDefaultCounters<
+  TCounter extends string,
+  TState extends ObservableCounterGroupState<TCounter>,
+>(
   observer: BatchObservableObserver,
   counters: Record<TCounter, Observable>,
   counterKeys: TCounter[],
-  state: DefaultObservableCounterState<TCounter>
+  state: TState
 ): void {
   for (const counterKey of counterKeys) {
     const value = state[counterKey]
 
-    if (value > 0) {
-      observer.observe(counters[counterKey], value, state.attributes)
+    if (isObservableCounterState(value) && value.count > 0) {
+      observer.observe(counters[counterKey], value.count, value.attributes)
+      continue
     }
+
+    if (!isRecord(value)) {
+      continue
+    }
+
+    for (const key in value) {
+      const series = value[key]
+      if (isObservableCounterState(series) && series.count > 0) {
+        observer.observe(counters[counterKey], series.count, series.attributes)
+      }
+    }
+  }
+}
+
+function addCounterState(counterState: ObservableCounterSeries, amount = 1): void {
+  if (isAddableCounterAmount(amount)) {
+    counterState.count = safeAddCounter(counterState.count, amount)
   }
 }
 
@@ -90,10 +146,14 @@ export function createBatchObservableCounterGroup<
   TCounter extends string,
   TInput,
   TKey extends {},
-  TState extends DefaultObservableCounterState<TCounter>,
+  TState extends ObservableCounterGroupState<TCounter>,
 >(
-  options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState>
-): DefaultBatchObservableCounterGroup<TCounter, TInput, TState>
+  options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState> & {
+    observe?: CustomObservableCounterGroupOptions<TCounter, TInput, TKey, TState>['observe']
+  }
+): BatchObservableCounterGroup<TInput, TState> & {
+  add(input: TInput, counterKey: TCounter, amount?: number): void
+} & AutoAddCounterMethods<TCounter, TInput, TState>
 
 export function createBatchObservableCounterGroup<
   TCounter extends string,
@@ -113,9 +173,7 @@ export function createBatchObservableCounterGroup<
   options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState> & {
     observe?: CustomObservableCounterGroupOptions<TCounter, TInput, TKey, TState>['observe']
   }
-): BatchObservableCounterGroup<TInput, TState> & {
-  add(input: TInput, counterKey: TCounter, amount?: number): void
-} {
+): Record<string, unknown> {
   if (!Number.isInteger(options.maxStates) || options.maxStates < 1) {
     throw new Error('maxStates must be a positive integer')
   }
@@ -143,7 +201,7 @@ export function createBatchObservableCounterGroup<
         observer,
         counters,
         counterKeys,
-        state as unknown as DefaultObservableCounterState<TCounter>
+        state as unknown as ObservableCounterGroupState<TCounter>
       ))
 
   options.meter.addBatchObservableCallback(
@@ -165,16 +223,44 @@ export function createBatchObservableCounterGroup<
     return state
   }
 
-  return {
-    state: getState,
-    add(input, counterKey, amount = 1) {
-      if (!Number.isFinite(amount) || amount <= 0) {
-        return
-      }
+  const addCounter = (
+    input: TInput,
+    counterKey: TCounter,
+    arg1?: unknown,
+    arg2?: unknown
+  ): void => {
+    const state = getState(input) as Record<string, unknown>
+    const value = state[counterKey]
 
-      const state = getState(input) as unknown as DefaultObservableCounterState<TCounter>
-      const counterState = state as Record<TCounter, number>
-      counterState[counterKey] = safeAddCounter(counterState[counterKey], amount)
-    },
+    if (isObservableCounterState(value)) {
+      const amount = typeof arg1 === 'number' ? arg1 : 1
+      addCounterState(value, amount)
+      return
+    }
+
+    if (!isRecord(value) || typeof arg1 !== 'string') {
+      return
+    }
+
+    const countState = value[arg1]
+    const amount = typeof arg2 === 'number' ? arg2 : 1
+
+    if (isObservableCounterState(countState)) {
+      addCounterState(countState, amount)
+    }
   }
+
+  const group = {
+    state: getState,
+    add: (input: TInput, counterKey: TCounter, amount = 1) => addCounter(input, counterKey, amount),
+  } as BatchObservableCounterGroup<TInput, TState> & {
+    add(input: TInput, counterKey: TCounter, amount?: number): void
+  } & Record<string, unknown>
+
+  for (const counterKey of counterKeys) {
+    group[addMethodName(counterKey)] = (input: TInput, arg1?: unknown, arg2?: unknown) =>
+      addCounter(input, counterKey, arg1, arg2)
+  }
+
+  return group
 }

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -20,6 +20,14 @@ type BatchObservableCounterGroup<TInput, TState> = {
   state(input: TInput): TState
 }
 
+type DefaultBatchObservableCounterGroup<
+  TCounter extends string,
+  TInput,
+  TState,
+> = BatchObservableCounterGroup<TInput, TState> & {
+  add(input: TInput, counterKey: TCounter, amount?: number): void
+}
+
 type BatchObservableCounterGroupOptions<
   TCounter extends string,
   TInput,
@@ -47,6 +55,22 @@ type CustomObservableCounterGroupOptions<
   ): void
 }
 
+export const SAFE_COUNTER_THRESHOLD = Number.MAX_SAFE_INTEGER - 1_000_000_000
+
+export function safeAddCounter(current: number, amount: number): number {
+  const next = current + amount
+
+  if (
+    current >= SAFE_COUNTER_THRESHOLD ||
+    next >= SAFE_COUNTER_THRESHOLD ||
+    !Number.isSafeInteger(next)
+  ) {
+    return Math.min(amount, SAFE_COUNTER_THRESHOLD)
+  }
+
+  return next
+}
+
 function observeDefaultCounters<TCounter extends string>(
   observer: BatchObservableObserver,
   counters: Record<TCounter, Observable>,
@@ -69,7 +93,7 @@ export function createBatchObservableCounterGroup<
   TState extends DefaultObservableCounterState<TCounter>,
 >(
   options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState>
-): BatchObservableCounterGroup<TInput, TState>
+): DefaultBatchObservableCounterGroup<TCounter, TInput, TState>
 
 export function createBatchObservableCounterGroup<
   TCounter extends string,
@@ -89,7 +113,9 @@ export function createBatchObservableCounterGroup<
   options: BatchObservableCounterGroupOptions<TCounter, TInput, TKey, TState> & {
     observe?: CustomObservableCounterGroupOptions<TCounter, TInput, TKey, TState>['observe']
   }
-): BatchObservableCounterGroup<TInput, TState> {
+): BatchObservableCounterGroup<TInput, TState> & {
+  add(input: TInput, counterKey: TCounter, amount?: number): void
+} {
   if (!Number.isInteger(options.maxStates) || options.maxStates < 1) {
     throw new Error('maxStates must be a positive integer')
   }
@@ -127,17 +153,28 @@ export function createBatchObservableCounterGroup<
     counterKeys.map((counterKey) => counters[counterKey])
   )
 
-  return {
-    state(input) {
-      const key = options.getKey(input)
-      let state = states.get(key)
+  const getState = (input: TInput): TState => {
+    const key = options.getKey(input)
+    let state = states.get(key)
 
-      if (!state) {
-        state = options.createState(input)
-        states.set(key, state)
+    if (!state) {
+      state = options.createState(input)
+      states.set(key, state)
+    }
+
+    return state
+  }
+
+  return {
+    state: getState,
+    add(input, counterKey, amount = 1) {
+      if (!Number.isFinite(amount) || amount <= 0) {
+        return
       }
 
-      return state
+      const state = getState(input) as unknown as DefaultObservableCounterState<TCounter>
+      const counterState = state as Record<TCounter, number>
+      counterState[counterKey] = safeAddCounter(counterState[counterKey], amount)
     },
   }
 }

--- a/src/internal/monitoring/counter/batch-observable-counter.ts
+++ b/src/internal/monitoring/counter/batch-observable-counter.ts
@@ -1,4 +1,5 @@
 import type { BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
+import { LRUCache } from 'lru-cache'
 
 type BatchObservableObserver = Parameters<BatchObservableCallback>[0]
 
@@ -18,12 +19,13 @@ type BatchObservableCounterGroup<TInput, TState> = {
 export function createBatchObservableCounterGroup<
   TCounter extends string,
   TInput,
-  TKey,
-  TState,
+  TKey extends {},
+  TState extends {},
 >(options: {
   meter: Meter
   registerMetric: RegisterCounterMetric
   counters: Record<TCounter, ObservableCounterConfig>
+  maxStates: number
   getKey(input: TInput): TKey
   createState(input: TInput): TState
   observe(
@@ -32,7 +34,11 @@ export function createBatchObservableCounterGroup<
     state: TState
   ): void
 }): BatchObservableCounterGroup<TInput, TState> {
-  const states = new Map<TKey, TState>()
+  if (!Number.isInteger(options.maxStates) || options.maxStates < 1) {
+    throw new Error('maxStates must be a positive integer')
+  }
+
+  const states = new LRUCache<TKey, TState>({ max: options.maxStates })
   const counterKeys = Object.keys(options.counters) as TCounter[]
   const counters = {} as Record<TCounter, Observable>
 

--- a/src/internal/monitoring/counter/index.ts
+++ b/src/internal/monitoring/counter/index.ts
@@ -1,0 +1,1 @@
+export * from './batch-observable-counter'

--- a/src/internal/monitoring/metric-limits.ts
+++ b/src/internal/monitoring/metric-limits.ts
@@ -1,4 +1,5 @@
 export const HTTP_SIZE_METRICS_MAX_STATES = 4096
 
-// The OTel SDK reserves one aggregation cardinality slot for overflow.
-export const HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT = HTTP_SIZE_METRICS_MAX_STATES + 1
+// The app exports one overflow series, and the OTel SDK reserves one more slot
+// for its own overflow aggregation.
+export const HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT = HTTP_SIZE_METRICS_MAX_STATES + 2

--- a/src/internal/monitoring/metric-limits.ts
+++ b/src/internal/monitoring/metric-limits.ts
@@ -1,0 +1,4 @@
+export const HTTP_SIZE_METRICS_MAX_STATES = 4096
+
+// The OTel SDK reserves one aggregation cardinality slot for overflow.
+export const HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT = HTTP_SIZE_METRICS_MAX_STATES + 1

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -1,4 +1,4 @@
-import type { Meter } from '@opentelemetry/api'
+import type { BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 interface CapturedObservable {
@@ -13,21 +13,35 @@ interface CapturedObservation {
   attributes?: Record<string, unknown>
 }
 
+interface CapturedBatchObservable {
+  callback: BatchObservableCallback
+  observables: Observable[]
+}
+
 function createMockMeter(): {
   meter: Meter
   invoke: (name: string) => CapturedObservation[]
 } {
   const observables: CapturedObservable[] = []
+  const batchObservables: CapturedBatchObservable[] = []
+  const observableNames = new Map<Observable, string>()
   const noopMetric = {
     add: vi.fn(),
     record: vi.fn(),
   }
 
-  const createObservable = () => (name: string) => ({
-    addCallback(callback: CapturedObservable['callback']) {
-      observables.push({ name, callback })
-    },
-  })
+  const createObservable = () => (name: string) => {
+    const observable = {
+      addCallback(callback: CapturedObservable['callback']) {
+        observables.push({ name, callback })
+      },
+      removeCallback: vi.fn(),
+    } as unknown as Observable
+
+    observableNames.set(observable, name)
+
+    return observable
+  }
 
   const meter = {
     createCounter: vi.fn(() => noopMetric),
@@ -36,7 +50,11 @@ function createMockMeter(): {
     createObservableCounter: vi.fn(createObservable()),
     createObservableGauge: vi.fn(createObservable()),
     createUpDownCounter: vi.fn(() => noopMetric),
-    addBatchObservableCallback: vi.fn(),
+    addBatchObservableCallback: vi.fn(
+      (callback: BatchObservableCallback, observables: Observable[]) => {
+        batchObservables.push({ callback, observables })
+      }
+    ),
     removeBatchObservableCallback: vi.fn(),
   } as unknown as Meter
 
@@ -52,6 +70,24 @@ function createMockMeter(): {
       if (observable.name === name) {
         observable.callback(observer)
       }
+    }
+
+    for (const batchObservable of batchObservables) {
+      const hasObservable = batchObservable.observables.some(
+        (observable) => observableNames.get(observable) === name
+      )
+
+      if (!hasObservable) {
+        continue
+      }
+
+      void batchObservable.callback({
+        observe: (observable, value, attributes) => {
+          if (observableNames.get(observable) === name) {
+            observations.push({ value, attributes })
+          }
+        },
+      })
     }
 
     return observations

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -184,6 +184,35 @@ describe('metrics registry', () => {
     ])
   })
 
+  test('keeps http byte counters below the safe threshold', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+    const safeCounterThreshold = Number.MAX_SAFE_INTEGER - 1_000_000_000
+
+    const attributes = {
+      method: 'POST',
+      operation: 'object.upload',
+      status_code: '200',
+    }
+
+    metricsModule.recordHttpSizes(safeCounterThreshold - 1, undefined, attributes)
+    metricsModule.recordHttpSizes(2, undefined, attributes)
+    metricsModule.recordHttpSizes(undefined, Number.MAX_SAFE_INTEGER, attributes)
+
+    expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
+      {
+        value: 2,
+        attributes,
+      },
+    ])
+
+    expect(mockMeter.invoke('http_response_size_bytes')).toEqual([
+      {
+        value: safeCounterThreshold,
+        attributes,
+      },
+    ])
+  })
+
   test('ignores invalid http byte sizes without poisoning later observations', async () => {
     const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
 

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -152,7 +152,7 @@ describe('metrics registry', () => {
     ])
   })
 
-  test('observes cumulative http byte counters with stable attributes even when disabled', async () => {
+  test('accumulates request and response bytes independently, even when disabled', async () => {
     const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
 
     const attributes = {
@@ -165,34 +165,6 @@ describe('metrics registry', () => {
       { name: 'http_request_size_bytes', enabled: false },
       { name: 'http_response_size_bytes', enabled: false },
     ])
-    metricsModule.recordHttpSizes(7, undefined, attributes)
-    metricsModule.recordHttpSizes(3, undefined, { ...attributes })
-    metricsModule.recordHttpSizes(undefined, 2, attributes)
-
-    expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
-      {
-        value: 10,
-        attributes,
-      },
-    ])
-
-    expect(mockMeter.invoke('http_response_size_bytes')).toEqual([
-      {
-        value: 2,
-        attributes,
-      },
-    ])
-  })
-
-  test('observes request and response bytes recorded together', async () => {
-    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
-
-    const attributes = {
-      method: 'POST',
-      operation: 'object.upload',
-      status_code: '200',
-    }
-
     metricsModule.recordHttpSizes(7, 2, attributes)
     metricsModule.recordHttpSizes(3, undefined, { ...attributes })
     metricsModule.recordHttpSizes(undefined, 5, attributes)

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -115,4 +115,122 @@ describe('metrics registry', () => {
       },
     ])
   })
+
+  test('observes cumulative http byte counters with stable attributes even when disabled', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    const attributes = {
+      method: 'POST',
+      operation: 'object.upload',
+      status_code: '200',
+    }
+
+    metricsModule.setMetricsEnabled([
+      { name: 'http_request_size_bytes', enabled: false },
+      { name: 'http_response_size_bytes', enabled: false },
+    ])
+    metricsModule.recordHttpSizes(7, undefined, attributes)
+    metricsModule.recordHttpSizes(3, undefined, { ...attributes })
+    metricsModule.recordHttpSizes(undefined, 2, attributes)
+
+    expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
+      {
+        value: 10,
+        attributes,
+      },
+    ])
+
+    expect(mockMeter.invoke('http_response_size_bytes')).toEqual([
+      {
+        value: 2,
+        attributes,
+      },
+    ])
+  })
+
+  test('observes request and response bytes recorded together', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    const attributes = {
+      method: 'POST',
+      operation: 'object.upload',
+      status_code: '200',
+    }
+
+    metricsModule.recordHttpSizes(7, 2, attributes)
+    metricsModule.recordHttpSizes(3, undefined, { ...attributes })
+    metricsModule.recordHttpSizes(undefined, 5, attributes)
+
+    expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
+      {
+        value: 10,
+        attributes,
+      },
+    ])
+
+    expect(mockMeter.invoke('http_response_size_bytes')).toEqual([
+      {
+        value: 7,
+        attributes,
+      },
+    ])
+  })
+
+  test('ignores invalid http byte sizes without poisoning later observations', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    const attributes = {
+      method: 'POST',
+      operation: 'object.upload',
+      status_code: '200',
+    }
+
+    metricsModule.recordHttpSizes(Number.NaN, Number.POSITIVE_INFINITY, attributes)
+    metricsModule.recordHttpSizes(7, 2, attributes)
+
+    expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
+      {
+        value: 7,
+        attributes,
+      },
+    ])
+
+    expect(mockMeter.invoke('http_response_size_bytes')).toEqual([
+      {
+        value: 2,
+        attributes,
+      },
+    ])
+  })
+
+  test('observes cumulative upload counters with stable attributes even when disabled', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    metricsModule.setMetricsEnabled([
+      { name: 'upload_started', enabled: false },
+      { name: 'upload_success', enabled: false },
+    ])
+    metricsModule.recordUploadStarted('standard')
+    metricsModule.recordUploadStarted('standard')
+    metricsModule.recordUploadStarted('multipart')
+    metricsModule.recordUploadSuccess('standard')
+
+    expect(mockMeter.invoke('upload_started')).toEqual([
+      {
+        value: 2,
+        attributes: { uploadType: 'standard' },
+      },
+      {
+        value: 1,
+        attributes: { uploadType: 'multipart' },
+      },
+    ])
+
+    expect(mockMeter.invoke('upload_success')).toEqual([
+      {
+        value: 1,
+        attributes: { uploadType: 'standard' },
+      },
+    ])
+  })
 })

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -1,5 +1,6 @@
 import type { BatchObservableCallback, Meter, Observable } from '@opentelemetry/api'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { HTTP_SIZE_METRICS_MAX_STATES } from './metric-limits'
 
 interface CapturedObservable {
   name: string
@@ -155,19 +156,18 @@ describe('metrics registry', () => {
   test('accumulates request and response bytes independently, even when disabled', async () => {
     const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
 
-    const attributes = {
-      method: 'POST',
-      operation: 'object.upload',
-      status_code: '200',
-    }
+    const method = 'POST'
+    const operation = 'object.upload'
+    const statusCode = 200
+    const attributes = { method, operation, status_code: String(statusCode) }
 
     metricsModule.setMetricsEnabled([
       { name: 'http_request_size_bytes', enabled: false },
       { name: 'http_response_size_bytes', enabled: false },
     ])
-    metricsModule.recordHttpSizes(7, 2, attributes)
-    metricsModule.recordHttpSizes(3, undefined, { ...attributes })
-    metricsModule.recordHttpSizes(undefined, 5, attributes)
+    metricsModule.recordHttpRequestMetrics(0.001, 7, 2, method, operation, statusCode)
+    metricsModule.recordHttpRequestMetrics(0.001, 3, undefined, method, operation, statusCode)
+    metricsModule.recordHttpRequestMetrics(0.001, undefined, 5, method, operation, statusCode)
 
     expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
       {
@@ -188,19 +188,32 @@ describe('metrics registry', () => {
     const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
     const safeCounterThreshold = Number.MAX_SAFE_INTEGER - 1_000_000_000
 
-    const attributes = {
-      method: 'POST',
-      operation: 'object.upload',
-      status_code: '200',
-    }
+    const method = 'POST'
+    const operation = 'object.upload'
+    const statusCode = 200
+    const attributes = { method, operation, status_code: String(statusCode) }
 
-    metricsModule.recordHttpSizes(safeCounterThreshold - 1, undefined, attributes)
-    metricsModule.recordHttpSizes(2, undefined, attributes)
-    metricsModule.recordHttpSizes(undefined, Number.MAX_SAFE_INTEGER, attributes)
+    metricsModule.recordHttpRequestMetrics(
+      0.001,
+      safeCounterThreshold - 1,
+      undefined,
+      method,
+      operation,
+      statusCode
+    )
+    metricsModule.recordHttpRequestMetrics(0.001, 2, undefined, method, operation, statusCode)
+    metricsModule.recordHttpRequestMetrics(
+      0.001,
+      undefined,
+      Number.MAX_SAFE_INTEGER,
+      method,
+      operation,
+      statusCode
+    )
 
     expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
       {
-        value: 2,
+        value: safeCounterThreshold,
         attributes,
       },
     ])
@@ -216,14 +229,20 @@ describe('metrics registry', () => {
   test('ignores invalid http byte sizes without poisoning later observations', async () => {
     const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
 
-    const attributes = {
-      method: 'POST',
-      operation: 'object.upload',
-      status_code: '200',
-    }
+    const method = 'POST'
+    const operation = 'object.upload'
+    const statusCode = 200
+    const attributes = { method, operation, status_code: String(statusCode) }
 
-    metricsModule.recordHttpSizes(Number.NaN, Number.POSITIVE_INFINITY, attributes)
-    metricsModule.recordHttpSizes(7, 2, attributes)
+    metricsModule.recordHttpRequestMetrics(
+      0.001,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      method,
+      operation,
+      statusCode
+    )
+    metricsModule.recordHttpRequestMetrics(0.001, 7, 2, method, operation, statusCode)
 
     expect(mockMeter.invoke('http_request_size_bytes')).toEqual([
       {
@@ -238,6 +257,27 @@ describe('metrics registry', () => {
         attributes,
       },
     ])
+  })
+
+  test('routes new http metric states to overflow after the cap', async () => {
+    const { metricsModule, mockMeter } = await importMetricsWithMockMeter()
+
+    for (let i = 0; i <= HTTP_SIZE_METRICS_MAX_STATES; i++) {
+      metricsModule.recordHttpRequestMetrics(0.001, 1, undefined, 'GET', `operation-${i}`, 200)
+    }
+
+    expect(mockMeter.invoke('http_request_size_bytes')).toEqual(
+      expect.arrayContaining([
+        {
+          value: 1,
+          attributes: {
+            method: 'overflow',
+            operation: 'overflow',
+            status_code: 'overflow',
+          },
+        },
+      ])
+    )
   })
 
   test('observes cumulative upload counters with stable attributes even when disabled', async () => {

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -114,13 +114,6 @@ const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter'
     unit: 'bytes',
   })
 )
-httpRequestSizeBytes.addCallback((observer) => {
-  httpSizeMetricsState.forEach((state) => {
-    if (state.requestBytes > 0) {
-      observer.observe(state.requestBytes, state.attributes)
-    }
-  })
-})
 
 const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
   meter.createObservableCounter('http_response_size_bytes', {
@@ -128,13 +121,20 @@ const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counte
     unit: 'bytes',
   })
 )
-httpResponseSizeBytes.addCallback((observer) => {
-  httpSizeMetricsState.forEach((state) => {
-    if (state.responseBytes > 0) {
-      observer.observe(state.responseBytes, state.attributes)
-    }
-  })
-})
+
+meter.addBatchObservableCallback(
+  (observer) => {
+    httpSizeMetricsState.forEach((state) => {
+      if (state.requestBytes > 0) {
+        observer.observe(httpRequestSizeBytes, state.requestBytes, state.attributes)
+      }
+      if (state.responseBytes > 0) {
+        observer.observe(httpResponseSizeBytes, state.responseBytes, state.attributes)
+      }
+    })
+  },
+  [httpRequestSizeBytes, httpResponseSizeBytes]
+)
 
 /** Records request/response bytes by bumping in-process tallies with one state lookup. */
 export function recordHttpSizes(
@@ -192,26 +192,26 @@ const fileUploadStarted = registerMetric('upload_started', 'counter', () =>
     description: 'Total uploads started',
   })
 )
-fileUploadStarted.addCallback((observer) => {
-  uploadMetricsState.forEach((state) => {
-    if (state.started > 0) {
-      observer.observe(state.started, state.attributes)
-    }
-  })
-})
 
 const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
   meter.createObservableCounter('upload_success', {
     description: 'Total successful uploads',
   })
 )
-fileUploadedSuccess.addCallback((observer) => {
-  uploadMetricsState.forEach((state) => {
-    if (state.success > 0) {
-      observer.observe(state.success, state.attributes)
-    }
-  })
-})
+
+meter.addBatchObservableCallback(
+  (observer) => {
+    uploadMetricsState.forEach((state) => {
+      if (state.started > 0) {
+        observer.observe(fileUploadStarted, state.started, state.attributes)
+      }
+      if (state.success > 0) {
+        observer.observe(fileUploadedSuccess, state.success, state.attributes)
+      }
+    })
+  },
+  [fileUploadStarted, fileUploadedSuccess]
+)
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
@@ -277,34 +277,34 @@ const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () 
     description: 'Total cache lookups by cache and outcome',
   })
 )
-cacheRequestsTotal.addCallback((observer) => {
-  cacheMetricsState.forEach((state) => {
-    const requests = state.requests
-
-    if (requests.hit.count > 0) {
-      observer.observe(requests.hit.count, requests.hit.attributes)
-    }
-    if (requests.miss.count > 0) {
-      observer.observe(requests.miss.count, requests.miss.attributes)
-    }
-    if (requests.stale.count > 0) {
-      observer.observe(requests.stale.count, requests.stale.attributes)
-    }
-  })
-})
 
 const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
   meter.createObservableCounter('cache_evictions_total', {
     description: 'Total cache evictions',
   })
 )
-cacheEvictionsTotal.addCallback((observer) => {
-  cacheMetricsState.forEach((state) => {
-    if (state.evictions > 0) {
-      observer.observe(state.evictions, state.evictionAttributes)
-    }
-  })
-})
+
+meter.addBatchObservableCallback(
+  (observer) => {
+    cacheMetricsState.forEach((state) => {
+      const requests = state.requests
+
+      if (requests.hit.count > 0) {
+        observer.observe(cacheRequestsTotal, requests.hit.count, requests.hit.attributes)
+      }
+      if (requests.miss.count > 0) {
+        observer.observe(cacheRequestsTotal, requests.miss.count, requests.miss.attributes)
+      }
+      if (requests.stale.count > 0) {
+        observer.observe(cacheRequestsTotal, requests.stale.count, requests.stale.attributes)
+      }
+      if (state.evictions > 0) {
+        observer.observe(cacheEvictionsTotal, state.evictions, state.evictionAttributes)
+      }
+    })
+  },
+  [cacheRequestsTotal, cacheEvictionsTotal]
+)
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>
   meter.createObservableGauge('cache_entries', {

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,7 +1,7 @@
 import type { CacheLookupOutcome } from '@internal/cache/adapter'
 import type { CacheName } from '@internal/cache/names'
 import { type Attributes, metrics } from '@opentelemetry/api'
-import { createBatchObservableCounterGroup } from './counter'
+import { createBatchObservableCounterGroup, safeAddCounter } from './counter'
 import { HTTP_SIZE_METRICS_MAX_STATES } from './metric-limits'
 
 // ============================================================================
@@ -64,22 +64,6 @@ export function registerMetric<T>(name: string, type: MetricType, factory: () =>
 // cumulative observable counters, so skipping observations on runtime disable
 // would leave stale exported points and later jumps on re-enable.
 // ============================================================================
-const SAFE_COUNTER_THRESHOLD = Number.MAX_SAFE_INTEGER - 1_000_000_000
-
-function safeAdd(current: number, amount: number): number {
-  const next = current + amount
-
-  if (
-    current >= SAFE_COUNTER_THRESHOLD ||
-    next >= SAFE_COUNTER_THRESHOLD ||
-    !Number.isSafeInteger(next)
-  ) {
-    return Math.min(amount, SAFE_COUNTER_THRESHOLD)
-  }
-
-  return next
-}
-
 type HttpMetricAttributes = {
   method: string
   operation: string
@@ -151,11 +135,11 @@ export function recordHttpSizes(
   const state = httpSizeMetrics.state(attributes)
 
   if (shouldRecordRequestSize) {
-    state.requestBytes = safeAdd(state.requestBytes, requestSizeBytes)
+    state.requestBytes = safeAddCounter(state.requestBytes, requestSizeBytes)
   }
 
   if (shouldRecordResponseSize) {
-    state.responseBytes = safeAdd(state.responseBytes, responseSizeBytes)
+    state.responseBytes = safeAddCounter(state.responseBytes, responseSizeBytes)
   }
 }
 
@@ -195,14 +179,12 @@ const uploadMetrics = createBatchObservableCounterGroup({
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
-  const state = uploadMetrics.state(uploadType)
-  state.started = safeAdd(state.started, 1)
+  uploadMetrics.add(uploadType, 'started')
 }
 
 /** Records an upload success by bumping an in-process tally. */
 export function recordUploadSuccess(uploadType: string): void {
-  const state = uploadMetrics.state(uploadType)
-  state.success = safeAdd(state.success, 1)
+  uploadMetrics.add(uploadType, 'success')
 }
 
 // ============================================================================
@@ -270,13 +252,13 @@ const cacheMetrics = createBatchObservableCounterGroup({
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
   const state = cacheMetrics.state(cache).requests[outcome]
-  state.count = safeAdd(state.count, 1)
+  state.count = safeAddCounter(state.count, 1)
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
   const state = cacheMetrics.state(cache)
-  state.evictions = safeAdd(state.evictions, 1)
+  state.evictions = safeAddCounter(state.evictions, 1)
 }
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,6 +1,7 @@
 import type { CacheLookupOutcome } from '@internal/cache/adapter'
 import type { CacheName } from '@internal/cache/names'
 import { type Attributes, metrics } from '@opentelemetry/api'
+import { createBatchObservableCounterGroup } from './counter'
 
 // ============================================================================
 // Metric Registry — tracks all metrics for admin API
@@ -74,25 +75,41 @@ type HttpSizeMetricsState = {
   attributes: Attributes
 }
 
-const httpSizeMetricsState = new Map<string, HttpSizeMetricsState>()
-
-function getHttpSizeMetricsState(attributes: HttpMetricAttributes): HttpSizeMetricsState {
-  const key = `${attributes.method}\x00${attributes.operation}\x00${attributes.status_code}`
-  let state = httpSizeMetricsState.get(key)
-  if (!state) {
-    state = {
-      requestBytes: 0,
-      responseBytes: 0,
-      attributes: {
-        method: attributes.method,
-        operation: attributes.operation,
-        status_code: attributes.status_code,
-      },
+const httpSizeMetrics = createBatchObservableCounterGroup({
+  meter,
+  registerMetric,
+  counters: {
+    requestBytes: {
+      name: 'http_request_size_bytes',
+      description: 'Total bytes received in HTTP requests (from content-length header)',
+      unit: 'bytes',
+    },
+    responseBytes: {
+      name: 'http_response_size_bytes',
+      description: 'Total bytes sent in HTTP responses (from content-length header)',
+      unit: 'bytes',
+    },
+  },
+  getKey: (attributes: HttpMetricAttributes) =>
+    `${attributes.method}\x00${attributes.operation}\x00${attributes.status_code}`,
+  createState: (attributes: HttpMetricAttributes): HttpSizeMetricsState => ({
+    requestBytes: 0,
+    responseBytes: 0,
+    attributes: {
+      method: attributes.method,
+      operation: attributes.operation,
+      status_code: attributes.status_code,
+    },
+  }),
+  observe: (observer, counters, state) => {
+    if (state.requestBytes > 0) {
+      observer.observe(counters.requestBytes, state.requestBytes, state.attributes)
     }
-    httpSizeMetricsState.set(key, state)
-  }
-  return state
-}
+    if (state.responseBytes > 0) {
+      observer.observe(counters.responseBytes, state.responseBytes, state.attributes)
+    }
+  },
+})
 
 function isRecordableMetricValue(value: number | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
@@ -108,34 +125,6 @@ export const httpRequestDuration = registerMetric(
     })
 )
 
-const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter', () =>
-  meter.createObservableCounter('http_request_size_bytes', {
-    description: 'Total bytes received in HTTP requests (from content-length header)',
-    unit: 'bytes',
-  })
-)
-
-const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
-  meter.createObservableCounter('http_response_size_bytes', {
-    description: 'Total bytes sent in HTTP responses (from content-length header)',
-    unit: 'bytes',
-  })
-)
-
-meter.addBatchObservableCallback(
-  (observer) => {
-    httpSizeMetricsState.forEach((state) => {
-      if (state.requestBytes > 0) {
-        observer.observe(httpRequestSizeBytes, state.requestBytes, state.attributes)
-      }
-      if (state.responseBytes > 0) {
-        observer.observe(httpResponseSizeBytes, state.responseBytes, state.attributes)
-      }
-    })
-  },
-  [httpRequestSizeBytes, httpResponseSizeBytes]
-)
-
 /** Records request/response bytes by bumping in-process tallies with one state lookup. */
 export function recordHttpSizes(
   requestSizeBytes: number | undefined,
@@ -149,7 +138,7 @@ export function recordHttpSizes(
     return
   }
 
-  const state = getHttpSizeMetricsState(attributes)
+  const state = httpSizeMetrics.state(attributes)
 
   if (shouldRecordRequestSize) {
     state.requestBytes += requestSizeBytes
@@ -172,55 +161,43 @@ type UploadMetricsState = {
   attributes: Attributes
 }
 
-const uploadMetricsState = new Map<string, UploadMetricsState>()
-
-function getUploadMetricsState(uploadType: string): UploadMetricsState {
-  let state = uploadMetricsState.get(uploadType)
-  if (!state) {
-    state = {
-      started: 0,
-      success: 0,
-      attributes: { uploadType },
-    }
-    uploadMetricsState.set(uploadType, state)
-  }
-  return state
-}
-
-const fileUploadStarted = registerMetric('upload_started', 'counter', () =>
-  meter.createObservableCounter('upload_started', {
-    description: 'Total uploads started',
-  })
-)
-
-const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
-  meter.createObservableCounter('upload_success', {
-    description: 'Total successful uploads',
-  })
-)
-
-meter.addBatchObservableCallback(
-  (observer) => {
-    uploadMetricsState.forEach((state) => {
-      if (state.started > 0) {
-        observer.observe(fileUploadStarted, state.started, state.attributes)
-      }
-      if (state.success > 0) {
-        observer.observe(fileUploadedSuccess, state.success, state.attributes)
-      }
-    })
+const uploadMetrics = createBatchObservableCounterGroup({
+  meter,
+  registerMetric,
+  counters: {
+    started: {
+      name: 'upload_started',
+      description: 'Total uploads started',
+    },
+    success: {
+      name: 'upload_success',
+      description: 'Total successful uploads',
+    },
   },
-  [fileUploadStarted, fileUploadedSuccess]
-)
+  getKey: (uploadType: string) => uploadType,
+  createState: (uploadType: string): UploadMetricsState => ({
+    started: 0,
+    success: 0,
+    attributes: { uploadType },
+  }),
+  observe: (observer, counters, state) => {
+    if (state.started > 0) {
+      observer.observe(counters.started, state.started, state.attributes)
+    }
+    if (state.success > 0) {
+      observer.observe(counters.success, state.success, state.attributes)
+    }
+  },
+})
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
-  getUploadMetricsState(uploadType).started++
+  uploadMetrics.state(uploadType).started++
 }
 
 /** Records an upload success by bumping an in-process tally. */
 export function recordUploadSuccess(uploadType: string): void {
-  getUploadMetricsState(uploadType).success++
+  uploadMetrics.state(uploadType).success++
 }
 
 // ============================================================================
@@ -243,68 +220,56 @@ type CacheMetricsState = {
   evictionAttributes: Attributes
 }
 
-const cacheMetricsState = new Map<CacheName, CacheMetricsState>()
+const cacheMetrics = createBatchObservableCounterGroup({
+  meter,
+  registerMetric,
+  counters: {
+    requests: {
+      name: 'cache_requests_total',
+      description: 'Total cache lookups by cache and outcome',
+    },
+    evictions: {
+      name: 'cache_evictions_total',
+      description: 'Total cache evictions',
+    },
+  },
+  getKey: (cache: CacheName) => cache,
+  createState: (cache: CacheName): CacheMetricsState => ({
+    requests: {
+      hit: { count: 0, attributes: { cache, outcome: 'hit' } },
+      miss: { count: 0, attributes: { cache, outcome: 'miss' } },
+      stale: { count: 0, attributes: { cache, outcome: 'stale' } },
+    },
+    evictions: 0,
+    evictionAttributes: { cache },
+  }),
+  observe: (observer, counters, state) => {
+    const requests = state.requests
 
-function getCacheMetricsState(cache: CacheName): CacheMetricsState {
-  let state = cacheMetricsState.get(cache)
-  if (!state) {
-    state = {
-      requests: {
-        hit: { count: 0, attributes: { cache, outcome: 'hit' } },
-        miss: { count: 0, attributes: { cache, outcome: 'miss' } },
-        stale: { count: 0, attributes: { cache, outcome: 'stale' } },
-      },
-      evictions: 0,
-      evictionAttributes: { cache },
+    if (requests.hit.count > 0) {
+      observer.observe(counters.requests, requests.hit.count, requests.hit.attributes)
     }
-    cacheMetricsState.set(cache, state)
-  }
-  return state
-}
+    if (requests.miss.count > 0) {
+      observer.observe(counters.requests, requests.miss.count, requests.miss.attributes)
+    }
+    if (requests.stale.count > 0) {
+      observer.observe(counters.requests, requests.stale.count, requests.stale.attributes)
+    }
+    if (state.evictions > 0) {
+      observer.observe(counters.evictions, state.evictions, state.evictionAttributes)
+    }
+  },
+})
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
-  getCacheMetricsState(cache).requests[outcome].count++
+  cacheMetrics.state(cache).requests[outcome].count++
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
-  getCacheMetricsState(cache).evictions++
+  cacheMetrics.state(cache).evictions++
 }
-
-const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () =>
-  meter.createObservableCounter('cache_requests_total', {
-    description: 'Total cache lookups by cache and outcome',
-  })
-)
-
-const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
-  meter.createObservableCounter('cache_evictions_total', {
-    description: 'Total cache evictions',
-  })
-)
-
-meter.addBatchObservableCallback(
-  (observer) => {
-    cacheMetricsState.forEach((state) => {
-      const requests = state.requests
-
-      if (requests.hit.count > 0) {
-        observer.observe(cacheRequestsTotal, requests.hit.count, requests.hit.attributes)
-      }
-      if (requests.miss.count > 0) {
-        observer.observe(cacheRequestsTotal, requests.miss.count, requests.miss.attributes)
-      }
-      if (requests.stale.count > 0) {
-        observer.observe(cacheRequestsTotal, requests.stale.count, requests.stale.attributes)
-      }
-      if (state.evictions > 0) {
-        observer.observe(cacheEvictionsTotal, state.evictions, state.evictionAttributes)
-      }
-    })
-  },
-  [cacheRequestsTotal, cacheEvictionsTotal]
-)
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>
   meter.createObservableGauge('cache_entries', {

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -60,8 +60,7 @@ export function registerMetric<T>(name: string, type: MetricType, factory: () =>
 //
 // HTTP byte counters intentionally do not check `isMetricEnabled()`. They use
 // cumulative observable counters, so skipping observations on runtime disable
-// would leave stale exported points and later jumps on re-enable. Active arrays
-// keep collection on emitted series only.
+// would leave stale exported points and later jumps on re-enable.
 // ============================================================================
 type HttpMetricAttributes = {
   method: string
@@ -76,8 +75,6 @@ type HttpSizeMetricsState = {
 }
 
 const httpSizeMetricsState = new Map<string, HttpSizeMetricsState>()
-const httpRequestSizeMetricStates: HttpSizeMetricsState[] = []
-const httpResponseSizeMetricStates: HttpSizeMetricsState[] = []
 
 function getHttpSizeMetricsState(attributes: HttpMetricAttributes): HttpSizeMetricsState {
   const key = `${attributes.method}\x00${attributes.operation}\x00${attributes.status_code}`
@@ -118,10 +115,11 @@ const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter'
   })
 )
 httpRequestSizeBytes.addCallback((observer) => {
-  for (let index = 0; index < httpRequestSizeMetricStates.length; index++) {
-    const state = httpRequestSizeMetricStates[index]
-    observer.observe(state.requestBytes, state.attributes)
-  }
+  httpSizeMetricsState.forEach((state) => {
+    if (state.requestBytes > 0) {
+      observer.observe(state.requestBytes, state.attributes)
+    }
+  })
 })
 
 const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
@@ -131,10 +129,11 @@ const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counte
   })
 )
 httpResponseSizeBytes.addCallback((observer) => {
-  for (let index = 0; index < httpResponseSizeMetricStates.length; index++) {
-    const state = httpResponseSizeMetricStates[index]
-    observer.observe(state.responseBytes, state.attributes)
-  }
+  httpSizeMetricsState.forEach((state) => {
+    if (state.responseBytes > 0) {
+      observer.observe(state.responseBytes, state.attributes)
+    }
+  })
 })
 
 /** Records request/response bytes by bumping in-process tallies with one state lookup. */
@@ -153,16 +152,10 @@ export function recordHttpSizes(
   const state = getHttpSizeMetricsState(attributes)
 
   if (shouldRecordRequestSize) {
-    if (state.requestBytes === 0) {
-      httpRequestSizeMetricStates.push(state)
-    }
     state.requestBytes += requestSizeBytes
   }
 
   if (shouldRecordResponseSize) {
-    if (state.responseBytes === 0) {
-      httpResponseSizeMetricStates.push(state)
-    }
     state.responseBytes += responseSizeBytes
   }
 }
@@ -171,8 +164,7 @@ export function recordHttpSizes(
 // Upload Metrics
 //
 // Upload counters follow the same cumulative observable-counter semantics as
-// HTTP/cache: runtime disables must not suppress observations, and active arrays
-// avoid export-time scans over inactive series.
+// HTTP/cache: runtime disables must not suppress observations.
 // ============================================================================
 type UploadMetricsState = {
   started: number
@@ -181,8 +173,6 @@ type UploadMetricsState = {
 }
 
 const uploadMetricsState = new Map<string, UploadMetricsState>()
-const uploadStartedMetricStates: UploadMetricsState[] = []
-const uploadSuccessMetricStates: UploadMetricsState[] = []
 
 function getUploadMetricsState(uploadType: string): UploadMetricsState {
   let state = uploadMetricsState.get(uploadType)
@@ -203,10 +193,11 @@ const fileUploadStarted = registerMetric('upload_started', 'counter', () =>
   })
 )
 fileUploadStarted.addCallback((observer) => {
-  for (let index = 0; index < uploadStartedMetricStates.length; index++) {
-    const state = uploadStartedMetricStates[index]
-    observer.observe(state.started, state.attributes)
-  }
+  uploadMetricsState.forEach((state) => {
+    if (state.started > 0) {
+      observer.observe(state.started, state.attributes)
+    }
+  })
 })
 
 const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
@@ -215,28 +206,21 @@ const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
   })
 )
 fileUploadedSuccess.addCallback((observer) => {
-  for (let index = 0; index < uploadSuccessMetricStates.length; index++) {
-    const state = uploadSuccessMetricStates[index]
-    observer.observe(state.success, state.attributes)
-  }
+  uploadMetricsState.forEach((state) => {
+    if (state.success > 0) {
+      observer.observe(state.success, state.attributes)
+    }
+  })
 })
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
-  const state = getUploadMetricsState(uploadType)
-  if (state.started === 0) {
-    uploadStartedMetricStates.push(state)
-  }
-  state.started++
+  getUploadMetricsState(uploadType).started++
 }
 
 /** Records an upload success by bumping an in-process tally. */
 export function recordUploadSuccess(uploadType: string): void {
-  const state = getUploadMetricsState(uploadType)
-  if (state.success === 0) {
-    uploadSuccessMetricStates.push(state)
-  }
-  state.success++
+  getUploadMetricsState(uploadType).success++
 }
 
 // ============================================================================
@@ -246,8 +230,7 @@ export function recordUploadSuccess(uploadType: string): void {
 // With cumulative async OTel instruments, skipping `observe()` after a runtime
 // disable can keep the previous point exported, then jump on re-enable because
 // the in-process tally kept advancing. Drop these metrics at exporter/view
-// configuration if they need to be suppressed entirely. Like HTTP/upload, cache
-// counters keep active arrays so callbacks do not scan inactive series.
+// configuration if they need to be suppressed entirely.
 // ============================================================================
 type CacheRequestMetricsState = {
   count: number
@@ -261,8 +244,6 @@ type CacheMetricsState = {
 }
 
 const cacheMetricsState = new Map<CacheName, CacheMetricsState>()
-const cacheRequestMetricStates: CacheRequestMetricsState[] = []
-const cacheEvictionMetricStates: CacheMetricsState[] = []
 
 function getCacheMetricsState(cache: CacheName): CacheMetricsState {
   let state = cacheMetricsState.get(cache)
@@ -283,20 +264,12 @@ function getCacheMetricsState(cache: CacheName): CacheMetricsState {
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
-  const state = getCacheMetricsState(cache).requests[outcome]
-  if (state.count === 0) {
-    cacheRequestMetricStates.push(state)
-  }
-  state.count++
+  getCacheMetricsState(cache).requests[outcome].count++
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
-  const state = getCacheMetricsState(cache)
-  if (state.evictions === 0) {
-    cacheEvictionMetricStates.push(state)
-  }
-  state.evictions++
+  getCacheMetricsState(cache).evictions++
 }
 
 const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () =>
@@ -305,10 +278,19 @@ const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () 
   })
 )
 cacheRequestsTotal.addCallback((observer) => {
-  for (let index = 0; index < cacheRequestMetricStates.length; index++) {
-    const state = cacheRequestMetricStates[index]
-    observer.observe(state.count, state.attributes)
-  }
+  cacheMetricsState.forEach((state) => {
+    const requests = state.requests
+
+    if (requests.hit.count > 0) {
+      observer.observe(requests.hit.count, requests.hit.attributes)
+    }
+    if (requests.miss.count > 0) {
+      observer.observe(requests.miss.count, requests.miss.attributes)
+    }
+    if (requests.stale.count > 0) {
+      observer.observe(requests.stale.count, requests.stale.attributes)
+    }
+  })
 })
 
 const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
@@ -317,10 +299,11 @@ const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', (
   })
 )
 cacheEvictionsTotal.addCallback((observer) => {
-  for (let index = 0; index < cacheEvictionMetricStates.length; index++) {
-    const state = cacheEvictionMetricStates[index]
-    observer.observe(state.evictions, state.evictionAttributes)
-  }
+  cacheMetricsState.forEach((state) => {
+    if (state.evictions > 0) {
+      observer.observe(state.evictions, state.evictionAttributes)
+    }
+  })
 })
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,4 +1,4 @@
-import { CACHE_LOOKUP_OUTCOMES, type CacheLookupOutcome } from '@internal/cache/adapter'
+import type { CacheLookupOutcome } from '@internal/cache/adapter'
 import type { CacheName } from '@internal/cache/names'
 import { type Attributes, metrics } from '@opentelemetry/api'
 
@@ -57,7 +57,50 @@ export function registerMetric<T>(name: string, type: MetricType, factory: () =>
 
 // ============================================================================
 // HTTP Request Metrics
+//
+// HTTP byte counters intentionally do not check `isMetricEnabled()`. They use
+// cumulative observable counters, so skipping observations on runtime disable
+// would leave stale exported points and later jumps on re-enable. Active arrays
+// keep collection on emitted series only.
 // ============================================================================
+type HttpMetricAttributes = {
+  method: string
+  operation: string
+  status_code: string
+}
+
+type HttpSizeMetricsState = {
+  requestBytes: number
+  responseBytes: number
+  attributes: Attributes
+}
+
+const httpSizeMetricsState = new Map<string, HttpSizeMetricsState>()
+const httpRequestSizeMetricStates: HttpSizeMetricsState[] = []
+const httpResponseSizeMetricStates: HttpSizeMetricsState[] = []
+
+function getHttpSizeMetricsState(attributes: HttpMetricAttributes): HttpSizeMetricsState {
+  const key = `${attributes.method}\x00${attributes.operation}\x00${attributes.status_code}`
+  let state = httpSizeMetricsState.get(key)
+  if (!state) {
+    state = {
+      requestBytes: 0,
+      responseBytes: 0,
+      attributes: {
+        method: attributes.method,
+        operation: attributes.operation,
+        status_code: attributes.status_code,
+      },
+    }
+    httpSizeMetricsState.set(key, state)
+  }
+  return state
+}
+
+function isRecordableMetricValue(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
 export const httpRequestDuration = registerMetric(
   'http_request_duration_seconds',
   'histogram',
@@ -68,34 +111,133 @@ export const httpRequestDuration = registerMetric(
     })
 )
 
-export const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter', () =>
-  meter.createCounter('http_request_size_bytes', {
+const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter', () =>
+  meter.createObservableCounter('http_request_size_bytes', {
     description: 'Total bytes received in HTTP requests (from content-length header)',
     unit: 'bytes',
   })
 )
+httpRequestSizeBytes.addCallback((observer) => {
+  for (let index = 0; index < httpRequestSizeMetricStates.length; index++) {
+    const state = httpRequestSizeMetricStates[index]
+    observer.observe(state.requestBytes, state.attributes)
+  }
+})
 
-export const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
-  meter.createCounter('http_response_size_bytes', {
+const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
+  meter.createObservableCounter('http_response_size_bytes', {
     description: 'Total bytes sent in HTTP responses (from content-length header)',
     unit: 'bytes',
   })
 )
+httpResponseSizeBytes.addCallback((observer) => {
+  for (let index = 0; index < httpResponseSizeMetricStates.length; index++) {
+    const state = httpResponseSizeMetricStates[index]
+    observer.observe(state.responseBytes, state.attributes)
+  }
+})
+
+/** Records request/response bytes by bumping in-process tallies with one state lookup. */
+export function recordHttpSizes(
+  requestSizeBytes: number | undefined,
+  responseSizeBytes: number | undefined,
+  attributes: HttpMetricAttributes
+): void {
+  const shouldRecordRequestSize = isRecordableMetricValue(requestSizeBytes)
+  const shouldRecordResponseSize = isRecordableMetricValue(responseSizeBytes)
+
+  if (!shouldRecordRequestSize && !shouldRecordResponseSize) {
+    return
+  }
+
+  const state = getHttpSizeMetricsState(attributes)
+
+  if (shouldRecordRequestSize) {
+    if (state.requestBytes === 0) {
+      httpRequestSizeMetricStates.push(state)
+    }
+    state.requestBytes += requestSizeBytes
+  }
+
+  if (shouldRecordResponseSize) {
+    if (state.responseBytes === 0) {
+      httpResponseSizeMetricStates.push(state)
+    }
+    state.responseBytes += responseSizeBytes
+  }
+}
 
 // ============================================================================
 // Upload Metrics
+//
+// Upload counters follow the same cumulative observable-counter semantics as
+// HTTP/cache: runtime disables must not suppress observations, and active arrays
+// avoid export-time scans over inactive series.
 // ============================================================================
-export const fileUploadStarted = registerMetric('upload_started', 'counter', () =>
-  meter.createCounter('upload_started', {
+type UploadMetricsState = {
+  started: number
+  success: number
+  attributes: Attributes
+}
+
+const uploadMetricsState = new Map<string, UploadMetricsState>()
+const uploadStartedMetricStates: UploadMetricsState[] = []
+const uploadSuccessMetricStates: UploadMetricsState[] = []
+
+function getUploadMetricsState(uploadType: string): UploadMetricsState {
+  let state = uploadMetricsState.get(uploadType)
+  if (!state) {
+    state = {
+      started: 0,
+      success: 0,
+      attributes: { uploadType },
+    }
+    uploadMetricsState.set(uploadType, state)
+  }
+  return state
+}
+
+const fileUploadStarted = registerMetric('upload_started', 'counter', () =>
+  meter.createObservableCounter('upload_started', {
     description: 'Total uploads started',
   })
 )
+fileUploadStarted.addCallback((observer) => {
+  for (let index = 0; index < uploadStartedMetricStates.length; index++) {
+    const state = uploadStartedMetricStates[index]
+    observer.observe(state.started, state.attributes)
+  }
+})
 
-export const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
-  meter.createCounter('upload_success', {
+const fileUploadedSuccess = registerMetric('upload_success', 'counter', () =>
+  meter.createObservableCounter('upload_success', {
     description: 'Total successful uploads',
   })
 )
+fileUploadedSuccess.addCallback((observer) => {
+  for (let index = 0; index < uploadSuccessMetricStates.length; index++) {
+    const state = uploadSuccessMetricStates[index]
+    observer.observe(state.success, state.attributes)
+  }
+})
+
+/** Records an upload start by bumping an in-process tally. */
+export function recordUploadStarted(uploadType: string): void {
+  const state = getUploadMetricsState(uploadType)
+  if (state.started === 0) {
+    uploadStartedMetricStates.push(state)
+  }
+  state.started++
+}
+
+/** Records an upload success by bumping an in-process tally. */
+export function recordUploadSuccess(uploadType: string): void {
+  const state = getUploadMetricsState(uploadType)
+  if (state.success === 0) {
+    uploadSuccessMetricStates.push(state)
+  }
+  state.success++
+}
 
 // ============================================================================
 // Cache Metrics
@@ -104,26 +246,32 @@ export const fileUploadedSuccess = registerMetric('upload_success', 'counter', (
 // With cumulative async OTel instruments, skipping `observe()` after a runtime
 // disable can keep the previous point exported, then jump on re-enable because
 // the in-process tally kept advancing. Drop these metrics at exporter/view
-// configuration if they need to be suppressed entirely.
+// configuration if they need to be suppressed entirely. Like HTTP/upload, cache
+// counters keep active arrays so callbacks do not scan inactive series.
 // ============================================================================
+type CacheRequestMetricsState = {
+  count: number
+  attributes: Attributes
+}
+
 type CacheMetricsState = {
-  requests: Record<CacheLookupOutcome, number>
-  requestAttributes: Record<CacheLookupOutcome, Attributes>
+  requests: Record<CacheLookupOutcome, CacheRequestMetricsState>
   evictions: number
   evictionAttributes: Attributes
 }
 
 const cacheMetricsState = new Map<CacheName, CacheMetricsState>()
+const cacheRequestMetricStates: CacheRequestMetricsState[] = []
+const cacheEvictionMetricStates: CacheMetricsState[] = []
 
 function getCacheMetricsState(cache: CacheName): CacheMetricsState {
   let state = cacheMetricsState.get(cache)
   if (!state) {
     state = {
-      requests: { hit: 0, miss: 0, stale: 0 },
-      requestAttributes: {
-        hit: { cache, outcome: 'hit' },
-        miss: { cache, outcome: 'miss' },
-        stale: { cache, outcome: 'stale' },
+      requests: {
+        hit: { count: 0, attributes: { cache, outcome: 'hit' } },
+        miss: { count: 0, attributes: { cache, outcome: 'miss' } },
+        stale: { count: 0, attributes: { cache, outcome: 'stale' } },
       },
       evictions: 0,
       evictionAttributes: { cache },
@@ -135,40 +283,43 @@ function getCacheMetricsState(cache: CacheName): CacheMetricsState {
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
-  getCacheMetricsState(cache).requests[outcome]++
+  const state = getCacheMetricsState(cache).requests[outcome]
+  if (state.count === 0) {
+    cacheRequestMetricStates.push(state)
+  }
+  state.count++
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
-  getCacheMetricsState(cache).evictions++
+  const state = getCacheMetricsState(cache)
+  if (state.evictions === 0) {
+    cacheEvictionMetricStates.push(state)
+  }
+  state.evictions++
 }
 
-export const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () =>
+const cacheRequestsTotal = registerMetric('cache_requests_total', 'counter', () =>
   meter.createObservableCounter('cache_requests_total', {
     description: 'Total cache lookups by cache and outcome',
   })
 )
 cacheRequestsTotal.addCallback((observer) => {
-  for (const state of cacheMetricsState.values()) {
-    for (const outcome of CACHE_LOOKUP_OUTCOMES) {
-      const count = state.requests[outcome]
-      if (count > 0) {
-        observer.observe(count, state.requestAttributes[outcome])
-      }
-    }
+  for (let index = 0; index < cacheRequestMetricStates.length; index++) {
+    const state = cacheRequestMetricStates[index]
+    observer.observe(state.count, state.attributes)
   }
 })
 
-export const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
+const cacheEvictionsTotal = registerMetric('cache_evictions_total', 'counter', () =>
   meter.createObservableCounter('cache_evictions_total', {
     description: 'Total cache evictions',
   })
 )
 cacheEvictionsTotal.addCallback((observer) => {
-  for (const state of cacheMetricsState.values()) {
-    if (state.evictions > 0) {
-      observer.observe(state.evictions, state.evictionAttributes)
-    }
+  for (let index = 0; index < cacheEvictionMetricStates.length; index++) {
+    const state = cacheEvictionMetricStates[index]
+    observer.observe(state.evictions, state.evictionAttributes)
   }
 })
 

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -119,14 +119,6 @@ const httpSizeMetrics = createBatchObservableCounterGroup({
       status_code: attributes.status_code,
     },
   }),
-  observe: (observer, counters, state) => {
-    if (state.requestBytes > 0) {
-      observer.observe(counters.requestBytes, state.requestBytes, state.attributes)
-    }
-    if (state.responseBytes > 0) {
-      observer.observe(counters.responseBytes, state.responseBytes, state.attributes)
-    }
-  },
 })
 
 function isRecordableMetricValue(value: number | undefined): value is number {
@@ -199,14 +191,6 @@ const uploadMetrics = createBatchObservableCounterGroup({
     success: 0,
     attributes: { uploadType },
   }),
-  observe: (observer, counters, state) => {
-    if (state.started > 0) {
-      observer.observe(counters.started, state.started, state.attributes)
-    }
-    if (state.success > 0) {
-      observer.observe(counters.success, state.success, state.attributes)
-    }
-  },
 })
 
 /** Records an upload start by bumping an in-process tally. */

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -64,49 +64,99 @@ export function registerMetric<T>(name: string, type: MetricType, factory: () =>
 // cumulative observable counters, so skipping observations on runtime disable
 // would leave stale exported points and later jumps on re-enable.
 // ============================================================================
-type HttpMetricAttributes = {
-  method: string
-  operation: string
-  status_code: string
-}
-
 type HttpSizeMetricsState = {
   requestBytes: number
   responseBytes: number
   attributes: Attributes
 }
 
-const httpSizeMetrics = createBatchObservableCounterGroup({
-  meter,
-  registerMetric,
-  maxStates: HTTP_SIZE_METRICS_MAX_STATES,
-  counters: {
-    requestBytes: {
-      name: 'http_request_size_bytes',
-      description: 'Total bytes received in HTTP requests (from content-length header)',
-      unit: 'bytes',
-    },
-    responseBytes: {
-      name: 'http_response_size_bytes',
-      description: 'Total bytes sent in HTTP responses (from content-length header)',
-      unit: 'bytes',
-    },
-  },
-  getKey: (attributes: HttpMetricAttributes) =>
-    `${attributes.method}\x00${attributes.operation}\x00${attributes.status_code}`,
-  createState: (attributes: HttpMetricAttributes): HttpSizeMetricsState => ({
-    requestBytes: 0,
-    responseBytes: 0,
-    attributes: {
-      method: attributes.method,
-      operation: attributes.operation,
-      status_code: attributes.status_code,
-    },
-  }),
-})
+const HTTP_METRICS_OVERFLOW_LABEL = 'overflow'
+
+const httpStatusCodeLabels = new Map<number, string>()
+const httpSizeMetricStates = new Set<HttpSizeMetricsState>()
+// Nested maps avoid allocating a composite key on the HTTP request hot path.
+const httpSizeMetricsByMethod = new Map<string, Map<string, Map<number, HttpSizeMetricsState>>>()
+let httpSizeMetricStateCount = 0
+
+const httpSizeOverflowState = createHttpSizeMetricsState(
+  HTTP_METRICS_OVERFLOW_LABEL,
+  HTTP_METRICS_OVERFLOW_LABEL,
+  HTTP_METRICS_OVERFLOW_LABEL
+)
+httpSizeMetricStates.add(httpSizeOverflowState)
 
 function isRecordableMetricValue(value: number | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function createHttpSizeMetricsState(
+  method: string,
+  operation: string,
+  statusCodeLabel: string
+): HttpSizeMetricsState {
+  return {
+    requestBytes: 0,
+    responseBytes: 0,
+    attributes: {
+      method,
+      operation,
+      status_code: statusCodeLabel,
+    },
+  }
+}
+
+function getStatusCodeLabel(statusCode: number): string {
+  let label = httpStatusCodeLabels.get(statusCode)
+
+  if (!label) {
+    label = String(statusCode)
+    httpStatusCodeLabels.set(statusCode, label)
+  }
+
+  return label
+}
+
+function getHttpSizeMetricsState(
+  method: string,
+  operation: string,
+  statusCode: number
+): HttpSizeMetricsState {
+  let byOperation = httpSizeMetricsByMethod.get(method)
+
+  if (!byOperation) {
+    if (httpSizeMetricStateCount >= HTTP_SIZE_METRICS_MAX_STATES) {
+      return httpSizeOverflowState
+    }
+
+    byOperation = new Map()
+    httpSizeMetricsByMethod.set(method, byOperation)
+  }
+
+  let byStatusCode = byOperation.get(operation)
+
+  if (!byStatusCode) {
+    if (httpSizeMetricStateCount >= HTTP_SIZE_METRICS_MAX_STATES) {
+      return httpSizeOverflowState
+    }
+
+    byStatusCode = new Map()
+    byOperation.set(operation, byStatusCode)
+  }
+
+  let state = byStatusCode.get(statusCode)
+
+  if (!state) {
+    if (httpSizeMetricStateCount >= HTTP_SIZE_METRICS_MAX_STATES) {
+      return httpSizeOverflowState
+    }
+
+    state = createHttpSizeMetricsState(method, operation, getStatusCodeLabel(statusCode))
+    byStatusCode.set(statusCode, state)
+    httpSizeMetricStates.add(state)
+    httpSizeMetricStateCount++
+  }
+
+  return state
 }
 
 export const httpRequestDuration = registerMetric(
@@ -119,28 +169,60 @@ export const httpRequestDuration = registerMetric(
     })
 )
 
-/** Records request/response bytes by bumping in-process tallies with one state lookup. */
-export function recordHttpSizes(
+const httpRequestSizeBytes = registerMetric('http_request_size_bytes', 'counter', () =>
+  meter.createObservableCounter('http_request_size_bytes', {
+    description: 'Total bytes received in HTTP requests (from content-length header)',
+    unit: 'bytes',
+  })
+)
+
+const httpResponseSizeBytes = registerMetric('http_response_size_bytes', 'counter', () =>
+  meter.createObservableCounter('http_response_size_bytes', {
+    description: 'Total bytes sent in HTTP responses (from content-length header)',
+    unit: 'bytes',
+  })
+)
+
+meter.addBatchObservableCallback(
+  (observer) => {
+    for (const state of httpSizeMetricStates) {
+      if (state.requestBytes > 0) {
+        observer.observe(httpRequestSizeBytes, state.requestBytes, state.attributes)
+      }
+      if (state.responseBytes > 0) {
+        observer.observe(httpResponseSizeBytes, state.responseBytes, state.attributes)
+      }
+    }
+  },
+  [httpRequestSizeBytes, httpResponseSizeBytes]
+)
+
+function recordHttpByteSizesForState(
+  state: HttpSizeMetricsState,
   requestSizeBytes: number | undefined,
-  responseSizeBytes: number | undefined,
-  attributes: HttpMetricAttributes
+  responseSizeBytes: number | undefined
 ): void {
-  const shouldRecordRequestSize = isRecordableMetricValue(requestSizeBytes)
-  const shouldRecordResponseSize = isRecordableMetricValue(responseSizeBytes)
-
-  if (!shouldRecordRequestSize && !shouldRecordResponseSize) {
-    return
-  }
-
-  const state = httpSizeMetrics.state(attributes)
-
-  if (shouldRecordRequestSize) {
+  if (isRecordableMetricValue(requestSizeBytes)) {
     state.requestBytes = safeAddCounter(state.requestBytes, requestSizeBytes)
   }
 
-  if (shouldRecordResponseSize) {
+  if (isRecordableMetricValue(responseSizeBytes)) {
     state.responseBytes = safeAddCounter(state.responseBytes, responseSizeBytes)
   }
+}
+
+export function recordHttpRequestMetrics(
+  durationSeconds: number,
+  requestSizeBytes: number | undefined,
+  responseSizeBytes: number | undefined,
+  method: string,
+  operation: string,
+  statusCode: number
+): void {
+  const state = getHttpSizeMetricsState(method, operation, statusCode)
+
+  httpRequestDuration.record(durationSeconds, state.attributes)
+  recordHttpByteSizesForState(state, requestSizeBytes, responseSizeBytes)
 }
 
 // ============================================================================

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -63,6 +63,22 @@ export function registerMetric<T>(name: string, type: MetricType, factory: () =>
 // cumulative observable counters, so skipping observations on runtime disable
 // would leave stale exported points and later jumps on re-enable.
 // ============================================================================
+const SAFE_COUNTER_THRESHOLD = Number.MAX_SAFE_INTEGER - 1_000_000_000
+
+function safeAdd(current: number, amount: number): number {
+  const next = current + amount
+
+  if (
+    current >= SAFE_COUNTER_THRESHOLD ||
+    next >= SAFE_COUNTER_THRESHOLD ||
+    !Number.isSafeInteger(next)
+  ) {
+    return Math.min(amount, SAFE_COUNTER_THRESHOLD)
+  }
+
+  return next
+}
+
 type HttpMetricAttributes = {
   method: string
   operation: string
@@ -142,11 +158,11 @@ export function recordHttpSizes(
   const state = httpSizeMetrics.state(attributes)
 
   if (shouldRecordRequestSize) {
-    state.requestBytes += requestSizeBytes
+    state.requestBytes = safeAdd(state.requestBytes, requestSizeBytes)
   }
 
   if (shouldRecordResponseSize) {
-    state.responseBytes += responseSizeBytes
+    state.responseBytes = safeAdd(state.responseBytes, responseSizeBytes)
   }
 }
 
@@ -194,12 +210,14 @@ const uploadMetrics = createBatchObservableCounterGroup({
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
-  uploadMetrics.state(uploadType).started++
+  const state = uploadMetrics.state(uploadType)
+  state.started = safeAdd(state.started, 1)
 }
 
 /** Records an upload success by bumping an in-process tally. */
 export function recordUploadSuccess(uploadType: string): void {
-  uploadMetrics.state(uploadType).success++
+  const state = uploadMetrics.state(uploadType)
+  state.success = safeAdd(state.success, 1)
 }
 
 // ============================================================================
@@ -266,12 +284,14 @@ const cacheMetrics = createBatchObservableCounterGroup({
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
-  cacheMetrics.state(cache).requests[outcome].count++
+  const state = cacheMetrics.state(cache).requests[outcome]
+  state.count = safeAdd(state.count, 1)
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
-  cacheMetrics.state(cache).evictions++
+  const state = cacheMetrics.state(cache)
+  state.evictions = safeAdd(state.evictions, 1)
 }
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -78,6 +78,7 @@ type HttpSizeMetricsState = {
 const httpSizeMetrics = createBatchObservableCounterGroup({
   meter,
   registerMetric,
+  maxStates: 4096,
   counters: {
     requestBytes: {
       name: 'http_request_size_bytes',
@@ -164,6 +165,7 @@ type UploadMetricsState = {
 const uploadMetrics = createBatchObservableCounterGroup({
   meter,
   registerMetric,
+  maxStates: 32,
   counters: {
     started: {
       name: 'upload_started',
@@ -223,6 +225,7 @@ type CacheMetricsState = {
 const cacheMetrics = createBatchObservableCounterGroup({
   meter,
   registerMetric,
+  maxStates: 64,
   counters: {
     requests: {
       name: 'cache_requests_total',

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -1,7 +1,11 @@
 import type { CacheLookupOutcome } from '@internal/cache/adapter'
 import type { CacheName } from '@internal/cache/names'
 import { type Attributes, metrics } from '@opentelemetry/api'
-import { createBatchObservableCounterGroup, safeAddCounter } from './counter'
+import {
+  createBatchObservableCounterGroup,
+  type ObservableCounterSeries,
+  safeAddCounter,
+} from './counter'
 import { HTTP_SIZE_METRICS_MAX_STATES } from './metric-limits'
 
 // ============================================================================
@@ -232,9 +236,8 @@ export function recordHttpRequestMetrics(
 // HTTP/cache: runtime disables must not suppress observations.
 // ============================================================================
 type UploadMetricsState = {
-  started: number
-  success: number
-  attributes: Attributes
+  started: ObservableCounterSeries
+  success: ObservableCounterSeries
 }
 
 const uploadMetrics = createBatchObservableCounterGroup({
@@ -253,20 +256,19 @@ const uploadMetrics = createBatchObservableCounterGroup({
   },
   getKey: (uploadType: string) => uploadType,
   createState: (uploadType: string): UploadMetricsState => ({
-    started: 0,
-    success: 0,
-    attributes: { uploadType },
+    started: { count: 0, attributes: { uploadType } },
+    success: { count: 0, attributes: { uploadType } },
   }),
 })
 
 /** Records an upload start by bumping an in-process tally. */
 export function recordUploadStarted(uploadType: string): void {
-  uploadMetrics.add(uploadType, 'started')
+  uploadMetrics.addStarted(uploadType)
 }
 
 /** Records an upload success by bumping an in-process tally. */
 export function recordUploadSuccess(uploadType: string): void {
-  uploadMetrics.add(uploadType, 'success')
+  uploadMetrics.addSuccess(uploadType)
 }
 
 // ============================================================================
@@ -278,15 +280,9 @@ export function recordUploadSuccess(uploadType: string): void {
 // the in-process tally kept advancing. Drop these metrics at exporter/view
 // configuration if they need to be suppressed entirely.
 // ============================================================================
-type CacheRequestMetricsState = {
-  count: number
-  attributes: Attributes
-}
-
 type CacheMetricsState = {
-  requests: Record<CacheLookupOutcome, CacheRequestMetricsState>
-  evictions: number
-  evictionAttributes: Attributes
+  requests: Record<CacheLookupOutcome, ObservableCounterSeries>
+  evictions: ObservableCounterSeries
 }
 
 const cacheMetrics = createBatchObservableCounterGroup({
@@ -310,37 +306,18 @@ const cacheMetrics = createBatchObservableCounterGroup({
       miss: { count: 0, attributes: { cache, outcome: 'miss' } },
       stale: { count: 0, attributes: { cache, outcome: 'stale' } },
     },
-    evictions: 0,
-    evictionAttributes: { cache },
+    evictions: { count: 0, attributes: { cache } },
   }),
-  observe: (observer, counters, state) => {
-    const requests = state.requests
-
-    if (requests.hit.count > 0) {
-      observer.observe(counters.requests, requests.hit.count, requests.hit.attributes)
-    }
-    if (requests.miss.count > 0) {
-      observer.observe(counters.requests, requests.miss.count, requests.miss.attributes)
-    }
-    if (requests.stale.count > 0) {
-      observer.observe(counters.requests, requests.stale.count, requests.stale.attributes)
-    }
-    if (state.evictions > 0) {
-      observer.observe(counters.evictions, state.evictions, state.evictionAttributes)
-    }
-  },
 })
 
 /** Records a single cache lookup outcome by bumping an in-process tally. */
 export function recordCacheRequest(cache: CacheName, outcome: CacheLookupOutcome): void {
-  const state = cacheMetrics.state(cache).requests[outcome]
-  state.count = safeAddCounter(state.count, 1)
+  cacheMetrics.addRequests(cache, outcome)
 }
 
 /** Records a single capacity/ttl cache eviction by bumping an in-process tally. */
 export function recordCacheEviction(cache: CacheName): void {
-  const state = cacheMetrics.state(cache)
-  state.evictions = safeAddCounter(state.evictions, 1)
+  cacheMetrics.addEvictions(cache)
 }
 
 export const cacheEntries = registerMetric('cache_entries', 'gauge', () =>

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -2,6 +2,7 @@ import type { CacheLookupOutcome } from '@internal/cache/adapter'
 import type { CacheName } from '@internal/cache/names'
 import { type Attributes, metrics } from '@opentelemetry/api'
 import { createBatchObservableCounterGroup } from './counter'
+import { HTTP_SIZE_METRICS_MAX_STATES } from './metric-limits'
 
 // ============================================================================
 // Metric Registry — tracks all metrics for admin API
@@ -94,7 +95,7 @@ type HttpSizeMetricsState = {
 const httpSizeMetrics = createBatchObservableCounterGroup({
   meter,
   registerMetric,
-  maxStates: 4096,
+  maxStates: HTTP_SIZE_METRICS_MAX_STATES,
   counters: {
     requestBytes: {
       name: 'http_request_size_bytes',

--- a/src/internal/monitoring/otel-metrics.test.ts
+++ b/src/internal/monitoring/otel-metrics.test.ts
@@ -262,6 +262,11 @@ describe('otel metrics', () => {
     expect(MeterProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         views: expect.arrayContaining([
+          expect.objectContaining({
+            meterName: 'storage-api',
+            instrumentName: 'http_request_duration_seconds',
+            aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
+          }),
           {
             meterName: 'storage-api',
             instrumentName: 'http_request_size_bytes',

--- a/src/internal/monitoring/otel-metrics.test.ts
+++ b/src/internal/monitoring/otel-metrics.test.ts
@@ -4,6 +4,7 @@ interface OTelGlobalState {
 
 import fs from 'node:fs'
 import { vi } from 'vitest'
+import { HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT } from './metric-limits'
 
 const mockedMetricsModules = [
   '../../config',
@@ -173,7 +174,7 @@ describe('otel metrics', () => {
     )
   })
 
-  test('registers a view overriding v8js.gc.duration buckets on the runtime-node meter', async () => {
+  test('registers metric views for HTTP size cardinality and runtime GC buckets', async () => {
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
     delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 
@@ -261,6 +262,16 @@ describe('otel metrics', () => {
     expect(MeterProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         views: expect.arrayContaining([
+          {
+            meterName: 'storage-api',
+            instrumentName: 'http_request_size_bytes',
+            aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
+          },
+          {
+            meterName: 'storage-api',
+            instrumentName: 'http_response_size_bytes',
+            aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
+          },
           {
             meterName: '@opentelemetry/instrumentation-runtime-node',
             instrumentName: 'v8js.gc.duration',

--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -157,6 +157,7 @@ const views = [
     meterName: 'storage-api',
     instrumentName: 'http_request_duration_seconds',
     aggregation: histogramAggregation,
+    aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
   },
   {
     meterName: 'storage-api',

--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -20,6 +20,7 @@ import { getGlobal } from '@platformatic/globals'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import * as os from 'os'
 import { getConfig } from '../../config'
+import { HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT } from './metric-limits'
 
 const {
   version,
@@ -156,6 +157,16 @@ const views = [
     meterName: 'storage-api',
     instrumentName: 'http_request_duration_seconds',
     aggregation: histogramAggregation,
+  },
+  {
+    meterName: 'storage-api',
+    instrumentName: 'http_request_size_bytes',
+    aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
+  },
+  {
+    meterName: 'storage-api',
+    instrumentName: 'http_response_size_bytes',
+    aggregationCardinalityLimit: HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT,
   },
   {
     meterName: 'storage-api',

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -1,6 +1,6 @@
 import { ERRORS, StorageBackendError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
-import { fileUploadedSuccess, fileUploadStarted } from '@internal/monitoring/metrics'
+import { recordUploadStarted, recordUploadSuccess } from '@internal/monitoring/metrics'
 import { StorageObjectLocator } from '@storage/locator'
 import { randomUUID } from 'crypto'
 import { FastifyRequest } from 'fastify'
@@ -104,9 +104,7 @@ export class Uploader {
    */
   async prepareUpload(options: CanUploadOptions & { uploadType: UploadType }) {
     await this.canUpload(options)
-    fileUploadStarted.add(1, {
-      uploadType: options.uploadType,
-    })
+    recordUploadStarted(options.uploadType)
 
     return randomUUID()
   }
@@ -281,9 +279,7 @@ export class Uploader {
 
         await Promise.all(events)
 
-        fileUploadedSuccess.add(1, {
-          uploadType,
-        })
+        recordUploadSuccess(uploadType)
 
         return { obj: newObject, isNew, metadata: objectMetadata }
       })

--- a/src/test/uploader.test.ts
+++ b/src/test/uploader.test.ts
@@ -2,7 +2,7 @@ import { once } from 'events'
 import { FastifyRequest } from 'fastify'
 import { PassThrough, Readable } from 'stream'
 import { ErrorCode, isStorageError, StorageBackendError } from '../internal/errors'
-import { fileUploadedSuccess, fileUploadStarted } from '../internal/monitoring/metrics'
+import * as monitoringMetrics from '../internal/monitoring/metrics'
 import { ObjectAdminDelete, ObjectCreatedPostEvent } from '../storage/events'
 import { TenantLocation } from '../storage/locator'
 import { fileUploadFromRequest, Uploader } from '../storage/uploader'
@@ -399,7 +399,7 @@ describe('fileUploadFromRequest', () => {
 
 describe('Uploader metrics', () => {
   test('prepareUpload records upload start attributes without tenant id labels', async () => {
-    const addSpy = vi.spyOn(fileUploadStarted, 'add')
+    const recordSpy = vi.spyOn(monitoringMetrics, 'recordUploadStarted')
     const uploader = createUploader(
       {
         uploadObject: vi.fn(),
@@ -418,14 +418,14 @@ describe('Uploader metrics', () => {
         uploadType: 'standard',
       })
 
-      expect(addSpy).toHaveBeenCalledWith(1, { uploadType: 'standard' })
+      expect(recordSpy).toHaveBeenCalledWith('standard')
     } finally {
-      addSpy.mockRestore()
+      recordSpy.mockRestore()
     }
   })
 
   test('completeUpload records upload success attributes without tenant id labels', async () => {
-    const addSpy = vi.spyOn(fileUploadedSuccess, 'add')
+    const recordSpy = vi.spyOn(monitoringMetrics, 'recordUploadSuccess')
     const sendWebhookSpy = vi
       .spyOn(ObjectCreatedPostEvent, 'sendWebhook')
       .mockResolvedValue(undefined)
@@ -469,9 +469,9 @@ describe('Uploader metrics', () => {
         userMetadata: undefined,
       })
 
-      expect(addSpy).toHaveBeenCalledWith(1, { uploadType: 'standard' })
+      expect(recordSpy).toHaveBeenCalledWith('standard')
     } finally {
-      addSpy.mockRestore()
+      recordSpy.mockRestore()
       sendWebhookSpy.mockRestore()
     }
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for performance

## What is the current behavior?

Sync allocation/hashing for counter metrics. 

## What is the new behavior?

Convert counters to observables tallied by in-memory integers.
Use batch observer to traverse related states once (for example res and req size)

## Additional context

Related to https://github.com/supabase/storage/pull/1157
