### PR TITLE
fix: handle invalid svgs

### DIFF
--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -612,6 +612,12 @@ describe('ImageRenderer fetch client', () => {
       400,
       'The source image is invalid or unsupported for rendering',
     ],
+    [
+      500,
+      'glib: XML parse error: warning code=100 (3) in (null):8:23: xmlns: URI ns_sfw; is not absolute',
+      400,
+      'The source image is invalid or unsupported for rendering',
+    ],
     [422, 'Invalid source image', 400, 'The source image is invalid or unsupported for rendering'],
     [
       422,

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -77,6 +77,10 @@ const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
   },
   {
     message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /XML parse error:/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
     pattern: /^Invalid source image$/i,
   },
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Rendering invalid svg fails with 500.  

## What is the new behavior?

Handles as 400 with relevant message.

## Additional context

SVG/XML mamespace must be absolute if exists.
