### PR TITLE
fix: cap delete objects by config

### DIFF
--- a/migrations/multitenant/0027-delete-objects-limit.sql
+++ b/migrations/multitenant/0027-delete-objects-limit.sql
@@ -1,0 +1,8 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS delete_objects_limit int NULL;
+
+ALTER TABLE tenants
+  DROP CONSTRAINT IF EXISTS tenants_delete_objects_limit_positive;
+
+ALTER TABLE tenants
+  ADD CONSTRAINT tenants_delete_objects_limit_positive
+  CHECK (delete_objects_limit IS NULL OR delete_objects_limit > 0);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -7,6 +7,7 @@ const CONFIG_ENV_KEYS = [
   'TENANT_POOL_CACHE_HIT_LOG_SAMPLE_RATE',
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
   'DATABASE_POOL_DRAIN_TIMEOUT',
+  'REQUEST_HARD_LIMITS_ENABLED',
 ] as const
 
 type ConfigEnvKey = (typeof CONFIG_ENV_KEYS)[number]
@@ -56,6 +57,27 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheHitLogSampleRate).toBe(0)
     expect(config.tenantPoolCacheMissLogSampleRate).toBe(0)
     expect(config.databasePoolDrainTimeout).toBe(30_000)
+    expect(config.requestHardLimitsEnabled).toBe(false)
+  })
+
+  test('parses request hard limits as disabled by default', async () => {
+    setConfigEnv({})
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.requestHardLimitsEnabled).toBe(false)
+  })
+
+  test('enables request hard limits from env', async () => {
+    setConfigEnv({
+      REQUEST_HARD_LIMITS_ENABLED: 'true',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.requestHardLimitsEnabled).toBe(true)
   })
 
   test('parses database pool drain timeout in milliseconds', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,7 @@ type StorageConfigType = {
   databaseStatementTimeout: number
   databaseApplicationName: string
   region: string
+  requestHardLimitsEnabled: boolean
   requestTraceHeader?: string
   requestEtagHeaders: string[]
   responseSMaxAge: number
@@ -314,6 +315,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     requestAllowXForwardedPrefix:
       getOptionalConfigFromEnv('REQUEST_ALLOW_X_FORWARDED_PATH') === 'true',
+    requestHardLimitsEnabled: getOptionalConfigFromEnv('REQUEST_HARD_LIMITS_ENABLED') === 'true',
     storagePublicUrl: getOptionalConfigFromEnv('STORAGE_PUBLIC_URL'),
     requestTraceHeader: getOptionalConfigFromEnv('REQUEST_TRACE_HEADER', 'REQUEST_ID_HEADER'),
     requestEtagHeaders: getOptionalConfigFromEnv('REQUEST_ETAG_HEADERS')?.trim().split(',') || [

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -40,6 +40,7 @@ const patchSchema = {
       maxConnections: { type: 'number' },
       jwks: { type: 'object', nullable: true },
       fileSizeLimit: { type: 'number' },
+      deleteObjectsLimit: { type: 'integer', minimum: 1, nullable: true },
       jwtSecret: { type: 'string' },
       serviceKey: { type: 'string' },
       tracingMode: { type: 'string' },
@@ -121,6 +122,7 @@ interface tenantDBInterface {
   jwks: { keys?: JwksConfigKey[] } | null
   service_key: string
   file_size_limit?: number
+  delete_objects_limit?: number | null
   feature_s3_protocol?: boolean
   feature_purge_cache?: boolean
   feature_image_transformation?: boolean
@@ -264,6 +266,7 @@ export default async function routes(fastify: FastifyInstance) {
         database_pool_url,
         max_connections,
         file_size_limit,
+        delete_objects_limit,
         jwt_secret,
         jwks,
         service_key,
@@ -296,6 +299,10 @@ export default async function routes(fastify: FastifyInstance) {
           : {}),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
+        deleteObjectsLimit:
+          delete_objects_limit === null || delete_objects_limit === undefined
+            ? undefined
+            : Number(delete_objects_limit),
         migrationVersion: migrations_version,
         migrationStatus: migrations_status,
         tracingMode: tracing_mode,
@@ -341,6 +348,7 @@ export default async function routes(fastify: FastifyInstance) {
         database_pool_url,
         max_connections,
         file_size_limit,
+        delete_objects_limit,
         jwt_secret,
         jwks,
         service_key,
@@ -381,6 +389,10 @@ export default async function routes(fastify: FastifyInstance) {
           : {}),
         maxConnections: max_connections ? Number(max_connections) : undefined,
         fileSizeLimit: Number(file_size_limit),
+        deleteObjectsLimit:
+          delete_objects_limit === null || delete_objects_limit === undefined
+            ? undefined
+            : Number(delete_objects_limit),
         capabilities,
         features: {
           imageTransformation: {
@@ -422,6 +434,7 @@ export default async function routes(fastify: FastifyInstance) {
         anonKey,
         databaseUrl,
         fileSizeLimit,
+        deleteObjectsLimit,
         jwtSecret,
         jwks,
         serviceKey,
@@ -439,6 +452,7 @@ export default async function routes(fastify: FastifyInstance) {
         database_pool_url: databasePoolUrl ? encrypt(databasePoolUrl) : undefined,
         max_connections: maxConnections ? Number(maxConnections) : undefined,
         file_size_limit: fileSizeLimit,
+        delete_objects_limit: deleteObjectsLimit,
         jwt_secret: encrypt(jwtSecret),
         jwks: jwks || null,
         service_key: encrypt(serviceKey),
@@ -486,6 +500,7 @@ export default async function routes(fastify: FastifyInstance) {
         anonKey,
         databaseUrl,
         fileSizeLimit,
+        deleteObjectsLimit,
         jwtSecret,
         jwks,
         serviceKey,
@@ -507,6 +522,7 @@ export default async function routes(fastify: FastifyInstance) {
             : undefined,
         max_connections: maxConnections ? Number(maxConnections) : undefined,
         file_size_limit: fileSizeLimit,
+        delete_objects_limit: deleteObjectsLimit,
         jwt_secret: jwtSecret !== undefined ? encrypt(jwtSecret) : undefined,
         jwks,
         service_key: serviceKey !== undefined ? encrypt(serviceKey) : undefined,
@@ -557,6 +573,7 @@ export default async function routes(fastify: FastifyInstance) {
         anonKey,
         databaseUrl,
         fileSizeLimit,
+        deleteObjectsLimit,
         jwtSecret,
         jwks,
         serviceKey,
@@ -581,6 +598,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       if (fileSizeLimit) {
         tenantInfo.file_size_limit = fileSizeLimit
+      }
+
+      if (typeof deleteObjectsLimit !== 'undefined') {
+        tenantInfo.delete_objects_limit = deleteObjectsLimit
       }
 
       if (typeof features?.imageTransformation?.enabled !== 'undefined') {

--- a/src/http/routes/object/deleteObjects.ts
+++ b/src/http/routes/object/deleteObjects.ts
@@ -1,4 +1,4 @@
-import { objectRequestLimitSchema } from '@storage/limits'
+import { DELETE_OBJECTS_LIMIT_DESCRIPTION, enforceDeleteObjectsLimit } from '@storage/limits'
 import { objectSchema } from '@storage/schemas/object'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -20,7 +20,7 @@ const deleteObjectsBodySchema = {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
-      ...objectRequestLimitSchema(),
+      description: DELETE_OBJECTS_LIMIT_DESCRIPTION,
       examples: [['folder/cat.png', 'folder/morecats.png']],
     },
   },
@@ -60,6 +60,8 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketName } = request.params
       const prefixes = request.body['prefixes']
+
+      await enforceDeleteObjectsLimit(request.tenantId, prefixes.length)
 
       const results = await request.storage.from(bucketName).deleteObjects(prefixes)
 

--- a/src/http/routes/object/deleteObjects.ts
+++ b/src/http/routes/object/deleteObjects.ts
@@ -1,4 +1,4 @@
-import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
+import { objectRequestLimitSchema } from '@storage/limits'
 import { objectSchema } from '@storage/schemas/object'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -20,7 +20,7 @@ const deleteObjectsBodySchema = {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
-      maxItems: MAX_OBJECTS_PER_REQUEST,
+      ...objectRequestLimitSchema(),
       examples: [['folder/cat.png', 'folder/morecats.png']],
     },
   },

--- a/src/http/routes/s3/commands/delete-object.ts
+++ b/src/http/routes/s3/commands/delete-object.ts
@@ -1,4 +1,4 @@
-import { objectRequestLimitSchema } from '@storage/limits'
+import { DELETE_OBJECTS_LIMIT_DESCRIPTION, enforceDeleteObjectsLimit } from '@storage/limits'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { getConfig } from '../../../../config'
 import { ROUTE_OPERATIONS } from '../../operations'
@@ -34,7 +34,7 @@ const DeleteObjectsInput = {
         properties: {
           Object: {
             type: 'array',
-            ...objectRequestLimitSchema(),
+            description: DELETE_OBJECTS_LIMIT_DESCRIPTION,
             items: {
               type: 'object',
               properties: {
@@ -65,7 +65,9 @@ export default function DeleteObject(s3Router: S3Router) {
   s3Router.post(
     '/:Bucket?delete',
     { schema: DeleteObjectsInput, operation: ROUTE_OPERATIONS.S3_DELETE_OBJECTS },
-    (req, ctx) => {
+    async (req, ctx) => {
+      await enforceDeleteObjectsLimit(ctx.tenantId, req.Body.Delete.Object.length)
+
       const s3Protocol = new S3ProtocolHandler(ctx.storage, ctx.tenantId, ctx.owner)
 
       return s3Protocol.deleteObjects({

--- a/src/http/routes/s3/commands/delete-object.ts
+++ b/src/http/routes/s3/commands/delete-object.ts
@@ -1,4 +1,4 @@
-import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
+import { objectRequestLimitSchema } from '@storage/limits'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { getConfig } from '../../../../config'
 import { ROUTE_OPERATIONS } from '../../operations'
@@ -34,7 +34,7 @@ const DeleteObjectsInput = {
         properties: {
           Object: {
             type: 'array',
-            maxItems: MAX_OBJECTS_PER_REQUEST,
+            ...objectRequestLimitSchema(),
             items: {
               type: 'object',
               properties: {

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -278,7 +278,7 @@ describe('DeleteObject route mapping', () => {
     expect(validate.errors).toBeNull()
   })
 
-  it('rejects DeleteObjects payloads over the object request cap in router validation', async () => {
+  it('accepts DeleteObjects payloads over the object request cap by default', async () => {
     const { default: DeleteObject } = await import('./commands/delete-object')
     const router = new Router()
 
@@ -308,13 +308,63 @@ describe('DeleteObject route mapping', () => {
       },
     }
 
-    expect(validate(data)).toBe(false)
-    expect(validate.errors).toEqual([
-      expect.objectContaining({
-        instancePath: '/Body/Delete/Object',
-        keyword: 'maxItems',
-      }),
-    ])
+    expect(validate(data)).toBe(true)
+    expect(validate.errors).toBeNull()
+  })
+
+  it('rejects DeleteObjects payloads over the object request cap when hard limits are enabled', async () => {
+    const previousHardLimitsEnabled = process.env.REQUEST_HARD_LIMITS_ENABLED
+    process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
+    vi.resetModules()
+
+    try {
+      const [{ Router: FreshRouter }, { default: DeleteObject }] = await Promise.all([
+        import('./router'),
+        import('./commands/delete-object'),
+      ])
+      const router = new FreshRouter()
+
+      DeleteObject(router as unknown as S3Router)
+
+      const route = router
+        .routes()
+        .get('/:Bucket')
+        ?.find(
+          (candidate) =>
+            candidate.method === 'post' &&
+            candidate.querystringMatches.some((match) => match.key === 'delete')
+        )
+
+      expect(route).toBeDefined()
+
+      const validate = route!.compiledSchema()
+      const data = {
+        Params: { Bucket: 'bucket' },
+        Querystring: { delete: '' },
+        Body: {
+          Delete: {
+            Object: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map((i) => ({
+              Key: `object-${i}`,
+            })),
+          },
+        },
+      }
+
+      expect(validate(data)).toBe(false)
+      expect(validate.errors).toEqual([
+        expect.objectContaining({
+          instancePath: '/Body/Delete/Object',
+          keyword: 'maxItems',
+        }),
+      ])
+    } finally {
+      if (previousHardLimitsEnabled === undefined) {
+        delete process.env.REQUEST_HARD_LIMITS_ENABLED
+      } else {
+        process.env.REQUEST_HARD_LIMITS_ENABLED = previousHardLimitsEnabled
+      }
+      vi.resetModules()
+    }
   })
 
   it('returns 204 from iceberg single-object deletes', async () => {

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -312,7 +312,7 @@ describe('DeleteObject route mapping', () => {
     expect(validate.errors).toBeNull()
   })
 
-  it('rejects DeleteObjects payloads over the object request cap when hard limits are enabled', async () => {
+  it('keeps DeleteObjects router validation tenant-agnostic when hard limits are enabled', async () => {
     const previousHardLimitsEnabled = process.env.REQUEST_HARD_LIMITS_ENABLED
     process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
     vi.resetModules()
@@ -350,18 +350,77 @@ describe('DeleteObject route mapping', () => {
         },
       }
 
-      expect(validate(data)).toBe(false)
-      expect(validate.errors).toEqual([
-        expect.objectContaining({
-          instancePath: '/Body/Delete/Object',
-          keyword: 'maxItems',
-        }),
-      ])
+      expect(validate(data)).toBe(true)
+      expect(validate.errors).toBeNull()
     } finally {
       if (previousHardLimitsEnabled === undefined) {
         delete process.env.REQUEST_HARD_LIMITS_ENABLED
       } else {
         process.env.REQUEST_HARD_LIMITS_ENABLED = previousHardLimitsEnabled
+      }
+      vi.resetModules()
+    }
+  })
+
+  it('rejects DeleteObjects payloads over the default cap in the handler when hard limits are enabled', async () => {
+    const previousHardLimitsEnabled = process.env.REQUEST_HARD_LIMITS_ENABLED
+    const previousMultiTenant = process.env.MULTI_TENANT
+    process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
+    process.env.MULTI_TENANT = 'false'
+    vi.resetModules()
+
+    try {
+      const [{ Router: FreshRouter }, { default: DeleteObject }] = await Promise.all([
+        import('./router'),
+        import('./commands/delete-object'),
+      ])
+      const router = new FreshRouter()
+
+      DeleteObject(router as unknown as S3Router)
+
+      const route = router
+        .routes()
+        .get('/:Bucket')
+        ?.find(
+          (candidate) =>
+            candidate.method === 'post' &&
+            candidate.querystringMatches.some((match) => match.key === 'delete')
+        )
+
+      expect(route).toBeDefined()
+
+      await expect(
+        route!.handler!(
+          {
+            Params: { Bucket: 'bucket' },
+            Querystring: { delete: '' },
+            Headers: {},
+            Body: {
+              Delete: {
+                Object: [...Array(MAX_OBJECTS_PER_REQUEST + 1).keys()].map((i) => ({
+                  Key: `object-${i}`,
+                })),
+              },
+            },
+          },
+          {
+            tenantId: 'tenant-id',
+          } as never
+        )
+      ).rejects.toMatchObject({
+        code: 'InvalidRequest',
+        message: `Bulk object requests are limited to ${MAX_OBJECTS_PER_REQUEST} objects per request.`,
+      })
+    } finally {
+      if (previousHardLimitsEnabled === undefined) {
+        delete process.env.REQUEST_HARD_LIMITS_ENABLED
+      } else {
+        process.env.REQUEST_HARD_LIMITS_ENABLED = previousHardLimitsEnabled
+      }
+      if (previousMultiTenant === undefined) {
+        delete process.env.MULTI_TENANT
+      } else {
+        process.env.MULTI_TENANT = previousMultiTenant
       }
       vi.resetModules()
     }

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -21,6 +21,7 @@ export interface TenantConfigRow {
   jwks?: { keys?: JwksConfigKey[] } | null
   service_key: string
   file_size_limit?: number
+  delete_objects_limit?: number | null
   feature_s3_protocol?: boolean
   feature_purge_cache?: boolean
   feature_image_transformation?: boolean
@@ -51,6 +52,7 @@ const tenantWritableColumns = [
   'jwks',
   'service_key',
   'file_size_limit',
+  'delete_objects_limit',
   'feature_s3_protocol',
   'feature_purge_cache',
   'feature_image_transformation',

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -35,6 +35,7 @@ interface TenantConfig {
   serviceKeyPayload: {
     role: string
   }
+  deleteObjectsLimit?: number
   migrationVersion?: keyof typeof DBMigration
   migrationStatus?: TenantMigrationStatus
   syncMigrationsDone?: boolean
@@ -227,6 +228,7 @@ export async function getTenantConfig(
       image_transformation_max_resolution,
       database_pool_url,
       max_connections,
+      delete_objects_limit,
       migrations_version,
       migrations_status,
       tracing_mode,
@@ -246,6 +248,10 @@ export async function getTenantConfig(
       serviceKey,
       serviceKeyPayload: { role: dbServiceRole },
       maxConnections: max_connections ? Number(max_connections) : undefined,
+      deleteObjectsLimit:
+        delete_objects_limit === null || delete_objects_limit === undefined
+          ? undefined
+          : Number(delete_objects_limit),
       features: {
         imageTransformation: {
           enabled: Boolean(feature_image_transformation),
@@ -387,6 +393,16 @@ export async function getJwtSecret(tenantId: string): Promise<{
 export async function getFileSizeLimit(tenantId: string): Promise<number> {
   const { fileSizeLimit } = await getTenantConfig(tenantId)
   return fileSizeLimit
+}
+
+/**
+ * Get the maximum objects allowed per bulk object request for a tenant.
+ * Undefined means the tenant uses the service default.
+ * @param tenantId
+ */
+export async function getDeleteObjectsLimit(tenantId: string): Promise<number | undefined> {
+  const { deleteObjectsLimit } = await getTenantConfig(tenantId)
+  return deleteObjectsLimit
 }
 
 /**

--- a/src/storage/limits.test.ts
+++ b/src/storage/limits.test.ts
@@ -1,31 +1,59 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-describe('objectRequestLimitSchema', () => {
+const ENV = { ...process.env }
+
+describe('enforceDeleteObjectsLimit', () => {
   afterEach(() => {
-    delete process.env.REQUEST_HARD_LIMITS_ENABLED
+    process.env = { ...ENV }
+    vi.doUnmock('../internal/database/tenant')
     vi.resetModules()
   })
 
-  it('omits maxItems when hard limits are disabled', async () => {
-    delete process.env.REQUEST_HARD_LIMITS_ENABLED
+  it('does not enforce the object request cap until hard limits are enabled', async () => {
+    process.env.MULTI_TENANT = 'false'
+    process.env.REQUEST_HARD_LIMITS_ENABLED = 'false'
     vi.resetModules()
 
-    const { objectRequestLimitSchema, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
+    const { enforceDeleteObjectsLimit, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
 
-    expect(objectRequestLimitSchema()).toEqual({
-      description: `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`,
-    })
+    await expect(
+      enforceDeleteObjectsLimit('tenant-id', MAX_OBJECTS_PER_REQUEST + 1)
+    ).resolves.toBeUndefined()
   })
 
-  it('caps maxItems at the object request limit when hard limits are enabled', async () => {
+  it('enforces the default object request cap when hard limits are enabled', async () => {
+    process.env.MULTI_TENANT = 'false'
     process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
     vi.resetModules()
 
-    const { objectRequestLimitSchema, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
+    const { enforceDeleteObjectsLimit, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
 
-    expect(objectRequestLimitSchema()).toEqual({
-      maxItems: MAX_OBJECTS_PER_REQUEST,
-      description: `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`,
+    await expect(
+      enforceDeleteObjectsLimit('tenant-id', MAX_OBJECTS_PER_REQUEST + 1)
+    ).rejects.toMatchObject({
+      code: 'InvalidRequest',
+      message: `Bulk object requests are limited to ${MAX_OBJECTS_PER_REQUEST} objects per request.`,
     })
+  })
+
+  it('uses the tenant delete objects limit in multitenant mode', async () => {
+    process.env.MULTI_TENANT = 'true'
+    process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
+    const getDeleteObjectsLimit = vi.fn().mockResolvedValue(2000)
+    vi.doMock('../internal/database/tenant', () => ({
+      getDeleteObjectsLimit,
+      getFeatures: vi.fn(),
+      getFileSizeLimit: vi.fn(),
+    }))
+    vi.resetModules()
+
+    const { enforceDeleteObjectsLimit } = await import('./limits')
+
+    await expect(enforceDeleteObjectsLimit('tenant-id', 1500)).resolves.toBeUndefined()
+    await expect(enforceDeleteObjectsLimit('tenant-id', 2001)).rejects.toMatchObject({
+      code: 'InvalidRequest',
+      message: 'Bulk object requests are limited to 2000 objects per request.',
+    })
+    expect(getDeleteObjectsLimit).toHaveBeenCalledWith('tenant-id')
   })
 })

--- a/src/storage/limits.test.ts
+++ b/src/storage/limits.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('objectRequestLimitSchema', () => {
+  afterEach(() => {
+    delete process.env.REQUEST_HARD_LIMITS_ENABLED
+    vi.resetModules()
+  })
+
+  it('omits maxItems when hard limits are disabled', async () => {
+    delete process.env.REQUEST_HARD_LIMITS_ENABLED
+    vi.resetModules()
+
+    const { objectRequestLimitSchema, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
+
+    expect(objectRequestLimitSchema()).toEqual({
+      description: `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`,
+    })
+  })
+
+  it('caps maxItems at the object request limit when hard limits are enabled', async () => {
+    process.env.REQUEST_HARD_LIMITS_ENABLED = 'true'
+    vi.resetModules()
+
+    const { objectRequestLimitSchema, MAX_OBJECTS_PER_REQUEST } = await import('./limits')
+
+    expect(objectRequestLimitSchema()).toEqual({
+      maxItems: MAX_OBJECTS_PER_REQUEST,
+      description: `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`,
+    })
+  })
+})

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { getConfig } from '../config'
 import {
+  getDeleteObjectsLimit as getDeleteObjectsLimitForTenant,
   getFeatures,
   getFileSizeLimit as getFileSizeLimitForTenant,
 } from '../internal/database/tenant'
@@ -22,16 +23,30 @@ export const MAX_OBJECTS_PER_LOOKUP_BATCH = MAX_OBJECTS_PER_REQUEST
 export const ICEBERG_BUCKET_RESERVED_SUFFIX = icebergBucketDetectionSuffix
 export const RESERVED_BUCKET_SUFFIXES = [icebergBucketDetectionSuffix]
 
-export function objectRequestLimitSchema(): { maxItems?: number; description: string } {
-  const description = `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`
-  return requestHardLimitsEnabled
-    ? {
-        maxItems: MAX_OBJECTS_PER_REQUEST,
-        description,
-      }
-    : {
-        description,
-      }
+export const DELETE_OBJECTS_LIMIT_DESCRIPTION = `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`
+
+export async function getDeleteObjectsLimit(tenantId: string): Promise<number> {
+  if (isMultitenant) {
+    return (await getDeleteObjectsLimitForTenant(tenantId)) ?? MAX_OBJECTS_PER_REQUEST
+  }
+
+  return MAX_OBJECTS_PER_REQUEST
+}
+
+export async function enforceDeleteObjectsLimit(
+  tenantId: string,
+  objectCount: number
+): Promise<void> {
+  if (!requestHardLimitsEnabled) {
+    return
+  }
+
+  const deleteObjectsLimit = await getDeleteObjectsLimit(tenantId)
+  if (objectCount > deleteObjectsLimit) {
+    throw ERRORS.InvalidRequest(
+      `Bulk object requests are limited to ${deleteObjectsLimit} objects per request.`
+    )
+  }
 }
 
 /**

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -5,7 +5,12 @@ import {
   getFileSizeLimit as getFileSizeLimitForTenant,
 } from '../internal/database/tenant'
 
-const { isMultitenant, imageTransformationEnabled, icebergBucketDetectionSuffix } = getConfig()
+const {
+  isMultitenant,
+  imageTransformationEnabled,
+  icebergBucketDetectionSuffix,
+  requestHardLimitsEnabled,
+} = getConfig()
 
 export type BucketType = 'STANDARD' | 'ANALYTICS'
 
@@ -16,6 +21,18 @@ export const MAX_OBJECTS_PER_DELETE_BATCH = Math.floor(MAX_KEYS_PER_S3_DELETE / 
 export const MAX_OBJECTS_PER_LOOKUP_BATCH = MAX_OBJECTS_PER_REQUEST
 export const ICEBERG_BUCKET_RESERVED_SUFFIX = icebergBucketDetectionSuffix
 export const RESERVED_BUCKET_SUFFIXES = [icebergBucketDetectionSuffix]
+
+export function objectRequestLimitSchema(): { maxItems?: number; description: string } {
+  const description = `At most ${MAX_OBJECTS_PER_REQUEST} objects can be deleted per request.`
+  return requestHardLimitsEnabled
+    ? {
+        maxItems: MAX_OBJECTS_PER_REQUEST,
+        description,
+      }
+    : {
+        description,
+      }
+}
 
 /**
  * Get the maximum file size for a specific project

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1871,7 +1871,7 @@ describe('testing deleting multiple objects', () => {
     }
   })
 
-  test('rejects delete requests over the object request cap', async () => {
+  test('allows delete requests over the object request cap when hard limits are disabled', async () => {
     const response = await appInstance.inject({
       method: 'DELETE',
       url: '/object/bucket2',
@@ -1885,7 +1885,8 @@ describe('testing deleting multiple objects', () => {
       },
     })
 
-    expect(response.statusCode).toBe(400)
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual([])
     expect(S3Backend.prototype.deleteObjects).not.toHaveBeenCalled()
   })
 

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -2,6 +2,7 @@ import { encrypt, signJWT } from '@internal/auth'
 import { TENANT_CONFIG_CACHE_NAME } from '@internal/cache'
 import {
   closeMultitenantPg,
+  getDeleteObjectsLimit,
   jwksManager,
   multitenantPgExecutor,
   PgTenantConnection,
@@ -35,6 +36,7 @@ const payload = {
   databasePoolUrl: 'v',
   maxConnections: 12,
   fileSizeLimit: 1,
+  deleteObjectsLimit: 1500,
   jwtSecret: 'c',
   serviceKey: 'd',
   jwks: { keys: [] },
@@ -77,6 +79,7 @@ const payload2 = {
   databasePoolUrl: 'm',
   maxConnections: 14,
   fileSizeLimit: 2,
+  deleteObjectsLimit: 2000,
   jwtSecret: 'g',
   serviceKey: 'h',
   jwks: null,
@@ -228,6 +231,7 @@ describe('Tenant configs', () => {
 
     await expect(getServiceKey('abc')).resolves.toBe(payload.serviceKey)
     await expect(getFileSizeLimit('abc')).resolves.toBe(payload.fileSizeLimit)
+    await expect(getDeleteObjectsLimit('abc')).resolves.toBe(payload.deleteObjectsLimit)
     await expect(getFeatures('abc')).resolves.toEqual(payload.features)
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Delete objects are capped at 1000.

## What is the new behavior?

Add env configuration to control hard enable or disable. By default, be forgiving but update OpenAPI with the limit because it will be limited soon.
Have tenant specific config to provide time to adapt.

## Additional context

Related to #1160