### PR TITLE
fix: full app profiling for changing worker ids

### DIFF
--- a/src/http/routes/admin/pprof.test.ts
+++ b/src/http/routes/admin/pprof.test.ts
@@ -19,6 +19,7 @@ const runtimeApiClient = vi.hoisted(() => ({
   close: vi.fn(),
 }))
 const waitForMultipartPprofWindowMock = vi.hoisted(() => vi.fn())
+const getManagementMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@platformatic/control', () => ({
   RuntimeApiClient: class MockRuntimeApiClient {
@@ -31,6 +32,7 @@ vi.mock('@platformatic/control', () => ({
 
 vi.mock('@platformatic/globals', () => ({
   getGlobal: vi.fn(),
+  getManagement: getManagementMock,
 }))
 
 vi.mock('../../plugins/apikey', () => ({
@@ -296,6 +298,7 @@ describe('admin pprof routes', () => {
       applicationId: 'storage',
       workerId: 2,
     } as never)
+    getManagementMock.mockReturnValue(undefined)
 
     runtimeApiClient.getRuntimeApplications.mockResolvedValue({
       applications: [{ id: 'storage', workers: 2 }],
@@ -616,6 +619,80 @@ describe('admin pprof routes', () => {
           .map((sample) => sample.value[0])
           .sort((left, right) => Number(left) - Number(right))
       ).toEqual([11, 22])
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('retries whole-app captures with live worker ids from worker-not-found errors', async () => {
+    runtimeApiClient.startApplicationProfiling.mockImplementation(
+      async (_pid, applicationId: string) => {
+        if (applicationId === 'storage:0' || applicationId === 'storage:1') {
+          throw Object.assign(
+            new Error(
+              `Failed to start profiling for service "${applicationId}": ` +
+                'Worker 0 of application storage not found. Available applications are: 4, 5, 6'
+            ),
+            {
+              code: 'PLT_CTR_FAILED_TO_START_PROFILING',
+            }
+          )
+        }
+      }
+    )
+    runtimeApiClient.stopApplicationProfiling
+      .mockResolvedValueOnce(buildProfile('worker-four', 44).buffer)
+      .mockResolvedValueOnce(buildProfile('worker-five', 55).buffer)
+      .mockResolvedValueOnce(buildProfile('worker-six', 66).buffer)
+
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/heap?seconds=1',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['x-platformatic-worker-count']).toBe('3')
+      expect(runtimeApiClient.startApplicationProfiling).toHaveBeenCalledTimes(5)
+      for (const workerId of [0, 1, 4, 5, 6]) {
+        expect(runtimeApiClient.startApplicationProfiling).toHaveBeenCalledWith(
+          process.pid,
+          `storage:${workerId}`,
+          {
+            type: 'heap',
+          }
+        )
+      }
+      expect(runtimeApiClient.stopApplicationProfiling).toHaveBeenCalledTimes(3)
+      for (const [call, workerId] of [
+        [1, 4],
+        [2, 5],
+        [3, 6],
+      ]) {
+        expect(runtimeApiClient.stopApplicationProfiling).toHaveBeenNthCalledWith(
+          call,
+          process.pid,
+          `storage:${workerId}`,
+          {
+            type: 'heap',
+          }
+        )
+      }
+
+      const parts = parseMultipartParts(response.rawPayload, response.headers['content-type'])
+      expect(JSON.parse(parts[0].body.toString('utf8'))).toMatchObject({
+        event: 'started',
+        workerCount: 3,
+      })
+
+      const mergedProfile = Profile.decode(parts[1].body)
+      expect(
+        mergedProfile.sample
+          .map((sample) => sample.value[0])
+          .sort((left, right) => Number(left) - Number(right))
+      ).toEqual([44, 55, 66])
     } finally {
       await app.close()
     }

--- a/src/http/routes/admin/pprof.ts
+++ b/src/http/routes/admin/pprof.ts
@@ -14,7 +14,9 @@ import {
   normalizeNodeModulesSourceMaps,
   PPROF_CONTROL_ERROR_CODES,
   resolvePprofFilenameTarget,
+  resolveRuntimeWorkerIdsFromError,
   resolveWattPprofSelection,
+  resolveWattPprofSelectionForWorkerIds,
 } from '@internal/monitoring/pprof/runtime'
 import type {
   ActivePprofSession,
@@ -200,18 +202,33 @@ async function startPprofSession(
     return session
   } catch (error) {
     activePprofSessions.delete(key)
+    await stopProfilingTargets(client, startedTargets, options.type)
+    throw error
+  }
+}
 
-    if (startedTargets.length > 0) {
-      await Promise.allSettled(
-        startedTargets.map((target) =>
-          client.stopApplicationProfiling(target.runtimePid, target.targetApplicationId, {
-            type: options.type,
-          })
-        )
-      )
+async function startPprofSessionWithLiveWorkerRetry(
+  client: ProfilingRuntimeApiClient,
+  selection: WattPprofSelection,
+  options: PprofCaptureOptions
+) {
+  try {
+    return await startPprofSession(client, selection, options)
+  } catch (error) {
+    if (options.signal.aborted || selection.requestedWorkerId !== undefined) {
+      throw error
     }
 
-    throw error
+    const liveWorkerSelection = resolveWattPprofSelectionForWorkerIds(
+      selection,
+      resolveRuntimeWorkerIdsFromError(error)
+    )
+
+    if (!liveWorkerSelection) {
+      throw error
+    }
+
+    return startPprofSession(client, liveWorkerSelection, options)
   }
 }
 
@@ -221,7 +238,10 @@ async function captureAndSendPprof(
   client: ProfilingRuntimeApiClient = asProfilingRuntimeApiClient(new RuntimeApiClient())
 ) {
   try {
-    const selection = await resolveWattPprofSelection(client, options.workerId)
+    let selection: WattPprofSelection | null = await resolveWattPprofSelection(
+      client,
+      options.workerId
+    )
 
     if (!selection) {
       return reply.status(501).send({
@@ -233,7 +253,8 @@ async function captureAndSendPprof(
     let writer: MultipartPprofWriter | undefined
 
     try {
-      session = await startPprofSession(client, selection, options)
+      session = await startPprofSessionWithLiveWorkerRetry(client, selection, options)
+      selection = session
       writer = createMultipartPprofWriter(reply, selection, options.type, options.seconds)
       await waitForMultipartPprofWindow(reply, writer, options.seconds, options.signal)
 

--- a/src/internal/monitoring/pprof/runtime.test.ts
+++ b/src/internal/monitoring/pprof/runtime.test.ts
@@ -1,11 +1,16 @@
 import { vi } from 'vitest'
 
 const getGlobalMock = vi.hoisted(() => vi.fn())
+const getManagementMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@platformatic/globals', () => ({
   getGlobal: getGlobalMock,
+  getManagement: getManagementMock,
 }))
 
+import { FailedToStartProfiling } from '@platformatic/control'
+// @ts-expect-error the deep errors module ships no type declarations
+import { WorkerNotFoundError } from '@platformatic/runtime/lib/errors.js'
 import {
   asProfilingRuntimeApiClient,
   buildPprofFilename,
@@ -18,9 +23,17 @@ import {
   normalizeNodeModulesSourceMaps,
   PPROF_CONTROL_ERROR_CODES,
   resolvePprofFilenameTarget,
+  resolveRuntimeWorkerIdsFromError,
   resolveWattPprofSelection,
 } from './runtime'
 import type { ProfilingRuntimeApiClient, WattPprofSelection } from './types'
+
+// The shipped platformatic .d.ts files lag the real @fastify/error constructors, so re-type
+// them as plain error constructors for fixture building.
+type PlatformaticErrorConstructor = new (...args: (string | number)[]) => Error
+const workerNotFoundError = WorkerNotFoundError as PlatformaticErrorConstructor
+const failedToStartProfilingError =
+  FailedToStartProfiling as unknown as PlatformaticErrorConstructor
 
 function createClient(overrides?: {
   close?: ProfilingRuntimeApiClient['close']
@@ -45,6 +58,7 @@ function createClient(overrides?: {
 describe('pprof runtime helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getManagementMock.mockReturnValue(undefined)
   })
 
   describe('normalizeNodeModulesSourceMaps', () => {
@@ -346,6 +360,227 @@ describe('pprof runtime helpers', () => {
       })
     })
 
+    it('uses live worker ids when the runtime exposes non-dense worker details', async () => {
+      getGlobalMock.mockReturnValue({
+        applicationId: 'storage',
+        workerId: '4',
+      })
+
+      const client = createClient({
+        getRuntimeApplications: vi.fn().mockResolvedValue({
+          applications: [
+            {
+              id: 'storage',
+              workers: [{ worker: 4 }, { worker: 5 }],
+            },
+          ],
+        }),
+      })
+
+      await expect(resolveWattPprofSelection(client, undefined)).resolves.toEqual({
+        applicationId: 'storage',
+        runtimePid: process.pid,
+        servingWorkerId: 4,
+        scopeKey: 'all',
+        targets: [
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:4',
+            workerId: 4,
+          },
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:5',
+            workerId: 5,
+          },
+        ],
+      })
+    })
+
+    it('uses the management worker map before falling back to count-based selection', async () => {
+      getGlobalMock.mockReturnValue({
+        applicationId: 'storage',
+        workerId: '4',
+      })
+      getManagementMock.mockReturnValue({
+        getWorkers: vi.fn().mockResolvedValue({
+          'storage:4': {
+            application: 'storage',
+            worker: '4',
+            status: 'started',
+            thread: 11,
+          },
+          'storage:5': {
+            application: 'storage',
+            worker: '5',
+            status: 'started',
+            thread: 12,
+          },
+          'worker-service:2': {
+            application: 'worker-service',
+            worker: '2',
+            status: 'started',
+            thread: 13,
+          },
+        }),
+      })
+
+      const client = createClient({
+        getRuntimeApplications: vi.fn().mockResolvedValue({
+          applications: [{ id: 'storage', workers: 2 }],
+        }),
+      })
+
+      await expect(resolveWattPprofSelection(client, undefined)).resolves.toEqual({
+        applicationId: 'storage',
+        runtimePid: process.pid,
+        servingWorkerId: 4,
+        scopeKey: 'all',
+        targets: [
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:4',
+            workerId: 4,
+          },
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:5',
+            workerId: 5,
+          },
+        ],
+      })
+      expect(client.getRuntimeApplications).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-started workers from the management worker map', async () => {
+      getGlobalMock.mockReturnValue({
+        applicationId: 'storage',
+        workerId: '4',
+      })
+      getManagementMock.mockReturnValue({
+        getWorkers: vi.fn().mockResolvedValue({
+          'storage:4': {
+            application: 'storage',
+            worker: '4',
+            status: 'started',
+            thread: 11,
+          },
+          'storage:5': {
+            application: 'storage',
+            worker: '5',
+            status: 'starting',
+            thread: 12,
+          },
+          'storage:6': {
+            application: 'storage',
+            worker: '6',
+            status: 'stopping',
+            thread: 13,
+          },
+        }),
+      })
+
+      const client = createClient()
+
+      await expect(resolveWattPprofSelection(client, undefined)).resolves.toEqual({
+        applicationId: 'storage',
+        runtimePid: process.pid,
+        servingWorkerId: 4,
+        scopeKey: 'all',
+        targets: [
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:4',
+            workerId: 4,
+          },
+        ],
+      })
+      expect(client.getRuntimeApplications).not.toHaveBeenCalled()
+    })
+
+    it('falls back to runtime application discovery when management workers are unavailable', async () => {
+      getGlobalMock.mockReturnValue({
+        applicationId: 'storage',
+        workerId: '4',
+      })
+      getManagementMock.mockReturnValue({
+        getWorkers: vi.fn().mockRejectedValue(new Error('Operation "getWorkers" is not allowed')),
+      })
+
+      const client = createClient({
+        getRuntimeApplications: vi.fn().mockResolvedValue({
+          applications: [{ id: 'storage', workers: 2 }],
+        }),
+      })
+
+      await expect(resolveWattPprofSelection(client, undefined)).resolves.toEqual({
+        applicationId: 'storage',
+        requestedWorkerId: undefined,
+        runtimePid: process.pid,
+        servingWorkerId: 4,
+        scopeKey: 'all',
+        targets: [
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:0',
+            workerId: 0,
+          },
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:1',
+            workerId: 1,
+          },
+        ],
+      })
+      expect(client.getRuntimeApplications).toHaveBeenCalledWith(process.pid)
+    })
+
+    it('falls back to dense worker ids when worker details are only partially recognized', async () => {
+      getGlobalMock.mockReturnValue({
+        applicationId: 'storage',
+        workerId: '4',
+      })
+
+      const client = createClient({
+        getRuntimeApplications: vi.fn().mockResolvedValue({
+          applications: [
+            {
+              id: 'storage',
+              workers: [{ worker: 4 }, { status: 'starting' }],
+            },
+          ],
+        }),
+      })
+
+      await expect(resolveWattPprofSelection(client, undefined)).resolves.toEqual({
+        applicationId: 'storage',
+        runtimePid: process.pid,
+        servingWorkerId: 4,
+        scopeKey: 'all',
+        targets: [
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:0',
+            workerId: 0,
+          },
+          {
+            applicationId: 'storage',
+            runtimePid: process.pid,
+            targetApplicationId: 'storage:1',
+            workerId: 1,
+          },
+        ],
+      })
+    })
+
     it('falls back to the current worker when only one worker is reported', async () => {
       getGlobalMock.mockReturnValue({
         applicationId: 'storage',
@@ -399,6 +634,45 @@ describe('pprof runtime helpers', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('resolveRuntimeWorkerIdsFromError', () => {
+    it('extracts live worker ids from the installed platformatic error classes', () => {
+      // Built from the real error classes so a wattpm upgrade that rewords the message turns
+      // this into a failing test instead of a silently dead retry.
+      const workerNotFound = new workerNotFoundError(0, 'storage', '4, 5')
+      const failedToStart = new failedToStartProfilingError('storage:0', workerNotFound.message)
+
+      expect(failedToStart.message).toBe(
+        'Failed to start profiling for service "storage:0": ' +
+          'Worker 0 of application storage not found. Available applications are: 4, 5'
+      )
+      expect(resolveRuntimeWorkerIdsFromError(failedToStart)).toEqual([4, 5])
+    })
+
+    it('keeps the full id list when text follows it', () => {
+      expect(
+        resolveRuntimeWorkerIdsFromError(
+          new Error(
+            'Worker 0 of application storage not found. Available applications are: 4, 5\n2 workers required'
+          )
+        )
+      ).toEqual([4, 5])
+    })
+
+    it('returns undefined for errors without a worker-not-found message', () => {
+      expect(
+        resolveRuntimeWorkerIdsFromError(
+          new Error('Profiling is already started for application "storage" (all workers).')
+        )
+      ).toBeUndefined()
+      expect(
+        resolveRuntimeWorkerIdsFromError(
+          new Error('Application storage not found. Available applications are: 4, 5')
+        )
+      ).toBeUndefined()
+      expect(resolveRuntimeWorkerIdsFromError(undefined)).toBeUndefined()
     })
   })
 })

--- a/src/internal/monitoring/pprof/runtime.ts
+++ b/src/internal/monitoring/pprof/runtime.ts
@@ -1,4 +1,4 @@
-import { getGlobal } from '@platformatic/globals'
+import { getGlobal, getManagement } from '@platformatic/globals'
 import type {
   PprofCaptureType,
   PprofKnownError,
@@ -40,6 +40,10 @@ function normalizeWorkersCount(value: unknown): number | undefined {
     return value
   }
 
+  if (Array.isArray(value) && value.length > 0) {
+    return value.length
+  }
+
   if (typeof value === 'object' && value !== null) {
     const workerConfig = value as {
       static?: unknown
@@ -55,6 +59,78 @@ function normalizeWorkersCount(value: unknown): number | undefined {
   }
 
   return undefined
+}
+
+function normalizeWorkerDetailId(value: unknown) {
+  if (typeof value === 'object' && value !== null) {
+    const worker = value as {
+      id?: unknown
+      worker?: unknown
+      workerId?: unknown
+    }
+
+    return (
+      normalizeWorkerId(worker.worker) ??
+      normalizeWorkerId(worker.workerId) ??
+      normalizeWorkerId(worker.id)
+    )
+  }
+
+  return normalizeWorkerId(value)
+}
+
+function normalizeRuntimeWorkerIds(value: unknown) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined
+  }
+
+  const workerIds = new Set<number>()
+
+  for (const worker of value) {
+    const workerId = normalizeWorkerDetailId(worker)
+
+    if (workerId === undefined) {
+      return undefined
+    }
+
+    workerIds.add(workerId)
+  }
+
+  return [...workerIds]
+}
+
+function normalizeManagementWorkerIds(value: unknown, applicationId: string) {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+
+  const workerIds = new Set<number>()
+
+  for (const [key, worker] of Object.entries(value)) {
+    if (
+      typeof worker !== 'object' ||
+      worker === null ||
+      !('application' in worker) ||
+      worker.application !== applicationId ||
+      !('status' in worker) ||
+      worker.status !== 'started'
+    ) {
+      continue
+    }
+
+    const fallbackWorkerId = key.startsWith(`${applicationId}:`)
+      ? key.slice(applicationId.length + 1)
+      : undefined
+    const workerId = normalizeWorkerDetailId(worker) ?? normalizeWorkerId(fallbackWorkerId)
+
+    if (workerId === undefined) {
+      return undefined
+    }
+
+    workerIds.add(workerId)
+  }
+
+  return workerIds.size > 0 ? [...workerIds] : undefined
 }
 
 export function normalizeNodeModulesSourceMaps(value: string | string[] | undefined) {
@@ -139,6 +215,56 @@ function getErrorMessage(error: unknown) {
     typeof error.message === 'string'
     ? error.message
     : undefined
+}
+
+export function resolveRuntimeWorkerIdsFromError(error: unknown) {
+  const message = getErrorMessage(error)
+  if (!message || !/\bWorker\s+\d+\s+of application\b/i.test(message)) {
+    return undefined
+  }
+
+  // Capture only a comma-separated id list so trailing text like
+  // "Available applications are: 4, 5\n2 workers required" can never glue onto the last id.
+  const match = message.match(/\bAvailable (?:applications|workers) are:\s*(\d+(?:\s*,\s*\d+)*)/i)
+  if (!match) {
+    return undefined
+  }
+
+  return normalizeRuntimeWorkerIds(match[1].split(','))
+}
+
+export function resolveWattPprofSelectionForWorkerIds(
+  selection: Omit<WattPprofSelection, 'targets'>,
+  workerIds: number[] | undefined
+) {
+  if (!workerIds || workerIds.length === 0) {
+    return undefined
+  }
+
+  return {
+    ...selection,
+    requestedWorkerId: undefined,
+    scopeKey: 'all',
+    targets: workerIds.map((workerId) => ({
+      applicationId: selection.applicationId,
+      runtimePid: selection.runtimePid,
+      targetApplicationId: `${selection.applicationId}:${workerId}`,
+      workerId,
+    })),
+  } satisfies WattPprofSelection
+}
+
+async function resolveManagementWorkerIds(applicationId: string) {
+  const management = getManagement({ throwOnMissing: false })
+  if (typeof management?.getWorkers !== 'function') {
+    return undefined
+  }
+
+  try {
+    return normalizeManagementWorkerIds(await management.getWorkers(), applicationId)
+  } catch {
+    return undefined
+  }
 }
 
 function getErrorCause(error: unknown) {
@@ -274,6 +400,21 @@ export async function resolveWattPprofSelection(
     } satisfies WattPprofSelection
   }
 
+  const baseSelection = {
+    applicationId: context.applicationId,
+    runtimePid: context.runtimePid,
+    servingWorkerId: context.workerId,
+    scopeKey: 'all',
+  } satisfies Omit<WattPprofSelection, 'targets'>
+  const managementWorkerSelection = resolveWattPprofSelectionForWorkerIds(
+    baseSelection,
+    await resolveManagementWorkerIds(context.applicationId)
+  )
+
+  if (managementWorkerSelection) {
+    return managementWorkerSelection
+  }
+
   const runtimeApplications = await client.getRuntimeApplications(context.runtimePid)
   const currentApplication = runtimeApplications.applications?.find(
     (application) => application.id === context.applicationId
@@ -282,36 +423,26 @@ export async function resolveWattPprofSelection(
     normalizeWorkersCount(currentApplication?.workers) ??
     normalizeWorkersCount(currentApplication?.config?.workers) ??
     1
+  const workerIds =
+    normalizeRuntimeWorkerIds(currentApplication?.workers) ??
+    (workersCount > 1 ? Array.from({ length: workersCount }, (_, workerId) => workerId) : undefined)
+  const workerSelection = resolveWattPprofSelectionForWorkerIds(baseSelection, workerIds)
 
-  if (workersCount <= 1) {
-    const workerId = context.workerId
-    return {
-      applicationId: context.applicationId,
-      runtimePid: context.runtimePid,
-      servingWorkerId: context.workerId,
-      scopeKey: 'all',
-      targets: [
-        {
-          applicationId: context.applicationId,
-          runtimePid: context.runtimePid,
-          targetApplicationId:
-            workerId === undefined ? context.applicationId : `${context.applicationId}:${workerId}`,
-          workerId,
-        },
-      ],
-    } satisfies WattPprofSelection
+  if (workerSelection) {
+    return workerSelection
   }
 
+  const workerId = context.workerId
   return {
-    applicationId: context.applicationId,
-    runtimePid: context.runtimePid,
-    servingWorkerId: context.workerId,
-    scopeKey: 'all',
-    targets: Array.from({ length: workersCount }, (_, workerId) => ({
-      applicationId: context.applicationId,
-      runtimePid: context.runtimePid,
-      targetApplicationId: `${context.applicationId}:${workerId}`,
-      workerId,
-    })),
+    ...baseSelection,
+    targets: [
+      {
+        applicationId: context.applicationId,
+        runtimePid: context.runtimePid,
+        targetApplicationId:
+          workerId === undefined ? context.applicationId : `${context.applicationId}:${workerId}`,
+        workerId,
+      },
+    ],
   } satisfies WattPprofSelection
 }

--- a/watt.json
+++ b/watt.json
@@ -16,6 +16,9 @@
       "maxUnhealthyChecks": "{WATT_HEALTH_MAX_UNHEALTHY_CHECKS}",
       "interval": "{WATT_HEALTH_INTERVAL}"
     },
+    "management": {
+      "operations": ["getWorkers"]
+    },
     "managementApi": "{PLT_MANAGEMENT_API}"
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Worker ids are changing and doesn't start from zero since https://github.com/supabase/storage/pull/1190

## What is the new behavior?

Extract ids from management api, application or error message with retry in the desired order.