### PR TITLE
fix: drop ip-address dependency in favor of std

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "fastify-plugin": "^5.1.0",
         "fs-xattr": "0.3.1",
         "ioredis": "^5.2.4",
-        "ip-address": "^10.2.0",
         "jose": "^6.2.3",
         "json-bigint": "^1.0.0",
         "lru-cache": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "fastify-plugin": "^5.1.0",
     "fs-xattr": "0.3.1",
     "ioredis": "^5.2.4",
-    "ip-address": "^10.2.0",
     "jose": "^6.2.3",
     "json-bigint": "^1.0.0",
     "lru-cache": "^11.2.0",

--- a/src/internal/database/ssl.ts
+++ b/src/internal/database/ssl.ts
@@ -1,5 +1,5 @@
+import { isIP } from 'node:net'
 import { logger } from '@internal/monitoring'
-import * as ipAddr from 'ip-address'
 import { ConnectionOptions } from 'tls'
 
 export function getSslSettings({
@@ -30,5 +30,5 @@ export function getSslSettings({
 export function isIpAddress(ip: string) {
   // IP might be URL-encoded
   const decodedIp = decodeURIComponent(ip)
-  return ipAddr.Address6.isValid(decodedIp) || ipAddr.Address4.isValid(decodedIp)
+  return isIP(decodedIp) !== 0
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

We use ip-address dependency to check hostname is an IP.

## What is the new behavior?

Use standard library instead. Optimized and less supply chain risk.

## Additional context

https://github.com/beaugunderson/ip-address
https://nodejs.org/docs/latest-v24.x/api/net.html#netisipinput
