### PR TITLE
perf(s3): improve router performance

### DIFF
--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -43,7 +43,7 @@ export default async function routes(fastify: FastifyInstance) {
           const matchHeaders = (req.headers as Record<string, string>) || {}
 
           for (const route of routesByMethod) {
-            if (s3Router.matchRoute(route, matchType, matchQuery, matchHeaders)) {
+            if (route.matches(matchType, matchQuery, matchHeaders)) {
               if (!route.handler) {
                 throw new Error('no handler found')
               }
@@ -55,7 +55,7 @@ export default async function routes(fastify: FastifyInstance) {
               }
 
               try {
-                req.operation = { type: route.operation }
+                req.operation = route.operationConfig
 
                 if (req.operation.type && typeof req.opentelemetry === 'function') {
                   req.opentelemetry()?.span?.setAttribute('http.operation', req.operation.type)

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -15,7 +15,7 @@ import {
 import { s3ErrorHandler } from './error-handler'
 import { findArrayPathsInSchemas, getRouter, RequestInput, RouteQuery } from './router'
 
-const { s3ProtocolEnabled, tracingEnabled } = getConfig()
+const { s3ProtocolEnabled } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
   if (!s3ProtocolEnabled) {
@@ -60,7 +60,7 @@ export default async function routes(fastify: FastifyInstance) {
               try {
                 req.operation = route.operationConfig
 
-                if (tracingEnabled && req.operation.type) {
+                if (req.operation.type && typeof req.opentelemetry === 'function') {
                   req.opentelemetry()?.span?.setAttribute('http.operation', req.operation.type)
                 }
 

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -15,7 +15,7 @@ import {
 import { s3ErrorHandler } from './error-handler'
 import { findArrayPathsInSchemas, getRouter, RequestInput, RouteQuery } from './router'
 
-const { s3ProtocolEnabled } = getConfig()
+const { s3ProtocolEnabled, tracingEnabled } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
   if (!s3ProtocolEnabled) {
@@ -36,13 +36,16 @@ export default async function routes(fastify: FastifyInstance) {
 
       methods.forEach((method) => {
         const routesByMethod = routes.filter((e) => e.method === method)
+        const icebergRoutes = routesByMethod.filter((e) => e.type === 'iceberg')
+        const standardRoutes = routesByMethod.filter((e) => e.type === undefined)
 
         const routeHandler: RouteHandlerMethod = async (req, reply) => {
           const matchType = req.isIcebergBucket ? 'iceberg' : undefined
           const matchQuery = (req.query as RouteQuery) || {}
           const matchHeaders = (req.headers as Record<string, string>) || {}
+          const candidates = matchType === 'iceberg' ? icebergRoutes : standardRoutes
 
-          for (const route of routesByMethod) {
+          for (const route of candidates) {
             if (route.matches(matchType, matchQuery, matchHeaders)) {
               if (!route.handler) {
                 throw new Error('no handler found')
@@ -57,7 +60,7 @@ export default async function routes(fastify: FastifyInstance) {
               try {
                 req.operation = route.operationConfig
 
-                if (req.operation.type && typeof req.opentelemetry === 'function') {
+                if (tracingEnabled && req.operation.type) {
                   req.opentelemetry()?.span?.setAttribute('http.operation', req.operation.type)
                 }
 

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -55,11 +55,7 @@ export default async function routes(fastify: FastifyInstance) {
               }
 
               try {
-                const operation = route.type
-                  ? route.operation.replaceAll('s3.', `s3.${route.type}.`)
-                  : route.operation
-
-                req.operation = { type: operation }
+                req.operation = { type: route.operation }
 
                 if (req.operation.type && typeof req.opentelemetry === 'function') {
                   req.opentelemetry()?.span?.setAttribute('http.operation', req.operation.type)
@@ -71,15 +67,14 @@ export default async function routes(fastify: FastifyInstance) {
                   Headers: req.headers,
                   Querystring: req.query,
                 } as RequestInput<typeof route.schema>
-                const compiler = route.compiledSchema()
-                const isValid = compiler(data)
+                const isValid = route.validate(data)
 
                 if (!isValid) {
                   const validationError = ERRORS.InvalidRequest('Invalid request') as Error & {
                     validation?: unknown
                   }
                   // validation property is required to send correct reply in error-handler.ts
-                  validationError.validation = compiler.errors
+                  validationError.validation = route.validate.errors
                   throw validationError
                 }
 

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -13,7 +13,7 @@ import {
   xmlParser,
 } from '../../plugins'
 import { s3ErrorHandler } from './error-handler'
-import { findArrayPathsInSchemas, getRouter, RequestInput, RouteQuery } from './router'
+import { findArrayPathsInSchemas, getRouter, RequestInput, RouteMatch, RouteQuery } from './router'
 
 const { s3ProtocolEnabled } = getConfig()
 
@@ -38,14 +38,14 @@ export default async function routes(fastify: FastifyInstance) {
         const routesByMethod = routes.filter((e) => e.method === method)
 
         const routeHandler: RouteHandlerMethod = async (req, reply) => {
+          const match: RouteMatch = {
+            type: req.isIcebergBucket ? 'iceberg' : undefined,
+            query: (req.query as RouteQuery) || {},
+            headers: (req.headers as Record<string, string>) || {},
+          }
+
           for (const route of routesByMethod) {
-            if (
-              s3Router.matchRoute(route, {
-                type: req.isIcebergBucket ? 'iceberg' : undefined,
-                query: (req.query as RouteQuery) || {},
-                headers: (req.headers as Record<string, string>) || {},
-              })
-            ) {
+            if (s3Router.matchRoute(route, match)) {
               if (!route.handler) {
                 throw new Error('no handler found')
               }

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -13,7 +13,7 @@ import {
   xmlParser,
 } from '../../plugins'
 import { s3ErrorHandler } from './error-handler'
-import { findArrayPathsInSchemas, getRouter, RequestInput, RouteMatch, RouteQuery } from './router'
+import { findArrayPathsInSchemas, getRouter, RequestInput, RouteQuery } from './router'
 
 const { s3ProtocolEnabled } = getConfig()
 
@@ -38,14 +38,12 @@ export default async function routes(fastify: FastifyInstance) {
         const routesByMethod = routes.filter((e) => e.method === method)
 
         const routeHandler: RouteHandlerMethod = async (req, reply) => {
-          const match: RouteMatch = {
-            type: req.isIcebergBucket ? 'iceberg' : undefined,
-            query: (req.query as RouteQuery) || {},
-            headers: (req.headers as Record<string, string>) || {},
-          }
+          const matchType = req.isIcebergBucket ? 'iceberg' : undefined
+          const matchQuery = (req.query as RouteQuery) || {}
+          const matchHeaders = (req.headers as Record<string, string>) || {}
 
           for (const route of routesByMethod) {
-            if (s3Router.matchRoute(route, match)) {
+            if (s3Router.matchRoute(route, matchType, matchQuery, matchHeaders)) {
               if (!route.handler) {
                 throw new Error('no handler found')
               }

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -40,12 +40,7 @@ describe('S3 router query matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(
-      router.matchRoute(route!, {
-        query: { uploads: undefined },
-        headers: {},
-      })
-    ).toBe(true)
+    expect(router.matchRoute(route!, undefined, { uploads: undefined }, {})).toBe(true)
   })
 
   it('matches valued query params when the value matches', () => {
@@ -63,12 +58,7 @@ describe('S3 router query matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(
-      router.matchRoute(route!, {
-        query: { 'list-type': '2' },
-        headers: {},
-      })
-    ).toBe(true)
+    expect(router.matchRoute(route!, undefined, { 'list-type': '2' }, {})).toBe(true)
   })
 
   it('does not match valued query params when the value differs', () => {
@@ -86,12 +76,7 @@ describe('S3 router query matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(
-      router.matchRoute(route!, {
-        query: { 'list-type': '1' },
-        headers: {},
-      })
-    ).toBe(false)
+    expect(router.matchRoute(route!, undefined, { 'list-type': '1' }, {})).toBe(false)
   })
 
   it('matches wildcard routes even when the request has query params', () => {
@@ -109,12 +94,7 @@ describe('S3 router query matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(
-      router.matchRoute(route!, {
-        query: { uploads: undefined },
-        headers: {},
-      })
-    ).toBe(true)
+    expect(router.matchRoute(route!, undefined, { uploads: undefined }, {})).toBe(true)
   })
 
   it('does not enumerate request query keys for wildcard-only routes', () => {
@@ -141,12 +121,7 @@ describe('S3 router query matching', () => {
       }
     )
 
-    expect(
-      router.matchRoute(route!, {
-        query,
-        headers: {},
-      })
-    ).toBe(true)
+    expect(router.matchRoute(route!, undefined, query, {})).toBe(true)
   })
 })
 
@@ -167,10 +142,7 @@ describe('S3 router header matching', () => {
     expect(route).toBeDefined()
 
     expect(
-      router.matchRoute(route!, {
-        query: {},
-        headers: { 'x-amz-copy-source': '/source-bucket/source-key' },
-      })
+      router.matchRoute(route!, undefined, {}, { 'x-amz-copy-source': '/source-bucket/source-key' })
     ).toBe(true)
   })
 
@@ -190,10 +162,12 @@ describe('S3 router header matching', () => {
     expect(route).toBeDefined()
 
     expect(
-      router.matchRoute(route!, {
-        query: {},
-        headers: { 'content-type': 'multipart/form-data; boundary=abc123' },
-      })
+      router.matchRoute(
+        route!,
+        undefined,
+        {},
+        { 'content-type': 'multipart/form-data; boundary=abc123' }
+      )
     ).toBe(true)
   })
 
@@ -212,18 +186,10 @@ describe('S3 router header matching', () => {
     const route = router.routes().get('/:Bucket')?.[0]
     expect(route).toBeDefined()
 
-    expect(
-      router.matchRoute(route!, {
-        query: {},
-        headers: {},
-      })
-    ).toBe(false)
-    expect(
-      router.matchRoute(route!, {
-        query: {},
-        headers: { 'content-type': 'application/json' },
-      })
-    ).toBe(false)
+    expect(router.matchRoute(route!, undefined, {}, {})).toBe(false)
+    expect(router.matchRoute(route!, undefined, {}, { 'content-type': 'application/json' })).toBe(
+      false
+    )
   })
 })
 
@@ -244,8 +210,8 @@ describe('S3 router type matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(router.matchRoute(route!, { type: 'iceberg', query: {}, headers: {} })).toBe(true)
-    expect(router.matchRoute(route!, { query: {}, headers: {} })).toBe(false)
+    expect(router.matchRoute(route!, 'iceberg', {}, {})).toBe(true)
+    expect(router.matchRoute(route!, undefined, {}, {})).toBe(false)
   })
 
   it('matches untyped routes only for untyped requests', () => {
@@ -263,8 +229,8 @@ describe('S3 router type matching', () => {
     const route = router.routes().get('/:Bucket/*')?.[0]
     expect(route).toBeDefined()
 
-    expect(router.matchRoute(route!, { query: {}, headers: {} })).toBe(true)
-    expect(router.matchRoute(route!, { type: 'iceberg', query: {}, headers: {} })).toBe(false)
+    expect(router.matchRoute(route!, undefined, {}, {})).toBe(true)
+    expect(router.matchRoute(route!, 'iceberg', {}, {})).toBe(false)
   })
 })
 

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -116,6 +116,156 @@ describe('S3 router query matching', () => {
       })
     ).toBe(true)
   })
+
+  it('does not enumerate request query keys for wildcard-only routes', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    const query = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error('wildcard-only query match should not enumerate request query keys')
+        },
+      }
+    )
+
+    expect(
+      router.matchRoute(route!, {
+        query,
+        headers: {},
+      })
+    ).toBe(true)
+  })
+})
+
+describe('S3 router header matching', () => {
+  it('matches routes that require a header by presence', () => {
+    const router = new Router()
+
+    router.put(
+      '/:Bucket/*|x-amz-copy-source',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      router.matchRoute(route!, {
+        query: {},
+        headers: { 'x-amz-copy-source': '/source-bucket/source-key' },
+      })
+    ).toBe(true)
+  })
+
+  it('matches routes that require a header value prefix', () => {
+    const router = new Router()
+
+    router.post(
+      '/:Bucket|content-type=multipart/form-data',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      router.matchRoute(route!, {
+        query: {},
+        headers: { 'content-type': 'multipart/form-data; boundary=abc123' },
+      })
+    ).toBe(true)
+  })
+
+  it('rejects routes when a required header is missing or has the wrong value', () => {
+    const router = new Router()
+
+    router.post(
+      '/:Bucket|content-type=multipart/form-data',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      router.matchRoute(route!, {
+        query: {},
+        headers: {},
+      })
+    ).toBe(false)
+    expect(
+      router.matchRoute(route!, {
+        query: {},
+        headers: { 'content-type': 'application/json' },
+      })
+    ).toBe(false)
+  })
+})
+
+describe('S3 router type matching', () => {
+  it('matches iceberg-typed routes only for iceberg requests', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*',
+      {
+        schema: {},
+        operation: 'test.operation',
+        type: 'iceberg',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(router.matchRoute(route!, { type: 'iceberg', query: {}, headers: {} })).toBe(true)
+    expect(router.matchRoute(route!, { query: {}, headers: {} })).toBe(false)
+  })
+
+  it('matches untyped routes only for untyped requests', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(router.matchRoute(route!, { query: {}, headers: {} })).toBe(true)
+    expect(router.matchRoute(route!, { type: 'iceberg', query: {}, headers: {} })).toBe(false)
+  })
 })
 
 describe('S3ProtocolHandler.parseMetadataHeaders', () => {

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -234,6 +234,67 @@ describe('S3 router type matching', () => {
   })
 })
 
+describe('S3 router registration precomputation', () => {
+  it('stores the compiled validator directly on the route', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*?list-type=2',
+      {
+        schema: {
+          Params: {
+            type: 'object',
+            properties: {
+              Bucket: { type: 'string' },
+              '*': { type: 'string' },
+            },
+            required: ['Bucket', '*'],
+          },
+          Querystring: {
+            type: 'object',
+            properties: {
+              'list-type': { type: 'string', enum: ['2'] },
+            },
+            required: ['list-type'],
+          },
+        },
+        operation: 'storage.s3.object.list',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      route!.validate({
+        Params: { Bucket: 'bucket', '*': 'object' },
+        Querystring: { 'list-type': '2' },
+      })
+    ).toBe(true)
+    expect(route!.validate.errors).toBeNull()
+  })
+
+  it('precomputes typed route operation names', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*',
+      {
+        schema: {},
+        operation: 'storage.s3.object.get',
+        type: 'iceberg',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(route!.operation).toBe('storage.s3.iceberg.object.get')
+  })
+})
+
 describe('S3ProtocolHandler.parseMetadataHeaders', () => {
   it('returns only x-amz-meta headers without the prefix', () => {
     const handler = createHandler()
@@ -376,7 +437,7 @@ describe('DeleteObject route mapping', () => {
 
     expect(route).toBeDefined()
 
-    const validate = route!.compiledSchema()
+    const validate = route!.validate
     const data = {
       Params: { Bucket: 'bucket' },
       Querystring: { delete: '' },
@@ -411,7 +472,7 @@ describe('DeleteObject route mapping', () => {
 
     expect(route).toBeDefined()
 
-    const validate = route!.compiledSchema()
+    const validate = route!.validate
     const data = {
       Params: { Bucket: 'bucket' },
       Querystring: { delete: '' },
@@ -453,7 +514,7 @@ describe('DeleteObject route mapping', () => {
 
       expect(route).toBeDefined()
 
-      const validate = route!.compiledSchema()
+      const validate = route!.validate
       const data = {
         Params: { Bucket: 'bucket' },
         Querystring: { delete: '' },

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -293,6 +293,26 @@ describe('S3 router registration precomputation', () => {
 
     expect(route!.operation).toBe('storage.s3.iceberg.object.get')
   })
+
+  it('stores a reusable operation object for request metadata', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*',
+      {
+        schema: {},
+        operation: 'storage.s3.object.get',
+        type: 'iceberg',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(route!.operationConfig).toEqual({ type: 'storage.s3.iceberg.object.get' })
+    expect(route!.operationConfig).toBe(route!.operationConfig)
+  })
 })
 
 describe('S3ProtocolHandler.parseMetadataHeaders', () => {

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -1,9 +1,10 @@
 import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
+import type { FastifyInstance } from 'fastify'
 import { vi } from 'vitest'
 import { S3ProtocolHandler } from '../../../storage/protocols/s3/s3-handler'
 import { Uploader } from '../../../storage/uploader'
 import CompleteMultipartUpload from './commands/complete-multipart-upload'
-import { Router, type S3Router } from './router'
+import { getRouter, type RouteQuery, Router, type S3Router } from './router'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -123,6 +124,49 @@ describe('S3 router query matching', () => {
 
     expect(router.matchRoute(route!, undefined, query, {})).toBe(true)
   })
+
+  it('requires every key-only query matcher to be present', () => {
+    const router = new Router()
+
+    router.put(
+      '/:Bucket/*?partNumber&uploadId',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      router.matchRoute(route!, undefined, { partNumber: '1', uploadId: 'upload-id' }, {})
+    ).toBe(true)
+    expect(router.matchRoute(route!, undefined, { partNumber: '1' }, {})).toBe(false)
+    expect(router.matchRoute(route!, undefined, { uploadId: 'upload-id' }, {})).toBe(false)
+    expect(router.matchRoute(route!, undefined, {}, {})).toBe(false)
+  })
+
+  it('allows wildcard query matchers to fall back when valued query matchers miss', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*?list-type=2&*',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(router.matchRoute(route!, undefined, { 'list-type': '2' }, {})).toBe(true)
+    expect(router.matchRoute(route!, undefined, { 'list-type': '1' }, {})).toBe(true)
+    expect(router.matchRoute(route!, undefined, {}, {})).toBe(true)
+  })
 })
 
 describe('S3 router header matching', () => {
@@ -191,6 +235,148 @@ describe('S3 router header matching', () => {
       false
     )
   })
+
+  it('requires query and header matchers to pass together', () => {
+    const router = new Router()
+
+    router.put(
+      '/:Bucket/*?partNumber&uploadId|x-amz-copy-source',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    expect(
+      router.matchRoute(
+        route!,
+        undefined,
+        { partNumber: '1', uploadId: 'upload-id' },
+        { 'x-amz-copy-source': '/source-bucket/source-key' }
+      )
+    ).toBe(true)
+    expect(
+      router.matchRoute(
+        route!,
+        undefined,
+        { partNumber: '1' },
+        { 'x-amz-copy-source': '/source-bucket/source-key' }
+      )
+    ).toBe(false)
+    expect(
+      router.matchRoute(route!, undefined, { partNumber: '1', uploadId: 'upload-id' }, {})
+    ).toBe(false)
+  })
+})
+
+describe('S3 router route resolution', () => {
+  it('keeps first-match order for overlapping standard PUT object routes', () => {
+    const router = getRouter()
+    const routes = router
+      .routes()
+      .get('/:Bucket/*')
+      ?.filter((route) => route.method === 'put' && route.type === undefined)
+
+    expect(routes?.map((route) => route.operation)).toEqual([
+      'storage.s3.upload.part_copy',
+      'storage.s3.object.copy',
+      'storage.s3.upload.part',
+      'storage.s3.upload',
+    ])
+
+    const findOperation = (
+      query: RouteQuery,
+      headers: Record<string, string>
+    ): string | undefined => {
+      return routes?.find((route) => route.matches(undefined, query, headers))?.operation
+    }
+
+    expect(
+      findOperation(
+        { partNumber: '1', uploadId: 'upload-id' },
+        { 'x-amz-copy-source': '/source-bucket/source-key' }
+      )
+    ).toBe('storage.s3.upload.part_copy')
+    expect(findOperation({}, { 'x-amz-copy-source': '/source-bucket/source-key' })).toBe(
+      'storage.s3.object.copy'
+    )
+    expect(findOperation({ partNumber: '1', uploadId: 'upload-id' }, {})).toBe(
+      'storage.s3.upload.part'
+    )
+    expect(findOperation({}, {})).toBe('storage.s3.upload')
+  })
+})
+
+describe('S3 route handler matching', () => {
+  it('returns 404 from the S3 route handler when no command route matches', async () => {
+    const previousS3ProtocolEnabled = process.env.S3_PROTOCOL_ENABLED
+    process.env.S3_PROTOCOL_ENABLED = 'true'
+
+    vi.resetModules()
+    vi.doMock('../../../config', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../../../config')>()
+
+      return {
+        ...actual,
+        getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
+          ...actual.getConfig(options),
+          s3ProtocolEnabled: true,
+          tracingEnabled: false,
+        }),
+      }
+    })
+    vi.doMock('../../plugins', async () => {
+      const { default: fastifyPlugin } = await import('fastify-plugin')
+      const noopPlugin = fastifyPlugin(async () => {})
+      const routeMarkerPlugin = fastifyPlugin(async (fastify: FastifyInstance) => {
+        fastify.addHook('preHandler', async (_request, reply) => {
+          reply.header('x-s3-route-handler-test', '1')
+        })
+      })
+
+      return {
+        db: noopPlugin,
+        detectS3IcebergBucket: noopPlugin,
+        icebergRestCatalog: noopPlugin,
+        requireTenantFeature: () => routeMarkerPlugin,
+        signatureV4: noopPlugin,
+        storage: noopPlugin,
+        xmlParser: noopPlugin,
+      }
+    })
+
+    const { default: fastify } = await import('fastify')
+    const { default: routes } = await import('./index')
+    const app = fastify()
+
+    try {
+      await app.register(routes)
+      await app.ready()
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/bucket/object',
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.headers['x-s3-route-handler-test']).toBe('1')
+    } finally {
+      await app.close()
+      vi.doUnmock('../../plugins')
+      vi.doUnmock('../../../config')
+      vi.resetModules()
+
+      if (previousS3ProtocolEnabled === undefined) {
+        delete process.env.S3_PROTOCOL_ENABLED
+      } else {
+        process.env.S3_PROTOCOL_ENABLED = previousS3ProtocolEnabled
+      }
+    }
+  })
 })
 
 describe('S3 router type matching', () => {
@@ -235,6 +421,30 @@ describe('S3 router type matching', () => {
 })
 
 describe('S3 router registration precomputation', () => {
+  it('delegates public route matching to the precompiled route matcher', () => {
+    const router = new Router()
+
+    router.get(
+      '/:Bucket/*?uploads',
+      {
+        schema: {},
+        operation: 'test.operation',
+      },
+      async () => ({})
+    )
+
+    const route = router.routes().get('/:Bucket/*')?.[0]
+    expect(route).toBeDefined()
+
+    const query = { uploads: undefined }
+    const headers = { 'x-test-header': 'value' }
+    route!.matches = vi.fn(() => true)
+
+    expect(router.matchRoute(route!, 'iceberg', query, headers)).toBe(true)
+    expect(route!.matches).toHaveBeenCalledTimes(1)
+    expect(route!.matches).toHaveBeenCalledWith('iceberg', query, headers)
+  })
+
   it('stores the compiled validator directly on the route', () => {
     const router = new Router()
 

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -1,5 +1,5 @@
 import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { vi } from 'vitest'
 import { S3ProtocolHandler } from '../../../storage/protocols/s3/s3-handler'
 import { Uploader } from '../../../storage/uploader'
@@ -312,7 +312,13 @@ describe('S3 router route resolution', () => {
 })
 
 describe('S3 route handler matching', () => {
-  it('returns 404 from the S3 route handler when no command route matches', async () => {
+  async function withMockedS3App(
+    callback: (app: FastifyInstance) => Promise<void>,
+    options: {
+      configureRequest?: (request: FastifyRequest) => void
+      tracingEnabled?: boolean
+    } = {}
+  ) {
     const previousS3ProtocolEnabled = process.env.S3_PROTOCOL_ENABLED
     process.env.S3_PROTOCOL_ENABLED = 'true'
 
@@ -322,10 +328,10 @@ describe('S3 route handler matching', () => {
 
       return {
         ...actual,
-        getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
-          ...actual.getConfig(options),
+        getConfig: (getConfigOptions?: Parameters<typeof actual.getConfig>[0]) => ({
+          ...actual.getConfig(getConfigOptions),
           s3ProtocolEnabled: true,
-          tracingEnabled: false,
+          tracingEnabled: options.tracingEnabled ?? false,
         }),
       }
     })
@@ -333,8 +339,9 @@ describe('S3 route handler matching', () => {
       const { default: fastifyPlugin } = await import('fastify-plugin')
       const noopPlugin = fastifyPlugin(async () => {})
       const routeMarkerPlugin = fastifyPlugin(async (fastify: FastifyInstance) => {
-        fastify.addHook('preHandler', async (_request, reply) => {
+        fastify.addHook('preHandler', async (request, reply) => {
           reply.header('x-s3-route-handler-test', '1')
+          options.configureRequest?.(request)
         })
       })
 
@@ -356,14 +363,7 @@ describe('S3 route handler matching', () => {
     try {
       await app.register(routes)
       await app.ready()
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/bucket/object',
-      })
-
-      expect(response.statusCode).toBe(404)
-      expect(response.headers['x-s3-route-handler-test']).toBe('1')
+      await callback(app)
     } finally {
       await app.close()
       vi.doUnmock('../../plugins')
@@ -376,6 +376,51 @@ describe('S3 route handler matching', () => {
         process.env.S3_PROTOCOL_ENABLED = previousS3ProtocolEnabled
       }
     }
+  }
+
+  it('returns 404 from the S3 route handler when no command route matches', async () => {
+    await withMockedS3App(async (app) => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/bucket/object',
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(response.headers['x-s3-route-handler-test']).toBe('1')
+    })
+  })
+
+  it('sets the S3 operation span attribute when opentelemetry is available', async () => {
+    const setAttribute = vi.fn()
+
+    await withMockedS3App(
+      async (app) => {
+        const response = await app.inject({
+          method: 'GET',
+          url: '/',
+        })
+
+        expect(response.statusCode).toBe(200)
+      },
+      {
+        configureRequest: (request) => {
+          Object.assign(request, {
+            opentelemetry: () => ({ span: { setAttribute } }),
+            owner: 'owner-id',
+            signals: {
+              body: new AbortController(),
+              response: new AbortController(),
+            },
+            storage: {
+              listBuckets: vi.fn().mockResolvedValue([]),
+            },
+            tenantId: 'tenant-id',
+          })
+        },
+      }
+    )
+
+    expect(setAttribute).toHaveBeenCalledWith('http.operation', 'storage.s3.bucket.list')
   })
 })
 

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -105,7 +105,18 @@ export type QuerystringMatch = {
   value: string | undefined
 }
 
+export type HeaderMatch = {
+  name: string
+  value?: string
+}
+
 export type RouteQuery = Record<string, string | undefined>
+
+export type RouteMatch = {
+  query: RouteQuery
+  headers: Record<string, string>
+  type?: string
+}
 
 type Route<S extends Schema, Context> = {
   method: HTTPMethod
@@ -120,6 +131,9 @@ type Route<S extends Schema, Context> = {
   acceptMultiformData?: boolean
   operation: string
   compiledSchema: () => ValidateFunction<JTDDataType<S>>
+  // Precompiled matcher: the query/header criteria are parsed once at registration
+  // time so request-time matching is a single closure call with no string parsing.
+  matches: (match: RouteMatch) => boolean
 }
 
 interface RouteOptions<S extends Schema> {
@@ -221,6 +235,7 @@ export class Router<Context = unknown> {
       acceptMultiformData,
       operation,
       type: options.type,
+      matches: compileMatcher(query, headers, options.type),
     }
 
     if (!existingPath) {
@@ -274,81 +289,100 @@ export class Router<Context = unknown> {
     return this._routes
   }
 
-  matchRoute(
-    route: Route<Schema, Context>,
-    match: { query: RouteQuery; headers: Record<string, string>; type?: string }
-  ) {
-    const isOfType = match.type ? match.type === route.type : route.type === undefined
+  matchRoute(route: Route<Schema, Context>, match: RouteMatch) {
+    return route.matches(match)
+  }
+}
 
-    if ((route.headersMatches?.length || 0) > 0) {
-      return (
-        this.matchHeaders(route.headersMatches, match.headers) &&
-        this.matchQueryString(route.querystringMatches, match.query) &&
-        isOfType
-      )
+/**
+ * Precompiles a route's query/header/type criteria into a single matcher closure.
+ *
+ * The query wildcard flag and the header name/value pairs are derived once here
+ * instead of on every request, so request-time matching is a closure call with no
+ * per-request string splitting or array scanning to recompute static information.
+ */
+function compileMatcher(
+  query: QuerystringMatch[],
+  headers: string[],
+  type?: string
+): (match: RouteMatch) => boolean {
+  const hasWildcardQuery = query.some((match) => match.key === '*')
+  const valuedQueryMatches = query.filter((match) => match.key !== '*')
+  const headerMatches = headers.map(parseHeaderMatch)
+  const hasHeaderMatches = headerMatches.length > 0
+
+  return (match: RouteMatch) => {
+    const isOfType = match.type ? match.type === type : type === undefined
+    if (!isOfType) {
+      return false
     }
 
-    return this.matchQueryString(route.querystringMatches, match.query) && isOfType
+    if (hasHeaderMatches && !matchHeaders(headerMatches, match.headers)) {
+      return false
+    }
+
+    return matchQueryString(valuedQueryMatches, hasWildcardQuery, match.query)
+  }
+}
+
+function parseHeaderMatch(header: string): HeaderMatch {
+  const separatorIndex = header.indexOf('=')
+  if (separatorIndex === -1) {
+    return { name: header }
+  }
+  return { name: header.slice(0, separatorIndex), value: header.slice(separatorIndex + 1) }
+}
+
+function matchHeaders(matches: HeaderMatch[], received?: Record<string, string>) {
+  if (!received) {
+    return matches.length === 0
   }
 
-  protected matchHeaders(headers: string[], received?: Record<string, string>) {
-    if (!received) {
-      return headers.length === 0
+  for (const match of matches) {
+    const value = received[match.name]
+    if (value === undefined) {
+      return false
     }
-
-    return headers.every((header) => {
-      const headerParts = header.split('=')
-      const headerName = headerParts[0]
-      const headerValue = headerParts[1]
-
-      const matchHeaderName = received[headerName] !== undefined
-      const matchHeaderValue = headerValue ? received[headerName]?.startsWith(headerValue) : true
-
-      return matchHeaderName && matchHeaderValue
-    })
+    if (match.value && !value.startsWith(match.value)) {
+      return false
+    }
   }
 
-  protected matchQueryString(matches: QuerystringMatch[], received?: RouteQuery) {
-    let hasWildcard = false
-    for (const match of matches) {
-      if (match.key === '*') {
-        hasWildcard = true
-        break
-      }
-    }
+  return true
+}
 
-    if (!received) {
+function matchQueryString(
+  valuedMatches: QuerystringMatch[],
+  hasWildcard: boolean,
+  received?: RouteQuery
+) {
+  if (!received) {
+    return hasWildcard
+  }
+
+  let hasReceivedQuery = false
+  for (const key in received) {
+    if (Object.prototype.hasOwnProperty.call(received, key)) {
+      hasReceivedQuery = true
+      break
+    }
+  }
+
+  if (!hasReceivedQuery) {
+    return hasWildcard
+  }
+
+  for (const match of valuedMatches) {
+    if (!Object.prototype.hasOwnProperty.call(received, match.key)) {
       return hasWildcard
     }
 
-    let hasReceivedQuery = false
-    for (const key in received) {
-      if (Object.prototype.hasOwnProperty.call(received, key)) {
-        hasReceivedQuery = true
-        break
-      }
-    }
-
-    if (!hasReceivedQuery) {
+    if (match.value !== undefined && match.value !== received[match.key]) {
       return hasWildcard
     }
-
-    for (const match of matches) {
-      if (match.key === '*') {
-        continue
-      }
-
-      if (!Object.prototype.hasOwnProperty.call(received, match.key)) {
-        return hasWildcard
-      }
-
-      if (match.value !== undefined && match.value !== received[match.key]) {
-        return hasWildcard
-      }
-    }
-
-    return true
   }
+
+  return true
 }
 
 /**

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -375,7 +375,7 @@ function matchQueryString(
   received: RouteQuery
 ) {
   for (const match of valuedMatches) {
-    if (!Object.prototype.hasOwnProperty.call(received, match.key)) {
+    if (!(match.key in received)) {
       return hasWildcard
     }
 

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -112,12 +112,6 @@ export type HeaderMatch = {
 
 export type RouteQuery = Record<string, string | undefined>
 
-export type RouteMatch = {
-  query: RouteQuery
-  headers: Record<string, string>
-  type?: string
-}
-
 type Route<S extends Schema, Context> = {
   method: HTTPMethod
   type?: string
@@ -133,7 +127,7 @@ type Route<S extends Schema, Context> = {
   compiledSchema: () => ValidateFunction<JTDDataType<S>>
   // Precompiled matcher: the query/header criteria are parsed once at registration
   // time so request-time matching is a single closure call with no string parsing.
-  matches: (match: RouteMatch) => boolean
+  matches: (type: string | undefined, query: RouteQuery, headers: Record<string, string>) => boolean
 }
 
 interface RouteOptions<S extends Schema> {
@@ -289,8 +283,13 @@ export class Router<Context = unknown> {
     return this._routes
   }
 
-  matchRoute(route: Route<Schema, Context>, match: RouteMatch) {
-    return route.matches(match)
+  matchRoute(
+    route: Route<Schema, Context>,
+    type: string | undefined,
+    query: RouteQuery,
+    headers: Record<string, string>
+  ) {
+    return route.matches(type, query, headers)
   }
 }
 
@@ -305,20 +304,27 @@ function compileMatcher(
   query: QuerystringMatch[],
   headers: string[],
   type?: string
-): (match: RouteMatch) => boolean {
+): (
+  matchType: string | undefined,
+  reqQuery: RouteQuery,
+  reqHeaders: Record<string, string>
+) => boolean {
   const hasWildcardQuery = query.some((match) => match.key === '*')
   const valuedQueryMatches = query.filter((match) => match.key !== '*')
   const hasOnlyWildcardQuery = hasWildcardQuery && valuedQueryMatches.length === 0
   const headerMatches = headers.map(parseHeaderMatch)
   const hasHeaderMatches = headerMatches.length > 0
 
-  return (match: RouteMatch) => {
-    const isOfType = match.type ? match.type === type : type === undefined
-    if (!isOfType) {
+  return (
+    matchType: string | undefined,
+    reqQuery: RouteQuery,
+    reqHeaders: Record<string, string>
+  ) => {
+    if (matchType !== type) {
       return false
     }
 
-    if (hasHeaderMatches && !matchHeaders(headerMatches, match.headers)) {
+    if (hasHeaderMatches && !matchHeaders(headerMatches, reqHeaders)) {
       return false
     }
 
@@ -326,7 +332,7 @@ function compileMatcher(
       return true
     }
 
-    return matchQueryString(valuedQueryMatches, hasWildcardQuery, match.query)
+    return matchQueryString(valuedQueryMatches, hasWildcardQuery, reqQuery)
   }
 }
 
@@ -338,11 +344,7 @@ function parseHeaderMatch(header: string): HeaderMatch {
   return { name: header.slice(0, separatorIndex), value: header.slice(separatorIndex + 1) }
 }
 
-function matchHeaders(matches: HeaderMatch[], received?: Record<string, string>) {
-  if (!received) {
-    return matches.length === 0
-  }
-
+function matchHeaders(matches: HeaderMatch[], received: Record<string, string>) {
   for (const match of matches) {
     const value = received[match.name]
     if (value === undefined) {
@@ -359,12 +361,8 @@ function matchHeaders(matches: HeaderMatch[], received?: Record<string, string>)
 function matchQueryString(
   valuedMatches: QuerystringMatch[],
   hasWildcard: boolean,
-  received?: RouteQuery
+  received: RouteQuery
 ) {
-  if (!received) {
-    return hasWildcard
-  }
-
   for (const match of valuedMatches) {
     if (!Object.prototype.hasOwnProperty.call(received, match.key)) {
       return hasWildcard

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -308,6 +308,7 @@ function compileMatcher(
 ): (match: RouteMatch) => boolean {
   const hasWildcardQuery = query.some((match) => match.key === '*')
   const valuedQueryMatches = query.filter((match) => match.key !== '*')
+  const hasOnlyWildcardQuery = hasWildcardQuery && valuedQueryMatches.length === 0
   const headerMatches = headers.map(parseHeaderMatch)
   const hasHeaderMatches = headerMatches.length > 0
 
@@ -319,6 +320,10 @@ function compileMatcher(
 
     if (hasHeaderMatches && !matchHeaders(headerMatches, match.headers)) {
       return false
+    }
+
+    if (hasOnlyWildcardQuery) {
+      return true
     }
 
     return matchQueryString(valuedQueryMatches, hasWildcardQuery, match.query)
@@ -357,18 +362,6 @@ function matchQueryString(
   received?: RouteQuery
 ) {
   if (!received) {
-    return hasWildcard
-  }
-
-  let hasReceivedQuery = false
-  for (const key in received) {
-    if (Object.prototype.hasOwnProperty.call(received, key)) {
-      hasReceivedQuery = true
-      break
-    }
-  }
-
-  if (!hasReceivedQuery) {
     return hasWildcard
   }
 

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -124,7 +124,7 @@ type Route<S extends Schema, Context> = {
   allowEmptyJsonBody?: boolean
   acceptMultiformData?: boolean
   operation: string
-  compiledSchema: () => ValidateFunction<JTDDataType<S>>
+  validate: ValidateFunction<JTDDataType<S>>
   // Precompiled matcher: the query/header criteria are parsed once at registration
   // time so request-time matching is a single closure call with no string parsing.
   matches: (type: string | undefined, query: RouteQuery, headers: Record<string, string>) => boolean
@@ -202,7 +202,8 @@ export class Router<Context = unknown> {
       }
     })
 
-    const existingSchema = this.ajv.getSchema(method + url)
+    const schemaKey = method + url
+    const existingSchema = this.ajv.getSchema(schemaKey)
 
     if (!existingSchema) {
       this.ajv.addSchema(
@@ -211,9 +212,11 @@ export class Router<Context = unknown> {
           properties: schemaToCompile,
           required: required.filter(Boolean),
         },
-        method + url
+        schemaKey
       )
     }
+
+    const validate = this.ajv.getSchema(schemaKey) as ValidateFunction<JTDDataType<Schema>>
 
     const newRoute: Route<Schema, Context> = {
       method,
@@ -221,13 +224,12 @@ export class Router<Context = unknown> {
       querystringMatches: query,
       headersMatches: headers,
       schema,
-      compiledSchema: () =>
-        this.ajv.getSchema(method + url) as ValidateFunction<JTDDataType<Schema>>,
+      validate,
       handler,
       disableContentTypeParser,
       allowEmptyJsonBody,
       acceptMultiformData,
-      operation,
+      operation: compileOperation(operation, options.type),
       type: options.type,
       matches: compileMatcher(query, headers, options.type),
     }
@@ -291,6 +293,10 @@ export class Router<Context = unknown> {
   ) {
     return route.matches(type, query, headers)
   }
+}
+
+function compileOperation(operation: string, type?: string) {
+  return type ? operation.replaceAll('s3.', `s3.${type}.`) : operation
 }
 
 /**

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -124,6 +124,8 @@ type Route<S extends Schema, Context> = {
   allowEmptyJsonBody?: boolean
   acceptMultiformData?: boolean
   operation: string
+  // Precompiled operation: allocated operation object at registration
+  operationConfig: { type: string }
   validate: ValidateFunction<JTDDataType<S>>
   // Precompiled matcher: the query/header criteria are parsed once at registration
   // time so request-time matching is a single closure call with no string parsing.
@@ -218,6 +220,8 @@ export class Router<Context = unknown> {
 
     const validate = this.ajv.getSchema(schemaKey) as ValidateFunction<JTDDataType<Schema>>
 
+    const compiledOperation = compileOperation(operation, options.type)
+
     const newRoute: Route<Schema, Context> = {
       method,
       path: normalizedUrl,
@@ -229,7 +233,8 @@ export class Router<Context = unknown> {
       disableContentTypeParser,
       allowEmptyJsonBody,
       acceptMultiformData,
-      operation: compileOperation(operation, options.type),
+      operation: compiledOperation,
+      operationConfig: { type: compiledOperation },
       type: options.type,
       matches: compileMatcher(query, headers, options.type),
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for perf

## What is the current behavior?

S3 router is less efficient than it could be.

## What is the new behavior?

* precompile route matchers at registration
* ajv validator is moved out hot path
* operation is precomputed and cached on route
* prevent wrapper object allocation in match loop
* partition routes between iceberg and standard
