### PR TITLE
fix: skip req metadata serialization in general case

### DIFF
--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -126,6 +126,40 @@ describe('log-request plugin', () => {
     expect(requestLogLine).toContain('"project":"tenant-a"')
   })
 
+  it('keeps configured route metadata in request logs', async () => {
+    app.get(
+      '/metadata-log',
+      {
+        config: {
+          logMetadata: () => ({
+            bucketId: 'bucket-a',
+            objectName: 'file.txt',
+          }),
+        },
+      },
+      async () => {
+        return { ok: true }
+      }
+    )
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/metadata-log',
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+
+    expect(JSON.parse(requestLog.reqMetadata)).toEqual({
+      bucketId: 'bucket-a',
+      objectName: 'file.txt',
+    })
+  })
+
   it('logs redacted urls without leaking sensitive request data', async () => {
     const response = await app.inject({
       method: 'GET',

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -144,16 +144,18 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
   const error = req.raw.executionError || req.executionError
   const tenantId = req.tenantId
 
-  let reqMetadata: Record<string, unknown> = {}
+  let reqMetadata = '{}'
 
   if (req.routeOptions.config.logMetadata) {
     try {
-      reqMetadata = req.routeOptions.config.logMetadata(req)
+      const metadata = req.routeOptions.config.logMetadata(req)
 
-      if (reqMetadata) {
+      if (metadata) {
         try {
+          reqMetadata = JSON.stringify(metadata)
+
           if (typeof req.opentelemetry === 'function') {
-            req.opentelemetry()?.span?.setAttribute('http.metadata', JSON.stringify(reqMetadata))
+            req.opentelemetry()?.span?.setAttribute('http.metadata', reqMetadata)
           }
         } catch (e) {
           // do nothing

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -84,17 +84,6 @@ export const baseLogger = pino({
     error(error) {
       return normalizeRawError(error, logLevel)
     },
-    reqMetadata(metadata?: Record<string, unknown>) {
-      if (!metadata) {
-        return undefined
-      }
-
-      try {
-        return JSON.stringify(metadata)
-      } catch {
-        // no-op
-      }
-    },
     // doRequestLog passes branded values from serializeRequestLog/serializeReplyLog,
     // so the common path is a passthrough. If Fastify's auto-logger ever emits raw
     // FastifyRequest/Reply values, fall back to the safe serializers.
@@ -151,7 +140,7 @@ export interface RequestLog extends RequestLogContext {
   type: 'request'
   req: SerializedRequestLog
   res?: SerializedReplyLog
-  reqMetadata?: Record<string, unknown>
+  reqMetadata: string
   responseTime: number
   executionTime?: number
   error?: Error | unknown


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`reqMetadata` is empty most of the time so assign string directly to skip json stringify/pino serializer overhead.

## What is the new behavior?

Update type to string and initialize with empty json shape. No log changes but faster to log.

## Additional context

It's serialized once when tracing is enabled, it was done twice before.