### PR TITLE
fix: improve performance of log redaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "aws-sigv4-sign": "^1.2.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
+        "fast-querystring": "^1.1.2",
         "fastify": "^5.8.5",
         "fastify-plugin": "^5.1.0",
         "fs-xattr": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "aws-sigv4-sign": "^1.2.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
+    "fast-querystring": "^1.1.2",
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fs-xattr": "0.3.1",

--- a/src/internal/monitoring/logger.test.ts
+++ b/src/internal/monitoring/logger.test.ts
@@ -46,6 +46,24 @@ function setupLoggerMocks(configOverrides: Record<string, unknown> = {}) {
 }
 
 describe('logger serializers', () => {
+  async function createRequestUrlRedactor() {
+    setupLoggerMocks()
+    const { serializeRequestLog } = await import('./logger')
+
+    return (url: string, query?: unknown) =>
+      serializeRequestLog({
+        id: 'trace-1',
+        method: 'GET',
+        url,
+        ...(query === undefined ? {} : { query }),
+        headers: {},
+        hostname: 'storage.test',
+        ip: '127.0.0.1',
+        protocol: 'https',
+        socket: { remotePort: 1234 },
+      } as never).url
+  }
+
   afterEach(() => {
     for (const moduleId of mockedLoggerModules) {
       vi.doUnmock(moduleId)
@@ -83,6 +101,54 @@ describe('logger serializers', () => {
       remoteAddress: '127.0.0.1',
       remotePort: 1234,
     })
+  })
+
+  test('redactLogUrl redacts sensitive keys from the parsed query', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?token=secret&keep=1', { token: 'secret', keep: '1' })).toBe(
+      '/o?token=redacted&keep=1'
+    )
+  })
+
+  test('redactLogUrl redacts encoded sensitive keys from the parsed query', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?to%6Ben=leaked-jwt', { token: 'leaked-jwt' })).toBe('/o?token=redacted')
+  })
+
+  test('redactLogUrl leaves URLs untouched when the parsed query has no sensitive keys', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?tokenizer=foo', { tokenizer: 'foo' })).toBe('/o?tokenizer=foo')
+    expect(redact('/o?keep=visible', { keep: 'visible' })).toBe('/o?keep=visible')
+  })
+
+  test('redactLogUrl redacts exact sensitive keys when no parsed query is available', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?a=1&X-Amz-Signature=sig&b=2')).toBe('/o?a=1&X-Amz-Signature=redacted&b=2')
+  })
+
+  test('redactLogUrl redacts encoded sensitive keys when no parsed query is available', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?X-Amz-%53ignature=leaked-sig')).toBe('/o?X-Amz-Signature=redacted')
+  })
+
+  test('redactLogUrl does not redact sensitive key prefixes or suffixes', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/o?tokenizer=foo')).toBe('/o?tokenizer=foo')
+    expect(redact('/o?notX-Amz-Signature=foo')).toBe('/o?notX-Amz-Signature=foo')
+  })
+
+  test('redactLogUrl does not treat path ampersands as query separators', async () => {
+    const redact = await createRequestUrlRedactor()
+
+    expect(redact('/object/sign/bucket/a&b.txt?token=leaked-jwt')).toBe(
+      '/object/sign/bucket/a&b.txt?token=redacted'
+    )
   })
 
   test('serializeReplyLog whitelists reply headers and tolerates undefined replies', async () => {

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
-import { URL } from 'node:url'
 import { normalizeRawError } from '@internal/errors'
+import fastQuerystring from 'fast-querystring'
 import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
 import pino, { Logger } from 'pino'
 import { getConfig } from '../../config'
@@ -246,7 +246,7 @@ export function serializeRequestLog(req: FastifyRequest): SerializedRequestLog {
     region,
     traceId: req.id,
     method: req.method,
-    url: redactLogUrl(req.url),
+    url: redactLogUrl(req.url, req.query),
     headers: whitelistHeaders(req.headers),
     hostname: req.hostname,
     remoteAddress: req.ip,
@@ -333,23 +333,30 @@ function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-function redactLogUrl(url: string) {
+function redactLogUrl(url: string, query?: unknown): string {
   const qIdx = url.indexOf('?')
 
   // Fast path: no query string, nothing to redact
   if (qIdx === -1) return url
 
-  const query = url.slice(qIdx + 1)
-  // Fast path: no sensitive params present
-  if (!redactedQueryParams.some((p) => query.includes(p))) return url
+  // Reuse the query Fastify already parsed (and percent-decoded) during routing;
+  // only parse here when it is unavailable, e.g. raw non-Fastify log values. A key
+  // sent as `to%6Ben` is decoded to `token`, so encoded secrets are still matched.
+  const parsed = isRecord(query) ? query : fastQuerystring.parse(url.slice(qIdx + 1))
 
-  const lUrl = new URL(url, 'http://storage.local')
-  redactedQueryParams.forEach((param) => {
-    if (lUrl.searchParams.has(param)) {
-      lUrl.searchParams.set(param, 'redacted')
+  // Redact only when a sensitive key is present, cloning lazily so the request's
+  // own query object is never mutated. When nothing is sensitive, return the URL
+  // untouched and do no extra work.
+  let redacted: Record<string, unknown> | undefined
+  for (const param of redactedQueryParams) {
+    if (param in parsed) {
+      redacted ??= { ...parsed }
+      redacted[param] = 'redacted'
     }
-  })
-  return `${lUrl.pathname}${lUrl.search}`
+  }
+  if (redacted === undefined) return url
+
+  return `${url.slice(0, qIdx)}?${fastQuerystring.stringify(redacted)}`
 }
 
 function statusOfType(statusCode: number, ofType: number) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Standard library Url parsing is used to redact sensitive data from logs but it's not performance friendly.

## What is the new behavior?

Use already parsed fastify query directly. Copy it if needed not to mutate original query. If missing, use `fast-querystring` to parse, and use the same dependency to stringify fast.   

## Additional context

[fast-querystring](https://www.npmjs.com/package/fast-querystring)
