### PR TITLE
fix: do not override tenant feature via global config

### DIFF
--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -137,8 +137,7 @@ interface tenantDBInterface {
   disable_events?: string[] | null
 }
 
-const { dbMigrationFreezeAt, icebergEnabled, vectorEnabled, adminReturnTenantSensitiveData } =
-  getConfig()
+const { dbMigrationFreezeAt, adminReturnTenantSensitiveData } = getConfig()
 const migrationQueueName = RunMigrationsOnTenants.getQueueName()
 const tenantConfigStorePg = new TenantConfigStorePg(multitenantPgExecutor)
 const migrationAdminStorePg = new MigrationAdminStorePg(multitenantPgExecutor, PG_BOSS_SCHEMA)
@@ -318,13 +317,13 @@ export default async function routes(fastify: FastifyInstance) {
             enabled: feature_s3_protocol,
           },
           icebergCatalog: {
-            enabled: icebergEnabled || feature_iceberg_catalog,
+            enabled: feature_iceberg_catalog,
             maxNamespaces: feature_iceberg_catalog_max_namespaces,
             maxTables: feature_iceberg_catalog_max_tables,
             maxCatalogs: feature_iceberg_catalog_max_catalogs,
           },
           vectorBuckets: {
-            enabled: vectorEnabled || feature_vector_buckets,
+            enabled: feature_vector_buckets,
             maxBuckets: feature_vector_buckets_max_buckets,
             maxIndexes: feature_vector_buckets_max_indexes,
           },
@@ -406,13 +405,13 @@ export default async function routes(fastify: FastifyInstance) {
             enabled: feature_s3_protocol,
           },
           icebergCatalog: {
-            enabled: icebergEnabled || feature_iceberg_catalog,
+            enabled: feature_iceberg_catalog,
             maxNamespaces: feature_iceberg_catalog_max_namespaces,
             maxTables: feature_iceberg_catalog_max_tables,
             maxCatalogs: feature_iceberg_catalog_max_catalogs,
           },
           vectorBuckets: {
-            enabled: vectorEnabled || feature_vector_buckets,
+            enabled: feature_vector_buckets,
             maxBuckets: feature_vector_buckets_max_buckets,
             maxIndexes: feature_vector_buckets_max_indexes,
           },

