### PR TITLE
fix: override child factory with identity

### DIFF
--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -186,6 +186,9 @@ async function httpServer(signal: AbortSignal) {
   const app: FastifyInstance<Server, IncomingMessage, ServerResponse> = build({
     loggerInstance: logger,
     disableRequestLogging: true,
+    childLoggerFactory(logger) {
+      return logger
+    },
     exposeDocs,
     requestIdHeader: requestTraceHeader,
     routerOptions: { maxParamLength: 2500 },
@@ -235,6 +238,9 @@ async function httpAdminServer(
   const adminApp = buildAdmin({
     loggerInstance: logger,
     disableRequestLogging: true,
+    childLoggerFactory(logger) {
+      return logger
+    },
     exposeDocs,
     requestIdHeader: adminRequestIdHeader,
   })

--- a/src/start/worker.ts
+++ b/src/start/worker.ts
@@ -64,6 +64,9 @@ export async function main() {
   const server = adminApp({
     loggerInstance: logger,
     disableRequestLogging: true,
+    childLoggerFactory(logger) {
+      return logger
+    },
     requestIdHeader: requestTraceHeader,
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fastify creates a child logger per request. It's useful to attach common fields into log lines but we don't use so child logger is per allocation/GC overhead.

## What is the new behavior?

Pass uniform factory to use parent logger directly to prevent allocation. 

## Additional context

This can roughly save 1-2% CPU and 10% of allocated objects.
