### PR TITLE
fix: inefficient traversal and intermediate allocations

### DIFF
--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -240,26 +240,25 @@ export default function PutObject(s3Router: S3Router) {
 }
 
 function fieldsToObject(fields: MultipartFields) {
-  return Object.keys(fields).reduce(
-    (acc, key) => {
-      const field = fields[key]
-      if (Array.isArray(field)) {
-        return acc
-      }
+  const acc: Record<string, string> = {}
 
-      if (!field) {
-        return acc
-      }
+  for (const key in fields) {
+    if (!Object.prototype.hasOwnProperty.call(fields, key)) {
+      continue
+    }
 
-      if (
-        field.type === 'field' &&
-        (typeof field.value === 'string' || field.value === 'number' || field.value === 'boolean')
-      ) {
-        acc[field.fieldname.toLowerCase()] = field.value
-      }
+    const field = fields[key]
+    if (Array.isArray(field) || !field) {
+      continue
+    }
 
-      return acc
-    },
-    {} as Record<string, string>
-  )
+    if (
+      field.type === 'field' &&
+      (typeof field.value === 'string' || field.value === 'number' || field.value === 'boolean')
+    ) {
+      acc[field.fieldname.toLowerCase()] = field.value
+    }
+  }
+
+  return acc
 }

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -99,11 +99,15 @@ export default async function routes(fastify: FastifyInstance) {
                 const headers = output.headers
 
                 if (headers) {
-                  Object.keys(headers).forEach((header) => {
+                  for (const header in headers) {
+                    if (!Object.prototype.hasOwnProperty.call(headers, header)) {
+                      continue
+                    }
+
                     if (headers[header]) {
                       reply.header(header, headers[header])
                     }
-                  })
+                  }
                 }
                 return reply.status(output.statusCode || 200).send(output.responseBody)
               } catch (e) {

--- a/src/internal/testing/generators/array.ts
+++ b/src/internal/testing/generators/array.ts
@@ -6,20 +6,3 @@ export async function eachParallel<T>(times: number, fn: (index: number) => Prom
 
   return Promise.all(promises)
 }
-
-// export function pickRandomFromArray<T>(arr: T[]): T {
-//   return arr[Math.floor(Math.random() * arr.length)]
-// }
-
-// export function pickRandomRangeFromArray<T>(arr: T[], range: number): T[] {
-//   if (arr.length <= range) {
-//     return arr
-//   }
-
-//   const result = new Set<T>()
-//   while (result.size < range) {
-//     result.add(pickRandomFromArray(arr))
-//   }
-
-//   return Array.from(result)
-// }

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -2,6 +2,7 @@ import {
   DeleteObjectsCommand,
   GetObjectCommand,
   HeadObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3'
@@ -160,6 +161,53 @@ describe('S3Backend', () => {
       const result = await backend.getObject('test-bucket', 'test-key', undefined)
 
       expect(result.metadata.mimetype).toBe('image/png')
+    })
+  })
+
+  describe('list', () => {
+    test('filters listed keys by cutoff date and strips the requested prefix', async () => {
+      mockSend.mockResolvedValue({
+        Contents: [
+          {
+            Key: 'tenant/bucket/old.txt',
+            LastModified: new Date('2024-01-01T00:00:00.000Z'),
+            Size: 12,
+          },
+          {
+            Key: 'tenant/bucket/new.txt',
+            LastModified: new Date('2024-01-03T00:00:00.000Z'),
+            Size: 34,
+          },
+          {
+            Key: 'tenant/bucket/no-date.txt',
+            Size: 56,
+          },
+          {
+            LastModified: new Date('2024-01-01T00:00:00.000Z'),
+            Size: 78,
+          },
+        ],
+        NextContinuationToken: 'next-page',
+      })
+
+      const backend = createBackend()
+
+      await expect(
+        backend.list('test-bucket', {
+          prefix: 'tenant/bucket',
+          beforeDate: new Date('2024-01-02T00:00:00.000Z'),
+        })
+      ).resolves.toEqual({
+        keys: [{ name: 'old.txt', size: 12 }],
+        nextToken: 'next-page',
+      })
+
+      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend.mock.calls[0][0]).toBeInstanceOf(ListObjectsV2Command)
+      expect(mockSend.mock.calls[0][0].input).toMatchObject({
+        Bucket: 'test-bucket',
+        Prefix: 'tenant/bucket',
+      })
     })
   })
 

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -393,26 +393,27 @@ export class S3Backend implements StorageBackendAdapter {
         StartAfter: options?.startAfter,
       })
       const data = await this.client.send(command)
