### PR TITLE
fix: split s3 checksum config for req/res

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -98,6 +98,9 @@ STORAGE_S3_MAX_SOCKETS=200
 STORAGE_S3_ENDPOINT=http://127.0.0.1:9000
 STORAGE_S3_FORCE_PATH_STYLE=true
 STORAGE_S3_REGION=us-east-1
+# Checksum behavior values: WHEN_SUPPORTED | WHEN_REQUIRED.
+# STORAGE_S3_REQUEST_CHECKSUM_CALCULATION=WHEN_SUPPORTED
+# STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION=WHEN_REQUIRED
 # Optional endpoint used only when signing private source URLs
 # for internal consumers like imgproxy.
 # For local Docker imgproxy + MinIO acceptance runs, use http://minio:9000.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -8,6 +8,8 @@ const CONFIG_ENV_KEYS = [
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
   'DATABASE_POOL_DRAIN_TIMEOUT',
   'REQUEST_HARD_LIMITS_ENABLED',
+  'STORAGE_S3_REQUEST_CHECKSUM_CALCULATION',
+  'STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION',
 ] as const
 
 type ConfigEnvKey = (typeof CONFIG_ENV_KEYS)[number]
@@ -78,6 +80,29 @@ describe('tenant pool cache config parsing', () => {
     const config = getConfig({ reload: true })
 
     expect(config.requestHardLimitsEnabled).toBe(true)
+  })
+
+  test('does not force S3 checksum config by default', async () => {
+    setConfigEnv({})
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.storageS3RequestChecksumCalculation).toBeUndefined()
+    expect(config.storageS3ResponseChecksumValidation).toBeUndefined()
+  })
+
+  test('parses split S3 checksum config independently', async () => {
+    setConfigEnv({
+      STORAGE_S3_REQUEST_CHECKSUM_CALCULATION: 'WHEN_SUPPORTED',
+      STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION: 'WHEN_REQUIRED',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.storageS3RequestChecksumCalculation).toBe('WHEN_SUPPORTED')
+    expect(config.storageS3ResponseChecksumValidation).toBe('WHEN_REQUIRED')
   })
 
   test('parses database pool drain timeout in milliseconds', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export type StorageBackendType = 'file' | 's3'
 export type VectorBucketProvider = 's3' | 'pgvector'
 export type IcebergCatalogAuthType = 'sigv4' | 'token'
 export type DatabaseEngine = 'postgres' | 'multigres'
+export type StorageS3ChecksumConfig = 'WHEN_SUPPORTED' | 'WHEN_REQUIRED'
 const DEFAULT_S3_UPLOAD_PART_SIZE = 16 * 1024 * 1024
 const MIN_S3_UPLOAD_PART_SIZE = 5 * 1024 * 1024
 export enum MultitenantMigrationStrategy {
@@ -72,7 +73,8 @@ type StorageConfigType = {
   storageFileEtagAlgorithm: 'mtime' | 'md5'
   storageS3InternalTracesEnabled?: boolean
   storageS3MaxSockets: number
-  storageS3DisableChecksum: boolean
+  storageS3RequestChecksumCalculation?: StorageS3ChecksumConfig
+  storageS3ResponseChecksumValidation?: StorageS3ChecksumConfig
   storageS3UploadPartSize: number
   storageS3UploadQueueSize: number
   storageS3Bucket: string
@@ -260,6 +262,22 @@ export function normalizeDatabaseEngine(engine: string | null | undefined): Data
   throw new Error(`Invalid database engine "${engine}". Expected "postgres" or "multigres".`)
 }
 
+function normalizeStorageS3ChecksumConfig(
+  value: string | undefined,
+  envKey: string
+): StorageS3ChecksumConfig | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const normalizedValue = value.toUpperCase()
+  if (normalizedValue === 'WHEN_SUPPORTED' || normalizedValue === 'WHEN_REQUIRED') {
+    return normalizedValue
+  }
+
+  throw new Error(`Invalid ${envKey} "${value}". Expected "WHEN_SUPPORTED" or "WHEN_REQUIRED".`)
+}
+
 function getOptionalIfMultitenantConfigFromEnv(key: string, fallback?: string): string | undefined {
   return getOptionalConfigFromEnv('MULTI_TENANT', 'IS_MULTITENANT') === 'true'
     ? getOptionalConfigFromEnv(key, fallback)
@@ -285,7 +303,6 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
   envPaths.map((envPath) => dotenv.config({ path: envPath, override: false }))
 
   const isMultitenant = getOptionalConfigFromEnv('MULTI_TENANT', 'IS_MULTITENANT') === 'true'
-
   config = {
     serviceName: getOptionalConfigFromEnv('SERVICE_NAME') || 'storage_api',
     numWorkers: envNumber(getOptionalConfigFromEnv('WORKERS_NUM'), 1),
@@ -397,7 +414,14 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       getOptionalConfigFromEnv('STORAGE_S3_MAX_SOCKETS', 'GLOBAL_S3_MAX_SOCKETS') || '200',
       10
     ),
-    storageS3DisableChecksum: getOptionalConfigFromEnv('STORAGE_S3_DISABLE_CHECKSUM') === 'true',
+    storageS3RequestChecksumCalculation: normalizeStorageS3ChecksumConfig(
+      getOptionalConfigFromEnv('STORAGE_S3_REQUEST_CHECKSUM_CALCULATION'),
+      'STORAGE_S3_REQUEST_CHECKSUM_CALCULATION'
+    ),
+    storageS3ResponseChecksumValidation: normalizeStorageS3ChecksumConfig(
+      getOptionalConfigFromEnv('STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION'),
+      'STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION'
+    ),
     storageS3UploadPartSize: Math.max(
       envNumber(getOptionalConfigFromEnv('STORAGE_S3_UPLOAD_PART_SIZE')) ??
         DEFAULT_S3_UPLOAD_PART_SIZE,

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -120,6 +120,50 @@ describe('S3Backend', () => {
     })
   }
 
+  describe('client config', () => {
+    test('passes split checksum settings independently to the AWS client', async () => {
+      const originalRequestChecksum = process.env.STORAGE_S3_REQUEST_CHECKSUM_CALCULATION
+      const originalResponseChecksum = process.env.STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION
+
+      try {
+        delete process.env.STORAGE_S3_REQUEST_CHECKSUM_CALCULATION
+        process.env.STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION = 'WHEN_REQUIRED'
+
+        vi.resetModules()
+        const { S3Backend: ReloadedS3Backend } = await import('./adapter')
+        const s3ClientMock = S3Client as unknown as Mock
+
+        s3ClientMock.mockClear()
+
+        new ReloadedS3Backend({
+          region: 'us-east-1',
+          endpoint: 'http://localhost:9000',
+        })
+
+        expect(s3ClientMock.mock.calls[0][0]).toMatchObject({
+          region: 'us-east-1',
+          endpoint: 'http://localhost:9000',
+          responseChecksumValidation: 'WHEN_REQUIRED',
+        })
+        expect(s3ClientMock.mock.calls[0][0].requestChecksumCalculation).toBeUndefined()
+      } finally {
+        if (originalRequestChecksum === undefined) {
+          delete process.env.STORAGE_S3_REQUEST_CHECKSUM_CALCULATION
+        } else {
+          process.env.STORAGE_S3_REQUEST_CHECKSUM_CALCULATION = originalRequestChecksum
+        }
+
+        if (originalResponseChecksum === undefined) {
+          delete process.env.STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION
+        } else {
+          process.env.STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION = originalResponseChecksum
+        }
+
+        vi.resetModules()
+      }
+    })
+  })
+
   describe('getObject', () => {
     test('should return correct default MIME type when S3 returns no ContentType', async () => {
       mockSend.mockResolvedValue({

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -41,7 +41,8 @@ const {
   tracingFeatures,
   storageS3MaxSockets,
   tracingEnabled,
-  storageS3DisableChecksum,
+  storageS3RequestChecksumCalculation,
+  storageS3ResponseChecksumValidation,
 } = getConfig()
 
 export const MAX_PUT_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 // 5GB
@@ -720,9 +721,11 @@ export class S3Backend implements StorageBackendAdapter {
       params.forcePathStyle = true
     }
 
-    if (storageS3DisableChecksum) {
-      params.requestChecksumCalculation = 'WHEN_REQUIRED'
-      params.responseChecksumValidation = 'WHEN_REQUIRED'
+    if (storageS3RequestChecksumCalculation) {
+      params.requestChecksumCalculation = storageS3RequestChecksumCalculation
+    }
+    if (storageS3ResponseChecksumValidation) {
+      params.responseChecksumValidation = storageS3ResponseChecksumValidation
     }
     return new S3Client(params)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There was a knob to disable s3 checksums (WHEN_SUPPORTED -> WHEN_REQUIRED) but it applies to both request and response where their benefits differ.

## What is the new behavior?

Split the config into request and response options to enable independently.
 
