### PR TITLE
perf: use fast-decode for uri component decoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "aws-sigv4-sign": "^1.2.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
+        "fast-decode-uri-component": "^1.0.1",
         "fastify": "^5.8.5",
         "fastify-plugin": "^5.1.0",
         "fs-xattr": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "aws-sigv4-sign": "^1.2.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
+    "fast-decode-uri-component": "^1.0.1",
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fs-xattr": "0.3.1",

--- a/src/internal/database/ssl.ts
+++ b/src/internal/database/ssl.ts
@@ -1,4 +1,5 @@
 import { logger } from '@internal/monitoring'
+import fastDecodeURIComponent from 'fast-decode-uri-component'
 import * as ipAddr from 'ip-address'
 import { ConnectionOptions } from 'tls'
 
@@ -28,7 +29,8 @@ export function getSslSettings({
 }
 
 export function isIpAddress(ip: string) {
-  // IP might be URL-encoded
-  const decodedIp = decodeURIComponent(ip)
+  // IP might be URL-encoded. fast-decode returns the input unchanged when there
+  // is nothing to decode, and null (rather than throwing) on malformed input.
+  const decodedIp = fastDecodeURIComponent(ip) ?? ip
   return ipAddr.Address6.isValid(decodedIp) || ipAddr.Address4.isValid(decodedIp)
 }

--- a/src/internal/monitoring/pprof/download.ts
+++ b/src/internal/monitoring/pprof/download.ts
@@ -1,3 +1,4 @@
+import fastDecodeURIComponent from 'fast-decode-uri-component'
 import fs from 'fs'
 import { mkdir } from 'fs/promises'
 import path from 'path'
@@ -93,9 +94,12 @@ function parseMultipartFilename(headers: MultipartHeaders) {
 
   const extendedMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i)
   if (extendedMatch?.[1]) {
-    try {
-      return decodeURIComponent(extendedMatch[1])
-    } catch {}
+    // fast-decode returns null (rather than throwing) on malformed input, in
+    // which case we fall through to the quoted form below.
+    const decoded = fastDecodeURIComponent(extendedMatch[1])
+    if (decoded !== null) {
+      return decoded
+    }
   }
 
   const quotedMatch = disposition.match(/filename="([^"]+)"/i)

--- a/src/types/fast-decode-uri-component.d.ts
+++ b/src/types/fast-decode-uri-component.d.ts
@@ -1,0 +1,9 @@
+declare module 'fast-decode-uri-component' {
+  /**
+   * Decodes a URI component without allocating when there is nothing to decode
+   * (returns the input unchanged when it contains no `%`). Returns `null`
+   * instead of throwing when the input is malformed.
+   */
+  function fastDecodeURIComponent(uri: string): string | null
+  export default fastDecodeURIComponent
+}


### PR DESCRIPTION
Part of the performance work adopting patterns from fastify.

Swaps `decodeURIComponent` for [`fast-decode-uri-component`](https://github.com/fastify/fast-decode-uri-component) (the decoder fastify uses internally) at the URI-component decode sites. It returns the input unchanged when there is nothing to decode (no `%` → no allocation) and returns `null` instead of throwing on malformed input.

Changes:
- `isIpAddress` (database SSL): decode with fast-decode, falling back to the raw value on malformed input instead of throwing.
- pprof multipart filename parsing: use the `null` return to fall through to the quoted form, replacing the `try/catch`.
- Add `fast-decode-uri-component` as a direct dependency (previously transitive via fastify) plus a small ambient type declaration.

`decodeURI` in `object.ts` is intentionally left alone — its semantics differ from `decodeURIComponent` and aren't interchangeable.
