### PR TITLE
fix: drop sizeof and pass estimates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "jose": "^6.2.2",
         "json-bigint": "^1.0.0",
         "lru-cache": "^11.2.0",
-        "object-sizeof": "^2.6.4",
         "pg": "^8.12.0",
         "pg-boss": "github:supabase/pg-boss#feat/exactly_once",
         "pg-listen": "^1.7.0",
@@ -14849,37 +14848,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/object-sizeof": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-2.6.4.tgz",
-      "integrity": "sha512-YuJAf7Bi61KROcYmXm8RCeBrBw8UOaJDzTm1gp0eU7RjYi1xEte3/Nmg/VyPaHcJZ3sNojs1Y0xvSrgwkLmcFw==",
-      "dependencies": {
-        "buffer": "^6.0.3"
-      }
-    },
-    "node_modules/object-sizeof/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -27763,25 +27731,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
       "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA=="
-    },
-    "object-sizeof": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-2.6.4.tgz",
-      "integrity": "sha512-YuJAf7Bi61KROcYmXm8RCeBrBw8UOaJDzTm1gp0eU7RjYi1xEte3/Nmg/VyPaHcJZ3sNojs1Y0xvSrgwkLmcFw==",
-      "requires": {
-        "buffer": "^6.0.3"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
-      }
     },
     "obug": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "jose": "^6.2.2",
     "json-bigint": "^1.0.0",
     "lru-cache": "^11.2.0",
-    "object-sizeof": "^2.6.4",
     "pg": "^8.12.0",
     "pg-boss": "github:supabase/pg-boss#feat/exactly_once",
     "pg-listen": "^1.7.0",

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -1,12 +1,13 @@
 import { decrypt, encrypt, generateHS512JWK } from '@internal/auth'
 import {
+  calculateMaxCacheSizeBytes,
+  createConstantSizeCalculation,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_JWKS_CACHE_NAME,
 } from '@internal/cache'
 import { createMutexByKey } from '@internal/concurrency'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
-import objectSizeOf from 'object-sizeof'
 import { JwksConfig, JwksConfigKeyOCT } from '../../../config'
 import { TENANTS_JWKS_UPDATE_CHANNEL } from './channels'
 import { JWKSManagerStore } from './store'
@@ -15,15 +16,22 @@ const JWK_KIND_STORAGE_URL_SIGNING = 'storage-url-signing-key'
 const JWK_KID_SEPARATOR = '_'
 
 const tenantJwksMutex = createMutexByKey<JwksConfig>()
+// Max 16,384 items. At ~2.5KB per JWKS, this uses roughly ~40MB of heap memory worst-case.
 export const TENANT_JWKS_CACHE_MAX_ITEMS = 16384
