### PR TITLE
fix: cap signed url edge cache ttl

### DIFF
--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -76,6 +76,7 @@ export default async function routes(fastify: FastifyInstance) {
         version: obj.version,
         download,
         expires: new Date(exp * 1000).toUTCString(),
+        signedUrlExpiresAt: exp,
         xRobotsTag: obj.metadata?.['xRobotsTag'] as string | undefined,
         signal: request.signals.disconnect.signal,
       })

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -85,6 +85,7 @@ export default async function routes(fastify: FastifyInstance) {
           version: obj.version,
           download,
           expires: new Date(exp * 1000).toUTCString(),
+          signedUrlExpiresAt: exp,
           xRobotsTag: obj.metadata?.['xRobotsTag'] as string | undefined,
           signal: request.signals.disconnect.signal,
         })

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -361,6 +361,31 @@ describe('ImageRenderer fetch client', () => {
     )
   })
 
+  it('emits Cache-Control metadata when an Expires header is set', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {
+            cacheControl: 'max-age=31536000',
+          },
+        }
+      }
+    }
+
+    const reply = createReply()
+    await new TestRenderer().render(createRequest(), reply as never, {
+      ...createRenderOptions(),
+      expires: 'Wed, 30 Jun 2027 12:00:00 GMT',
+    })
+
+    expect(reply.header).toHaveBeenCalledWith('Expires', 'Wed, 30 Jun 2027 12:00:00 GMT')
+    expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'max-age=31536000')
+  })
+
   it('passes an undici dispatcher to fetch when imgproxy socket pooling is enabled', async () => {
     const agentInstances: Array<{ instance: unknown; options: unknown }> = []
     const composedHandlers: unknown[] = []

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -361,9 +361,13 @@ describe('ImageRenderer fetch client', () => {
     )
   })
 
-  it('emits Cache-Control metadata when an Expires header is set', async () => {
+  it('emits browser no-store and token-bounded Cloudflare cache control for signed URLs', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00.000Z'))
     await loadRendererModule()
     const { Renderer } = await import('./renderer')
+    const signedUrlExpiresAt = Math.floor(new Date('2026-06-30T12:01:40.000Z').getTime() / 1000)
+    const expires = new Date(signedUrlExpiresAt * 1000).toUTCString()
 
     class TestRenderer extends Renderer {
       async getAsset() {
@@ -379,11 +383,73 @@ describe('ImageRenderer fetch client', () => {
     const reply = createReply()
     await new TestRenderer().render(createRequest(), reply as never, {
       ...createRenderOptions(),
-      expires: 'Wed, 30 Jun 2027 12:00:00 GMT',
+      expires,
+      signedUrlExpiresAt,
     })
 
-    expect(reply.header).toHaveBeenCalledWith('Expires', 'Wed, 30 Jun 2027 12:00:00 GMT')
-    expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'max-age=31536000')
+    expect(reply.header).toHaveBeenCalledWith('Expires', expires)
+    expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'no-store')
+    expect(reply.header).toHaveBeenCalledWith(
+      'Cloudflare-CDN-Cache-Control',
+      'public, s-maxage=99, must-revalidate'
+    )
+  })
+
+  it('does not emit Cloudflare cache control for signed URLs with restrictive object cache metadata', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {
+            cacheControl: 'public, s-maxage=600, no-cache',
+          },
+        }
+      }
+    }
+
+    const reply = createReply()
+    await new TestRenderer().render(createRequest(), reply as never, {
+      ...createRenderOptions(),
+      expires: new Date(Date.now() + 60_000).toUTCString(),
+      signedUrlExpiresAt: Math.floor(Date.now() / 1000) + 60,
+    })
+
+    expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'no-store')
+    expect(reply.header).not.toHaveBeenCalledWith('Cloudflare-CDN-Cache-Control', expect.anything())
+  })
+
+  it('caps signed URL Cloudflare cache control by object s-maxage when shorter than token expiry', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00.000Z'))
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+    const signedUrlExpiresAt = Math.floor(new Date('2026-06-30T12:01:40.000Z').getTime() / 1000)
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {
+            cacheControl: 'public, max-age=0, s-maxage=12, immutable',
+          },
+        }
+      }
+    }
+
+    const reply = createReply()
+    await new TestRenderer().render(createRequest(), reply as never, {
+      ...createRenderOptions(),
+      expires: new Date(signedUrlExpiresAt * 1000).toUTCString(),
+      signedUrlExpiresAt,
+    })
+
+    expect(reply.header).toHaveBeenCalledWith(
+      'Cloudflare-CDN-Cache-Control',
+      'public, s-maxage=12, must-revalidate'
+    )
   })
 
   it('passes an undici dispatcher to fetch when imgproxy socket pooling is enabled', async () => {

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -128,9 +128,8 @@ export abstract class Renderer {
 
     if (options.expires) {
       response.header('Expires', options.expires)
-    } else {
-      this.handleCacheControl(request, response, data.metadata)
     }
+    this.handleCacheControl(request, response, data.metadata)
 
     if (data.metadata.contentRange) {
       response.header('Content-Range', data.metadata.contentRange)

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -11,6 +11,7 @@ export interface RenderOptions {
   version: string | undefined
   download?: string
   expires?: string
+  signedUrlExpiresAt?: number
   xRobotsTag?: string
   object?: Obj
   signal?: AbortSignal
@@ -40,6 +41,7 @@ type HttpMetadataError = {
 }
 
 const { requestEtagHeaders, responseSMaxAge } = getConfig()
+const SIGNED_URL_EDGE_CACHE_SAFETY_MARGIN_SECONDS = 1
 
 /**
  * Renderer
@@ -128,8 +130,10 @@ export abstract class Renderer {
 
     if (options.expires) {
       response.header('Expires', options.expires)
+      this.handleSignedUrlCacheControl(response, data.metadata, options.signedUrlExpiresAt)
+    } else {
+      this.handleCacheControl(request, response, data.metadata)
     }
-    this.handleCacheControl(request, response, data.metadata)
 
     if (data.metadata.contentRange) {
       response.header('Content-Range', data.metadata.contentRange)
@@ -180,6 +184,24 @@ export abstract class Renderer {
     }
 
     this.setCacheControlHeader(response, cacheControl)
+  }
+
+  protected handleSignedUrlCacheControl(
+    response: FastifyReply,
+    metadata: AssetMetadata,
+    signedUrlExpiresAt: number | undefined
+  ) {
+    response.header('Cache-Control', 'no-store')
+
+    const tokenTtl = getRemainingTokenTtlSeconds(signedUrlExpiresAt)
+    const objectTtl = getSharedCacheTtlSeconds(metadata.cacheControl)
+
+    if (!tokenTtl || !objectTtl) {
+      return
+    }
+
+    const edgeTtl = Math.min(tokenTtl, objectTtl)
+    response.header('Cloudflare-CDN-Cache-Control', `public, s-maxage=${edgeTtl}, must-revalidate`)
   }
 
   protected setContentLengthHeader(response: FastifyReply, contentLength: number | undefined) {
@@ -310,6 +332,106 @@ function normalizeContentType(contentType: string | undefined): string | undefin
     return 'text/plain'
   }
   return contentType
+}
+
+function getRemainingTokenTtlSeconds(signedUrlExpiresAt: number | undefined) {
+  if (!Number.isFinite(signedUrlExpiresAt)) {
+    return undefined
+  }
+
+  const nowSeconds = Math.ceil(Date.now() / 1000)
+  const remainingTtl =
+    (signedUrlExpiresAt as number) - nowSeconds - SIGNED_URL_EDGE_CACHE_SAFETY_MARGIN_SECONDS
+
+  return remainingTtl > 0 ? remainingTtl : undefined
+}
+
+function getSharedCacheTtlSeconds(cacheControl: string | undefined) {
+  const directives = parseCacheControlDirectives(cacheControl)
+
+  if (directives.has('no-store') || directives.has('no-cache') || directives.has('private')) {
+    return undefined
+  }
+
+  const sharedMaxAge = parsePositiveIntegerDirective(directives.get('s-maxage'))
+  if (sharedMaxAge) {
+    return sharedMaxAge
+  }
+
+  return parsePositiveIntegerDirective(directives.get('max-age'))
+}
+
+function parseCacheControlDirectives(cacheControl: string | undefined) {
+  const directives = new Map<string, string | undefined>()
+
+  if (!cacheControl) {
+    return directives
+  }
+
+  for (const rawDirective of splitCacheControl(cacheControl)) {
+    const separatorIndex = rawDirective.indexOf('=')
+    const rawName = separatorIndex === -1 ? rawDirective : rawDirective.slice(0, separatorIndex)
+    const name = rawName.trim().toLowerCase()
+
+    if (!name) {
+      continue
+    }
+
+    const rawValue = separatorIndex === -1 ? undefined : rawDirective.slice(separatorIndex + 1)
+    directives.set(name, normalizeDirectiveValue(rawValue))
+  }
+
+  return directives
+}
+
+function splitCacheControl(cacheControl: string) {
+  const directives: string[] = []
+  let start = 0
+  let isQuoted = false
+
+  for (let index = 0; index < cacheControl.length; index += 1) {
+    const char = cacheControl[index]
+    const previousChar = index > 0 ? cacheControl[index - 1] : ''
+
+    if (char === '"' && previousChar !== '\\') {
+      isQuoted = !isQuoted
+    }
+
+    if (char === ',' && !isQuoted) {
+      directives.push(cacheControl.slice(start, index))
+      start = index + 1
+    }
+  }
+
+  directives.push(cacheControl.slice(start))
+  return directives
+}
+
+function normalizeDirectiveValue(value: string | undefined) {
+  const trimmed = value?.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed
+}
+
+function parsePositiveIntegerDirective(value: string | undefined) {
+  if (!value || !/^\d+$/.test(value)) {
+    return undefined
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return undefined
+  }
+
+  return parsed
 }
 
 function getErrorMetadata(error: unknown): HttpMetadataError['$metadata'] {

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -2724,6 +2724,33 @@ describe('testing retrieving signed URL', () => {
     expect(response.headers['last-modified']).toBe('Thu, 12 Aug 2021 16:00:00 GMT')
   })
 
+  test('get object with a token preserves object Cache-Control with signed URL Expires', async () => {
+    vi.mocked(S3Backend.prototype.getObject).mockResolvedValueOnce({
+      metadata: {
+        httpStatusCode: 200,
+        size: 3746,
+        mimetype: 'image/png',
+        lastModified: new Date('Thu, 12 Aug 2021 16:00:00 GMT'),
+        eTag: 'abc',
+        cacheControl: 'max-age=31536000',
+        contentLength: 3746,
+      },
+      httpStatusCode: 200,
+      body: Buffer.from(''),
+    })
+
+    const urlToSign = 'bucket2/public/sadcat-upload.png'
+    const jwtToken = await signJWT({ url: urlToSign }, jwtSecret, 100)
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/sign/${urlToSign}?token=${jwtToken}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['expires']).toBeTruthy()
+    expect(response.headers['cache-control']).toBe('max-age=31536000')
+  })
+
   test('get object with jwk generated token', async () => {
     const signingJwk = { ...(await generateHS512JWK()), kid: 'abc-123' } as JwksConfigKeyOCT
     mergeConfig({ jwtJWKS: { keys: [signingJwk] } })

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -22,6 +22,7 @@ import app from '../app'
 import { getConfig, JwksConfig, JwksConfigKeyOCT, mergeConfig } from '../config'
 import { backends, Obj } from '../storage'
 import { ObjectAdminDelete } from '../storage/events'
+import { ObjectStorage } from '../storage/object'
 import { useMockObject, useMockQueue } from './common'
 import { useStorage, withDeleteEnabled } from './utils/storage'
 
@@ -2724,7 +2725,7 @@ describe('testing retrieving signed URL', () => {
     expect(response.headers['last-modified']).toBe('Thu, 12 Aug 2021 16:00:00 GMT')
   })
 
-  test('get object with a token preserves object Cache-Control with signed URL Expires', async () => {
+  test('get object with a token emits browser no-store and token-bounded Cloudflare cache control', async () => {
     vi.mocked(S3Backend.prototype.getObject).mockResolvedValueOnce({
       metadata: {
         httpStatusCode: 200,
@@ -2739,8 +2740,17 @@ describe('testing retrieving signed URL', () => {
       body: Buffer.from(''),
     })
 
-    const urlToSign = 'bucket2/public/sadcat-upload.png'
-    const jwtToken = await signJWT({ url: urlToSign }, jwtSecret, 100)
+    vi.spyOn(ObjectStorage.prototype, 'findObject').mockResolvedValueOnce({
+      version: '1',
+      metadata: {},
+    } as Obj)
+
+    const urlToSign = 'bucket2/authenticated/cat.jpg'
+    const jwtToken = await signJWT(
+      { url: urlToSign, scope: SIGNED_URL_SCOPE_DOWNLOAD },
+      jwtSecret,
+      100
+    )
     const response = await appInstance.inject({
       method: 'GET',
       url: `/object/sign/${urlToSign}?token=${jwtToken}`,
@@ -2748,7 +2758,18 @@ describe('testing retrieving signed URL', () => {
 
     expect(response.statusCode).toBe(200)
     expect(response.headers['expires']).toBeTruthy()
-    expect(response.headers['cache-control']).toBe('max-age=31536000')
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.headers['cloudflare-cdn-cache-control']).toMatch(
+      /^public, s-maxage=\d+, must-revalidate$/
+    )
+
+    const edgeMaxAge = Number(
+      /^public, s-maxage=(\d+), must-revalidate$/.exec(
+        String(response.headers['cloudflare-cdn-cache-control'])
+      )?.[1]
+    )
+    expect(edgeMaxAge).toBeGreaterThan(0)
+    expect(edgeMaxAge).toBeLessThanOrEqual(99)
   })
 
   test('get object with jwk generated token', async () => {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -2,6 +2,7 @@ import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import {
   generateHS512JWK,
+  SIGNED_URL_SCOPE_DOWNLOAD,
   SIGNED_URL_SCOPE_UPLOAD,
   SignedToken,
   signJWT,
@@ -15,7 +16,9 @@ import { Readable } from 'stream'
 import app from '../app'
 import { getConfig, JwksConfig, mergeConfig } from '../config'
 import { S3Backend } from '../storage/backend'
+import { ObjectStorage } from '../storage/object'
 import { ImageRenderer } from '../storage/renderer'
+import { Obj } from '../storage/schemas'
 import { useMockObject } from './common'
 
 dotenv.config({ path: '.env.test' })
@@ -241,11 +244,12 @@ describe('image rendering routes', () => {
         },
       },
       headers: {
-        authorization: `Bearer ${process.env.SERVICE_KEY}`,
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
     })
 
     const signedURLBody = signURLResponse.json<{ signedURL: string }>()
+    expect(signURLResponse.statusCode).toBe(200)
     expect(signedURLBody.signedURL).toContain('?token=')
 
     // verify was correctly signed with jwtSecret
@@ -271,26 +275,22 @@ describe('image rendering routes', () => {
     )
   })
 
-  it('will preserve Cache-Control when rendering a transformed image from a signed url', async () => {
+  it('will emit browser no-store and token-bounded Cloudflare cache control for a signed transformed image', async () => {
     const assetUrl = 'bucket2/authenticated/casestudy.png'
-    const signURLResponse = await appInstance.inject({
-      method: 'POST',
-      url: '/object/sign/' + assetUrl,
-      payload: {
-        expiresIn: 60000,
-        transform: {
-          width: 100,
-          height: 100,
-          resize: 'contain',
-        },
-      },
-      headers: {
-        authorization: `Bearer ${process.env.SERVICE_KEY}`,
-      },
-    })
+    vi.spyOn(ObjectStorage.prototype, 'findObject').mockResolvedValueOnce({
+      version: '1',
+      metadata: {},
+    } as Obj)
 
-    const signedURLBody = signURLResponse.json<{ signedURL: string }>()
-    expect(signedURLBody.signedURL).toContain('?token=')
+    const token = await signJWT(
+      {
+        url: assetUrl,
+        scope: SIGNED_URL_SCOPE_DOWNLOAD,
+        transformations: 'height:100,width:100,resize:contain',
+      },
+      jwtSecret,
+      60000
+    )
 
     const { client: testClient } = createMockRendererClient()
     vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
@@ -306,12 +306,23 @@ describe('image rendering routes', () => {
 
     const response = await appInstance.inject({
       method: 'GET',
-      url: signedURLBody.signedURL,
+      url: `/render/image/sign/${assetUrl}?token=${token}`,
     })
 
     expect(response.statusCode).toBe(200)
     expect(response.headers['expires']).toBeTruthy()
-    expect(response.headers['cache-control']).toBe('max-age=31536000')
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.headers['cloudflare-cdn-cache-control']).toMatch(
+      /^public, s-maxage=\d+, must-revalidate$/
+    )
+
+    const edgeMaxAge = Number(
+      /^public, s-maxage=(\d+), must-revalidate$/.exec(
+        String(response.headers['cloudflare-cdn-cache-control'])
+      )?.[1]
+    )
+    expect(edgeMaxAge).toBeGreaterThan(0)
+    expect(edgeMaxAge).toBeLessThanOrEqual(59999)
   })
 
   it('will render a transformed image providing a signed url (using url signing jwk if set)', async () => {

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -271,6 +271,49 @@ describe('image rendering routes', () => {
     )
   })
 
+  it('will preserve Cache-Control when rendering a transformed image from a signed url', async () => {
+    const assetUrl = 'bucket2/authenticated/casestudy.png'
+    const signURLResponse = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/' + assetUrl,
+      payload: {
+        expiresIn: 60000,
+        transform: {
+          width: 100,
+          height: 100,
+          resize: 'contain',
+        },
+      },
+      headers: {
+        authorization: `Bearer ${process.env.SERVICE_KEY}`,
+      },
+    })
+
+    const signedURLBody = signURLResponse.json<{ signedURL: string }>()
+    expect(signedURLBody.signedURL).toContain('?token=')
+
+    const { client: testClient } = createMockRendererClient()
+    vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
+    vi.mocked(S3Backend.prototype.headObject).mockResolvedValueOnce({
+      httpStatusCode: 200,
+      size: 3746,
+      mimetype: 'image/png',
+      eTag: 'abc',
+      cacheControl: 'max-age=31536000',
+      lastModified: new Date('Wed, 12 Oct 2022 11:17:02 GMT'),
+      contentLength: 3746,
+    })
+
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: signedURLBody.signedURL,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['expires']).toBeTruthy()
+    expect(response.headers['cache-control']).toBe('max-age=31536000')
+  })
+
   it('will render a transformed image providing a signed url (using url signing jwk if set)', async () => {
     const signingJwk = { ...(await generateHS512JWK()), kid: 'qwerty-09876' }
     const jwtJWKS: JwksConfig = { keys: [signingJwk], urlSigningKey: signingJwk }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / signed URL cache behavior alignment with the security model discussed in #1186.

## What is the current behavior?

Signed asset responses set an `Expires` header based on the signed URL token expiry. When `Expires` is present, the shared renderer skips normal `Cache-Control` handling, so private signed object and signed transformed image responses do not expose object cache metadata and repeatedly revalidate instead of reaching stable CDN HITs.

Returning the object's `Cache-Control` header directly would let browsers cache private signed content longer than the signed URL expiration, which is not acceptable for expiring URLs.

## What is the new behavior?

Signed asset responses keep the existing `Expires` header and split browser cache policy from Cloudflare edge cache policy:

- `Cache-Control: no-store` is returned to browsers for signed URL responses.
- `Cloudflare-CDN-Cache-Control: public, s-maxage=<ttl>, must-revalidate` is returned only when the object metadata contains a positive shared cache TTL.
- The Cloudflare edge TTL is capped to `min(object cache TTL, signed URL remaining lifetime - safety margin)`.
- Restrictive object cache directives such as `no-store`, `no-cache`, and `private` suppress Cloudflare edge caching.
- Object `s-maxage` is preferred over object `max-age` for shared-cache TTL calculation.

This should allow repeated requests for the exact same signed URL to become Cloudflare HITs while preventing browser reuse and preventing edge cache freshness from outliving the signed URL token.

Refs #1186.

## Tests

- `AUTH_JWT_SECRET=f023d3db-39dc-4ac9-87b2-b2be72e9162b DATABASE_URL=postgresql://postgres:postgres@127.0.0.1/postgres npm run test:unit -- src/storage/renderer/image.test.ts`
- `AUTH_JWT_SECRET=f023d3db-39dc-4ac9-87b2-b2be72e9162b DATABASE_URL=postgresql://postgres:postgres@127.0.0.1/postgres STORAGE_BACKEND=s3 STORAGE_FILE_BACKEND_PATH=/tmp/supabase-storage-file-backend npm run test:integration -- src/test/object.test.ts -t "token-bounded Cloudflare cache control"`
- `IMAGE_TRANSFORMATION_ENABLED=true AUTH_JWT_SECRET=f023d3db-39dc-4ac9-87b2-b2be72e9162b DATABASE_URL=postgresql://postgres:postgres@127.0.0.1/postgres STORAGE_BACKEND=s3 STORAGE_FILE_BACKEND_PATH=/tmp/supabase-storage-file-backend npm run test:integration -- src/test/render-routes.test.ts -t "token-bounded Cloudflare cache control"`
- `npm run lint`
- `AUTH_JWT_SECRET=f023d3db-39dc-4ac9-87b2-b2be72e9162b DATABASE_URL=postgresql://postgres:postgres@127.0.0.1/postgres npm run build`
