### PR TITLE
fix: cheaper hostname/SAN check

### DIFF
--- a/src/internal/database/ssl.test.ts
+++ b/src/internal/database/ssl.test.ts
@@ -32,6 +32,8 @@ describe('database utils', () => {
       })
       expect(settings?.secureContext).toBeDefined()
       expect(settings?.rejectUnauthorized).toBe(false)
+      expect(settings?.checkServerIdentity).toBeInstanceOf(Function)
+      expect(settings?.checkServerIdentity?.('1.2.3.4', {} as never)).toBeUndefined()
       expect(settings).not.toHaveProperty('ca')
     })
 
@@ -82,6 +84,7 @@ describe('database utils', () => {
       })
       expect(settings?.secureContext).toBeDefined()
       expect(settings?.rejectUnauthorized).toBeUndefined()
+      expect(settings?.checkServerIdentity).toBeUndefined()
       expect(settings).not.toHaveProperty('ca')
     })
 

--- a/src/internal/database/ssl.test.ts
+++ b/src/internal/database/ssl.test.ts
@@ -1,3 +1,4 @@
+import type { PeerCertificate } from 'node:tls'
 import { getSslSettings, isIpAddress } from '@internal/database/ssl'
 
 describe('database utils', () => {
@@ -33,7 +34,7 @@ describe('database utils', () => {
       expect(settings?.secureContext).toBeDefined()
       expect(settings?.rejectUnauthorized).toBe(false)
       expect(settings?.checkServerIdentity).toBeInstanceOf(Function)
-      expect(settings?.checkServerIdentity?.('1.2.3.4', {} as never)).toBeUndefined()
+      expect(settings?.checkServerIdentity?.('1.2.3.4', {} as PeerCertificate)).toBeUndefined()
       expect(settings).not.toHaveProperty('ca')
     })
 

--- a/src/internal/database/ssl.ts
+++ b/src/internal/database/ssl.ts
@@ -19,6 +19,8 @@ function getSharedSecureContext(rootCert: string): SecureContext {
   return secureContext
 }
 
+const dontCheckServerIdentity = () => undefined
+
 export function getSslSettings({
   connectionString,
   databaseSSLRootCert,
@@ -35,7 +37,11 @@ export function getSslSettings({
   // so we need to skip verification if host name is an IP address.
   const hostname = getConnectionStringHostname(connectionString)
   if (hostname && isIpAddress(hostname)) {
-    return { secureContext, rejectUnauthorized: false }
+    return {
+      secureContext,
+      rejectUnauthorized: false,
+      checkServerIdentity: dontCheckServerIdentity,
+    }
   }
 
   return { secureContext }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Node gets certificate and delivers it to the default identity checker, which always fails with IPs. This default does identity matching and error construction (allocation), then discards it. 

## What is the new behavior?

Replace identity checker with noop.

## Additional context

Certificate extraction price will still be paid (will check session resumption separately).