-      const keys =
-        data.Contents?.filter((ele) => {
-          if (options?.beforeDate) {
-            if (ele.LastModified && ele.LastModified < options.beforeDate) {
-              return ele.Key as string
-            }
-            return false
-          }
-          return ele.Key
-        }).map((ele) => {
-          if (options?.prefix) {
-            return {
-              // remove prefix and leading slash if present
-              name: (ele.Key as string).replace(options.prefix, '').replace(/^\//, ''),
-              size: ele.Size as number,
-            }
-          }
+      const keys: { name: string; size: number }[] = []
 
-          return { name: ele.Key as string, size: ele.Size as number }
-        }) || []
+      for (const ele of data.Contents || []) {
+        if (!ele.Key) {
+          continue
+        }
+
+        if (options?.beforeDate && (!ele.LastModified || ele.LastModified >= options.beforeDate)) {
+          continue
+        }
+
+        if (options?.prefix) {
+          keys.push({
+            // remove prefix and leading slash if present
+            name: ele.Key.replace(options.prefix, '').replace(/^\//, ''),
+            size: ele.Size as number,
+          })
+        } else {
+          keys.push({ name: ele.Key, size: ele.Size as number })
+        }
+      }
 
       return {
         keys,

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -349,19 +349,16 @@ export class StoragePgDB implements Database {
 
     try {
       const result = await this.runQuery('CreateBucket', async (db, signal) => {
-        const entries = Object.entries(bucketData).filter(([, value]) => value !== undefined)
-        const columns = entries.map(([column]) => quoteIdentifier(column))
-        const values = entries.map(([, value]) => value)
-        const placeholders = entries.map((_, index) => `$${index + 1}`)
+        const insert = buildInsert(bucketData as Record<string, unknown>)
 
         return this.query(
           db,
           {
             text: `
-              INSERT INTO storage.buckets (${columns.join(', ')})
-              VALUES (${placeholders.join(', ')})
+              INSERT INTO storage.buckets (${insert.columns})
+              VALUES (${insert.placeholders})
             `,
-            values,
+            values: insert.values,
           },
           signal
         )
@@ -840,10 +837,22 @@ export class StoragePgDB implements Database {
 
     const result = await this.runQuery('UpsertObject', async (db, signal) => {
       const insert = buildInsert(objectData)
-      const updateEntries = Object.entries(updateData).filter(([, value]) => value !== undefined)
-      const updateClause = updateEntries
-        .map(([column]) => `${quoteIdentifier(column)} = EXCLUDED.${quoteIdentifier(column)}`)
-        .join(', ')
+      const updateRecord = updateData as Record<string, unknown>
+      const updateClauses: string[] = []
+
+      for (const column in updateRecord) {
+        if (!Object.prototype.hasOwnProperty.call(updateRecord, column)) {
+          continue
+        }
+
+        if (updateRecord[column] === undefined) {
+          continue
+        }
+
+        updateClauses.push(`${quoteIdentifier(column)} = EXCLUDED.${quoteIdentifier(column)}`)
+      }
+
+      const updateClause = updateClauses.join(', ')
 
       return this.query<Obj>(
         db,
@@ -1632,17 +1641,21 @@ export class StoragePgDB implements Database {
     }
 
     await this.runUnscopedQuery('InsertS3KeysIntoTempTable', async (db, signal) => {
-      const values = keys.flatMap((key) => [key.key, key.size])
-      const placeholders = keys
-        .map((_, index) => `($${index * 2 + 1}, $${index * 2 + 2})`)
-        .join(', ')
+      const values: (string | number)[] = []
+      const placeholders: string[] = []
+
+      for (let index = 0; index < keys.length; index++) {
+        const key = keys[index]
+        placeholders.push(`($${index * 2 + 1}, $${index * 2 + 2})`)
+        values.push(key.key, key.size)
+      }
 
       await this.query(
         db,
         {
           text: `
             INSERT INTO ${quoteQualifiedIdentifier(tableName)} (key, size)
-            VALUES ${placeholders}
+            VALUES ${placeholders.join(', ')}
             ON CONFLICT DO NOTHING
           `,
           values,
@@ -1680,19 +1693,34 @@ export class StoragePgDB implements Database {
       }
 
       if (typeof columns === 'string') {
-        return columns
-          .split(',')
-          .map((column) => column.trim())
-          .filter((column) => !rule.newColumns.includes(column))
-          .join(',') as T
+        const normalizedColumns: string[] = []
+        for (const column of columns.split(',')) {
+          const trimmed = column.trim()
+          if (rule.newColumns.includes(trimmed)) {
+            continue
+          }
+
+          normalizedColumns.push(trimmed)
+        }
+
+        return normalizedColumns.join(',') as T
       }
 
-      const normalizedColumns: Record<string, unknown> = {
-        ...(columns as Record<string, unknown>),
+      const normalizedColumns: Record<string, unknown> = {}
+      const sourceColumns = columns as Record<string, unknown>
+
+      for (const column in sourceColumns) {
+        if (!Object.prototype.hasOwnProperty.call(sourceColumns, column)) {
+          continue
+        }
+
+        if (rule.newColumns.includes(column)) {
+          continue
+        }
+
+        normalizedColumns[column] = sourceColumns[column]
       }
-      for (const column of rule.newColumns) {
-        delete normalizedColumns[column]
-      }
+
       return normalizedColumns as T
     }
 
@@ -1700,13 +1728,16 @@ export class StoragePgDB implements Database {
   }
 
   protected normalizeMultipartUploadColumns(columns: string): string[] {
-    let normalizedColumns = this.normalizeColumns(columns)
-      .split(',')
-      .map((column) => column.trim())
-      .filter((column) => column.length > 0)
+    const normalizedColumns: string[] = []
+    const hasMetadataColumn = this.hasMultipartMetadataColumn()
 
-    if (!this.hasMultipartMetadataColumn()) {
-      normalizedColumns = normalizedColumns.filter((column) => column !== 'metadata')
+    for (const column of this.normalizeColumns(columns).split(',')) {
+      const trimmed = column.trim()
+      if (!trimmed || (!hasMetadataColumn && trimmed === 'metadata')) {
+        continue
+      }
+
+      normalizedColumns.push(trimmed)
     }
 
     return normalizedColumns
@@ -1904,19 +1935,34 @@ export class StoragePgDB implements Database {
 }
 
 function selectColumns(columns: string | string[]): string {
-  const columnNames = Array.isArray(columns)
-    ? columns
-    : columns.split(',').map((column) => column.trim())
+  const selected: string[] = []
 
-  const selected = columnNames
-    .filter((column) => column.length > 0)
-    .map((column) => {
-      if (column === '*') {
-        return '*'
+  if (Array.isArray(columns)) {
+    for (const column of columns) {
+      if (column.length === 0) {
+        continue
       }
 
-      return quoteIdentifier(column)
-    })
+      if (column === '*') {
+        selected.push('*')
+      } else {
+        selected.push(quoteIdentifier(column))
+      }
+    }
+  } else {
+    for (const column of columns.split(',')) {
+      const trimmed = column.trim()
+      if (trimmed.length === 0) {
+        continue
+      }
+
+      if (trimmed === '*') {
+        selected.push('*')
+      } else {
+        selected.push(quoteIdentifier(trimmed))
+      }
+    }
+  }
 
   return selected.length ? selected.join(', ') : quoteIdentifier('id')
 }
@@ -1930,16 +1976,33 @@ function buildInsert(data: Record<string, unknown>): {
   placeholders: string
   values: unknown[]
 } {
-  const entries = Object.entries(data).filter(([, value]) => value !== undefined)
+  const columns: string[] = []
+  const placeholders: string[] = []
+  const values: unknown[] = []
 
-  if (entries.length === 0) {
+  for (const column in data) {
+    if (!Object.prototype.hasOwnProperty.call(data, column)) {
+      continue
+    }
+
+    const value = data[column]
+    if (value === undefined) {
+      continue
+    }
+
+    values.push(value)
+    columns.push(quoteIdentifier(column))
+    placeholders.push(`$${values.length}`)
+  }
+
+  if (values.length === 0) {
     throw ERRORS.NoContentProvided()
   }
 
   return {
-    columns: entries.map(([column]) => quoteIdentifier(column)).join(', '),
-    placeholders: entries.map((_, index) => `$${index + 1}`).join(', '),
-    values: entries.map(([, value]) => value),
+    columns: columns.join(', '),
+    placeholders: placeholders.join(', '),
+    values,
   }
 }
 
@@ -1947,17 +2010,30 @@ function buildUpdate(data: Record<string, unknown>): {
   setClause: string
   values: unknown[]
 } {
-  const entries = Object.entries(data).filter(([, value]) => value !== undefined)
+  const setClauses: string[] = []
+  const values: unknown[] = []
 
-  if (entries.length === 0) {
+  for (const column in data) {
+    if (!Object.prototype.hasOwnProperty.call(data, column)) {
+      continue
+    }
+
+    const value = data[column]
+    if (value === undefined) {
+      continue
+    }
+
+    values.push(value)
+    setClauses.push(`${quoteIdentifier(column)} = $${values.length}`)
+  }
+
+  if (values.length === 0) {
     throw ERRORS.NoContentProvided()
   }
 
   return {
-    setClause: entries
-      .map(([column], index) => `${quoteIdentifier(column)} = $${index + 1}`)
-      .join(', '),
-    values: entries.map(([, value]) => value),
+    setClause: setClauses.join(', '),
+    values,
   }
 }
 
@@ -1965,9 +2041,18 @@ function buildTupleValues(values: { name: string; version: string }[]): {
   placeholders: string
   values: string[]
 } {
+  const placeholders: string[] = []
+  const queryValues: string[] = []
+
+  for (let index = 0; index < values.length; index++) {
+    const { name, version } = values[index]
+    placeholders.push(`($${index * 2 + 2}, $${index * 2 + 3})`)
+    queryValues.push(name, version)
+  }
+
   return {
-    placeholders: values.map((_, index) => `($${index * 2 + 2}, $${index * 2 + 3})`).join(', '),
-    values: values.flatMap(({ name, version }) => [name, version]),
+    placeholders: placeholders.join(', '),
+    values: queryValues,
   }
 }
 

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -660,28 +660,26 @@ export class ObjectStorage {
       searchResult = delimitedResults
     }
 
-    let isTruncated = false
-
-    if (searchResult.length > limit) {
-      searchResult = searchResult.slice(0, limit)
-      isTruncated = true
-    }
+    const isTruncated = searchResult.length > limit
+    const resultCount = isTruncated ? limit : searchResult.length
 
     const folders: Obj[] = []
     const objects: Obj[] = []
-    searchResult.forEach((obj) => {
+    for (let index = 0; index < resultCount; index++) {
+      const obj = searchResult[index]
       const target = obj.id === null ? folders : objects
       const name = obj.id === null && !obj.name.endsWith('/') ? obj.name + '/' : obj.name
       target.push({
         ...obj,
         name: options?.encodingType === 'url' ? encodeURIComponent(name) : name,
       })
-    })
+    }
 
     let nextContinuationToken: string | undefined
     let nextCursorKey: string | undefined
 
     if (isTruncated) {
+      const lastObject = searchResult[resultCount - 1]
       const sortColumn = (cursor?.sortColumn || options?.sortBy?.column) as
         | 'name'
         | 'created_at'
@@ -689,15 +687,15 @@ export class ObjectStorage {
         | undefined
 
       nextContinuationToken = encodeContinuationToken({
-        startAfter: searchResult[searchResult.length - 1].name,
+        startAfter: lastObject.name,
         sortOrder: cursor?.sortOrder || options?.sortBy?.order,
         sortColumn,
         sortColumnAfter:
-          sortColumn && sortColumn !== 'name' && searchResult[searchResult.length - 1][sortColumn]
-            ? new Date(searchResult[searchResult.length - 1][sortColumn] || '').toISOString()
+          sortColumn && sortColumn !== 'name' && lastObject[sortColumn]
+            ? new Date(lastObject[sortColumn] || '').toISOString()
             : undefined,
       })
-      nextCursorKey = searchResult[searchResult.length - 1].name
+      nextCursorKey = lastObject.name
     }
 
     return {
@@ -724,12 +722,16 @@ export class ObjectStorage {
   ) {
     await this.findObject(objectName)
 
-    metadata = Object.keys(metadata || {}).reduce((all, key) => {
-      if (!all[key]) {
-        delete all[key]
+    metadata = metadata || {}
+    for (const key in metadata) {
+      if (!Object.prototype.hasOwnProperty.call(metadata, key)) {
+        continue
       }
-      return all
-    }, metadata || {})
+
+      if (!metadata[key]) {
+        delete metadata[key]
+      }
+    }
 
     // security-in-depth: as signObjectUrl could be used as a signing oracle,
     // make sure it's never able to specify a role JWT claim, nor the claims that
@@ -781,7 +783,10 @@ export class ObjectStorage {
       }
     }
 
-    const nameSet = new Set(results.map(({ name }) => name))
+    const nameSet = new Set<string>()
+    for (const { name } of results) {
+      nameSet.add(name)
+    }
 
     const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
 

--- a/src/storage/protocols/iceberg/pg.ts
+++ b/src/storage/protocols/iceberg/pg.ts
@@ -569,21 +569,25 @@ export class PgMetastore implements Metastore<PgTransaction> {
     values: unknown[],
     limit: number
   ): Promise<number> {
-    const queryValues = [...values, limit]
-    const result = await this.query<{ count: string | number }>(
-      `
-        SELECT count(*) AS count
-        FROM (
-          SELECT 1
-          FROM ${this.table(tableName)}
-          ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
-          LIMIT $${queryValues.length}
-        ) limited_rows
-      `,
-      queryValues
-    )
+    values.push(limit)
+    try {
+      const result = await this.query<{ count: string | number }>(
+        `
+          SELECT count(*) AS count
+          FROM (
+            SELECT 1
+            FROM ${this.table(tableName)}
+            ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
+            LIMIT $${values.length}
+          ) limited_rows
+        `,
+        values
+      )
 
-    return Number(result.rows[0]?.count ?? 0)
+      return Number(result.rows[0]?.count ?? 0)
+    } finally {
+      values.pop()
+    }
   }
 
   private addTenantCondition(

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -228,14 +228,16 @@ export class S3ProtocolHandler {
       encodingType: command.EncodingType,
     })
 
-    const commonPrefixes = results.folders.map((object) => {
-      return {
+    const commonPrefixes: { Prefix: string }[] = []
+    for (const object of results.folders) {
+      commonPrefixes.push({
         Prefix: object.name,
-      }
-    })
+      })
+    }
 
-    const contents =
-      results.objects.map((o) => ({
+    const contents: NonNullable<ListObjectsV2Output['Contents']> = []
+    for (const o of results.objects) {
+      contents.push({
         Key: o.name,
         LastModified: (o.updated_at ? new Date(o.updated_at).toISOString() : undefined) as
           | Date
@@ -243,7 +245,8 @@ export class S3ProtocolHandler {
         ETag: o.metadata?.eTag as string,
         Size: (o.metadata?.size as number) || 0,
         StorageClass: 'STANDARD' as const,
-      })) || []
+      })
+    }
 
     const response: { ListBucketResult: ListObjectsV2Output } = {
       ListBucketResult: {
@@ -339,36 +342,42 @@ export class S3ProtocolHandler {
       results = delimitedResults
     }
 
-    let isTruncated = false
+    const isTruncated = results.length > limit
+    const resultCount = isTruncated ? limit : results.length
 
-    if (results.length > limit) {
-      results = results.slice(0, limit)
-      isTruncated = true
-    }
+    const commonPrefixes: { Prefix: string | undefined }[] = []
+    const uploads: {
+      Key: string | undefined
+      Initiated: string | undefined
+      UploadId: string | undefined
+      StorageClass: 'STANDARD'
+    }[] = []
 
-    const commonPrefixes = results
-      .filter((e) => e.isFolder)
-      .map((object) => {
-        return {
+    for (let index = 0; index < resultCount; index++) {
+      const object = results[index]
+
+      if (object.isFolder) {
+        commonPrefixes.push({
           Prefix: object.key,
-        }
-      })
-
-    const uploads =
-      results
-        .filter((o) => !o.isFolder)
-        .map((o) => ({
-          Key: command.EncodingType === 'url' && o.key ? encodeURIComponent(o.key) : o.key,
-          Initiated: o.created_at ? new Date(o.created_at).toISOString() : undefined,
-          UploadId: o.id,
+        })
+      } else {
+        uploads.push({
+          Key:
+            command.EncodingType === 'url' && object.key
+              ? encodeURIComponent(object.key)
+              : object.key,
+          Initiated: object.created_at ? new Date(object.created_at).toISOString() : undefined,
+          UploadId: object.id,
           StorageClass: 'STANDARD',
-        })) || []
+        })
+      }
+    }
 
     let keyNextContinuationToken: string | undefined
     let uploadNextContinuationToken: string | undefined
 
     if (isTruncated) {
-      const lastItem = results[results.length - 1]
+      const lastItem = results[resultCount - 1]
       keyNextContinuationToken = encodeContinuationToken(lastItem.key!)
       uploadNextContinuationToken = encodeContinuationToken(lastItem.id!)
     }
@@ -386,7 +395,7 @@ export class S3ProtocolHandler {
         MaxUploads: limit,
         Delimiter: delimiter,
         EncodingType: encodingType,
-        KeyCount: results.length,
+        KeyCount: resultCount,
         CommonPrefixes: commonPrefixes,
       },
     }
@@ -1046,13 +1055,25 @@ export class S3ProtocolHandler {
       return { responseBody: { DeleteResult: { Deleted: [], Error: [] } } }
     }
 
-    const requestedKeys = Delete.Objects.filter((object) => object.Key !== undefined).map(
-      (object) => object.Key || ''
-    )
+    const requestedKeys: string[] = []
+    for (const object of Delete.Objects) {
+      if (object.Key !== undefined) {
+        requestedKeys.push(object.Key || '')
+      }
+    }
 
     const deletedObjects = await this.storage.from(Bucket).deleteObjects(requestedKeys)
-    const deletedNames = new Set(deletedObjects.map((object) => object.name))
-    const unresolvedKeys = requestedKeys.filter((key) => !deletedNames.has(key))
+    const deletedNames = new Set<string>()
+    for (const object of deletedObjects) {
+      deletedNames.add(object.name)
+    }
+
+    const unresolvedKeys: string[] = []
+    for (const key of requestedKeys) {
+      if (!deletedNames.has(key)) {
+        unresolvedKeys.push(key)
+      }
+    }
 
     const remainingObjects =
       unresolvedKeys.length > 0
@@ -1063,7 +1084,10 @@ export class S3ProtocolHandler {
       await this.storage.asSuperUser().findBucket(Bucket)
     }
 
-    const remainingNames = new Set(remainingObjects.map((object) => object.name))
+    const remainingNames = new Set<string>()
+    for (const object of remainingObjects) {
+      remainingNames.add(object.name)
+    }
 
     const deleted: { Key: string }[] = []
     const errors: { Key?: string; Code: string; Message: string }[] = []
@@ -1185,22 +1209,28 @@ export class S3ProtocolHandler {
 
     const maxParts = Math.min(command.MaxParts || 1000, 1000)
 
-    let result = await this.storage.db.listParts(command.UploadId, {
+    const result = await this.storage.db.listParts(command.UploadId, {
       afterPart: command.PartNumberMarker,
       maxParts: maxParts + 1,
     })
 
     const isTruncated = result.length > maxParts
-    if (isTruncated) {
-      result = result.slice(0, maxParts)
-    }
-    const nextPartNumberMarker = isTruncated ? result[result.length - 1].part_number : undefined
+    const resultCount = isTruncated ? maxParts : result.length
+    const nextPartNumberMarker = isTruncated ? result[resultCount - 1].part_number : undefined
 
-    const parts = result.map((part) => ({
-      PartNumber: part.part_number,
-      LastModified: part.created_at ? new Date(part.created_at).toISOString() : undefined,
-      ETag: part.etag,
-    }))
+    const parts: {
+      PartNumber: number
+      LastModified: string | undefined
+      ETag: string | undefined
+    }[] = []
+    for (let index = 0; index < resultCount; index++) {
+      const part = result[index]
+      parts.push({
+        PartNumber: part.part_number,
+        LastModified: part.created_at ? new Date(part.created_at).toISOString() : undefined,
+        ETag: part.etag,
+      })
+    }
 
     return {
       responseBody: {
@@ -1445,14 +1475,18 @@ function toAwsMeatadataHeaders(records: Record<string, unknown>) {
   const metadataHeaders: Record<string, unknown> = {}
   let missingCount = 0
 
-  Object.keys(records).forEach((key) => {
+  for (const key in records) {
+    if (!Object.prototype.hasOwnProperty.call(records, key)) {
+      continue
+    }
+
     const value = records[key]
     if (value && typeof value === 'string' && isUSASCII(value) && isValidHeader(key, value)) {
       metadataHeaders['x-amz-meta-' + key.toLowerCase()] = value
     } else {
       missingCount++
     }
-  })
+  }
 
   if (missingCount > 0) {
     metadataHeaders['x-amz-missing-meta'] = missingCount

--- a/src/test/utils/storage.ts
+++ b/src/test/utils/storage.ts
@@ -16,9 +16,6 @@ import { Storage } from '@storage/storage'
 import { Uploader } from '@storage/uploader'
 import { getConfig } from '../../config'
 
-// import { CreateBucketCommand, HeadBucketCommand, S3Client } from '@aws-sdk/client-s3'
-// import { isS3Error } from '@internal/errors'
-
 const { databaseURL, tenantId, storageBackendType, storageS3Bucket } = getConfig()
 
 /**
@@ -91,9 +88,6 @@ export function useStorage(options: { ensureMigrations?: boolean } = {}) {
   })
 
   return {
-    // get connection() {
-    //   return connection
-    // },
     get random() {
       return {
         name(prefix: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring for performance

## What is the current behavior?

We have some inefficient iteration (Object.keys) and intermediate allocations (filter then map) in hot paths.

## What is the new behavior?

Use iterative for loops to get rid of them. 

