### PR TITLE
fix: improve ecs client, cache metadata and reduce list calls

### DIFF
--- a/src/internal/cluster/ecs.test.ts
+++ b/src/internal/cluster/ecs.test.ts
@@ -49,11 +49,11 @@ describe('ClusterDiscoveryECS', () => {
     expect(mockSend).not.toHaveBeenCalled()
   })
 
-  it('fetches ECS task metadata once and counts running plus pending tasks', async () => {
+  it('fetches ECS task metadata once and counts active tasks with one ECS list call', async () => {
     process.env.ECS_CONTAINER_METADATA_URI = 'http://169.254.170.2/v4/metadata'
 
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      return new Response(
         JSON.stringify({
           Cluster: 'cluster-a',
           Family: 'storage',
@@ -65,34 +65,73 @@ describe('ClusterDiscoveryECS', () => {
           },
         }
       )
-    )
+    })
     vi.stubGlobal('fetch', fetchMock)
 
-    mockSend
-      .mockResolvedValueOnce({
-        taskArns: ['task-1', 'task-2'],
-      })
-      .mockResolvedValueOnce({
-        taskArns: ['task-3'],
-      })
+    mockSend.mockResolvedValueOnce({
+      taskArns: ['task-1', 'task-2', 'task-3'],
+    })
 
     await expect(new ClusterDiscoveryECS().getClusterSize()).resolves.toBe(3)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith('http://169.254.170.2/v4/metadata/task')
-    expect(mockSend).toHaveBeenCalledTimes(2)
+    expect(mockSend).toHaveBeenCalledTimes(1)
     expect(mockSend.mock.calls[0][0]).toBeInstanceOf(ListTasksCommand)
     expect(mockSend.mock.calls[0][0].input).toEqual({
       cluster: 'cluster-a',
       desiredStatus: 'RUNNING',
       family: 'storage',
     })
-    expect(mockSend.mock.calls[1][0]).toBeInstanceOf(ListTasksCommand)
-    expect(mockSend.mock.calls[1][0].input).toEqual({
-      cluster: 'cluster-a',
-      desiredStatus: 'PENDING',
-      family: 'storage',
+  })
+
+  it('reuses successful ECS task metadata across cluster size checks', async () => {
+    process.env.ECS_CONTAINER_METADATA_URI = 'http://169.254.170.2/v4/metadata'
+
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          Cluster: 'cluster-a',
+          Family: 'storage',
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
     })
+    vi.stubGlobal('fetch', fetchMock)
+
+    mockSend
+      .mockResolvedValueOnce({
+        taskArns: ['task-1'],
+      })
+      .mockResolvedValueOnce({
+        taskArns: ['task-1', 'task-2'],
+      })
+
+    const clusterDiscovery = new ClusterDiscoveryECS()
+
+    await expect(clusterDiscovery.getClusterSize()).resolves.toBe(1)
+    await expect(clusterDiscovery.getClusterSize()).resolves.toBe(2)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('http://169.254.170.2/v4/metadata/task')
+    expect(mockSend).toHaveBeenCalledTimes(2)
+    expect(mockSend.mock.calls.map(([command]) => command.input)).toEqual([
+      {
+        cluster: 'cluster-a',
+        desiredStatus: 'RUNNING',
+        family: 'storage',
+      },
+      {
+        cluster: 'cluster-a',
+        desiredStatus: 'RUNNING',
+        family: 'storage',
+      },
+    ])
   })
 
   it('drains failed ECS task metadata responses before listing tasks', async () => {

--- a/src/internal/cluster/ecs.ts
+++ b/src/internal/cluster/ecs.ts
@@ -1,4 +1,4 @@
-import { type DesiredStatus, ECSClient, ListTasksCommand } from '@aws-sdk/client-ecs'
+import { ECSClient, ListTasksCommand } from '@aws-sdk/client-ecs'
 
 type ECSTaskMetadata = {
   Cluster: string
@@ -7,6 +7,7 @@ type ECSTaskMetadata = {
 
 export class ClusterDiscoveryECS {
   private client: ECSClient
+  private taskMetadata?: Promise<ECSTaskMetadata>
 
   constructor() {
     this.client = new ECSClient()
@@ -17,14 +18,9 @@ export class ClusterDiscoveryECS {
       throw new Error('ECS_CONTAINER_METADATA_URI is not set')
     }
 
-    const metadata = await this.getTaskMetadata(process.env.ECS_CONTAINER_METADATA_URI)
+    const metadata = await this.getCachedTaskMetadata(process.env.ECS_CONTAINER_METADATA_URI)
 
-    const [running, pending] = await Promise.all([
-      this.listTasks(metadata, 'RUNNING'),
-      this.listTasks(metadata, 'PENDING'),
-    ])
-
-    return running + pending
+    return await this.listTasks(metadata)
   }
 
   private async getTaskMetadata(metadataUri: string): Promise<ECSTaskMetadata> {
@@ -42,11 +38,20 @@ export class ClusterDiscoveryECS {
     return (await response.json()) as ECSTaskMetadata
   }
 
-  private async listTasks(metadata: ECSTaskMetadata, status: DesiredStatus) {
+  private getCachedTaskMetadata(metadataUri: string): Promise<ECSTaskMetadata> {
+    this.taskMetadata ??= this.getTaskMetadata(metadataUri).catch((error) => {
+      this.taskMetadata = undefined
+      throw error
+    })
+
+    return this.taskMetadata
+  }
+
+  private async listTasks(metadata: ECSTaskMetadata) {
     const command = new ListTasksCommand({
       family: metadata.Family,
       cluster: metadata.Cluster,
-      desiredStatus: status,
+      desiredStatus: 'RUNNING',
     })
     const response = await this.client.send(command)
     return response.taskArns?.length || 0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring for less resource usage

## What is the current behavior?

ECS cluster client fetches metadata at every poll and list task with desired status pending. 

## What is the new behavior?

Metadata doesn't change so does it once and cache.
Pending status doesn't return anything because it's not a desired status but last status.

## Additional context

[AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTasks.html#API_ListTasks_RequestSyntax)
