### PR TITLE
perf(logger): serialize request/reply logs with fast-json-stringify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "aws-sigv4-sign": "^1.2.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
+        "fast-json-stringify": "^6.3.0",
         "fast-querystring": "^1.1.2",
         "fastify": "^5.8.5",
         "fastify-plugin": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "aws-sigv4-sign": "^1.2.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
+    "fast-json-stringify": "^6.3.0",
     "fast-querystring": "^1.1.2",
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",

--- a/src/internal/monitoring/logger.test.ts
+++ b/src/internal/monitoring/logger.test.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'node:stream'
 import { vi } from 'vitest'
 
 const mockedLoggerModules = ['pino', '../../config'] as const
@@ -328,6 +329,110 @@ describe('logger serializers', () => {
       statusCode: 200,
       headers: { etag: 'fresh-etag' },
     })
+  })
+
+  test('base logger registers compiled req/res stringifiers on child loggers', async () => {
+    const lines: string[] = []
+    const stream = new Writable({
+      write(chunk, _encoding, callback) {
+        lines.push(chunk.toString())
+        callback()
+      },
+    })
+
+    vi.doMock('pino', async () => {
+      type PinoFactory = typeof import('pino')
+      const actual = await vi.importActual<{ default: PinoFactory } & Record<string, unknown>>(
+        'pino'
+      )
+      const actualPino = actual.default
+      const pinoMock = Object.assign(
+        vi.fn((options: unknown) =>
+          actualPino(
+            {
+              ...((options ?? {}) as Record<string, unknown>),
+              base: null,
+              timestamp: false,
+              transport: undefined,
+            } as never,
+            stream as never
+          )
+        ),
+        actualPino,
+        {
+          stdTimeFunctions: actualPino.stdTimeFunctions,
+          symbols: actualPino.symbols,
+        }
+      )
+
+      return {
+        ...actual,
+        default: pinoMock,
+      }
+    })
+    vi.doMock('../../config', () => ({
+      getConfig: vi.fn(() => ({
+        logLevel: 'info',
+        logflareApiKey: undefined,
+        logflareBatchSize: 1,
+        logflareEnabled: false,
+        logflareSourceToken: undefined,
+        region: 'local',
+        version: 'test-version',
+      })),
+    }))
+
+    const { logger, serializeReplyLog, serializeRequestLog } = await import('./logger')
+    const req = serializeRequestLog({
+      id: 'trace-1',
+      method: 'GET',
+      url: '/object?token=hidden-query&keep=visible',
+      query: { token: 'hidden-query', keep: 'visible' },
+      headers: {
+        authorization: 'Bearer hidden-auth',
+        'x-client-info': 'storage-js',
+      },
+      hostname: 'storage.test',
+      ip: '127.0.0.1',
+      protocol: 'https',
+      socket: { remotePort: 1234 },
+    } as never)
+    const res = serializeReplyLog({
+      statusCode: 200,
+      getHeaders: vi.fn(() => ({
+        etag: 'fresh-etag',
+        'set-cookie': 'hidden-cookie',
+      })),
+    } as never)!
+
+    ;(req as unknown as Record<string, unknown>).unknownRequestField = 'dropped-request-field'
+    ;(res as unknown as Record<string, unknown>).unknownReplyField = 'dropped-reply-field'
+
+    logger.info({ req, res }, 'compiled serializer smoke')
+
+    expect(lines).toHaveLength(1)
+    const log = JSON.parse(lines[0])
+    expect(log.req).toEqual({
+      region: 'local',
+      traceId: 'trace-1',
+      method: 'GET',
+      url: '/object?token=redacted&keep=visible',
+      headers: { x_client_info: 'storage-js' },
+      hostname: 'storage.test',
+      remoteAddress: '127.0.0.1',
+      remotePort: 1234,
+    })
+    expect(log.res).toEqual({
+      statusCode: 200,
+      headers: { etag: 'fresh-etag' },
+    })
+
+    const serializedLog = JSON.stringify(log)
+    expect(serializedLog).not.toContain('hidden-query')
+    expect(serializedLog).not.toContain('hidden-auth')
+    expect(serializedLog).not.toContain('hidden-cookie')
+    expect(serializedLog).not.toContain('dropped-request-field')
+    expect(serializedLog).not.toContain('dropped-reply-field')
   })
 
   test('buildTransport wires logflare hooks when logflare is enabled', async () => {

--- a/src/internal/monitoring/logger.test.ts
+++ b/src/internal/monitoring/logger.test.ts
@@ -286,6 +286,50 @@ describe('logger serializers', () => {
     expect(serializedRawValues).not.toContain('hidden-cookie')
   })
 
+  test('serializeRequestLogToJson emits schema JSON, dropping unknown keys and absent optionals', async () => {
+    setupLoggerMocks()
+    const { serializeRequestLog, serializeRequestLogToJson } = await import('./logger')
+
+    const request = {
+      id: 'trace-1',
+      method: 'GET',
+      url: '/object?keep=visible',
+      headers: { 'x-client-info': 'storage-js' },
+      hostname: 'storage.test',
+      ip: '127.0.0.1',
+      protocol: 'https',
+      socket: { remotePort: undefined },
+    } as never
+
+    const json = serializeRequestLogToJson(serializeRequestLog(request))
+
+    expect(JSON.parse(json)).toEqual({
+      region: 'local',
+      traceId: 'trace-1',
+      method: 'GET',
+      url: '/object?keep=visible',
+      headers: { x_client_info: 'storage-js' },
+      hostname: 'storage.test',
+      remoteAddress: '127.0.0.1',
+    })
+    expect(json).not.toContain('remotePort')
+  })
+
+  test('serializeReplyLogToJson emits schema JSON for the reply payload', async () => {
+    setupLoggerMocks()
+    const { serializeReplyLog, serializeReplyLogToJson } = await import('./logger')
+
+    const reply = serializeReplyLog({
+      statusCode: 200,
+      getHeaders: vi.fn(() => ({ etag: 'fresh-etag' })),
+    } as never)!
+
+    expect(JSON.parse(serializeReplyLogToJson(reply))).toEqual({
+      statusCode: 200,
+      headers: { etag: 'fresh-etag' },
+    })
+  })
+
   test('buildTransport wires logflare hooks when logflare is enabled', async () => {
     setupLoggerMocks({
       logLevel: 'debug',

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { normalizeRawError } from '@internal/errors'
+import fastJson from 'fast-json-stringify'
 import fastQuerystring from 'fast-querystring'
 import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
 import pino, { Logger } from 'pino'
@@ -33,6 +34,39 @@ interface SerializedReplyLogShape {
 export interface SerializedReplyLog extends SerializedReplyLogShape {
   readonly [serializedReplyLogSymbol]: true
 }
+
+const safeHeadersSchema = {
+  type: 'object',
+  additionalProperties: { type: 'string' },
+} as const
+
+// JSON schemas for the structured payloads that appear on every request log.
+// They are compiled into fast-json-stringify serializers and wired into pino as
+// per-key stringifiers (see registerLogStringifiers), so the hot path avoids
+// pino's generic stringify for these objects.
+export const serializeRequestLogToJson = fastJson({
+  type: 'object',
+  properties: {
+    region: { type: 'string' },
+    traceId: { type: 'string' },
+    method: { type: 'string' },
+    url: { type: 'string' },
+    headers: safeHeadersSchema,
+    hostname: { type: 'string' },
+    remoteAddress: { type: 'string' },
+    remotePort: { type: 'integer' },
+  },
+  additionalProperties: false,
+})
+
+export const serializeReplyLogToJson = fastJson({
+  type: 'object',
+  properties: {
+    statusCode: { type: 'integer' },
+    headers: safeHeadersSchema,
+  },
+  additionalProperties: false,
+})
 
 const {
   logLevel,
@@ -71,10 +105,39 @@ export const baseLogger = pino({
   timestamp: pino.stdTimeFunctions.isoTime,
 })
 
+registerLogStringifiers(baseLogger)
+
 export let logger = baseLogger.child({ region, appVersion })
 
 export function setLogger(newLogger: Logger) {
   logger = newLogger
+}
+
+type LogStringifier = (value: unknown) => string
+
+/**
+ * Wires the schema-compiled serializers into pino as per-key stringifiers.
+ *
+ * pino applies the `req`/`res` serializers first to normalize the values, then
+ * hands the result to the matching stringifier to produce the embedded JSON.
+ * Child loggers inherit the stringifiers through the prototype chain, so the
+ * whole logger tree benefits without re-registration.
+ */
+function registerLogStringifiers(target: Logger) {
+  const stringifiersSym = pino.symbols?.stringifiersSym
+  if (!stringifiersSym) {
+    return
+  }
+
+  const stringifiers = (target as unknown as Record<symbol, Record<string, LogStringifier>>)[
+    stringifiersSym
+  ]
+  if (!stringifiers) {
+    return
+  }
+
+  stringifiers.req = serializeRequestLogToJson as LogStringifier
+  stringifiers.res = serializeReplyLogToJson as LogStringifier
 }
 
 export interface RequestLogContext {


### PR DESCRIPTION
Defines JSON schemas for the structured request and reply log payloads and compiles them with `fast-json-stringify`. The compiled serializers are wired into pino as per-key stringifiers for `req`/`res`, so the hot logging path (emitted on every request) skips pino's generic stringify for these objects.

The existing `req`/`res` serializers still run first to normalize the values; the compiled stringifier then produces the embedded JSON. Child loggers inherit the stringifiers through the prototype chain, so the whole logger tree benefits without re-registration. Log output is unchanged — `req`/`res` remain nested JSON objects.

`fast-json-stringify` was already present transitively (via fastify); it's now declared as a direct dependency since we import it.