-export const TENANT_JWKS_CACHE_MAX_SIZE_BYTES = 1024 * 1024 * 50 // 50 MiB
+export const TENANT_JWKS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES = 2.5 * 1024
+export const TENANT_JWKS_CACHE_MAX_SIZE_BYTES = calculateMaxCacheSizeBytes(
+  TENANT_JWKS_CACHE_MAX_ITEMS,
+  TENANT_JWKS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+)
 export const TENANT_JWKS_CACHE_TTL_MS = 1000 * 60 * 60 // 1h
 
 const tenantJwksConfigCache = createLruCache<string, JwksConfig>(TENANT_JWKS_CACHE_NAME, {
   max: TENANT_JWKS_CACHE_MAX_ITEMS,
   maxSize: TENANT_JWKS_CACHE_MAX_SIZE_BYTES,
   ttl: TENANT_JWKS_CACHE_TTL_MS,
-  sizeCalculation: (value) => objectSizeOf(value),
+  sizeCalculation: createConstantSizeCalculation<JwksConfig, string>(
+    TENANT_JWKS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+  ),
   updateAgeOnGet: true,
   allowStale: false,
   purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
 import {
+  calculateMaxCacheSizeBytes,
+  createConstantSizeCalculation,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   JWT_CACHE_NAME,
@@ -15,7 +17,6 @@ import {
   jwtVerify,
   SignJWT,
 } from 'jose'
-import objectSizeOf from 'object-sizeof'
 import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
 
 const { jwtAlgorithm } = getConfig()
@@ -197,14 +198,21 @@ function getJWTCacheKey(token: string, secret: string, jwks?: { keys: JwksConfig
 
 // JWT payloads are comparatively small and high-churn, so keep a higher
 // cardinality guardrail than the longer-lived config-style caches.
+// Max 65,536 items. At ~2KB per JWT, this uses roughly ~130MB of heap memory worst-case.
 export const JWT_CACHE_MAX_ITEMS = 65536
-export const JWT_CACHE_MAX_SIZE_BYTES = 1024 * 1024 * 50 // 50 MiB
+export const JWT_CACHE_ESTIMATED_ENTRY_SIZE_BYTES = 2 * 1024
+export const JWT_CACHE_MAX_SIZE_BYTES = calculateMaxCacheSizeBytes(
+  JWT_CACHE_MAX_ITEMS,
+  JWT_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+)
 export const JWT_CACHE_TTL_RESOLUTION_MS = 5000 // 5 seconds
 
 const jwtCache = createLruCache<string, JWTPayload>(JWT_CACHE_NAME, {
   max: JWT_CACHE_MAX_ITEMS,
   maxSize: JWT_CACHE_MAX_SIZE_BYTES,
-  sizeCalculation: (value) => objectSizeOf(value),
+  sizeCalculation: createConstantSizeCalculation<JWTPayload, string>(
+    JWT_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+  ),
   ttlResolution: JWT_CACHE_TTL_RESOLUTION_MS,
   purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
 })

--- a/src/internal/cache/index.ts
+++ b/src/internal/cache/index.ts
@@ -1,4 +1,5 @@
 export * from './adapter'
 export * from './lru'
 export * from './names'
+export * from './size'
 export * from './ttl'

--- a/src/internal/cache/size.test.ts
+++ b/src/internal/cache/size.test.ts
@@ -1,0 +1,21 @@
+import { calculateMaxCacheSizeBytes, createConstantSizeCalculation } from './size'
+
+describe('cache sizing helpers', () => {
+  test('calculates max cache size from entry count and estimated entry size', () => {
+    expect(calculateMaxCacheSizeBytes(4, 512)).toBe(2048)
+  })
+
+  test('returns a stable per-entry size without inspecting cached values', () => {
+    const value = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('value should not be inspected')
+        },
+      }
+    )
+    const sizeCalculation = createConstantSizeCalculation<object, string>(512)
+
+    expect(sizeCalculation(value, 'cache-key')).toBe(512)
+  })
+})

--- a/src/internal/cache/size.ts
+++ b/src/internal/cache/size.ts
@@ -1,0 +1,25 @@
+function assertPositiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${name} must be a positive integer`)
+  }
+
+  return value
+}
+
+export function calculateMaxCacheSizeBytes(
+  maxItems: number,
+  estimatedEntrySizeBytes: number
+): number {
+  return (
+    assertPositiveInteger(maxItems, 'maxItems') *
+    assertPositiveInteger(estimatedEntrySizeBytes, 'estimatedEntrySizeBytes')
+  )
+}
+
+export function createConstantSizeCalculation<V, K>(
+  estimatedEntrySizeBytes: number
+): (value: V, key: K) => number {
+  const size = assertPositiveInteger(estimatedEntrySizeBytes, 'estimatedEntrySizeBytes')
+
+  return () => size
+}

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -1,4 +1,6 @@
 import {
+  calculateMaxCacheSizeBytes,
+  createConstantSizeCalculation,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_CONFIG_CACHE_NAME,
@@ -11,7 +13,6 @@ import {
   S3CredentialsManagerStorePg,
 } from '@storage/protocols/s3/credentials'
 import { JWTPayload } from 'jose'
-import objectSizeOf from 'object-sizeof'
 import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
 import { decrypt } from '../auth'
 import { JWKSManager, JWKSManagerStorePg } from '../auth/jwks'
@@ -88,15 +89,22 @@ const {
   databaseMaxConnections,
 } = getConfig()
 
+// Max 16,384 items. At ~2KB per config, this uses roughly ~32MB of heap memory worst-case.
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
-export const TENANT_CONFIG_CACHE_MAX_SIZE_BYTES = 1024 * 1024 * 50 // 50 MiB
+export const TENANT_CONFIG_CACHE_ESTIMATED_ENTRY_SIZE_BYTES = 2 * 1024
+export const TENANT_CONFIG_CACHE_MAX_SIZE_BYTES = calculateMaxCacheSizeBytes(
+  TENANT_CONFIG_CACHE_MAX_ITEMS,
+  TENANT_CONFIG_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+)
 export const TENANT_CONFIG_CACHE_TTL_MS = 1000 * 60 * 60 // 1h
 
 const tenantConfigCache = createLruCache<string, TenantConfig>(TENANT_CONFIG_CACHE_NAME, {
   max: TENANT_CONFIG_CACHE_MAX_ITEMS,
   maxSize: TENANT_CONFIG_CACHE_MAX_SIZE_BYTES,
   ttl: TENANT_CONFIG_CACHE_TTL_MS,
-  sizeCalculation: (value) => objectSizeOf(value),
+  sizeCalculation: createConstantSizeCalculation<TenantConfig, string>(
+    TENANT_CONFIG_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+  ),
   updateAgeOnGet: true,
   allowStale: false,
   purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,

--- a/src/storage/protocols/s3/credentials/manager.ts
+++ b/src/storage/protocols/s3/credentials/manager.ts
@@ -1,6 +1,8 @@
 import crypto from 'node:crypto'
 import { decrypt, encrypt } from '@internal/auth'
 import {
+  calculateMaxCacheSizeBytes,
+  createConstantSizeCalculation,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_S3_CREDENTIALS_CACHE_NAME,
@@ -8,15 +10,19 @@ import {
 import { createMutexByKey } from '@internal/concurrency'
 import { ERRORS } from '@internal/errors'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
-import objectSizeOf from 'object-sizeof'
 import { getConfig } from '../../../../config'
 import { S3Credentials, S3CredentialsManagerStore, S3CredentialsRaw } from './store'
 
 const TENANTS_S3_CREDENTIALS_UPDATE_CHANNEL = 'tenants_s3_credentials_update'
 // S3 credential entries are heavier and have a lower expected working-set
 // cardinality than JWT payloads, so keep a tighter entry-count guardrail.
+// Max 16,384 items. At ~0.5KB per credential, this uses roughly ~8MB of heap memory worst-case.
 export const TENANT_S3_CREDENTIALS_CACHE_MAX_ITEMS = 16384
-export const TENANT_S3_CREDENTIALS_CACHE_MAX_SIZE_BYTES = 1024 * 1024 * 50 // 50 MiB
+export const TENANT_S3_CREDENTIALS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES = 512
+export const TENANT_S3_CREDENTIALS_CACHE_MAX_SIZE_BYTES = calculateMaxCacheSizeBytes(
+  TENANT_S3_CREDENTIALS_CACHE_MAX_ITEMS,
+  TENANT_S3_CREDENTIALS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+)
 export const TENANT_S3_CREDENTIALS_CACHE_TTL_MS = 1000 * 60 * 60 // 1h
 
 const tenantS3CredentialsCache = createLruCache<string, S3Credentials>(
@@ -25,7 +31,9 @@ const tenantS3CredentialsCache = createLruCache<string, S3Credentials>(
     max: TENANT_S3_CREDENTIALS_CACHE_MAX_ITEMS,
     maxSize: TENANT_S3_CREDENTIALS_CACHE_MAX_SIZE_BYTES,
     ttl: TENANT_S3_CREDENTIALS_CACHE_TTL_MS,
-    sizeCalculation: (value) => objectSizeOf(value),
+    sizeCalculation: createConstantSizeCalculation<S3Credentials, string>(
+      TENANT_S3_CREDENTIALS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES
+    ),
     updateAgeOnGet: true,
     allowStale: false,
     purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,

--- a/src/test/tenant-s3-credentials.test.ts
+++ b/src/test/tenant-s3-credentials.test.ts
@@ -22,8 +22,8 @@ import {
 } from '@internal/database'
 import * as metrics from '@internal/monitoring/metrics'
 import { PostgresPubSub } from '@internal/pubsub'
+import { TENANT_S3_CREDENTIALS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES } from '@storage/protocols/s3/credentials'
 import dotenv from 'dotenv'
-import objectSizeOf from 'object-sizeof'
 import * as migrate from '../internal/database/migrations/migrate'
 import { adminApp } from './common'
 import { assertLogicalLookupMetrics } from './utils/cache-metrics'
@@ -500,17 +500,8 @@ describe('Tenant S3 credentials', () => {
 
   test('Config evicts oversized cold credentials from cache', async () => {
     const credentialBlob = 'x'.repeat(256)
-    const templateCredential = {
-      accessKey: 'template-access-key',
-      secretKey: encrypt('secret-template-access-key'),
-      claims: {
-        issuer: `supabase.storage.${tenantId}`,
-        role: 'service_role',
-        blob: credentialBlob,
-      },
-    }
     const s3CredentialsManagerWithSmallCache = await loadS3CredentialsManager(
-      objectSizeOf(templateCredential) + 1
+      TENANT_S3_CREDENTIALS_CACHE_ESTIMATED_ENTRY_SIZE_BYTES + 1
     )
     const getByKeySpy = vi.spyOn(s3CredentialsManagerWithSmallCache['storage'], 'getOneByAccessKey')
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

We use real byte size for caches but it traverses object and serializes in hot path. Huge CPU/GC pressure.

## What is the new behavior?

Entry sizes are more or less known beforehand even if there are small differences. It doesn't need to be exact, just needs to provide a worst-case prevention. That's why pass a constant estimate and limit by count.

## Additional context

Drop the dependency used to calculate size.