--- a/src/http/routes/iceberg/index.test.ts
+++ b/src/http/routes/iceberg/index.test.ts
@@ -1,0 +1,195 @@
+import type { FastifyInstance } from 'fastify'
+import { vi } from 'vitest'
+
+const icebergRouteModules = ['./bucket', './catalog', './namespace', './table']
+const icebergProbeRouteModule = './bucket'
+
+describe('iceberg routes', () => {
+  afterEach(() => {
+    vi.doUnmock('../../../config')
+    vi.doUnmock('@internal/database')
+    vi.doUnmock('../../plugins')
+    vi.doUnmock('../../error-handler')
+    icebergRouteModules.forEach((modulePath) => vi.doUnmock(modulePath))
+    vi.resetModules()
+  })
+
+  it.each([
+    {
+      icebergEnabled: true,
+      isMultitenant: true,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: true,
+    },
+    {
+      icebergEnabled: false,
+      isMultitenant: true,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: true,
+    },
+    {
+      icebergEnabled: true,
+      isMultitenant: false,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: false,
+    },
+    {
+      icebergEnabled: false,
+      isMultitenant: false,
+      shouldMountRoutes: false,
+      shouldRegisterTenantGuard: false,
+    },
+  ])('mounts routes: $shouldMountRoutes and tenant guard: $shouldRegisterTenantGuard', async ({
+    icebergEnabled,
+    isMultitenant,
+    shouldMountRoutes,
+    shouldRegisterTenantGuard,
+  }) => {
+    const { app, registerJwtAuthMock, requireTenantFeatureMock } = await loadRoutes({
+      icebergEnabled,
+      isMultitenant,
+    })
+
+    try {
+      if (shouldMountRoutes) {
+        expect(registerJwtAuthMock).toHaveBeenCalled()
+      } else {
+        expect(registerJwtAuthMock).not.toHaveBeenCalled()
+      }
+
+      if (shouldRegisterTenantGuard) {
+        expect(requireTenantFeatureMock).toHaveBeenCalledWith('icebergCatalog')
+      } else {
+        expect(requireTenantFeatureMock).not.toHaveBeenCalled()
+      }
+    } finally {
+      await app.close()
+    }
+  })
+
+  it.each([
+    {
+      expectedBody: {
+        error: 'FeatureNotEnabled',
+        statusCode: '403',
+        message: 'feature not enabled for this tenant',
+      },
+      expectedStatusCode: 403,
+      hasFeature: false,
+    },
+    {
+      expectedBody: { ok: true },
+      expectedStatusCode: 200,
+      hasFeature: true,
+    },
+  ])('returns $expectedStatusCode from an iceberg route when tenant feature enabled is $hasFeature', async ({
+    expectedBody,
+    expectedStatusCode,
+    hasFeature,
+  }) => {
+    const tenantHasFeatureMock = vi.fn().mockResolvedValue(hasFeature)
+    const { app } = await loadRoutes({
+      icebergEnabled: true,
+      isMultitenant: true,
+      useRealTenantFeatureGuard: true,
+      tenantHasFeatureMock,
+    })
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/probe',
+      })
+
+      expect(response.statusCode).toBe(expectedStatusCode)
+      expect(response.json()).toEqual(expectedBody)
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 'icebergCatalog')
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+async function loadRoutes({
+  icebergEnabled,
+  isMultitenant,
+  tenantHasFeatureMock = vi.fn(),
+  useRealTenantFeatureGuard = false,
+}: {
+  icebergEnabled: boolean
+  isMultitenant: boolean
+  tenantHasFeatureMock?: ReturnType<typeof vi.fn>
+  useRealTenantFeatureGuard?: boolean
+}) {
+  const registerJwtAuthMock = vi.fn()
+  const requireTenantFeatureMock = vi.fn()
+  const noopPlugin = async () => {}
+
+  vi.doMock('../../../config', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../config')>()
+
+    return {
+      ...actual,
+      getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
+        ...actual.getConfig(options),
+        dbServiceRole: 'service_role',
+        icebergEnabled,
+        isMultitenant,
+      }),
+    }
+  })
+  vi.doMock('@internal/database', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@internal/database')>()
+
+    return {
+      ...actual,
+      tenantHasFeature: tenantHasFeatureMock,
+    }
+  })
+
+  vi.doMock('../../plugins', async () => {
+    if (useRealTenantFeatureGuard) {
+      const { requireTenantFeature } = await import('../../plugins/tenant-feature')
+
+      return {
+        db: noopPlugin,
+        icebergRestCatalog: noopPlugin,
+        registerJwtAuth: registerJwtAuthMock,
+        requireTenantFeature,
+        storage: noopPlugin,
+      }
+    }
+
+    return {
+      db: noopPlugin,
+      icebergRestCatalog: noopPlugin,
+      registerJwtAuth: registerJwtAuthMock,
+      requireTenantFeature: requireTenantFeatureMock.mockReturnValue(noopPlugin),
+      storage: noopPlugin,
+    }
+  })
+  vi.doMock('../../error-handler', () => ({
+    setErrorHandler: vi.fn(),
+  }))
+  icebergRouteModules.forEach((modulePath) => {
+    vi.doMock(modulePath, () => ({
+      default: modulePath === icebergProbeRouteModule ? probeRoute : noopPlugin,
+    }))
+  })
+
+  const { default: fastify } = await import('fastify')
+  const { default: routes } = await import('./index')
+  const app = fastify()
+  app.addHook('onRequest', (request, _reply, done) => {
+    request.tenantId = 'tenant-a'
+    done()
+  })
+  await app.register(routes)
+  await app.ready()
+
+  return { app, registerJwtAuthMock, requireTenantFeatureMock }
+}
+
+async function probeRoute(fastify: FastifyInstance) {
+  fastify.get('/probe', async () => ({ ok: true }))
+}

