### PR TITLE
chore: drop pool mode

### DIFF
--- a/migrations/multitenant/0028-drop-pool-mode.sql
+++ b/migrations/multitenant/0028-drop-pool-mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants DROP COLUMN IF EXISTS database_pool_mode;


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore cleanup

## What is the current behavior?

Pool mode was dropped [before](https://github.com/supabase/storage/pull/1152) and not in use. 

## What is the new behavior?

Drop the column for cleanup.


