### PR TITLE
fix: limit for delete objects and sign urls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,6 @@ SERVER_REGION=local
 #######################################
 # Request / Response
 #######################################
-REQUEST_URL_LENGTH_LIMIT=7500
 REQUEST_TRACE_HEADER=trace-id
 REQUEST_ETAG_HEADERS=if-none-match
 RESPONSE_S_MAXAGE=0

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,7 +120,6 @@ type StorageConfigType = {
   emptyBucketMax: number
   storageBackendType: StorageBackendType
   tenantId: string
-  requestUrlLengthLimit: number
   requestXForwardedHostRegExp?: string
   requestAllowXForwardedPrefix?: boolean
   storagePublicUrl?: string
@@ -316,8 +315,6 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     requestAllowXForwardedPrefix:
       getOptionalConfigFromEnv('REQUEST_ALLOW_X_FORWARDED_PATH') === 'true',
     storagePublicUrl: getOptionalConfigFromEnv('STORAGE_PUBLIC_URL'),
-    requestUrlLengthLimit:
-      Number(getOptionalConfigFromEnv('REQUEST_URL_LENGTH_LIMIT', 'URL_LENGTH_LIMIT')) || 7_500,
     requestTraceHeader: getOptionalConfigFromEnv('REQUEST_TRACE_HEADER', 'REQUEST_ID_HEADER'),
     requestEtagHeaders: getOptionalConfigFromEnv('REQUEST_ETAG_HEADERS')?.trim().split(',') || [
       'if-none-match',

--- a/src/http/routes/object/deleteObjects.ts
+++ b/src/http/routes/object/deleteObjects.ts
@@ -1,3 +1,4 @@
+import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { objectSchema } from '@storage/schemas/object'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -19,6 +20,7 @@ const deleteObjectsBodySchema = {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
+      maxItems: MAX_OBJECTS_PER_REQUEST,
       examples: [['folder/cat.png', 'folder/morecats.png']],
     },
   },

--- a/src/http/routes/object/getSignedURLs.ts
+++ b/src/http/routes/object/getSignedURLs.ts
@@ -1,4 +1,5 @@
 import { assertValidNumericJWTExpiration } from '@internal/auth'
+import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema } from '../../routes-helper'
@@ -24,6 +25,7 @@ const getSignedURLsBodySchema = {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
+      maxItems: MAX_OBJECTS_PER_REQUEST,
       examples: [['folder/cat.png', 'folder/morecats.png']],
     },
   },

--- a/src/http/routes/s3/commands/delete-object.ts
+++ b/src/http/routes/s3/commands/delete-object.ts
@@ -1,3 +1,4 @@
+import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { getConfig } from '../../../../config'
 import { ROUTE_OPERATIONS } from '../../operations'