--- a/src/http/routes/iceberg/index.ts
+++ b/src/http/routes/iceberg/index.ts
@@ -13,9 +13,9 @@ import catalogue from './catalog'
 import namespace from './namespace'
 import table from './table'
 
-const { dbServiceRole, icebergEnabled, isMultitenant } = getConfig()
-
 export default async function routes(fastify: FastifyInstance) {
+  const { dbServiceRole, icebergEnabled, isMultitenant } = getConfig()
+
   // Disable iceberg routes if the feature is not enabled
   if (!icebergEnabled && !isMultitenant) {
     return
@@ -26,7 +26,7 @@ export default async function routes(fastify: FastifyInstance) {
       enforceJwtRoles: [dbServiceRole],
     })
 
-    if (!icebergEnabled && isMultitenant) {
+    if (isMultitenant) {
       fastify.register(requireTenantFeature('icebergCatalog'))
     }
 

--- a/src/http/routes/vector/index.test.ts
+++ b/src/http/routes/vector/index.test.ts
@@ -1,0 +1,211 @@
+import type { FastifyInstance } from 'fastify'
+import { vi } from 'vitest'
+
+const vectorCommandModules = [
+  './create-bucket',
+  './create-index',
+  './delete-bucket',
+  './delete-index',
+  './delete-vectors',
+  './get-bucket',
+  './get-index',
+  './get-vectors',
+  './list-buckets',
+  './list-indexes',
+  './list-vectors',
+  './put-vectors',
+  './query-vectors',
+]
+const vectorProbeRouteModule = './create-bucket'
+
+describe('vector routes', () => {
+  afterEach(() => {
+    vi.doUnmock('../../../config')
+    vi.doUnmock('@internal/database')
+    vi.doUnmock('../../plugins')
+    vi.doUnmock('../../error-handler')
+    vectorCommandModules.forEach((modulePath) => vi.doUnmock(modulePath))
+    vi.resetModules()
+  })
+
+  it.each([
+    {
+      isMultitenant: true,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: true,
+      vectorEnabled: true,
+    },
+    {
+      isMultitenant: true,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: true,
+      vectorEnabled: false,
+    },
+    {
+      isMultitenant: false,
+      shouldMountRoutes: true,
+      shouldRegisterTenantGuard: false,
+      vectorEnabled: true,
+    },
+    {
+      isMultitenant: false,
+      shouldMountRoutes: false,
+      shouldRegisterTenantGuard: false,
+      vectorEnabled: false,
+    },
+  ])('mounts routes: $shouldMountRoutes and tenant guard: $shouldRegisterTenantGuard', async ({
+    isMultitenant,
+    shouldMountRoutes,
+    vectorEnabled,
+    shouldRegisterTenantGuard,
+  }) => {
+    const { app, registerJwtAuthMock, requireTenantFeatureMock } = await loadRoutes({
+      isMultitenant,
+      vectorEnabled,
+    })
+
+    try {
+      if (shouldMountRoutes) {
+        expect(registerJwtAuthMock).toHaveBeenCalled()
+      } else {
+        expect(registerJwtAuthMock).not.toHaveBeenCalled()
+      }
+
+      if (shouldRegisterTenantGuard) {
+        expect(requireTenantFeatureMock).toHaveBeenCalledWith('vectorBuckets')
+      } else {
+        expect(requireTenantFeatureMock).not.toHaveBeenCalled()
+      }
+    } finally {
+      await app.close()
+    }
+  })
+
+  it.each([
+    {
+      expectedBody: {
+        error: 'FeatureNotEnabled',
+        statusCode: '403',
+        message: 'feature not enabled for this tenant',
+      },
+      expectedStatusCode: 403,
+      hasFeature: false,
+    },
+    {
+      expectedBody: { ok: true },
+      expectedStatusCode: 200,
+      hasFeature: true,
+    },
+  ])('returns $expectedStatusCode from a vector route when tenant feature enabled is $hasFeature', async ({
+    expectedBody,
+    expectedStatusCode,
+    hasFeature,
+  }) => {
+    const tenantHasFeatureMock = vi.fn().mockResolvedValue(hasFeature)
+    const { app } = await loadRoutes({
+      isMultitenant: true,
+      vectorEnabled: true,
+      useRealTenantFeatureGuard: true,
+      tenantHasFeatureMock,
+    })
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/probe',
+      })
+
+      expect(response.statusCode).toBe(expectedStatusCode)
+      expect(response.json()).toEqual(expectedBody)
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 'vectorBuckets')
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+async function loadRoutes({
+  isMultitenant,
+  tenantHasFeatureMock = vi.fn(),
+  useRealTenantFeatureGuard = false,
+  vectorEnabled,
+}: {
+  isMultitenant: boolean
+  tenantHasFeatureMock?: ReturnType<typeof vi.fn>
+  useRealTenantFeatureGuard?: boolean
+  vectorEnabled: boolean
+}) {
+  const registerJwtAuthMock = vi.fn()
+  const requireTenantFeatureMock = vi.fn()
+  const noopPlugin = async () => {}
+
+  vi.doMock('../../../config', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../config')>()
+
+    return {
+      ...actual,
+      getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
+        ...actual.getConfig(options),
+        dbServiceRole: 'service_role',
+        isMultitenant,
+        vectorEnabled,
+      }),
+    }
+  })
+  vi.doMock('@internal/database', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@internal/database')>()
+
+    return {
+      ...actual,
+      tenantHasFeature: tenantHasFeatureMock,
+    }
+  })
+
+  vi.doMock('../../plugins', async () => {
+    if (useRealTenantFeatureGuard) {
+      const { requireTenantFeature } = await import('../../plugins/tenant-feature')
+
+      return {
+        dbSuperUser: noopPlugin,
+        enforceJwtRole: noopPlugin,
+        registerJwtAuth: registerJwtAuthMock,
+        requireTenantFeature,
+        s3vector: noopPlugin,
+        signatureV4: noopPlugin,
+      }
+    }
+
+    return {
+      dbSuperUser: noopPlugin,
+      enforceJwtRole: noopPlugin,
+      registerJwtAuth: registerJwtAuthMock,
+      requireTenantFeature: requireTenantFeatureMock.mockReturnValue(noopPlugin),
+      s3vector: noopPlugin,
+      signatureV4: noopPlugin,
+    }
+  })
+  vi.doMock('../../error-handler', () => ({
+    setErrorHandler: vi.fn(),
+  }))
+  vectorCommandModules.forEach((modulePath) => {
+    vi.doMock(modulePath, () => ({
+      default: modulePath === vectorProbeRouteModule ? probeRoute : noopPlugin,
+    }))
+  })
+
+  const { default: fastify } = await import('fastify')
+  const { default: routes } = await import('./index')
+  const app = fastify()
+  app.addHook('onRequest', (request, _reply, done) => {
+    request.tenantId = 'tenant-a'
+    done()
+  })
+  await app.register(routes)
+  await app.ready()
+
+  return { app, registerJwtAuthMock, requireTenantFeatureMock }
+}
+
+async function probeRoute(fastify: FastifyInstance) {
+  fastify.get('/probe', async () => ({ ok: true }))
+}

