### PR TITLE
fix: handle brackets in ssl settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "aws-sigv4-sign": "^1.2.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
+        "fast-decode-uri-component": "^1.0.1",
         "fast-json-stringify": "^6.3.0",
         "fast-querystring": "^1.1.2",
         "fastify": "^5.8.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "aws-sigv4-sign": "^1.2.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
+    "fast-decode-uri-component": "^1.0.1",
     "fast-json-stringify": "^6.3.0",
     "fast-querystring": "^1.1.2",
     "fastify": "^5.8.5",

--- a/src/internal/database/ssl.test.ts
+++ b/src/internal/database/ssl.test.ts
@@ -10,6 +10,8 @@ describe('database utils', () => {
     ['121.212.187.123', true],
     ['121.212.187.5', true],
     ['2001:db8:3333:4444:5555:6666:7777:8888', true],
+    ['[2001:db8:3333:4444:5555:6666:7777:8888]', true],
+    ['%5B2001%3Adb8%3A3333%3A4444%3A5555%3A6666%3A7777%3A8888%5D', true],
     ['2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF', true],
     ['2406%3Ada18%3A4fd%3A9b09%3A2c76%3A5d38%3Ade30%3A7904', true],
   ])('is %s ip address, expected %s', (text: string, expected: boolean) => {
@@ -30,6 +32,55 @@ describe('database utils', () => {
           databaseSSLRootCert: '<cert>',
         })
       ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+    })
