### PR TITLE
fix: build secure context once

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -42,7 +42,7 @@ jobs:
   acceptance_local:
     name: Local / ${{ matrix.storage_backend }} / ${{ matrix.database }} / ${{ matrix.tenancy }}
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.acceptance_environment == 'local' }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/src/internal/database/ssl.test.ts
+++ b/src/internal/database/ssl.test.ts
@@ -25,13 +25,14 @@ describe('database utils', () => {
       ).toBeUndefined()
     })
 
-    test('should return SSL settings if hostname is an IP address', () => {
-      expect(
-        getSslSettings({
-          connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+    test('should skip verification with a shared context if hostname is an IP address', () => {
+      const settings = getSslSettings({
+        connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBe(false)
+      expect(settings).not.toHaveProperty('ca')
     })
 
     test('should detect IP host without constructing a URL', () => {
@@ -44,61 +45,88 @@ describe('database utils', () => {
           }
         } as unknown as typeof URL
 
-        expect(
-          getSslSettings({
-            connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
-            databaseSSLRootCert: '<cert>',
-          })
-        ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+        const settings = getSslSettings({
+          connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
+          databaseSSLRootCert: '<cert>',
+        })
+        expect(settings?.secureContext).toBeDefined()
+        expect(settings?.rejectUnauthorized).toBe(false)
       } finally {
         global.URL = originalUrl
       }
     })
 
-    test('should return SSL settings if hostname is a bracketed IPv6 address', () => {
-      expect(
-        getSslSettings({
-          connectionString:
-            'postgres://foo:bar@[2001:db8:3333:4444:5555:6666:7777:8888]:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+    test('should skip verification if hostname is a bracketed IPv6 address', () => {
+      const settings = getSslSettings({
+        connectionString:
+          'postgres://foo:bar@[2001:db8:3333:4444:5555:6666:7777:8888]:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBe(false)
     })
 
     test('should detect an IP host even when the password contains an @', () => {
-      expect(
-        getSslSettings({
-          connectionString: 'postgres://user:p@ss@1.2.3.4:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>', rejectUnauthorized: false })
+      const settings = getSslSettings({
+        connectionString: 'postgres://user:p@ss@1.2.3.4:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBe(false)
     })
 
-    test('should not treat an IP in the userinfo as the host', () => {
-      expect(
-        getSslSettings({
-          connectionString: 'postgres://1.2.3.4@db.ref.supabase.red:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>' })
+    test('should verify (no rejectUnauthorized override) when an IP is only in the userinfo', () => {
+      const settings = getSslSettings({
+        connectionString: 'postgres://1.2.3.4@db.ref.supabase.red:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBeUndefined()
+      expect(settings).not.toHaveProperty('ca')
     })
 
-    test('should return SSL settings if hostname is not an IP address', () => {
-      expect(
-        getSslSettings({
-          connectionString: 'postgres://foo:bar@db.ref.supabase.red:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>' })
+    test('should verify against the shared context if hostname is not an IP address', () => {
+      const settings = getSslSettings({
+        connectionString: 'postgres://foo:bar@db.ref.supabase.red:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBeUndefined()
+      expect(settings).not.toHaveProperty('ca')
     })
 
     test('should return SSL settings if hostname is not parseable', () => {
-      expect(
-        getSslSettings({
-          connectionString: 'postgres://foo:bar@db.ref.supabase."red:5432/postgres',
-          databaseSSLRootCert: '<cert>',
-        })
-      ).toStrictEqual({ ca: '<cert>' })
+      const settings = getSslSettings({
+        connectionString: 'postgres://foo:bar@db.ref.supabase."red:5432/postgres',
+        databaseSSLRootCert: '<cert>',
+      })
+      expect(settings?.secureContext).toBeDefined()
+      expect(settings?.rejectUnauthorized).toBeUndefined()
+    })
+
+    test('reuses one SecureContext per root cert across different hosts', () => {
+      const ipHost = getSslSettings({
+        connectionString: 'postgres://foo:bar@1.2.3.4:5432/postgres',
+        databaseSSLRootCert: '<shared-cert>',
+      })
+      const namedHost = getSslSettings({
+        connectionString: 'postgres://foo:bar@db.ref.supabase.red:5432/postgres',
+        databaseSSLRootCert: '<shared-cert>',
+      })
+      expect(ipHost?.secureContext).toBeDefined()
+      expect(ipHost?.secureContext).toBe(namedHost?.secureContext)
+    })
+
+    test('builds distinct SecureContexts for distinct root certs', () => {
+      const certA = getSslSettings({
+        connectionString: 'postgres://foo:bar@db.ref.supabase.red:5432/postgres',
+        databaseSSLRootCert: '<cert-a>',
+      })
+      const certB = getSslSettings({
+        connectionString: 'postgres://foo:bar@db.ref.supabase.red:5432/postgres',
+        databaseSSLRootCert: '<cert-b>',
+      })
+      expect(certA?.secureContext).not.toBe(certB?.secureContext)
     })
   })
 })

--- a/src/internal/database/ssl.ts
+++ b/src/internal/database/ssl.ts
@@ -1,6 +1,23 @@
 import { isIP } from 'node:net'
 import fastDecodeURIComponent from 'fast-decode-uri-component'
-import { ConnectionOptions } from 'tls'
+import { ConnectionOptions, createSecureContext, SecureContext } from 'tls'
+
+// A SecureContext encapsulates only the CA trust anchor and crypto parameters,
+// not the target host (SNI/servername and hostname verification stay
+// per-connection tls.connect options). Passing a raw `ca` PEM string instead
+// forces to re-parse the PEM and rebuild the X509 trust store on every TLS handshake.
+// Build the context once and share it across all pools/connections.
+// Keyed by cert string so this stays correct if differing certs are ever passed in.
+const secureContextCache = new Map<string, SecureContext>()
+
+function getSharedSecureContext(rootCert: string): SecureContext {
+  let secureContext = secureContextCache.get(rootCert)
+  if (!secureContext) {
+    secureContext = createSecureContext({ ca: rootCert })
+    secureContextCache.set(rootCert, secureContext)
+  }
+  return secureContext
+}
 
 export function getSslSettings({
   connectionString,
@@ -11,15 +28,17 @@ export function getSslSettings({
 }): ConnectionOptions | undefined {
   if (!databaseSSLRootCert) return undefined
 
+  const secureContext = getSharedSecureContext(databaseSSLRootCert)
+
   // When connecting through PGBouncer, we connect through an IPv6 address rather than a hostname.
   // When passing in the root CA for SSL, this will always fail,
-  // so we need to skip passing the SSL root cert if host name is an IP address.
+  // so we need to skip verification if host name is an IP address.
   const hostname = getConnectionStringHostname(connectionString)
   if (hostname && isIpAddress(hostname)) {
-    return { ca: databaseSSLRootCert, rejectUnauthorized: false }
+    return { secureContext, rejectUnauthorized: false }
   }
 
-  return { ca: databaseSSLRootCert }
+  return { secureContext }
 }
 
 export function isIpAddress(ip: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for perf

## What is the current behavior?

Cert is reparsed and trust store is recreated for every connection which is CPU intensive. 

## What is the new behavior?

It's immutable and can be shared because connection level parameters are independent.

## Additional context

This is a meaningful performance gain for connection setup.

* [tls.connect](https://nodejs.org/docs/latest-v24.x/api/tls.html#tlsconnectoptions-callback)
* [tls.createSecureContext](https://nodejs.org/docs/latest-v24.x/api/tls.html#tlscreatesecurecontextoptions)