--- a/src/http/routes/vector/index.ts
+++ b/src/http/routes/vector/index.ts
@@ -32,7 +32,7 @@ export default async function routes(fastify: FastifyInstance) {
   }
 
   fastify.register(async function authenticated(fastify) {
-    if (!vectorEnabled && isMultitenant) {
+    if (isMultitenant) {
       fastify.register(requireTenantFeature('vectorBuckets'))
     }
 

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -80,14 +80,7 @@ export enum TenantMigrationStatus {
   FAILED_STALE = 'FAILED_STALE',
 }
 
-const {
-  isMultitenant,
-  dbServiceRole,
-  dbMigrationFreezeAt,
-  icebergEnabled,
-  vectorEnabled,
-  databaseMaxConnections,
-} = getConfig()
+const { isMultitenant, dbServiceRole, dbMigrationFreezeAt, databaseMaxConnections } = getConfig()
 
 // Max 16,384 items. At ~2KB per config, this uses roughly ~32MB of heap memory worst-case.
 export const TENANT_CONFIG_CACHE_MAX_ITEMS = 16384
@@ -272,13 +265,13 @@ export async function getTenantConfig(
           enabled: Boolean(feature_purge_cache),
         },
         icebergCatalog: {
-          enabled: Boolean(icebergEnabled || feature_iceberg_catalog),
+          enabled: Boolean(feature_iceberg_catalog),
           maxNamespaces: feature_iceberg_catalog_max_namespaces ?? 0,
           maxTables: feature_iceberg_catalog_max_tables ?? 0,
           maxCatalogs: feature_iceberg_catalog_max_catalogs ?? 0,
         },
         vectorBuckets: {
-          enabled: Boolean(vectorEnabled || feature_vector_buckets),
+          enabled: Boolean(feature_vector_buckets),
           maxBuckets: feature_vector_buckets_max_buckets ?? 0,
           maxIndexes: feature_vector_buckets_max_indexes ?? 0,
         },

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -587,6 +587,108 @@ describe('Tenant configs', () => {
     expect(getResponseJSON).toEqual({ ...payload, fileSizeLimit: 2 })
   })
 
+  test('Update tenant config partially can disable globally enabled icebergCatalog', async () => {
+    const createResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/abc`,
+      payload,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(createResponse.statusCode).toBe(201)
+
+    const patchResponse = await adminApp.inject({
+      method: 'PATCH',
+      url: `/tenants/abc`,
+      payload: {
+        features: {
+          icebergCatalog: {
+            enabled: false,
+          },
+        },
+      },
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(patchResponse.statusCode).toBe(204)
+
+    const getResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/abc`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(getResponse.statusCode).toBe(200)
+    expect(JSON.parse(getResponse.body).features.icebergCatalog).toEqual({
+      ...payload.features.icebergCatalog,
+      enabled: false,
+    })
+
+    deleteTenantConfig('abc')
+    await expect(getTenantConfig('abc')).resolves.toMatchObject({
+      features: {
+        icebergCatalog: {
+          ...payload.features.icebergCatalog,
+          enabled: false,
+        },
+      },
+    })
+  })
+
+  test('Update tenant config partially can disable globally enabled vectorBuckets', async () => {
+    const createResponse = await adminApp.inject({
+      method: 'POST',
+      url: `/tenants/abc`,
+      payload,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(createResponse.statusCode).toBe(201)
+
+    const patchResponse = await adminApp.inject({
+      method: 'PATCH',
+      url: `/tenants/abc`,
+      payload: {
+        features: {
+          vectorBuckets: {
+            enabled: false,
+          },
+        },
+      },
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(patchResponse.statusCode).toBe(204)
+
+    const getResponse = await adminApp.inject({
+      method: 'GET',
+      url: `/tenants/abc`,
+      headers: {
+        apikey: process.env.ADMIN_API_KEYS,
+      },
+    })
+    expect(getResponse.statusCode).toBe(200)
+    expect(JSON.parse(getResponse.body).features.vectorBuckets).toEqual({
+      ...payload.features.vectorBuckets,
+      enabled: false,
+    })
+
+    deleteTenantConfig('abc')
+    await expect(getTenantConfig('abc')).resolves.toMatchObject({
+      features: {
+        vectorBuckets: {
+          ...payload.features.vectorBuckets,
+          enabled: false,
+        },
+      },
+    })
+  })
+
   test('Tenant config maxConnections nullish transitions do not destroy cached pg pool', async () => {
     const tenantId = 'pool-max-connections-nullish-change'
     const encryptedTenant = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When iceberg/vector are enabled via config, in multitenant mode, tenant feature is saved correctly but falls back to config value.

## What is the new behavior?

Global config value works as before in single tenant mode. In multitenant mode, tenant feature decides if feature is enabled or not.

## Additional context

This removes enabling feature via config for all tenants in multitenant mode.