+
+    test('should detect IP host without constructing a URL', () => {
+      const originalUrl = global.URL
+
+      try {
+        global.URL = class {
+          constructor() {
+            throw new Error('URL parsing should not be used')
+          }
+        } as unknown as typeof URL
+
+        expect(
+          getSslSettings({
+            connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
+            databaseSSLRootCert: '<cert>',
+          })
+        ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+      } finally {
+        global.URL = originalUrl
+      }
+    })
+
+    test('should return SSL settings if hostname is a bracketed IPv6 address', () => {
+      expect(
+        getSslSettings({
+          connectionString:
+            'postgres://foo:bar@[2001:db8:3333:4444:5555:6666:7777:8888]:5432/postgres',
+          databaseSSLRootCert: '<cert>',
+        })
+      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+    })
+
+    test('should detect an IP host even when the password contains an @', () => {
+      expect(
+        getSslSettings({
+          connectionString: 'postgres://user:p@ss@1.2.3.4:5432/postgres',
+          databaseSSLRootCert: '<cert>',
+        })
+      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+    })
+
+    test('should not treat an IP in the userinfo as the host', () => {
+      expect(
+        getSslSettings({
+          connectionString: 'postgres://1.2.3.4@db.ref.supabase.red:5432/postgres',
+          databaseSSLRootCert: '<cert>',
+        })
+      ).toStrictEqual({ ca: '<cert>' })
     })
 
     test('should return SSL settings if hostname is not an IP address', () => {

--- a/src/internal/database/ssl.ts
+++ b/src/internal/database/ssl.ts
@@ -1,5 +1,5 @@
 import { isIP } from 'node:net'
-import { logger } from '@internal/monitoring'
+import fastDecodeURIComponent from 'fast-decode-uri-component'
 import { ConnectionOptions } from 'tls'
 
 export function getSslSettings({
@@ -11,24 +11,86 @@ export function getSslSettings({
 }): ConnectionOptions | undefined {
   if (!databaseSSLRootCert) return undefined
 
-  try {
-    // When connecting through PGBouncer, we connect through an IPv6 address rather than a hostname
-    // When passing in the root CA for SSL, this will always fail, so we need to skip passing in the SSL root cert
-    // in case the hostname is an IP address
-    const url = new URL(connectionString)
-    if (url.hostname && isIpAddress(url.hostname)) {
-      return { ca: databaseSSLRootCert, rejectUnauthorized: false }
-    }
-  } catch (err) {
-    // ignore to ensure this never breaks the connection in case of an invalid URL
-    logger.warn(err, 'Failed to parse connection string')
+  // When connecting through PGBouncer, we connect through an IPv6 address rather than a hostname.
+  // When passing in the root CA for SSL, this will always fail,
+  // so we need to skip passing the SSL root cert if host name is an IP address.
+  const hostname = getConnectionStringHostname(connectionString)
+  if (hostname && isIpAddress(hostname)) {
+    return { ca: databaseSSLRootCert, rejectUnauthorized: false }
   }
 
   return { ca: databaseSSLRootCert }
 }
 
 export function isIpAddress(ip: string) {
-  // IP might be URL-encoded
-  const decodedIp = decodeURIComponent(ip)
-  return isIP(decodedIp) !== 0
+  const decoded = fastDecodeURIComponent(ip) ?? ip
+
+  if (decoded.startsWith('[') && decoded.endsWith(']')) {
+    return isIP(decoded.slice(1, -1)) !== 0
+  }
+
+  return isIP(decoded) !== 0
+}
+
+function getConnectionStringHostname(connectionString: string): string | undefined {
+  const protocolSeparatorIndex = connectionString.indexOf('://')
+  if (protocolSeparatorIndex === -1) {
+    return undefined
+  }
+
+  const authorityStartIndex = protocolSeparatorIndex + 3
+  let authorityEndIndex = connectionString.length
+
+  for (let index = authorityStartIndex; index < connectionString.length; index++) {
+    const charCode = connectionString.charCodeAt(index)
+    if (charCode === 47 /* / */ || charCode === 63 /* ? */ || charCode === 35 /* # */) {
+      authorityEndIndex = index
+      break
+    }
+  }
+
+  if (authorityStartIndex >= authorityEndIndex) {
+    return undefined
+  }
+
+  let hostStartIndex = authorityStartIndex
+  for (let index = authorityEndIndex - 1; index >= authorityStartIndex; index--) {
+    if (connectionString.charCodeAt(index) === 64 /* @ */) {
+      hostStartIndex = index + 1
+      break
+    }
+  }
+
+  if (hostStartIndex >= authorityEndIndex) {
+    return undefined
+  }
+
+  if (connectionString.charCodeAt(hostStartIndex) === 91 /* [ */) {
+    const bracketEndIndex = connectionString.indexOf(']', hostStartIndex + 1)
+
+    if (
+      bracketEndIndex === -1 ||
+      bracketEndIndex >= authorityEndIndex ||
+      (bracketEndIndex + 1 < authorityEndIndex &&
+        connectionString.charCodeAt(bracketEndIndex + 1) !== 58) /* : */
+    ) {
+      return undefined
+    }
+
+    return connectionString.slice(hostStartIndex + 1, bracketEndIndex)
+  }
+
+  let hostEndIndex = authorityEndIndex
+  for (let index = hostStartIndex; index < authorityEndIndex; index++) {
+    if (connectionString.charCodeAt(index) === 58 /* : */) {
+      hostEndIndex = index
+      break
+    }
+  }
+
+  if (hostStartIndex >= hostEndIndex) {
+    return undefined
+  }
+
+  return connectionString.slice(hostStartIndex, hostEndIndex)
 }

--- a/src/types/fast-decode-uri-component.d.ts
+++ b/src/types/fast-decode-uri-component.d.ts
@@ -1,0 +1,9 @@
+declare module 'fast-decode-uri-component' {
+  /**
+   * Decodes a URI component without allocating when there is nothing to decode
+   * (returns the input unchanged when it contains no `%`). Returns `null`
+   * instead of throwing when the input is malformed.
+   */
+  function fastDecodeURIComponent(uri: string): string | null
+  export default fastDecodeURIComponent
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

IP detection for SSL settings doesn't handle brackets in the url.

## What is the new behavior?

It's handled correctly and covered by tests.

## Additional context

Bug is prior to #1173 but while on it, addressed.
Also hand roll hostname parser to drop full url parsing.
