### PR TITLE
fix: make hooks sync unless needed

### DIFF
--- a/src/http/plugins/header-validator.ts
+++ b/src/http/plugins/header-validator.ts
@@ -16,9 +16,10 @@ interface HeaderValidatorOptions {
 export const headerValidator = (options: HeaderValidatorOptions = {}) =>
   fastifyPlugin(
     async function headerValidatorPlugin(fastify: FastifyInstance) {
-      fastify.addHook('onSend', async (request: FastifyRequest, reply: FastifyReply, payload) => {
+      fastify.addHook('onSend', (request: FastifyRequest, reply: FastifyReply, payload, done) => {
         if (options.excludeUrls?.includes(request.url.toLowerCase())) {
-          return payload
+          done(null, payload)
+          return
         }
 
         const headers = reply.getHeaders()
@@ -41,7 +42,7 @@ export const headerValidator = (options: HeaderValidatorOptions = {}) =>
           }
         }
 
-        return payload
+        done(null, payload)
       })
     },
     { name: 'header-validator' }

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -40,7 +40,7 @@ declare module 'fastify' {
 export const logRequest = (options: RequestLoggerOptions) =>
   fastifyPlugin(
     async (fastify) => {
-      fastify.addHook('onRequest', async (req, res) => {
+      fastify.addHook('onRequest', (req, res, done) => {
         req.startTime = Date.now()
 
         res.raw.once('close', () => {
@@ -61,12 +61,13 @@ export const logRequest = (options: RequestLoggerOptions) =>
             })
           }
         })
+        done()
       })
 
       /**
        * Adds req.resources and req.operation to the request object
        */
-      fastify.addHook('preHandler', async (req) => {
+      fastify.addHook('preHandler', (req, _reply, done) => {
         let resources = req.resources
 
         if (resources === undefined) {
@@ -97,14 +98,15 @@ export const logRequest = (options: RequestLoggerOptions) =>
         if (req.operation && typeof req.opentelemetry === 'function') {
           req.opentelemetry()?.span?.setAttribute('http.operation', req.operation.type)
         }
+        done()
       })
 
-      fastify.addHook('onSend', async (req, _, payload) => {
+      fastify.addHook('onSend', (req, _reply, payload, done) => {
         req.executionTime = Date.now() - req.startTime
-        return payload
+        done(null, payload)
       })
 
-      fastify.addHook('onResponse', async (req, reply) => {
+      fastify.addHook('onResponse', (req, reply, done) => {
         doRequestLog(req, {
           reply,
           excludeUrls: options.excludeUrls,
@@ -112,6 +114,7 @@ export const logRequest = (options: RequestLoggerOptions) =>
           responseTime: reply.elapsedTime,
           executionTime: req.executionTime,
         })
+        done()
       })
     },
     { name: 'log-request' }

--- a/src/http/plugins/metrics.ts
+++ b/src/http/plugins/metrics.ts
@@ -66,21 +66,26 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
       ]
 
       // Hook into request lifecycle to measure duration
-      fastify.addHook('onRequest', async (request) => {
+      fastify.addHook('onRequest', (request, _reply, done) => {
         // Store start time on request for later use
         request.metricsStartTime = process.hrtime.bigint()
+        done()
       })
 
-      fastify.addHook('onResponse', async (request, reply) => {
+      fastify.addHook('onResponse', (request, reply, done) => {
         const route = request.routeOptions?.url || 'unknown'
 
         // Skip excluded routes (match start of path)
         if (excludeRoutes.some((r) => route === r || route.startsWith(r + '/'))) {
+          done()
           return
         }
 
         const startTime = request.metricsStartTime
-        if (!startTime) return
+        if (!startTime) {
+          done()
+          return
+        }
 
         // Calculate duration in seconds
         const endTime = process.hrtime.bigint()
@@ -106,6 +111,7 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
           operation,
           reply.statusCode
         )
+        done()
       })
     },
     { name: 'http-metrics' }

--- a/src/http/plugins/request-context.ts
+++ b/src/http/plugins/request-context.ts
@@ -10,8 +10,9 @@ declare module 'fastify' {
 export const requestContext = fastifyPlugin(
   async (fastify) => {
     fastify.decorateRequest('sbReqId', undefined)
-    fastify.addHook('onRequest', async (request) => {
+    fastify.addHook('onRequest', (request, _reply, done) => {
       request.sbReqId = getSbReqId(request.headers)
+      done()
     })
   },
   { name: 'request-context' }

--- a/src/http/plugins/signals.ts
+++ b/src/http/plugins/signals.ts
@@ -124,12 +124,14 @@ export const signals = fastifyPlugin(
   async function (fastify: FastifyInstance) {
     fastify.decorateRequest('signals')
 
-    fastify.addHook('onRequest', async (req, res) => {
+    fastify.addHook('onRequest', (req, res, done) => {
       req.signals = new RequestSignals(req.raw, res.raw)
+      done()
     })
 
-    fastify.addHook('onRequestAbort', async (req) => {
+    fastify.addHook('onRequestAbort', (req, done) => {
       req.signals.abortRequest()
+      done()
     })
   },
   { name: 'request-signals' }

--- a/src/http/plugins/sync-hooks.test.ts
+++ b/src/http/plugins/sync-hooks.test.ts
@@ -1,0 +1,92 @@
+import type { FastifyInstance } from 'fastify'
+import Fastify from 'fastify'
+import { headerValidator } from './header-validator'
+import { logRequest } from './log-request'
+import { httpMetrics } from './metrics'
+import { requestContext } from './request-context'
+import { signals as signalsPlugin } from './signals'
+import { adminTenantId, tenantId } from './tenant-id'
+
+type CapturedHook = {
+  name: string
+  hook: HookFunction
+}
+
+type HookFunction = (...args: unknown[]) => unknown
+
+function captureHooks(app: FastifyInstance): CapturedHook[] {
+  const hooks: CapturedHook[] = []
+  const addHook = app.addHook.bind(app) as unknown as (
+    name: string,
+    hook: HookFunction
+  ) => FastifyInstance
+
+  vi.spyOn(app, 'addHook').mockImplementation(((name: string, hook: HookFunction) => {
+    hooks.push({ name, hook })
+    return addHook(name, hook)
+  }) as typeof app.addHook)
+
+  return hooks
+}
+
+async function collectHooks(register: (app: FastifyInstance) => Promise<unknown> | unknown) {
+  const app = Fastify()
+  const hooks = captureHooks(app)
+
+  try {
+    await register(app)
+    await app.ready()
+    return hooks
+  } finally {
+    await app.close()
+  }
+}
+
+describe('sync request lifecycle hooks', () => {
+  it.each([
+    {
+      name: 'requestContext',
+      register: (app: FastifyInstance) => app.register(requestContext),
+      hooks: ['onRequest'],
+    },
+    {
+      name: 'tenantId',
+      register: (app: FastifyInstance) => app.register(tenantId),
+      hooks: ['onRequest'],
+    },
+    {
+      name: 'adminTenantId',
+      register: (app: FastifyInstance) => app.register(adminTenantId),
+      hooks: ['onRequest'],
+    },
+    {
+      name: 'signals',
+      register: (app: FastifyInstance) => app.register(signalsPlugin),
+      hooks: ['onRequest', 'onRequestAbort'],
+    },
+    {
+      name: 'httpMetrics',
+      register: (app: FastifyInstance) => app.register(httpMetrics()),
+      hooks: ['onRequest', 'onResponse'],
+    },
+    {
+      name: 'logRequest',
+      register: (app: FastifyInstance) => app.register(logRequest({})),
+      hooks: ['onRequest', 'preHandler', 'onSend', 'onResponse'],
+    },
+    {
+      name: 'headerValidator',
+      register: (app: FastifyInstance) => app.register(headerValidator()),
+      hooks: ['onSend'],
+    },
+  ])('registers $name hot hooks without async functions', async ({ register, hooks }) => {
+    const capturedHooks = await collectHooks(register)
+
+    for (const hookName of hooks) {
+      const hook = capturedHooks.find((candidate) => candidate.name === hookName)?.hook
+
+      expect(hook, `${hookName} hook should be registered`).toBeDefined()
+      expect(hook?.constructor.name).not.toBe('AsyncFunction')
+    }
+  })
+})

--- a/src/http/plugins/tenant-id.ts
+++ b/src/http/plugins/tenant-id.ts
@@ -12,14 +12,26 @@ const { isMultitenant, tenantId: defaultTenantId, requestXForwardedHostRegExp } 
 export const tenantId = fastifyPlugin(
   async (fastify) => {
     fastify.decorateRequest('tenantId', defaultTenantId)
-    fastify.addHook('onRequest', async (request) => {
-      if (!isMultitenant || !requestXForwardedHostRegExp) return
+    fastify.addHook('onRequest', (request, _reply, done) => {
+      if (!isMultitenant || !requestXForwardedHostRegExp) {
+        done()
+        return
+      }
+
       const xForwardedHost = request.headers['x-forwarded-host']
-      if (typeof xForwardedHost !== 'string') return
+      if (typeof xForwardedHost !== 'string') {
+        done()
+        return
+      }
+
       const result = xForwardedHost.match(requestXForwardedHostRegExp)
-      if (!result) return
+      if (!result) {
+        done()
+        return
+      }
 
       request.tenantId = result[1]
+      done()
     })
   },
   { name: 'tenant-id' }
@@ -28,11 +40,15 @@ export const tenantId = fastifyPlugin(
 export const adminTenantId = fastifyPlugin(
   async (fastify) => {
     fastify.decorateRequest('tenantId', defaultTenantId)
-    fastify.addHook('onRequest', async (request) => {
+    fastify.addHook('onRequest', (request, _reply, done) => {
       const tenantId = (request.params as Record<string, undefined | string>).tenantId
-      if (!tenantId) return
+      if (!tenantId) {
+        done()
+        return
+      }
 
       request.tenantId = tenantId
+      done()
     })
   },
   { name: 'admin-tenant-id' }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There are some async hooks in hot path, that allocates a promise, even if they do no async work. 

## What is the new behavior?

Make them sync to reduce allocations.

## Additional context

Some hooks are property assignment and could be combined in a later iteration.