@@ -33,6 +34,7 @@ const DeleteObjectsInput = {
         properties: {
           Object: {
             type: 'array',
+            maxItems: MAX_OBJECTS_PER_REQUEST,
             items: {
               type: 'object',
               properties: {

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -1,3 +1,4 @@
+import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { vi } from 'vitest'
 import { S3ProtocolHandler } from '../../../storage/protocols/s3/s3-handler'
 import { Uploader } from '../../../storage/uploader'
@@ -242,6 +243,45 @@ describe('CompleteMultipartUpload route mapping', () => {
 })
 
 describe('DeleteObject route mapping', () => {
+  it('rejects DeleteObjects payloads over the object request cap in router validation', async () => {
+    const { default: DeleteObject } = await import('./commands/delete-object')
+    const router = new Router()
+
+    DeleteObject(router as unknown as S3Router)
+
+    const route = router
+      .routes()
+      .get('/:Bucket')
+      ?.find(
+        (candidate) =>
+          candidate.method === 'post' &&
+          candidate.querystringMatches.some((match) => match.key === 'delete')
+      )
+
+    expect(route).toBeDefined()
+
+    const validate = route!.compiledSchema()
+    const data = {
+      Params: { Bucket: 'bucket' },
+      Querystring: { delete: '' },
+      Body: {
+        Delete: {
+          Object: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map((i) => ({
+            Key: `object-${i}`,
+          })),
+        },
+      },
+    }
+
+    expect(validate(data)).toBe(false)
+    expect(validate.errors).toEqual([
+      expect.objectContaining({
+        instancePath: '/Body/Delete/Object',
+        keyword: 'maxItems',
+      }),
+    ])
+  })
+
   it('returns 204 from iceberg single-object deletes', async () => {
     const previousIcebergDeleteEnabled = process.env.ICEBERG_S3_DELETE_ENABLED
     process.env.ICEBERG_S3_DELETE_ENABLED = 'true'

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -243,13 +243,13 @@ describe('CompleteMultipartUpload route mapping', () => {
 })
 
 describe('DeleteObject route mapping', () => {
-  const getDeleteObjectsRoute = async () => {
+  it('accepts DeleteObjects payloads at the object request cap in router validation', async () => {
     const { default: DeleteObject } = await import('./commands/delete-object')
     const router = new Router()
 
     DeleteObject(router as unknown as S3Router)
 
-    return router
+    const route = router
       .routes()
       .get('/:Bucket')
       ?.find(
@@ -257,27 +257,21 @@ describe('DeleteObject route mapping', () => {
           candidate.method === 'post' &&
           candidate.querystringMatches.some((match) => match.key === 'delete')
       )
-  }
-
-  const createDeleteObjectsData = (objectCount: number) => ({
-    Params: { Bucket: 'bucket' },
-    Querystring: { delete: '' },
-    Body: {
-      Delete: {
-        Object: [...Array(objectCount).keys()].map((i) => ({
-          Key: `object-${i}`,
-        })),
-      },
-    },
-  })
-
-  it('accepts DeleteObjects payloads at the object request cap in router validation', async () => {
-    const route = await getDeleteObjectsRoute()
 
     expect(route).toBeDefined()
 
     const validate = route!.compiledSchema()
-    const data = createDeleteObjectsData(MAX_OBJECTS_PER_REQUEST)
+    const data = {
+      Params: { Bucket: 'bucket' },
+      Querystring: { delete: '' },
+      Body: {
+        Delete: {
+          Object: [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => ({
+            Key: `object-${i}`,
+          })),
+        },
+      },
+    }
 
     expect(data.Body.Delete.Object).toHaveLength(1000)
     expect(validate(data)).toBe(true)
@@ -285,12 +279,34 @@ describe('DeleteObject route mapping', () => {
   })
 
   it('rejects DeleteObjects payloads over the object request cap in router validation', async () => {
-    const route = await getDeleteObjectsRoute()
+    const { default: DeleteObject } = await import('./commands/delete-object')
+    const router = new Router()
+
+    DeleteObject(router as unknown as S3Router)
+
+    const route = router
+      .routes()
+      .get('/:Bucket')
+      ?.find(
+        (candidate) =>
+          candidate.method === 'post' &&
+          candidate.querystringMatches.some((match) => match.key === 'delete')
+      )
 
     expect(route).toBeDefined()
 
     const validate = route!.compiledSchema()
-    const data = createDeleteObjectsData(MAX_OBJECTS_PER_REQUEST + 1)
+    const data = {
+      Params: { Bucket: 'bucket' },
+      Querystring: { delete: '' },
+      Body: {
+        Delete: {
+          Object: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map((i) => ({
+            Key: `object-${i}`,
+          })),
+        },
+      },
+    }
 
     expect(validate(data)).toBe(false)
     expect(validate.errors).toEqual([

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -243,13 +243,13 @@ describe('CompleteMultipartUpload route mapping', () => {
 })
 
 describe('DeleteObject route mapping', () => {
-  it('rejects DeleteObjects payloads over the object request cap in router validation', async () => {
+  const getDeleteObjectsRoute = async () => {
     const { default: DeleteObject } = await import('./commands/delete-object')
     const router = new Router()
 
     DeleteObject(router as unknown as S3Router)
 
-    const route = router
+    return router
       .routes()
       .get('/:Bucket')
       ?.find(
@@ -257,21 +257,40 @@ describe('DeleteObject route mapping', () => {
           candidate.method === 'post' &&
           candidate.querystringMatches.some((match) => match.key === 'delete')
       )
+  }
+
+  const createDeleteObjectsData = (objectCount: number) => ({
+    Params: { Bucket: 'bucket' },
+    Querystring: { delete: '' },
+    Body: {
+      Delete: {
+        Object: [...Array(objectCount).keys()].map((i) => ({
+          Key: `object-${i}`,
+        })),
+      },
+    },
+  })
+
+  it('accepts DeleteObjects payloads at the object request cap in router validation', async () => {
+    const route = await getDeleteObjectsRoute()
 
     expect(route).toBeDefined()
 
     const validate = route!.compiledSchema()
-    const data = {
-      Params: { Bucket: 'bucket' },
-      Querystring: { delete: '' },
-      Body: {
-        Delete: {
-          Object: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map((i) => ({
-            Key: `object-${i}`,
-          })),
-        },
-      },
-    }
+    const data = createDeleteObjectsData(MAX_OBJECTS_PER_REQUEST)
+
+    expect(data.Body.Delete.Object).toHaveLength(1000)
+    expect(validate(data)).toBe(true)
+    expect(validate.errors).toBeNull()
+  })
+
+  it('rejects DeleteObjects payloads over the object request cap in router validation', async () => {
+    const route = await getDeleteObjectsRoute()
+
+    expect(route).toBeDefined()
+
+    const validate = route!.compiledSchema()
+    const data = createDeleteObjectsData(MAX_OBJECTS_PER_REQUEST + 1)
 
     expect(validate(data)).toBe(false)
     expect(validate.errors).toEqual([

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -273,7 +273,7 @@ describe('DeleteObject route mapping', () => {
       },
     }
 
-    expect(data.Body.Delete.Object).toHaveLength(1000)
+    expect(data.Body.Delete.Object).toHaveLength(MAX_OBJECTS_PER_REQUEST)
     expect(validate(data)).toBe(true)
     expect(validate.errors).toBeNull()
   })

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -1,7 +1,14 @@
-import { GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { ErrorCode, isStorageError } from '@internal/errors'
+import { MAX_KEYS_PER_S3_DELETE } from '@storage/limits'
 import { Readable } from 'stream'
 import { type Mock, vi } from 'vitest'
 import { getConfig } from '../../../config'
@@ -153,6 +160,37 @@ describe('S3Backend', () => {
       const result = await backend.getObject('test-bucket', 'test-key', undefined)
 
       expect(result.metadata.mimetype).toBe('image/png')
+    })
+  })
+
+  describe('deleteObjects', () => {
+    test('chunks DeleteObjectsCommand payloads to the S3 key limit', async () => {
+      mockSend.mockResolvedValue({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      })
+
+      const backend = createBackend()
+      const keys = [...Array(MAX_KEYS_PER_S3_DELETE + 1).keys()].map((i) => `object-${i}`)
+
+      await backend.deleteObjects('test-bucket', keys)
+
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(mockSend.mock.calls[0][0]).toBeInstanceOf(DeleteObjectsCommand)
+      expect(mockSend.mock.calls[0][0].input).toMatchObject({
+        Bucket: 'test-bucket',
+        Delete: {
+          Objects: keys.slice(0, MAX_KEYS_PER_S3_DELETE).map((Key) => ({ Key })),
+        },
+      })
+      expect(mockSend.mock.calls[1][0]).toBeInstanceOf(DeleteObjectsCommand)
+      expect(mockSend.mock.calls[1][0].input).toMatchObject({
+        Bucket: 'test-bucket',
+        Delete: {
+          Objects: [{ Key: `object-${MAX_KEYS_PER_S3_DELETE}` }],
+        },
+      })
     })
   })
 

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -192,6 +192,33 @@ describe('S3Backend', () => {
         },
       })
     })
+
+    test('sends DeleteObjectsCommand chunks concurrently', async () => {
+      const firstDelete = Promise.withResolvers<{ $metadata: { httpStatusCode: number } }>()
+      const secondDelete = Promise.withResolvers<{ $metadata: { httpStatusCode: number } }>()
+      mockSend.mockImplementationOnce(() => firstDelete.promise)
+      mockSend.mockImplementationOnce(() => secondDelete.promise)
+
+      const backend = createBackend()
+      const keys = [...Array(MAX_KEYS_PER_S3_DELETE + 1).keys()].map((i) => `object-${i}`)
+
+      const deletePromise = backend.deleteObjects('test-bucket', keys)
+
+      expect(mockSend).toHaveBeenCalledTimes(2)
+
+      firstDelete.resolve({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      })
+      secondDelete.resolve({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      })
+
+      await expect(deletePromise).resolves.toBeUndefined()
+    })
   })
 
   describe('privateAssetUrl', () => {

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -430,6 +430,8 @@ export class S3Backend implements StorageBackendAdapter {
    */
   async deleteObjects(bucket: string, prefixes: string[]): Promise<void> {
     try {
+      const deleteRequests: Promise<unknown>[] = []
+
       for (let i = 0; i < prefixes.length; i += MAX_KEYS_PER_S3_DELETE) {
         const s3Prefixes = prefixes.slice(i, i + MAX_KEYS_PER_S3_DELETE).map((ele) => {
           return { Key: ele }
@@ -441,7 +443,16 @@ export class S3Backend implements StorageBackendAdapter {
             Objects: s3Prefixes,
           },
         })
-        await this.client.send(command)
+        deleteRequests.push(this.client.send(command))
+      }
+
+      const results = await Promise.allSettled(deleteRequests)
+      const rejected = results.find((result): result is PromiseRejectedResult => {
+        return result.status === 'rejected'
+      })
+
+      if (rejected) {
+        throw rejected.reason
       }
     } catch (e) {
       throw StorageBackendError.fromError(e)

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -24,6 +24,7 @@ import { createAgent, InstrumentedAgent } from '@internal/http'
 import { monitorStream } from '@internal/streams'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { BackupObjectInfo, ObjectBackup } from '@storage/backend/s3/backup'
+import { MAX_KEYS_PER_S3_DELETE } from '@storage/limits'
 import { getConfig } from '../../../config'
 import {
   BrowserCacheHeaders,
@@ -429,17 +430,19 @@ export class S3Backend implements StorageBackendAdapter {
    */
   async deleteObjects(bucket: string, prefixes: string[]): Promise<void> {
     try {
-      const s3Prefixes = prefixes.map((ele) => {
-        return { Key: ele }
-      })
+      for (let i = 0; i < prefixes.length; i += MAX_KEYS_PER_S3_DELETE) {
+        const s3Prefixes = prefixes.slice(i, i + MAX_KEYS_PER_S3_DELETE).map((ele) => {
+          return { Key: ele }
+        })
 
-      const command = new DeleteObjectsCommand({
-        Bucket: bucket,
-        Delete: {
-          Objects: s3Prefixes,
-        },
-      })
-      await this.client.send(command)
+        const command = new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: {
+            Objects: s3Prefixes,
+          },
+        })
+        await this.client.send(command)
+      }
     } catch (e) {
       throw StorageBackendError.fromError(e)
     }

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -4,6 +4,7 @@ import { withOptionalVersion } from '@storage/backend'
 import { Job, SendOptions, WorkOptions } from 'pg-boss'
 import { getConfig } from '../../../config'
 import { Storage } from '../../index'
+import { MAX_OBJECTS_PER_DELETE_BATCH } from '../../limits'
 import { BaseEvent } from '../base-event'
 import { ObjectRemoved } from '../lifecycle/object-removed'
 
@@ -14,7 +15,7 @@ export interface ObjectDeleteAllBeforeEvent extends BasePayload {
   bucketId: string
 }
 
-const { storageS3Bucket, requestUrlLengthLimit } = getConfig()
+const { storageS3Bucket } = getConfig()
 
 export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeEvent> {
   static queueName = 'object:admin:delete-all-before'
@@ -57,7 +58,7 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
         }
       )
 
-      const batchLimit = Math.floor(requestUrlLengthLimit / (36 + 3))
+      const batchLimit = MAX_OBJECTS_PER_DELETE_BATCH
 
       let moreObjectsToDelete = false
       const start = Date.now()

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -9,6 +9,11 @@ const { isMultitenant, imageTransformationEnabled, icebergBucketDetectionSuffix 
 
 export type BucketType = 'STANDARD' | 'ANALYTICS'
 
+export const MAX_OBJECTS_PER_REQUEST = 1000
+export const MAX_KEYS_PER_S3_DELETE = 1000
+// Versioned object deletes expand to the object key plus a `.info` sidecar key.
+export const MAX_OBJECTS_PER_DELETE_BATCH = Math.floor(MAX_KEYS_PER_S3_DELETE / 2)
+export const MAX_OBJECTS_PER_LOOKUP_BATCH = MAX_OBJECTS_PER_REQUEST
 export const ICEBERG_BUCKET_RESERVED_SUFFIX = icebergBucketDetectionSuffix
 export const RESERVED_BUCKET_SUFFIXES = [icebergBucketDetectionSuffix]
 

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -2,6 +2,12 @@ import { ERRORS, ErrorCode } from '@internal/errors'
 import { describe, expect, it, vi } from 'vitest'
 import { StorageBackendAdapter } from './backend'
 import { Database } from './database'
+import { ObjectRemoved } from './events'
+import {
+  MAX_KEYS_PER_S3_DELETE,
+  MAX_OBJECTS_PER_DELETE_BATCH,
+  MAX_OBJECTS_PER_REQUEST,
+} from './limits'
 import { StorageObjectLocator } from './locator'
 import { ObjectStorage } from './object'
 
@@ -78,5 +84,53 @@ describe('ObjectStorage.deleteObject', () => {
 
     expect(deleteObject).not.toHaveBeenCalled()
     expect(backend.deleteObject).not.toHaveBeenCalled()
+  })
+})
+
+describe('ObjectStorage.deleteObjects', () => {
+  it('keeps versioned-object backend deletes within the S3 key limit', async () => {
+    const sendWebhook = vi.spyOn(ObjectRemoved, 'sendWebhook').mockResolvedValue(undefined)
+    const backend = {
+      deleteObjects: vi.fn(),
+    } as unknown as StorageBackendAdapter
+    const scopedDb = {
+      tenantId: 'tenant-id',
+      tenant: vi.fn(() => ({ ref: 'tenant-id' })),
+      deleteObjects: vi.fn((_bucketId: string, names: string[]) =>
+        names.map((name) => ({
+          name,
+          version: `version-${name}`,
+          metadata: {},
+        }))
+      ),
+    }
+    const db = {
+      tenantId: 'tenant-id',
+      reqId: 'req-id',
+      sbReqId: 'sb-req-id',
+      withTransaction: vi.fn((fn) => fn(scopedDb)),
+    } as unknown as Database
+    const location = {
+      getRootLocation: vi.fn(() => 'root-bucket'),
+      getKeyLocation: vi.fn(({ tenantId, bucketId, objectName, version }) =>
+        [tenantId, bucketId, objectName, version].filter(Boolean).join('/')
+      ),
+    } as unknown as StorageObjectLocator
+    const storage = new ObjectStorage(backend, db, location, 'bucket')
+    const objectNames = [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => `object-${i}`)
+
+    const results = await storage.deleteObjects(objectNames)
+
+    expect(results).toHaveLength(MAX_OBJECTS_PER_REQUEST)
+    expect(scopedDb.deleteObjects).toHaveBeenCalledTimes(
+      Math.ceil(MAX_OBJECTS_PER_REQUEST / MAX_OBJECTS_PER_DELETE_BATCH)
+    )
+    expect(backend.deleteObjects).toHaveBeenCalledTimes(
+      Math.ceil(MAX_OBJECTS_PER_REQUEST / MAX_OBJECTS_PER_DELETE_BATCH)
+    )
+    for (const [, keys] of vi.mocked(backend.deleteObjects).mock.calls) {
+      expect(keys).toHaveLength(MAX_KEYS_PER_S3_DELETE)
+    }
+    expect(sendWebhook).toHaveBeenCalledTimes(MAX_OBJECTS_PER_REQUEST)
   })
 })

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -1,5 +1,5 @@
 import { ERRORS, ErrorCode } from '@internal/errors'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { StorageBackendAdapter } from './backend'
 import { Database } from './database'
 import { ObjectRemoved } from './events'
@@ -88,6 +88,10 @@ describe('ObjectStorage.deleteObject', () => {
 })
 
 describe('ObjectStorage.deleteObjects', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('keeps versioned-object backend deletes within the S3 key limit', async () => {
     const sendWebhook = vi.spyOn(ObjectRemoved, 'sendWebhook').mockResolvedValue(undefined)
     const backend = {

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -766,13 +766,19 @@ export class ObjectStorage {
    * @param expiresIn
    */
   async signObjectUrls(paths: string[], expiresIn: number) {
-    const results: { name: string }[] = []
+    let results: { name: string }[]
 
-    for (let i = 0; i < paths.length; i += MAX_OBJECTS_PER_LOOKUP_BATCH) {
-      const pathsSubset = paths.slice(i, i + MAX_OBJECTS_PER_LOOKUP_BATCH)
+    if (paths.length <= MAX_OBJECTS_PER_LOOKUP_BATCH) {
+      results = await this.findObjects(paths, 'name')
+    } else {
+      results = []
 
-      const objects = await this.findObjects(pathsSubset, 'name')
-      results.push(...objects)
+      for (let i = 0; i < paths.length; i += MAX_OBJECTS_PER_LOOKUP_BATCH) {
+        const pathsSubset = paths.slice(i, i + MAX_OBJECTS_PER_LOOKUP_BATCH)
+
+        const objects = await this.findObjects(pathsSubset, 'name')
+        results.push(...objects)
+      }
     }
 
     const nameSet = new Set(results.map(({ name }) => name))

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -180,7 +180,7 @@ export class ObjectStorage {
    * @param prefixes
    */
   async deleteObjects(prefixes: string[]) {
-    let results: { name: string }[] = []
+    const results: { name: string }[] = []
 
     for (let i = 0; i < prefixes.length; i += MAX_OBJECTS_PER_DELETE_BATCH) {
       const prefixesSubset = prefixes.slice(i, i + MAX_OBJECTS_PER_DELETE_BATCH)
@@ -194,24 +194,17 @@ export class ObjectStorage {
           // if successfully deleted, delete from s3 too
           // todo: consider moving this to a queue
           const prefixesToDelete = data.reduce((all, { name, version }) => {
-            all.push(
-              this.location.getKeyLocation({
-                tenantId: db.tenantId,
-                bucketId: this.bucketId,
-                objectName: name,
-                version,
-              })
-            )
+            const location = this.location.getKeyLocation({
+              tenantId: db.tenantId,
+              bucketId: this.bucketId,
+              objectName: name,
+              version,
+            })
+
+            all.push(location)
 
             if (version) {
-              all.push(
-                this.location.getKeyLocation({
-                  tenantId: db.tenantId,
-                  bucketId: this.bucketId,
-                  objectName: name,
-                  version,
-                }) + '.info'
-              )
+              all.push(`${location}.info`)
             }
             return all
           }, [] as string[])
@@ -773,7 +766,7 @@ export class ObjectStorage {
    * @param expiresIn
    */
   async signObjectUrls(paths: string[], expiresIn: number) {
-    let results: { name: string }[] = []
+    const results: { name: string }[] = []
 
     for (let i = 0; i < paths.length; i += MAX_OBJECTS_PER_LOOKUP_BATCH) {
       const pathsSubset = paths.slice(i, i + MAX_OBJECTS_PER_LOOKUP_BATCH)

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -15,7 +15,6 @@ import { ERRORS } from '@internal/errors'
 import { StorageObjectLocator } from '@storage/locator'
 import { Obj } from '@storage/schemas'
 import { FastifyRequest } from 'fastify/types/request'
-import { getConfig } from '../config'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
 import { Database, FindObjectFilters, SearchObjectOption } from './database'
 import {
@@ -26,10 +25,12 @@ import {
   ObjectRemovedMove,
   ObjectUpdatedMetadata,
 } from './events'
-import { mustBeValidKey } from './limits'
+import {
+  MAX_OBJECTS_PER_DELETE_BATCH,
+  MAX_OBJECTS_PER_LOOKUP_BATCH,
+  mustBeValidKey,
+} from './limits'
 import { CanUploadMetadata, fileUploadFromRequest, Uploader, UploadRequest } from './uploader'
-
-const { requestUrlLengthLimit } = getConfig()
 
 interface CopyObjectParams {
   sourceKey: string
@@ -181,21 +182,14 @@ export class ObjectStorage {
   async deleteObjects(prefixes: string[]) {
     let results: { name: string }[] = []
 
-    for (let i = 0; i < prefixes.length; ) {
-      const prefixesSubset: string[] = []
-      let urlParamLength = 0
-
-      for (; i < prefixes.length && urlParamLength < requestUrlLengthLimit; i++) {
-        const prefix = prefixes[i]
-        prefixesSubset.push(prefix)
-        urlParamLength += encodeURIComponent(prefix).length + 9 // length of '%22%2C%22'
-      }
+    for (let i = 0; i < prefixes.length; i += MAX_OBJECTS_PER_DELETE_BATCH) {
+      const prefixesSubset = prefixes.slice(i, i + MAX_OBJECTS_PER_DELETE_BATCH)
 
       await this.db.withTransaction(async (db) => {
         const data = await db.deleteObjects(this.bucketId, prefixesSubset, 'name')
 
         if (data.length > 0) {
-          results = results.concat(data)
+          results.push(...data)
 
           // if successfully deleted, delete from s3 too
           // todo: consider moving this to a queue
@@ -781,18 +775,11 @@ export class ObjectStorage {
   async signObjectUrls(paths: string[], expiresIn: number) {
     let results: { name: string }[] = []
 
-    for (let i = 0; i < paths.length; ) {
-      const pathsSubset = []
-      let urlParamLength = 0
-
-      for (; i < paths.length && urlParamLength < requestUrlLengthLimit; i++) {
-        const path = paths[i]
-        pathsSubset.push(path)
-        urlParamLength += encodeURIComponent(path).length + 9 // length of '%22%2C%22'
-      }
+    for (let i = 0; i < paths.length; i += MAX_OBJECTS_PER_LOOKUP_BATCH) {
+      const pathsSubset = paths.slice(i, i + MAX_OBJECTS_PER_LOOKUP_BATCH)
 
       const objects = await this.findObjects(pathsSubset, 'name')
-      results = results.concat(objects)
+      results.push(...objects)
     }
 
     const nameSet = new Set(results.map(({ name }) => name))

--- a/src/test/db/02-dummy-data.sql
+++ b/src/test/db/02-dummy-data.sql
@@ -55,7 +55,7 @@ INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at
 ;
 INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at", "updated_at", "last_accessed_at", "metadata")
 SELECT gen_random_uuid(), 'bucket2', 'authenticated/' || i, '317eadce-631a-4429-a0bb-f19a7a517b4a', now(), now(), now(), '{"size": 1234}'
-from generate_series(0, 10000) i;
+from generate_series(0, 999) i;
 
 -- add policies
 -- allows user to CRUD all buckets

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@internal/auth'
 import { getPostgresConnection, getServiceKeyUser, PgTransaction } from '@internal/database'
 import { ErrorCode, StorageBackendError } from '@internal/errors'
+import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
 import FormData from 'form-data'
@@ -28,6 +29,11 @@ const { jwtSecret, serviceKeyAsync, tenantId } = getConfig()
 const anonKey = process.env.ANON_KEY || ''
 const S3Backend = backends.S3Backend
 let appInstance: FastifyInstance
+
+type SignedUrlResult = {
+  error: string | null
+  signedURL: string | null
+}
 
 let tnx: PgTransaction | undefined
 async function getSuperuserPostgrestClient() {
@@ -91,6 +97,20 @@ async function deleteObjectsByName(db: PgTransaction, bucketId: string, names: s
         AND name = ANY($2::text[])
     `,
     values: [bucketId, Array.isArray(names) ? names : [names]],
+  })
+}
+
+async function insertObjectNames(db: PgTransaction, bucketId: string, names: string[]) {
+  const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+  const versions = names.map((_, index) => `test-version-${randomUUID()}-${index}`)
+
+  await db.query({
+    text: `
+      INSERT INTO objects (bucket_id, name, owner, owner_id, version, metadata)
+      SELECT $1, seeded.name, $2::uuid, $2::text, seeded.version, $3::jsonb
+      FROM unnest($4::text[], $5::text[]) AS seeded(name, version)
+    `,
+    values: [bucketId, owner, { size: 1234 }, names, versions],
   })
 }
 
@@ -1810,6 +1830,47 @@ describe('testing delete object', () => {
  * */
 describe('testing deleting multiple objects', () => {
   test('check if RLS policies are respected: authenticated user is able to delete authenticated resource', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const objectNames = [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map(
+      (i) => `authenticated/bulk-delete-${runId}/${i}`
+    )
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjectNames(seedTx, bucketName, objectNames)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'DELETE',
+        url: `/object/${bucketName}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+        payload: {
+          prefixes: objectNames,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.deleteObjects).toHaveBeenCalled()
+
+      const result = JSON.parse(response.body)
+      expect(result).toHaveLength(MAX_OBJECTS_PER_REQUEST)
+      // Only the first two names are stable across the likely DELETE RETURNING plans.
+      expect(result[0].name).toBe(objectNames[0])
+      expect(result[1].name).toBe(objectNames[1])
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, bucketName, objectNames)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('rejects delete requests over the object request cap', async () => {
     const response = await appInstance.inject({
       method: 'DELETE',
       url: '/object/bucket2',
@@ -1817,16 +1878,14 @@ describe('testing deleting multiple objects', () => {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
       payload: {
-        prefixes: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
+        prefixes: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map(
+          (i) => `authenticated/too-many-${i}`
+        ),
       },
     })
-    expect(response.statusCode).toBe(200)
-    expect(S3Backend.prototype.deleteObjects).toHaveBeenCalled()
 
-    const result = JSON.parse(response.body)
-    expect(result).toHaveLength(10001)
-    expect(result[0].name).toBe('authenticated/0')
-    expect(result[1].name).toBe('authenticated/1')
+    expect(response.statusCode).toBe(400)
+    expect(S3Backend.prototype.deleteObjects).not.toHaveBeenCalled()
   })
 
   test('check if RLS policies are respected: anon user is not able to delete authenticated resource', async () => {
@@ -2452,20 +2511,45 @@ describe('testing uploading with generated signed upload URL', () => {
  */
 describe('testing generating signed URLs', () => {
   test('check if RLS policies are respected: authenticated user is able to sign URLs for an authenticated resource', async () => {
-    const response = await appInstance.inject({
-      method: 'POST',
-      url: '/object/sign/bucket2',
-      headers: {
-        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
-      },
-      payload: {
-        expiresIn: 1000,
-        paths: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
-      },
-    })
-    expect(response.statusCode).toBe(200)
-    const result = JSON.parse(response.body)
-    expect(result).toHaveLength(10001)
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const objectNames = [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map(
+      (i) => `authenticated/bulk-sign-${runId}/${i}`
+    )
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjectNames(seedTx, bucketName, objectNames)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/object/sign/${bucketName}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+        payload: {
+          expiresIn: 1000,
+          paths: objectNames,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const result = JSON.parse(response.body) as SignedUrlResult[]
+      expect(result).toHaveLength(MAX_OBJECTS_PER_REQUEST)
+      expect(
+        result.every(({ error, signedURL }) => {
+          return error === null && signedURL !== null
+        })
+      ).toBe(true)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, bucketName, objectNames)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
   })
 
   test('check if RLS policies are respected: anon user is not able to generate signedURLs for authenticated resource', async () => {
@@ -2477,7 +2561,7 @@ describe('testing generating signed URLs', () => {
       },
       payload: {
         expiresIn: 1000,
-        paths: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
+        paths: [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => `authenticated/${i}`),
       },
     })
     expect(response.statusCode).toBe(200)
@@ -2491,9 +2575,27 @@ describe('testing generating signed URLs', () => {
       url: '/object/sign/bucket2',
       payload: {
         expiresIn: 1000,
-        paths: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
+        paths: [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => `authenticated/${i}`),
       },
     })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('rejects signed URL requests over the object request cap', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+        paths: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map(
+          (i) => `authenticated/too-many-${i}`
+        ),
+      },
+    })
+
     expect(response.statusCode).toBe(400)
   })
 
@@ -2506,7 +2608,7 @@ describe('testing generating signed URLs', () => {
       },
       payload: {
         expiresIn: 1000,
-        paths: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
+        paths: [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => `authenticated/${i}`),
       },
     })
     expect(response.statusCode).toBe(200)

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1830,7 +1830,7 @@ describe('testing delete object', () => {
  * DELETE /objects
  * */
 describe('testing deleting multiple objects', () => {
-  test('check if RLS policies are respected: authenticated user is able to delete authenticated resource', async () => {
+  test('authenticated user can bulk delete objects up to the request cap', async () => {
     const runId = randomUUID()
     const bucketName = 'bucket2'
     const objectNames = [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map(

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -2512,6 +2512,23 @@ describe('testing uploading with generated signed upload URL', () => {
  */
 describe('testing generating signed URLs', () => {
   test('check if RLS policies are respected: authenticated user is able to sign URLs for an authenticated resource', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+        paths: [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map((i) => `authenticated/${i}`),
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    const result = JSON.parse(response.body)
+    expect(result).toHaveLength(MAX_OBJECTS_PER_REQUEST)
+  })
+
+  test('authenticated user can sign URLs up to the request cap', async () => {
     const runId = randomUUID()
     const bucketName = 'bucket2'
     const objectNames = [...Array(MAX_OBJECTS_PER_REQUEST).keys()].map(

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -32,6 +32,7 @@ let appInstance: FastifyInstance
 
 type SignedUrlResult = {
   error: string | null
+  path: string
   signedURL: string | null
 }
 
@@ -1857,9 +1858,9 @@ describe('testing deleting multiple objects', () => {
 
       const result = JSON.parse(response.body)
       expect(result).toHaveLength(MAX_OBJECTS_PER_REQUEST)
-      // Only the first two names are stable across the likely DELETE RETURNING plans.
-      expect(result[0].name).toBe(objectNames[0])
-      expect(result[1].name).toBe(objectNames[1])
+      expect(result.map((row: { name: string }) => row.name)).toEqual(
+        expect.arrayContaining(objectNames)
+      )
     } finally {
       const cleanupTx = await getSuperuserPostgrestClient()
       await withDeleteEnabled(cleanupTx, async (db) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Delete objects/sign urls don't have a proper max limit. They are capped according to url length for the old postgrest implementation but it makes unnecessary allocation and not user friendly. 

## What is the new behavior?

Set a clear limit of 1000.

## Additional context

Internal batching is 500 because it fanouts with `.info` objects.
