### PR TITLE
perf: lazily allocate per-request abort signals

### DIFF
--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -1,7 +1,11 @@
-import Fastify from 'fastify'
+import Fastify, { type FastifyRequest } from 'fastify'
 import { vi } from 'vitest'
 
-async function loadDbSuperUserPlugin() {
+async function loadDbPlugins({
+  databaseEnableQueryCancellation = false,
+}: {
+  databaseEnableQueryCancellation?: boolean
+} = {}) {
   vi.resetModules()
 
   const requestDb = {
@@ -41,14 +45,17 @@ async function loadDbSuperUserPlugin() {
   const configModule = await import('../../config')
   configModule.getConfig({ reload: true })
   configModule.mergeConfig({
+    databaseEnableQueryCancellation,
     isMultitenant: false,
   })
 
-  const { dbSuperUser } = await import('./db')
+  const { db, dbSuperUser } = await import('./db')
 
   return {
+    db,
     dbSuperUser,
     getPostgresConnection,
+    requestDb,
   }
 }
 
@@ -61,7 +68,7 @@ describe('dbSuperUser plugin', () => {
   })
 
   it('does not forward route-level maxConnections into shared tenant pool settings', async () => {
-    const { dbSuperUser, getPostgresConnection } = await loadDbSuperUserPlugin()
+    const { dbSuperUser, getPostgresConnection } = await loadDbPlugins()
     const app = Fastify()
 
     app.decorateRequest('tenantId')
@@ -86,6 +93,104 @@ describe('dbSuperUser plugin', () => {
       expect(response.statusCode).toBe(200)
       expect(getPostgresConnection).toHaveBeenCalledTimes(1)
       expect(getPostgresConnection.mock.calls[0][0]).not.toHaveProperty('maxConnections')
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+describe.each([
+  {
+    name: 'db plugin',
+    register: async (app: ReturnType<typeof Fastify>, plugins: Awaited<ReturnType<typeof loadDbPlugins>>) => {
+      app.addHook('onRequest', async (request: FastifyRequest) => {
+        request.jwt = 'user-jwt'
+        request.jwtPayload = {
+          role: 'authenticated',
+        }
+      })
+      await app.register(plugins.db)
+    },
+  },
+  {
+    name: 'dbSuperUser plugin',
+    register: async (
+      app: ReturnType<typeof Fastify>,
+      plugins: Awaited<ReturnType<typeof loadDbPlugins>>
+    ) => {
+      await app.register(plugins.dbSuperUser)
+    },
+  },
+])('$name query cancellation signal wiring', ({ register }) => {
+  afterEach(() => {
+    vi.doUnmock('@internal/database')
+    vi.doUnmock('@internal/database/migrations')
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('does not materialize the disconnect signal when query cancellation is disabled', async () => {
+    const plugins = await loadDbPlugins({ databaseEnableQueryCancellation: false })
+    const app = Fastify()
+
+    app.decorateRequest('tenantId')
+    app.decorateRequest('signals')
+    app.addHook('onRequest', async (request) => {
+      request.tenantId = 'tenant-id'
+      request.signals = {
+        get disconnect(): AbortController {
+          throw new Error('disconnect signal should stay lazy')
+        },
+      } as typeof request.signals
+    })
+    await register(app, plugins)
+    app.get('/test', async () => ({ ok: true }))
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: {
+          'x-forwarded-host': 'tenant.local.test',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(plugins.requestDb.setAbortSignal).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('materializes the disconnect signal when query cancellation is enabled', async () => {
+    const plugins = await loadDbPlugins({ databaseEnableQueryCancellation: true })
+    const app = Fastify()
+    const disconnectController = new AbortController()
+    const disconnectGetter = vi.fn(() => disconnectController)
+
+    app.decorateRequest('tenantId')
+    app.decorateRequest('signals')
+    app.addHook('onRequest', async (request) => {
+      request.tenantId = 'tenant-id'
+      request.signals = Object.defineProperty({}, 'disconnect', {
+        get: disconnectGetter,
+      }) as typeof request.signals
+    })
+    await register(app, plugins)
+    app.get('/test', async () => ({ ok: true }))
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: {
+          'x-forwarded-host': 'tenant.local.test',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(disconnectGetter).toHaveBeenCalledTimes(1)
+      expect(plugins.requestDb.setAbortSignal).toHaveBeenCalledWith(disconnectController.signal)
     } finally {
       await app.close()
     }

--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -102,7 +102,10 @@ describe('dbSuperUser plugin', () => {
 describe.each([
   {
     name: 'db plugin',
-    register: async (app: ReturnType<typeof Fastify>, plugins: Awaited<ReturnType<typeof loadDbPlugins>>) => {
+    register: async (
+      app: ReturnType<typeof Fastify>,
+      plugins: Awaited<ReturnType<typeof loadDbPlugins>>
+    ) => {
       app.addHook('onRequest', async (request: FastifyRequest) => {
         request.jwt = 'user-jwt'
         request.jwtPayload = {
@@ -191,6 +194,33 @@ describe.each([
       expect(response.statusCode).toBe(200)
       expect(disconnectGetter).toHaveBeenCalledTimes(1)
       expect(plugins.requestDb.setAbortSignal).toHaveBeenCalledWith(disconnectController.signal)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('does not require request signals when query cancellation is enabled', async () => {
+    const plugins = await loadDbPlugins({ databaseEnableQueryCancellation: true })
+    const app = Fastify()
+
+    app.decorateRequest('tenantId')
+    app.addHook('onRequest', async (request) => {
+      request.tenantId = 'tenant-id'
+    })
+    await register(app, plugins)
+    app.get('/test', async () => ({ ok: true }))
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: {
+          'x-forwarded-host': 'tenant.local.test',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(plugins.requestDb.setAbortSignal).not.toHaveBeenCalled()
     } finally {
       await app.close()
     }

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -57,7 +57,7 @@ export const db = fastifyPlugin(
       })
 
       // Connect abort signal to DB connection for query cancellation
-      if (request.signals?.disconnect?.signal && databaseEnableQueryCancellation) {
+      if (databaseEnableQueryCancellation && request.signals) {
         request.db.setAbortSignal(request.signals.disconnect.signal)
       }
     })
@@ -103,7 +103,7 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
       })
 
       // Connect abort signal to DB connection for query cancellation
-      if (request.signals?.disconnect?.signal && databaseEnableQueryCancellation) {
+      if (databaseEnableQueryCancellation && request.signals) {
         request.db.setAbortSignal(request.signals.disconnect.signal)
       }
     })

--- a/src/http/plugins/signals.test.ts
+++ b/src/http/plugins/signals.test.ts
@@ -1,7 +1,6 @@
-import { EventEmitter } from 'node:events'
-import { request as httpRequest } from 'node:http'
+import { EventEmitter, once } from 'node:events'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { setTimeout as sleep } from 'node:timers/promises'
+import { request as httpRequest } from 'node:http'
 import Fastify from 'fastify'
 import { describe, expect, it } from 'vitest'
 import { RequestSignals, signals as signalsPlugin } from './signals'
@@ -23,6 +22,21 @@ function build() {
     res as unknown as ServerResponse
   )
   return { req, res, signals }
+}
+
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), 1000)
+  })
+
+  try {
+    return await Promise.race([promise, timeoutPromise])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
 }
 
 describe('RequestSignals', () => {
@@ -174,20 +188,60 @@ describe('signals plugin', () => {
     try {
       client.flushHeaders()
       client.write('partial body')
-      await Promise.race([
-        requestStarted,
-        sleep(1000).then(() => {
-          throw new Error('Timed out waiting for request start')
-        }),
-      ])
+      await withTimeout(requestStarted, 'Timed out waiting for request start')
       client.destroy()
 
-      await Promise.race([
-        bodyAborted,
-        sleep(1000).then(() => {
-          throw new Error('Timed out waiting for request abort')
-        }),
-      ])
+      await withTimeout(bodyAborted, 'Timed out waiting for request abort')
+    } finally {
+      client.destroy()
+      await app.close()
+    }
+  })
+
+  it('aborts response and disconnect signals for real socket disconnects mid-response', async () => {
+    const app = Fastify()
+    let resolveResponseAbort!: () => void
+    let resolveDisconnectAbort!: () => void
+    const responseAborted = new Promise<void>((resolve) => {
+      resolveResponseAbort = resolve
+    })
+    const disconnectAborted = new Promise<void>((resolve) => {
+      resolveDisconnectAbort = resolve
+    })
+
+    await app.register(signalsPlugin)
+    app.get('/stream', async (request, reply) => {
+      request.signals.response.signal.addEventListener('abort', resolveResponseAbort, {
+        once: true,
+      })
+      request.signals.disconnect.signal.addEventListener('abort', resolveDisconnectAbort, {
+        once: true,
+      })
+
+      reply.hijack()
+      reply.raw.writeHead(200, { 'content-type': 'text/plain' })
+      reply.raw.write('partial response')
+
+      await Promise.all([responseAborted, disconnectAborted])
+    })
+
+    const address = await app.listen({ host: '127.0.0.1', port: 0 })
+    const client = httpRequest(`${address}/stream`, { method: 'GET' })
+    client.on('error', () => {})
+
+    try {
+      client.end()
+      const [response] = await withTimeout(
+        once(client, 'response') as Promise<[IncomingMessage]>,
+        'Timed out waiting for streaming response'
+      )
+      await withTimeout(once(response, 'data'), 'Timed out waiting for response data')
+      response.destroy()
+
+      await withTimeout(
+        Promise.all([responseAborted, disconnectAborted]),
+        'Timed out waiting for response abort'
+      )
     } finally {
       client.destroy()
       await app.close()

--- a/src/http/plugins/signals.test.ts
+++ b/src/http/plugins/signals.test.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from 'node:events'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { describe, expect, it } from 'vitest'
+import { RequestSignals } from './signals'
+
+class FakeReq extends EventEmitter {
+  aborted = false
+}
+
+class FakeRes extends EventEmitter {
+  closed = false
+  writableFinished = false
+}
+
+function build() {
+  const req = new FakeReq()
+  const res = new FakeRes()
+  const signals = new RequestSignals(
+    req as unknown as IncomingMessage,
+    res as unknown as ServerResponse
+  )
+  return { req, res, signals }
+}
+
+describe('RequestSignals', () => {
+  it('does not wire socket listeners until a signal is accessed', () => {
+    const { req, res, signals } = build()
+
+    expect(req.listenerCount('close')).toBe(0)
+    expect(res.listenerCount('close')).toBe(0)
+
+    // touch a signal
+    void signals.body
+
+    expect(req.listenerCount('close')).toBe(1)
+    expect(res.listenerCount('close')).toBe(1)
+  })
+
+  it('wires the socket listeners only once across multiple accesses', () => {
+    const { req, res, signals } = build()
+
+    void signals.body
+    void signals.response
+    void signals.disconnect
+
+    expect(req.listenerCount('close')).toBe(1)
+    expect(res.listenerCount('close')).toBe(1)
+  })
+
+  it('returns the same controller instance on repeated access', () => {
+    const { signals } = build()
+    expect(signals.body).toBe(signals.body)
+    expect(signals.disconnect).toBe(signals.disconnect)
+  })
+
+  it('aborts body and disconnect when the request closes after being aborted', () => {
+    const { req, signals } = build()
+
+    const body = signals.body
+    const disconnect = signals.disconnect
+    const response = signals.response
+
+    req.aborted = true
+    req.emit('close')
+
+    expect(body.signal.aborted).toBe(true)
+    expect(disconnect.signal.aborted).toBe(true)
+    expect(response.signal.aborted).toBe(false)
+  })
+
+  it('does not abort body when the request closes cleanly', () => {
+    const { req, signals } = build()
+
+    const body = signals.body
+    req.aborted = false
+    req.emit('close')
+
+    expect(body.signal.aborted).toBe(false)
+  })
+
+  it('aborts response and disconnect when the response closes before finishing', () => {
+    const { res, signals } = build()
+
+    const body = signals.body
+    const response = signals.response
+    const disconnect = signals.disconnect
+
+    res.writableFinished = false
+    res.emit('close')
+
+    expect(response.signal.aborted).toBe(true)
+    expect(disconnect.signal.aborted).toBe(true)
+    expect(body.signal.aborted).toBe(false)
+  })
+
+  it('does not abort response when the response finishes normally', () => {
+    const { res, signals } = build()
+
+    const response = signals.response
+    res.writableFinished = true
+    res.emit('close')
+
+    expect(response.signal.aborted).toBe(false)
+  })
+
+  it('aborts immediately when accessed after the request was already aborted', () => {
+    const { req, signals } = build()
+    req.aborted = true
+
+    expect(signals.body.signal.aborted).toBe(true)
+    expect(signals.disconnect.signal.aborted).toBe(true)
+  })
+
+  it('aborts immediately when accessed after the response was already aborted', () => {
+    const { res, signals } = build()
+    res.closed = true
+    res.writableFinished = false
+
+    expect(signals.response.signal.aborted).toBe(true)
+    expect(signals.disconnect.signal.aborted).toBe(true)
+  })
+
+  it('abortRequest aborts only the controllers that were created', () => {
+    const { signals } = build()
+
+    // only body has been accessed
+    const body = signals.body
+    signals.abortRequest()
+
+    expect(body.signal.aborted).toBe(true)
+    // disconnect was never accessed; accessing it now should create a fresh,
+    // non-aborted controller since the raw request was never actually aborted
+    expect(signals.disconnect.signal.aborted).toBe(false)
+  })
+})

--- a/src/http/plugins/signals.test.ts
+++ b/src/http/plugins/signals.test.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from 'node:events'
+import { request as httpRequest } from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { setTimeout as sleep } from 'node:timers/promises'
+import Fastify from 'fastify'
 import { describe, expect, it } from 'vitest'
-import { RequestSignals } from './signals'
+import { RequestSignals, signals as signalsPlugin } from './signals'
 
 class FakeReq extends EventEmitter {
   aborted = false
@@ -131,5 +134,63 @@ describe('RequestSignals', () => {
     // disconnect was never accessed; accessing it now should create a fresh,
     // non-aborted controller since the raw request was never actually aborted
     expect(signals.disconnect.signal.aborted).toBe(false)
+  })
+})
+
+describe('signals plugin', () => {
+  it('aborts request-side signals through Fastify onRequestAbort for real socket disconnects', async () => {
+    const app = Fastify()
+    let resolveBodyAbort!: () => void
+    let resolveRequestStarted!: () => void
+    const bodyAborted = new Promise<void>((resolve) => {
+      resolveBodyAbort = resolve
+    })
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve
+    })
+
+    await app.register(signalsPlugin)
+    app.addHook('onRequest', async (request) => {
+      resolveRequestStarted()
+      request.signals.body.signal.addEventListener('abort', resolveBodyAbort, { once: true })
+    })
+    app.addContentTypeParser('application/octet-stream', (_request, payload, done) => {
+      payload.resume()
+      payload.once('end', () => done(null))
+      payload.once('error', done)
+    })
+    app.post('/upload', async () => ({ ok: true }))
+
+    const address = await app.listen({ host: '127.0.0.1', port: 0 })
+    const client = httpRequest(`${address}/upload`, {
+      headers: {
+        'content-length': '1000000',
+        'content-type': 'application/octet-stream',
+      },
+      method: 'POST',
+    })
+    client.on('error', () => {})
+
+    try {
+      client.flushHeaders()
+      client.write('partial body')
+      await Promise.race([
+        requestStarted,
+        sleep(1000).then(() => {
+          throw new Error('Timed out waiting for request start')
+        }),
+      ])
+      client.destroy()
+
+      await Promise.race([
+        bodyAborted,
+        sleep(1000).then(() => {
+          throw new Error('Timed out waiting for request abort')
+        }),
+      ])
+    } finally {
+      client.destroy()
+      await app.close()
+    }
   })
 })

--- a/src/http/plugins/signals.ts
+++ b/src/http/plugins/signals.ts
@@ -1,55 +1,135 @@
 import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
+import type { IncomingMessage, ServerResponse } from 'http'
 
 declare module 'fastify' {
   interface FastifyRequest {
-    signals: {
-      body: AbortController
-      response: AbortController
-      disconnect: AbortController
+    signals: RequestSignals
+  }
+}
+
+/**
+ * Per-request abort controllers, allocated lazily.
+ *
+ * Creating `AbortController`s and wiring socket `close` listeners is relatively
+ * expensive, and the majority of requests on high-RPS routes never read any of
+ * these signals. Mirroring Fastify's own lazy `request.signal` allocation, the
+ * controllers and their listeners are only created the first time a signal is
+ * accessed — requests that never touch them pay nothing.
+ */
+export class RequestSignals {
+  private _body?: AbortController
+  private _response?: AbortController
+  private _disconnect?: AbortController
+  private wired = false
+
+  constructor(
+    private readonly rawReq: IncomingMessage,
+    private readonly rawRes: ServerResponse
+  ) {}
+
+  /** Aborted when the client terminates before the request body is fully received. */
+  get body(): AbortController {
+    if (!this._body) {
+      this._body = new AbortController()
+      this.wire()
+      if (this.isRequestAborted()) {
+        this._body.abort()
+      }
     }
+    return this._body
+  }
+
+  /** Aborted when the client terminates before the response is fully sent. */
+  get response(): AbortController {
+    if (!this._response) {
+      this._response = new AbortController()
+      this.wire()
+      if (this.isResponseAborted()) {
+        this._response.abort()
+      }
+    }
+    return this._response
+  }
+
+  /** Aborted when the client disconnects at any point during the request. */
+  get disconnect(): AbortController {
+    if (!this._disconnect) {
+      this._disconnect = new AbortController()
+      this.wire()
+      if (this.isRequestAborted() || this.isResponseAborted()) {
+        this._disconnect.abort()
+      }
+    }
+    return this._disconnect
+  }
+
+  /** Abort the request-side signals. Invoked from Fastify's `onRequestAbort` hook. */
+  abortRequest(): void {
+    this.onRequestClosed()
+  }
+
+  private isRequestAborted(): boolean {
+    return this.rawReq.aborted
+  }
+
+  private isResponseAborted(): boolean {
+    return this.rawRes.closed && !this.rawRes.writableFinished
+  }
+
+  private onRequestClosed(): void {
+    if (this._body && !this._body.signal.aborted) {
+      this._body.abort()
+    }
+    this.abortDisconnect()
+  }
+
+  private onResponseClosed(): void {
+    if (this._response && !this._response.signal.aborted) {
+      this._response.abort()
+    }
+    this.abortDisconnect()
+  }
+
+  private abortDisconnect(): void {
+    if (this._disconnect && !this._disconnect.signal.aborted) {
+      this._disconnect.abort()
+    }
+  }
+
+  /** Wire the socket `close` listeners once, on first access of any signal. */
+  private wire(): void {
+    if (this.wired) {
+      return
+    }
+    this.wired = true
+
+    // Client terminated the request before the body was fully sent
+    this.rawReq.once('close', () => {
+      if (this.rawReq.aborted) {
+        this.onRequestClosed()
+      }
+    })
+
+    // Client terminated the request before the server finished sending the response
+    this.rawRes.once('close', () => {
+      if (!this.rawRes.writableFinished) {
+        this.onResponseClosed()
+      }
+    })
   }
 }
 
 export const signals = fastifyPlugin(
   async function (fastify: FastifyInstance) {
+    fastify.decorateRequest('signals')
+
     fastify.addHook('onRequest', async (req, res) => {
-      req.signals = {
-        body: new AbortController(),
-        response: new AbortController(),
-        disconnect: new AbortController(),
-      }
-
-      // Client terminated the request before the body was fully sent
-      req.raw.once('close', () => {
-        if (req.raw.aborted) {
-          req.signals.body.abort()
-
-          if (!req.signals.disconnect.signal.aborted) {
-            req.signals.disconnect.abort()
-          }
-        }
-      })
-
-      // Client terminated the request before server finished sending the response
-      res.raw.once('close', () => {
-        const aborted = !res.raw.writableFinished
-        if (aborted) {
-          req.signals.response.abort()
-
-          if (!req.signals.disconnect.signal.aborted) {
-            req.signals.disconnect.abort()
-          }
-        }
-      })
+      req.signals = new RequestSignals(req.raw, res.raw)
     })
 
     fastify.addHook('onRequestAbort', async (req) => {
-      req.signals.body.abort()
-
-      if (!req.signals.disconnect.signal.aborted) {
-        req.signals.disconnect.abort()
-      }
+      req.signals.abortRequest()
     })
   },
   { name: 'request-signals' }

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -87,8 +87,12 @@ export default async function routes(fastify: FastifyInstance) {
                   tenantId: req.tenantId,
                   owner: req.owner,
                   signals: {
-                    body: req.signals.body.signal,
-                    response: req.signals.response.signal,
+                    get body() {
+                      return req.signals.body.signal
+                    },
+                    get response() {
+                      return req.signals.response.signal
+                    },
                   },
                 })
 


### PR DESCRIPTION
The `signals` plugin eagerly created three `AbortController`s and wired two socket `close` listeners on every request, even though most requests on high-RPS routes never read any of them.

Following Fastify's own lazy `request.signal` allocation, `req.signals` is now a lightweight per-request holder whose `body` / `response` / `disconnect` controllers (and their socket listeners) are created only on first access. Requests that never touch a signal pay nothing; already-aborted requests still abort immediately on access, and the `onRequestAbort` hook only aborts controllers that were actually created.

Also:
- Made the S3 router's `ctx.signals` lazy (getters) so commands only allocate the signal they use.
- Reordered the DB query-cancellation check to short-circuit on the config flag before touching `request.signals`.

Added a unit test covering lazy wiring, abort propagation, and the already-aborted paths.