### PR TITLE
feat: add tls session resumption

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ type StorageConfigType = {
   databasePoolURL?: string
   databaseMaxConnections: number
   databaseFreePoolAfterInactivity: number
+  databaseTlsSessionResumption: boolean
   databasePoolDrainTimeout: number
   databaseConnectionTimeout: number
   databaseEnableQueryCancellation: boolean
@@ -491,6 +492,8 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
       getOptionalConfigFromEnv('DATABASE_FREE_POOL_AFTER_INACTIVITY') || (1000 * 60).toString(),
       10
     ),
+    databaseTlsSessionResumption:
+      getOptionalConfigFromEnv('DATABASE_TLS_SESSION_RESUMPTION') === 'true',
     databasePoolDrainTimeout: envPositiveInteger(
       getOptionalConfigFromEnv('DATABASE_POOL_DRAIN_TIMEOUT'),
       30_000

--- a/src/internal/cache/names.ts
+++ b/src/internal/cache/names.ts
@@ -3,6 +3,7 @@ export const TENANT_CONFIG_CACHE_NAME = 'tenant_config' as const
 export const TENANT_JWKS_CACHE_NAME = 'tenant_jwks' as const
 export const TENANT_POOL_CACHE_NAME = 'tenant_pool' as const
 export const TENANT_S3_CREDENTIALS_CACHE_NAME = 'tenant_s3_credentials' as const
+export const TLS_SESSION_CACHE_NAME = 'tls_session' as const
 
 export type CacheName =
   | typeof JWT_CACHE_NAME
@@ -10,3 +11,4 @@ export type CacheName =
   | typeof TENANT_JWKS_CACHE_NAME
   | typeof TENANT_POOL_CACHE_NAME
   | typeof TENANT_S3_CREDENTIALS_CACHE_NAME
+  | typeof TLS_SESSION_CACHE_NAME

--- a/src/internal/cache/names.ts
+++ b/src/internal/cache/names.ts
@@ -3,7 +3,6 @@ export const TENANT_CONFIG_CACHE_NAME = 'tenant_config' as const
 export const TENANT_JWKS_CACHE_NAME = 'tenant_jwks' as const
 export const TENANT_POOL_CACHE_NAME = 'tenant_pool' as const
 export const TENANT_S3_CREDENTIALS_CACHE_NAME = 'tenant_s3_credentials' as const
-export const TLS_SESSION_CACHE_NAME = 'tls_session' as const
 
 export type CacheName =
   | typeof JWT_CACHE_NAME
@@ -11,4 +10,3 @@ export type CacheName =
   | typeof TENANT_JWKS_CACHE_NAME
   | typeof TENANT_POOL_CACHE_NAME
   | typeof TENANT_S3_CREDENTIALS_CACHE_NAME
-  | typeof TLS_SESSION_CACHE_NAME

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -1104,7 +1104,7 @@ describe('PgPoolStrategy TLS session resumption wiring', () => {
       databaseSSLRootCert: '<cert>',
       databaseTlsSessionResumption: true,
     })
-    const { getTlsSessionResumptionClient } = await import('./tls-session-resumption')
+    const { TlsSessionResumptionClient } = await import('./tls-session-resumption')
     const DynamicTestablePgPoolStrategy = createDynamicTestablePgPoolStrategy(DynamicPgPoolStrategy)
     const strategy = new DynamicTestablePgPoolStrategy(
       createPoolStrategySettings({
@@ -1117,7 +1117,7 @@ describe('PgPoolStrategy TLS session resumption wiring', () => {
       const ssl = pool.options.ssl as object
 
       expect(ssl).toBeDefined()
-      expect(pool.options.Client).toBe(getTlsSessionResumptionClient())
+      expect(pool.options.Client).toBe(TlsSessionResumptionClient)
 
       const sessionDescriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
       expect(sessionDescriptor?.get).toBeInstanceOf(Function)

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -166,6 +166,24 @@ async function waitForDrainCheck(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve))
 }
 
+async function loadPgConnectionModuleWithConfig(configOverrides: Record<string, unknown>) {
+  vi.resetModules()
+
+  const configModule = await import('../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({
+    databaseApplicationName: 'storage-test',
+    databaseConnectionTimeout: 3000,
+    databaseFreePoolAfterInactivity: 1000,
+    databaseMaxConnections: 20,
+    databaseSSLRootCert: undefined,
+    databaseTlsSessionResumption: false,
+    ...configOverrides,
+  } as Parameters<typeof configModule.mergeConfig>[0])
+
+  return import('./pg-connection')
+}
+
 describe('getPgCancelConnectionTarget', () => {
   it('uses direct client host and port for TCP cancel connections', () => {
     expect(
@@ -1064,6 +1082,98 @@ describe('PgPoolStrategy', () => {
     } finally {
       logSpy.mockRestore()
       vi.useRealTimers()
+    }
+  })
+})
+
+describe('PgPoolStrategy TLS session resumption wiring', () => {
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  function createDynamicTestablePgPoolStrategy(PgPoolStrategyCtor: typeof PgPoolStrategy) {
+    return class DynamicTestablePgPoolStrategy extends PgPoolStrategyCtor {
+      getCurrentPoolForTest(): Pool {
+        return this.getPool()
+      }
+    }
+  }
+
+  it('installs the session getter, slot marker, and custom client when enabled with SSL', async () => {
+    const { PgPoolStrategy: DynamicPgPoolStrategy } = await loadPgConnectionModuleWithConfig({
+      databaseSSLRootCert: '<cert>',
+      databaseTlsSessionResumption: true,
+    })
+    const { getTlsSessionResumptionClient } = await import('./tls-session-resumption')
+    const DynamicTestablePgPoolStrategy = createDynamicTestablePgPoolStrategy(DynamicPgPoolStrategy)
+    const strategy = new DynamicTestablePgPoolStrategy(
+      createPoolStrategySettings({
+        dbUrl: 'postgres://postgres:postgres@1.2.3.4:5432/postgres',
+      })
+    )
+
+    try {
+      const pool = strategy.getCurrentPoolForTest()
+      const ssl = pool.options.ssl as object
+
+      expect(ssl).toBeDefined()
+      expect(pool.options.Client).toBe(getTlsSessionResumptionClient())
+
+      const sessionDescriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
+      expect(sessionDescriptor?.get).toBeInstanceOf(Function)
+      expect(sessionDescriptor?.enumerable).toBe(true)
+      expect(sessionDescriptor?.configurable).toBe(true)
+      expect(sessionDescriptor?.get?.call(ssl)).toBeUndefined()
+
+      expect(Object.getOwnPropertySymbols(ssl)).toHaveLength(1)
+      const tlsConnectOptions = Object.assign({}, ssl)
+      expect(Object.getOwnPropertySymbols(tlsConnectOptions)).toHaveLength(0)
+      expect(Object.prototype.hasOwnProperty.call(tlsConnectOptions, 'session')).toBe(true)
+    } finally {
+      await strategy.destroy()
+    }
+  })
+
+  it('leaves SSL options untouched when the feature flag is disabled', async () => {
+    const { PgPoolStrategy: DynamicPgPoolStrategy } = await loadPgConnectionModuleWithConfig({
+      databaseSSLRootCert: '<cert>',
+      databaseTlsSessionResumption: false,
+    })
+    const DynamicTestablePgPoolStrategy = createDynamicTestablePgPoolStrategy(DynamicPgPoolStrategy)
+    const strategy = new DynamicTestablePgPoolStrategy(
+      createPoolStrategySettings({
+        dbUrl: 'postgres://postgres:postgres@1.2.3.4:5432/postgres',
+      })
+    )
+
+    try {
+      const pool = strategy.getCurrentPoolForTest()
+      const ssl = pool.options.ssl as object
+
+      expect(ssl).toBeDefined()
+      expect(pool.options.Client).toBeUndefined()
+      expect(Object.getOwnPropertyDescriptor(ssl, 'session')).toBeUndefined()
+      expect(Object.getOwnPropertySymbols(ssl)).toHaveLength(0)
+    } finally {
+      await strategy.destroy()
+    }
+  })
+
+  it('does not install the custom client when SSL settings are absent', async () => {
+    const { PgPoolStrategy: DynamicPgPoolStrategy } = await loadPgConnectionModuleWithConfig({
+      databaseSSLRootCert: undefined,
+      databaseTlsSessionResumption: true,
+    })
+    const DynamicTestablePgPoolStrategy = createDynamicTestablePgPoolStrategy(DynamicPgPoolStrategy)
+    const strategy = new DynamicTestablePgPoolStrategy(createPoolStrategySettings())
+
+    try {
+      const pool = strategy.getCurrentPoolForTest()
+
+      expect(pool.options.ssl).toBeUndefined()
+      expect(pool.options.Client).toBeUndefined()
+    } finally {
+      await strategy.destroy()
     }
   })
 })

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -13,6 +13,7 @@ import {
   TenantConnectionOptions,
 } from './pool'
 import { getSslSettings } from './ssl'
+import { getTlsSessionResumptionClient } from './tls-session-resumption'
 
 const {
   databaseApplicationName,
@@ -22,6 +23,7 @@ const {
   databasePoolDrainTimeout,
   databaseSSLRootCert,
   databaseStatementTimeout,
+  databaseTlsSessionResumption,
 } = getConfig()
 
 pg.types.setTypeParser(20, 'text', parseInt)
@@ -184,6 +186,8 @@ export class PgPoolStrategy {
         connectionTimeoutMillis: databaseConnectionTimeout,
         idleTimeoutMillis: settings.idleTimeoutMillis,
         ssl: sslSettings ? { ...sslSettings } : undefined,
+        Client:
+          databaseTlsSessionResumption && sslSettings ? getTlsSessionResumptionClient() : undefined,
         application_name: databaseApplicationName,
         options: settings.searchPath
           ? `-c search_path=${settings.searchPath.join(',')}`

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -15,9 +15,9 @@ import {
 import { getSslSettings } from './ssl'
 import {
   createTlsSessionSlot,
-  getTlsSessionResumptionClient,
   installTlsSessionResumption,
-  TlsSessionSlot,
+  TlsSessionResumptionClient,
+  type TlsSessionSlot,
 } from './tls-session-resumption'
 
 const {
@@ -198,7 +198,7 @@ export class PgPoolStrategy {
         connectionTimeoutMillis: databaseConnectionTimeout,
         idleTimeoutMillis: settings.idleTimeoutMillis,
         ssl,
-        Client: databaseTlsSessionResumption && ssl ? getTlsSessionResumptionClient() : undefined,
+        Client: databaseTlsSessionResumption && ssl ? TlsSessionResumptionClient : undefined,
         application_name: databaseApplicationName,
         options: settings.searchPath
           ? `-c search_path=${settings.searchPath.join(',')}`

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -13,7 +13,12 @@ import {
   TenantConnectionOptions,
 } from './pool'
 import { getSslSettings } from './ssl'
-import { getTlsSessionResumptionClient } from './tls-session-resumption'
+import {
+  createTlsSessionSlot,
+  getTlsSessionResumptionClient,
+  installTlsSessionResumption,
+  TlsSessionSlot,
+} from './tls-session-resumption'
 
 const {
   databaseApplicationName,
@@ -88,6 +93,7 @@ export type PgCancelConnectionTarget =
 
 export class PgPoolStrategy {
   protected pool?: Pool
+  protected tlsSession?: TlsSessionSlot
 
   constructor(protected readonly options: TenantConnectionOptions) {}
 
@@ -178,6 +184,12 @@ export class PgPoolStrategy {
       databaseSSLRootCert,
     })
 
+    const ssl = sslSettings ? { ...sslSettings } : undefined
+    if (databaseTlsSessionResumption && ssl) {
+      this.tlsSession ??= createTlsSessionSlot()
+      installTlsSessionResumption(ssl, this.tlsSession)
+    }
+
     return attachPgPoolErrorHandler(
       new Pool({
         min: 0,
@@ -185,9 +197,8 @@ export class PgPoolStrategy {
         connectionString: settings.dbUrl,
         connectionTimeoutMillis: databaseConnectionTimeout,
         idleTimeoutMillis: settings.idleTimeoutMillis,
-        ssl: sslSettings ? { ...sslSettings } : undefined,
-        Client:
-          databaseTlsSessionResumption && sslSettings ? getTlsSessionResumptionClient() : undefined,
+        ssl,
+        Client: databaseTlsSessionResumption && ssl ? getTlsSessionResumptionClient() : undefined,
         application_name: databaseApplicationName,
         options: settings.searchPath
           ? `-c search_path=${settings.searchPath.join(',')}`

--- a/src/internal/database/tls-session-resumption.test.ts
+++ b/src/internal/database/tls-session-resumption.test.ts
@@ -1,0 +1,338 @@
+import { execFileSync } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import tls from 'node:tls'
+import {
+  attachTlsSessionCapture,
+  clearTlsSessionCache,
+  getTlsSession,
+  getTlsSessionCacheMaxEntries,
+  getTlsSessionCacheSize,
+  getTlsSessionResumptionClient,
+  installTlsSessionInjection,
+  observeTlsSessionResumption,
+  storeTlsSession,
+  TLS_SESSION_CACHE_MAX_AGE_MS,
+} from '@internal/database/tls-session-resumption'
+import * as metrics from '@internal/monitoring/metrics'
+import { vi } from 'vitest'
+
+describe('tls session cache', () => {
+  afterEach(() => {
+    clearTlsSessionCache()
+    vi.restoreAllMocks()
+  })
+
+  test('stores and returns the latest session per key', () => {
+    const first = Buffer.from('first')
+    const second = Buffer.from('second')
+
+    storeTlsSession('host:5432', first)
+    expect(getTlsSession('host:5432')).toBe(first)
+
+    storeTlsSession('host:5432', second)
+    expect(getTlsSession('host:5432')).toBe(second)
+    expect(getTlsSession('other:5432')).toBeUndefined()
+  })
+
+  test('expires sessions after the max age', async () => {
+    let now = 1
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+    storeTlsSession('host:5432', Buffer.from('ticket'))
+
+    now += TLS_SESSION_CACHE_MAX_AGE_MS - 1
+    expect(getTlsSession('host:5432')).toBeInstanceOf(Buffer)
+
+    await new Promise((resolve) => setTimeout(resolve, 2))
+
+    now += 2
+    expect(getTlsSession('host:5432')).toBeUndefined()
+    expect(getTlsSessionCacheSize()).toBe(0)
+  })
+
+  test('evicts the oldest entry beyond the size bound', () => {
+    const maxEntries = getTlsSessionCacheMaxEntries()
+    const session = Buffer.from('ticket')
+    for (let i = 0; i <= maxEntries; i++) {
+      storeTlsSession(`host-${i}:5432`, session)
+    }
+
+    expect(getTlsSessionCacheSize()).toBe(maxEntries)
+    expect(getTlsSession('host-0:5432')).toBeUndefined()
+    expect(getTlsSession(`host-${maxEntries}:5432`)).toBe(session)
+  })
+
+  test('injection getter is enumerable and re-evaluated per Object.assign', () => {
+    const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
+    installTlsSessionInjection(ssl, 'host:5432')
+
+    const descriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
+    expect(descriptor?.get).toBeInstanceOf(Function)
+    expect(descriptor?.enumerable).toBe(true)
+
+    expect(Object.assign({}, ssl).session).toBeUndefined()
+
+    const first = Buffer.from('first')
+    storeTlsSession('host:5432', first)
+    expect(Object.assign({}, ssl).session).toBe(first)
+
+    const second = Buffer.from('second')
+    storeTlsSession('host:5432', second)
+    expect(Object.assign({}, ssl).session).toBe(second)
+  })
+
+  test('injection install is idempotent', () => {
+    const ssl: tls.ConnectionOptions = {}
+    installTlsSessionInjection(ssl, 'host:5432')
+    installTlsSessionInjection(ssl, 'other:5432')
+
+    storeTlsSession('host:5432', Buffer.from('host-session'))
+    storeTlsSession('other:5432', Buffer.from('other-session'))
+
+    expect(Object.assign({}, ssl).session).toEqual(Buffer.from('host-session'))
+  })
+
+  test('capture stores every session emitted by the socket', () => {
+    const socket = new EventEmitter()
+    attachTlsSessionCapture(socket, 'host:5432')
+
+    const first = Buffer.from('first')
+    const second = Buffer.from('second')
+    socket.emit('session', first)
+    expect(getTlsSession('host:5432')).toBe(first)
+
+    socket.emit('session', second)
+    expect(getTlsSession('host:5432')).toBe(second)
+  })
+
+  test('capture tolerates streams without listener support', () => {
+    expect(() => attachTlsSessionCapture(undefined, 'host:5432')).not.toThrow()
+    expect(() => attachTlsSessionCapture({}, 'host:5432')).not.toThrow()
+    expect(() => attachTlsSessionCapture(null, 'host:5432')).not.toThrow()
+  })
+})
+
+describe('resumption outcome observability', () => {
+  afterEach(() => {
+    clearTlsSessionCache()
+    vi.restoreAllMocks()
+  })
+
+  function fakeTlsSocket(reused: boolean) {
+    const socket = new EventEmitter() as EventEmitter & { isSessionReused: () => boolean }
+    socket.isSessionReused = () => reused
+    return socket
+  }
+
+  test("records 'resumed' when the server accepts the offered session", () => {
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+    storeTlsSession('host:5432', Buffer.from('ticket'))
+
+    const socket = fakeTlsSocket(true)
+    observeTlsSessionResumption(socket, 'host:5432')
+    socket.emit('secureConnect')
+
+    expect(recordSpy).toHaveBeenCalledWith('resumed')
+  })
+
+  test("records 'rejected' when a session was offered but the handshake was full", () => {
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+    storeTlsSession('host:5432', Buffer.from('ticket'))
+
+    const socket = fakeTlsSocket(false)
+    observeTlsSessionResumption(socket, 'host:5432')
+    socket.emit('secureConnect')
+
+    expect(recordSpy).toHaveBeenCalledWith('rejected')
+  })
+
+  test("records 'uncached' when no session was available to offer", () => {
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+
+    const socket = fakeTlsSocket(false)
+    observeTlsSessionResumption(socket, 'host:5432')
+    socket.emit('secureConnect')
+
+    expect(recordSpy).toHaveBeenCalledWith('uncached')
+  })
+
+  test('offer peek does not distort cache request metrics', () => {
+    const cacheSpy = vi.spyOn(metrics, 'recordCacheRequest')
+
+    observeTlsSessionResumption(fakeTlsSocket(false), 'host:5432')
+
+    expect(cacheSpy).not.toHaveBeenCalled()
+  })
+
+  test('tolerates sockets without resumption support', () => {
+    expect(() => observeTlsSessionResumption(new EventEmitter(), 'host:5432')).not.toThrow()
+    expect(() => observeTlsSessionResumption(undefined, 'host:5432')).not.toThrow()
+    expect(() => observeTlsSessionResumption({}, 'host:5432')).not.toThrow()
+  })
+})
+
+// A pg upgrade that reshapes event or configuration must fail here
+// rather than silently disabling the feature.
+describe('TlsSessionResumptionClient pg wiring', () => {
+  afterEach(() => {
+    clearTlsSessionCache()
+    vi.restoreAllMocks()
+  })
+
+  test('returns the same class on every call', () => {
+    expect(getTlsSessionResumptionClient()).toBe(getTlsSessionResumptionClient())
+  })
+
+  test('installs injection on the ssl object and captures sessions on sslconnect', () => {
+    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
+    const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
+    const client = new TlsSessionResumptionClient({
+      host: '1.2.3.4',
+      port: 5433,
+      user: 'user',
+      password: 'password',
+      database: 'db',
+      ssl,
+    })
+
+    const descriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
+    expect(descriptor?.get).toBeInstanceOf(Function)
+
+    const internals = client as unknown as {
+      connection: EventEmitter & { stream: unknown }
+    }
+    expect(internals.connection).toBeDefined()
+    expect(internals.connection.listenerCount('sslconnect')).toBe(1)
+
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+    const stream = new EventEmitter() as EventEmitter & { isSessionReused: () => boolean }
+    stream.isSessionReused = () => false
+    internals.connection.stream = stream
+    internals.connection.emit('sslconnect')
+
+    const session = Buffer.from('ticket')
+    stream.emit('session', session)
+    expect(getTlsSession('1.2.3.4:5433')).toBe(session)
+
+    expect(Object.assign({}, ssl).session).toBe(session)
+
+    stream.emit('secureConnect')
+    expect(recordSpy).toHaveBeenCalledWith('uncached')
+  })
+
+  test('does nothing without object-form ssl settings', () => {
+    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
+    const client = new TlsSessionResumptionClient({
+      host: 'db.example.com',
+      port: 5432,
+      user: 'user',
+      password: 'password',
+      database: 'db',
+    })
+
+    const internals = client as unknown as { connection: EventEmitter }
+    expect(internals.connection.listenerCount('sslconnect')).toBe(0)
+  })
+})
+
+const opensslAvailable = (() => {
+  try {
+    execFileSync('openssl', ['version'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+})()
+
+describe.runIf(opensslAvailable)('TLS session resumption against a real TLS server', () => {
+  let certDir: string
+  let serverKey: Buffer
+  let serverCert: Buffer
+
+  beforeAll(() => {
+    certDir = mkdtempSync(join(tmpdir(), 'tls-resume-'))
+    execFileSync(
+      'openssl',
+      [
+        'req',
+        '-x509',
+        '-newkey',
+        'ec',
+        '-pkeyopt',
+        'ec_paramgen_curve:prime256v1',
+        '-nodes',
+        '-keyout',
+        join(certDir, 'key.pem'),
+        '-out',
+        join(certDir, 'cert.pem'),
+        '-days',
+        '2',
+        '-subj',
+        '/CN=localhost',
+      ],
+      { stdio: 'ignore' }
+    )
+    serverKey = readFileSync(join(certDir, 'key.pem'))
+    serverCert = readFileSync(join(certDir, 'cert.pem'))
+  })
+
+  afterAll(() => {
+    rmSync(certDir, { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    clearTlsSessionCache()
+  })
+
+  test.each([['TLSv1.2'], ['TLSv1.3']])('resumes a session over %s', async (version) => {
+    const tlsVersion = version as tls.SecureVersion
+    const server = tls.createServer({
+      key: serverKey,
+      cert: serverCert,
+      minVersion: tlsVersion,
+      maxVersion: tlsVersion,
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as AddressInfo).port
+    const cacheKey = `127.0.0.1:${port}`
+
+    try {
+      const first = tls.connect({ host: '127.0.0.1', port, rejectUnauthorized: false })
+      attachTlsSessionCapture(first, cacheKey)
+      const sessionArrived = new Promise<void>((resolve, reject) => {
+        first.once('session', () => resolve())
+        first.once('error', reject)
+      })
+      await new Promise<void>((resolve, reject) => {
+        first.once('secureConnect', resolve)
+        first.once('error', reject)
+      })
+      expect(first.isSessionReused()).toBe(false)
+      await sessionArrived
+      first.destroy()
+
+      expect(getTlsSession(cacheKey)).toBeInstanceOf(Buffer)
+
+      const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
+      installTlsSessionInjection(ssl, cacheKey)
+      const options: tls.ConnectionOptions = { host: '127.0.0.1', port }
+      Object.assign(options, ssl)
+
+      const second = tls.connect(options)
+      await new Promise<void>((resolve, reject) => {
+        second.once('secureConnect', resolve)
+        second.once('error', reject)
+      })
+      const reused = second.isSessionReused()
+      second.destroy()
+
+      expect(reused).toBe(true)
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+})

--- a/src/internal/database/tls-session-resumption.test.ts
+++ b/src/internal/database/tls-session-resumption.test.ts
@@ -8,12 +8,12 @@ import tls from 'node:tls'
 import {
   attachTlsSessionCapture,
   createTlsSessionSlot,
-  getTlsSessionResumptionClient,
   installTlsSessionResumption,
   observeTlsSessionResumption,
   peekTlsSession,
   storeTlsSession,
   TLS_SESSION_MAX_AGE_MS,
+  TlsSessionResumptionClient,
 } from '@internal/database/tls-session-resumption'
 import * as metrics from '@internal/monitoring/metrics'
 import { vi } from 'vitest'
@@ -192,12 +192,7 @@ describe('TlsSessionResumptionClient pg wiring', () => {
     vi.restoreAllMocks()
   })
 
-  test('returns the same class on every call', () => {
-    expect(getTlsSessionResumptionClient()).toBe(getTlsSessionResumptionClient())
-  })
-
   test('finds the slot on the ssl options and captures sessions on sslconnect', () => {
-    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
     const slot = createTlsSessionSlot()
     const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
     installTlsSessionResumption(ssl, slot)
@@ -234,7 +229,6 @@ describe('TlsSessionResumptionClient pg wiring', () => {
   })
 
   test('does nothing without a slot on the ssl options', () => {
-    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
     const client = new TlsSessionResumptionClient({
       host: '1.2.3.4',
       port: 5432,
@@ -249,7 +243,6 @@ describe('TlsSessionResumptionClient pg wiring', () => {
   })
 
   test('does nothing without object-form ssl settings', () => {
-    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
     const client = new TlsSessionResumptionClient({
       host: 'db.example.com',
       port: 5432,

--- a/src/internal/database/tls-session-resumption.test.ts
+++ b/src/internal/database/tls-session-resumption.test.ts
@@ -7,68 +7,54 @@ import { join } from 'node:path'
 import tls from 'node:tls'
 import {
   attachTlsSessionCapture,
-  clearTlsSessionCache,
-  getTlsSession,
-  getTlsSessionCacheMaxEntries,
-  getTlsSessionCacheSize,
+  createTlsSessionSlot,
   getTlsSessionResumptionClient,
-  installTlsSessionInjection,
+  installTlsSessionResumption,
   observeTlsSessionResumption,
+  peekTlsSession,
   storeTlsSession,
-  TLS_SESSION_CACHE_MAX_AGE_MS,
+  TLS_SESSION_MAX_AGE_MS,
 } from '@internal/database/tls-session-resumption'
 import * as metrics from '@internal/monitoring/metrics'
 import { vi } from 'vitest'
 
-describe('tls session cache', () => {
+describe('tls session slot', () => {
   afterEach(() => {
-    clearTlsSessionCache()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
-  test('stores and returns the latest session per key', () => {
+  test('stores and returns the latest session', () => {
+    const slot = createTlsSessionSlot()
     const first = Buffer.from('first')
     const second = Buffer.from('second')
 
-    storeTlsSession('host:5432', first)
-    expect(getTlsSession('host:5432')).toBe(first)
+    expect(peekTlsSession(slot)).toBeUndefined()
 
-    storeTlsSession('host:5432', second)
-    expect(getTlsSession('host:5432')).toBe(second)
-    expect(getTlsSession('other:5432')).toBeUndefined()
+    storeTlsSession(slot, first)
+    expect(peekTlsSession(slot)).toBe(first)
+
+    storeTlsSession(slot, second)
+    expect(peekTlsSession(slot)).toBe(second)
   })
 
-  test('expires sessions after the max age', async () => {
-    let now = 1
-    vi.spyOn(performance, 'now').mockImplementation(() => now)
+  test('expires sessions after the max age', () => {
+    vi.useFakeTimers()
+    const slot = createTlsSessionSlot()
 
-    storeTlsSession('host:5432', Buffer.from('ticket'))
+    storeTlsSession(slot, Buffer.from('ticket'))
+    vi.advanceTimersByTime(TLS_SESSION_MAX_AGE_MS - 1)
+    expect(peekTlsSession(slot)).toBeInstanceOf(Buffer)
 
-    now += TLS_SESSION_CACHE_MAX_AGE_MS - 1
-    expect(getTlsSession('host:5432')).toBeInstanceOf(Buffer)
-
-    await new Promise((resolve) => setTimeout(resolve, 2))
-
-    now += 2
-    expect(getTlsSession('host:5432')).toBeUndefined()
-    expect(getTlsSessionCacheSize()).toBe(0)
-  })
-
-  test('evicts the oldest entry beyond the size bound', () => {
-    const maxEntries = getTlsSessionCacheMaxEntries()
-    const session = Buffer.from('ticket')
-    for (let i = 0; i <= maxEntries; i++) {
-      storeTlsSession(`host-${i}:5432`, session)
-    }
-
-    expect(getTlsSessionCacheSize()).toBe(maxEntries)
-    expect(getTlsSession('host-0:5432')).toBeUndefined()
-    expect(getTlsSession(`host-${maxEntries}:5432`)).toBe(session)
+    vi.advanceTimersByTime(2)
+    expect(peekTlsSession(slot)).toBeUndefined()
+    expect(slot.session).toBeUndefined()
   })
 
   test('injection getter is enumerable and re-evaluated per Object.assign', () => {
+    const slot = createTlsSessionSlot()
     const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
-    installTlsSessionInjection(ssl, 'host:5432')
+    installTlsSessionResumption(ssl, slot)
 
     const descriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
     expect(descriptor?.get).toBeInstanceOf(Function)
@@ -77,48 +63,63 @@ describe('tls session cache', () => {
     expect(Object.assign({}, ssl).session).toBeUndefined()
 
     const first = Buffer.from('first')
-    storeTlsSession('host:5432', first)
+    storeTlsSession(slot, first)
     expect(Object.assign({}, ssl).session).toBe(first)
 
     const second = Buffer.from('second')
-    storeTlsSession('host:5432', second)
+    storeTlsSession(slot, second)
     expect(Object.assign({}, ssl).session).toBe(second)
   })
 
-  test('injection install is idempotent', () => {
+  test('slot reference does not leak into tls.connect options', () => {
+    const slot = createTlsSessionSlot()
+    const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
+    installTlsSessionResumption(ssl, slot)
+
+    // pg builds the tls.connect options with Object.assign(options, ssl) — only the
+    // enumerable `session` getter value may cross, never the slot itself
+    const options = Object.assign({ host: '127.0.0.1' }, ssl)
+    expect(Object.getOwnPropertySymbols(options)).toHaveLength(0)
+    expect(Object.keys(options).sort()).toEqual(['host', 'rejectUnauthorized', 'session'].sort())
+  })
+
+  test('install is idempotent', () => {
+    const first = createTlsSessionSlot()
+    const second = createTlsSessionSlot()
     const ssl: tls.ConnectionOptions = {}
-    installTlsSessionInjection(ssl, 'host:5432')
-    installTlsSessionInjection(ssl, 'other:5432')
+    installTlsSessionResumption(ssl, first)
+    installTlsSessionResumption(ssl, second)
 
-    storeTlsSession('host:5432', Buffer.from('host-session'))
-    storeTlsSession('other:5432', Buffer.from('other-session'))
+    storeTlsSession(first, Buffer.from('first-slot'))
+    storeTlsSession(second, Buffer.from('second-slot'))
 
-    expect(Object.assign({}, ssl).session).toEqual(Buffer.from('host-session'))
+    expect(Object.assign({}, ssl).session).toEqual(Buffer.from('first-slot'))
   })
 
   test('capture stores every session emitted by the socket', () => {
+    const slot = createTlsSessionSlot()
     const socket = new EventEmitter()
-    attachTlsSessionCapture(socket, 'host:5432')
+    attachTlsSessionCapture(socket, slot)
 
     const first = Buffer.from('first')
     const second = Buffer.from('second')
     socket.emit('session', first)
-    expect(getTlsSession('host:5432')).toBe(first)
+    expect(peekTlsSession(slot)).toBe(first)
 
     socket.emit('session', second)
-    expect(getTlsSession('host:5432')).toBe(second)
+    expect(peekTlsSession(slot)).toBe(second)
   })
 
   test('capture tolerates streams without listener support', () => {
-    expect(() => attachTlsSessionCapture(undefined, 'host:5432')).not.toThrow()
-    expect(() => attachTlsSessionCapture({}, 'host:5432')).not.toThrow()
-    expect(() => attachTlsSessionCapture(null, 'host:5432')).not.toThrow()
+    const slot = createTlsSessionSlot()
+    expect(() => attachTlsSessionCapture(undefined, slot)).not.toThrow()
+    expect(() => attachTlsSessionCapture({}, slot)).not.toThrow()
+    expect(() => attachTlsSessionCapture(null, slot)).not.toThrow()
   })
 })
 
 describe('resumption outcome observability', () => {
   afterEach(() => {
-    clearTlsSessionCache()
     vi.restoreAllMocks()
   })
 
@@ -130,10 +131,11 @@ describe('resumption outcome observability', () => {
 
   test("records 'resumed' when the server accepts the offered session", () => {
     const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
-    storeTlsSession('host:5432', Buffer.from('ticket'))
+    const slot = createTlsSessionSlot()
+    storeTlsSession(slot, Buffer.from('ticket'))
 
     const socket = fakeTlsSocket(true)
-    observeTlsSessionResumption(socket, 'host:5432')
+    observeTlsSessionResumption(socket, slot)
     socket.emit('secureConnect')
 
     expect(recordSpy).toHaveBeenCalledWith('resumed')
@@ -141,10 +143,11 @@ describe('resumption outcome observability', () => {
 
   test("records 'rejected' when a session was offered but the handshake was full", () => {
     const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
-    storeTlsSession('host:5432', Buffer.from('ticket'))
+    const slot = createTlsSessionSlot()
+    storeTlsSession(slot, Buffer.from('ticket'))
 
     const socket = fakeTlsSocket(false)
-    observeTlsSessionResumption(socket, 'host:5432')
+    observeTlsSessionResumption(socket, slot)
     socket.emit('secureConnect')
 
     expect(recordSpy).toHaveBeenCalledWith('rejected')
@@ -152,26 +155,33 @@ describe('resumption outcome observability', () => {
 
   test("records 'uncached' when no session was available to offer", () => {
     const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+    const slot = createTlsSessionSlot()
 
     const socket = fakeTlsSocket(false)
-    observeTlsSessionResumption(socket, 'host:5432')
+    observeTlsSessionResumption(socket, slot)
     socket.emit('secureConnect')
 
     expect(recordSpy).toHaveBeenCalledWith('uncached')
   })
 
-  test('offer peek does not distort cache request metrics', () => {
-    const cacheSpy = vi.spyOn(metrics, 'recordCacheRequest')
+  test('samples the offer when attached, not when the handshake completes', () => {
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
+    const slot = createTlsSessionSlot()
 
-    observeTlsSessionResumption(fakeTlsSocket(false), 'host:5432')
+    const socket = fakeTlsSocket(false)
+    observeTlsSessionResumption(socket, slot)
 
-    expect(cacheSpy).not.toHaveBeenCalled()
+    storeTlsSession(slot, Buffer.from('ticket'))
+    socket.emit('secureConnect')
+
+    expect(recordSpy).toHaveBeenCalledWith('uncached')
   })
 
   test('tolerates sockets without resumption support', () => {
-    expect(() => observeTlsSessionResumption(new EventEmitter(), 'host:5432')).not.toThrow()
-    expect(() => observeTlsSessionResumption(undefined, 'host:5432')).not.toThrow()
-    expect(() => observeTlsSessionResumption({}, 'host:5432')).not.toThrow()
+    const slot = createTlsSessionSlot()
+    expect(() => observeTlsSessionResumption(new EventEmitter(), slot)).not.toThrow()
+    expect(() => observeTlsSessionResumption(undefined, slot)).not.toThrow()
+    expect(() => observeTlsSessionResumption({}, slot)).not.toThrow()
   })
 })
 
@@ -179,7 +189,6 @@ describe('resumption outcome observability', () => {
 // rather than silently disabling the feature.
 describe('TlsSessionResumptionClient pg wiring', () => {
   afterEach(() => {
-    clearTlsSessionCache()
     vi.restoreAllMocks()
   })
 
@@ -187,9 +196,12 @@ describe('TlsSessionResumptionClient pg wiring', () => {
     expect(getTlsSessionResumptionClient()).toBe(getTlsSessionResumptionClient())
   })
 
-  test('installs injection on the ssl object and captures sessions on sslconnect', () => {
+  test('finds the slot on the ssl options and captures sessions on sslconnect', () => {
     const TlsSessionResumptionClient = getTlsSessionResumptionClient()
+    const slot = createTlsSessionSlot()
     const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
+    installTlsSessionResumption(ssl, slot)
+
     const client = new TlsSessionResumptionClient({
       host: '1.2.3.4',
       port: 5433,
@@ -198,9 +210,6 @@ describe('TlsSessionResumptionClient pg wiring', () => {
       database: 'db',
       ssl,
     })
-
-    const descriptor = Object.getOwnPropertyDescriptor(ssl, 'session')
-    expect(descriptor?.get).toBeInstanceOf(Function)
 
     const internals = client as unknown as {
       connection: EventEmitter & { stream: unknown }
@@ -216,12 +225,27 @@ describe('TlsSessionResumptionClient pg wiring', () => {
 
     const session = Buffer.from('ticket')
     stream.emit('session', session)
-    expect(getTlsSession('1.2.3.4:5433')).toBe(session)
+    expect(peekTlsSession(slot)).toBe(session)
 
     expect(Object.assign({}, ssl).session).toBe(session)
 
     stream.emit('secureConnect')
     expect(recordSpy).toHaveBeenCalledWith('uncached')
+  })
+
+  test('does nothing without a slot on the ssl options', () => {
+    const TlsSessionResumptionClient = getTlsSessionResumptionClient()
+    const client = new TlsSessionResumptionClient({
+      host: '1.2.3.4',
+      port: 5432,
+      user: 'user',
+      password: 'password',
+      database: 'db',
+      ssl: { rejectUnauthorized: false },
+    })
+
+    const internals = client as unknown as { connection: EventEmitter }
+    expect(internals.connection.listenerCount('sslconnect')).toBe(0)
   })
 
   test('does nothing without object-form ssl settings', () => {
@@ -285,7 +309,7 @@ describe.runIf(opensslAvailable)('TLS session resumption against a real TLS serv
   })
 
   afterEach(() => {
-    clearTlsSessionCache()
+    vi.restoreAllMocks()
   })
 
   test.each([['TLSv1.2'], ['TLSv1.3']])('resumes a session over %s', async (version) => {
@@ -298,11 +322,14 @@ describe.runIf(opensslAvailable)('TLS session resumption against a real TLS serv
     })
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
     const port = (server.address() as AddressInfo).port
-    const cacheKey = `127.0.0.1:${port}`
+    const slot = createTlsSessionSlot()
+
+    const recordSpy = vi.spyOn(metrics, 'recordTlsSessionResumption')
 
     try {
       const first = tls.connect({ host: '127.0.0.1', port, rejectUnauthorized: false })
-      attachTlsSessionCapture(first, cacheKey)
+      attachTlsSessionCapture(first, slot)
+      observeTlsSessionResumption(first, slot)
       const sessionArrived = new Promise<void>((resolve, reject) => {
         first.once('session', () => resolve())
         first.once('error', reject)
@@ -315,14 +342,16 @@ describe.runIf(opensslAvailable)('TLS session resumption against a real TLS serv
       await sessionArrived
       first.destroy()
 
-      expect(getTlsSession(cacheKey)).toBeInstanceOf(Buffer)
+      expect(peekTlsSession(slot)).toBeInstanceOf(Buffer)
+      expect(recordSpy).toHaveBeenNthCalledWith(1, 'uncached')
 
       const ssl: tls.ConnectionOptions = { rejectUnauthorized: false }
-      installTlsSessionInjection(ssl, cacheKey)
+      installTlsSessionResumption(ssl, slot)
       const options: tls.ConnectionOptions = { host: '127.0.0.1', port }
       Object.assign(options, ssl)
 
       const second = tls.connect(options)
+      observeTlsSessionResumption(second, slot)
       await new Promise<void>((resolve, reject) => {
         second.once('secureConnect', resolve)
         second.once('error', reject)
@@ -331,6 +360,7 @@ describe.runIf(opensslAvailable)('TLS session resumption against a real TLS serv
       second.destroy()
 
       expect(reused).toBe(true)
+      expect(recordSpy).toHaveBeenNthCalledWith(2, 'resumed')
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }

--- a/src/internal/database/tls-session-resumption.ts
+++ b/src/internal/database/tls-session-resumption.ts
@@ -1,83 +1,83 @@
-import {
-  createLruCache,
-  DisposableCache,
-  LruCacheSetOptions,
-  TLS_SESSION_CACHE_NAME,
-} from '@internal/cache'
 import { recordTlsSessionResumption } from '@internal/monitoring/metrics'
 import { Client } from 'pg'
 import type { ConnectionOptions } from 'tls'
-import { TENANT_CONFIG_CACHE_MAX_ITEMS } from './tenant'
 
 /**
- * Client-side TLS session cache for tenant DB connections.
+ * TLS session resumption for tenant DB connections, coupled to the pool.
  *
- * Node skips the per-handshake certificate extraction and identity verification work
- * only when a session is resumed and resumed handshakes are also cheaper on the wire.
- * pg implements no client session cache, so every reconnect pays the full handshake.
- * Pass a getter in ssl options of the pool which is reevaluated on every physical
- * connection and capture the session from the TLS socket. There can be multiple session
- * tickets per host but last one wins. Finally, a stale or rejected ticket downgrades to
- * a full handshake inside the same connection attempt and resumption failure is never
- * a connection error. If the server issues no tickets the cache, cache simply stays empty.
+ * Node skips the per-handshake certificate extraction and identity verification work only
+ * when a session is resumed, and resumed handshakes are cheaper on the wire. pg implements
+ * no client session cache, so every reconnect pays the full handshake.
+ *
+ * Each PgPoolStrategy owns one TlsSessionSlot (1 pool = 1 tenant = 1 host:port). The pool's
+ * ssl options get an enumerable session getter whose value pg copies into the tls.connect
+ * options with Object.assign on every physical connect, so each new connection offers the
+ * freshest ticket. The slot itself rides along as a non-enumerable property of the same ssl
+ * object to prevent copying into the tls.connect options while still being accessible to the
+ * client to attach a listener to the connection to capture newer tickets and observability.
+ *
+ * The slot lives exactly as long as the strategy is cached in the tenant pool cache.
+ * That's why it's important to have TENANT_POOL_CACHE_TTL_MS set appropriately (1-2h)
+ * to benefit from session resumption. Pool-cache entries refresh their TTL on access,
+ * so busy tenants keep the slot alive indefinitely, the slot's storedAt bound is the
+ * only cap on ticket age to free stale tickets on peek.
+ *
+ * A stale or rejected ticket downgrades to a full handshake inside the same connection
+ * attempt so resumption failure is never a connection error and if the server issues no
+ * tickets the slot simply stays empty.
  */
 
-export const TLS_SESSION_CACHE_MAX_SIZE_BYTES = 100 * 1024 * 1024 // 100MB
-export const TLS_SESSION_CACHE_MAX_AGE_MS = 60 * 60 * 1000
-export function getTlsSessionCacheMaxEntries(): number {
-  // 4x tenant config cache max entries due to longer TTL
-  return 4 * TENANT_CONFIG_CACHE_MAX_ITEMS
+export const TLS_SESSION_MAX_AGE_MS = 60 * 60 * 1000
+
+export type TlsSessionSlot = {
+  session?: Buffer
+  storedAt: number
 }
 
-type SessionCache = DisposableCache<string, Buffer, LruCacheSetOptions<string, Buffer>>
+const kTlsSessionSlot = Symbol('tlsSessionSlot')
 
-let sessionCache: SessionCache | undefined
+export function createTlsSessionSlot(): TlsSessionSlot {
+  return { storedAt: 0 }
+}
 
-// Lazy initialization to avoid metric observables if feature is unused.
-function getSessionCache(): SessionCache {
-  if (!sessionCache) {
-    sessionCache = createLruCache<string, Buffer>(TLS_SESSION_CACHE_NAME, {
-      max: getTlsSessionCacheMaxEntries(),
-      maxSize: TLS_SESSION_CACHE_MAX_SIZE_BYTES,
-      sizeCalculation: (session) => Math.max(session.length, 1),
-      ttl: TLS_SESSION_CACHE_MAX_AGE_MS,
-    })
+export function storeTlsSession(slot: TlsSessionSlot, session: Buffer): void {
+  slot.session = session
+  slot.storedAt = Date.now()
+}
+
+export function peekTlsSession(slot: TlsSessionSlot): Buffer | undefined {
+  if (!slot.session) {
+    return undefined
   }
 
-  return sessionCache
+  if (Date.now() - slot.storedAt > TLS_SESSION_MAX_AGE_MS) {
+    slot.session = undefined
+    return undefined
+  }
+
+  return slot.session
 }
 
-export function storeTlsSession(key: string, session: Buffer): void {
-  getSessionCache().set(key, session)
+function getTlsSessionSlot(ssl: object): TlsSessionSlot | undefined {
+  return (ssl as Record<symbol, TlsSessionSlot | undefined>)[kTlsSessionSlot]
 }
 
-export function getTlsSession(key: string): Buffer | undefined {
-  return getSessionCache().get(key)
-}
-
-export function clearTlsSessionCache(): void {
-  sessionCache?.dispose()
-  sessionCache = undefined
-}
-
-export function getTlsSessionCacheSize(): number {
-  return sessionCache?.getStats().entries ?? 0
-}
-
-export function installTlsSessionInjection(ssl: ConnectionOptions, key: string): void {
-  if (Object.getOwnPropertyDescriptor(ssl, 'session')) {
+export function installTlsSessionResumption(ssl: ConnectionOptions, slot: TlsSessionSlot): void {
+  if (getTlsSessionSlot(ssl) || Object.getOwnPropertyDescriptor(ssl, 'session')) {
     return
   }
 
+  // non-enumerable to prevent copying into the tls.connect options
+  Object.defineProperty(ssl, kTlsSessionSlot, { value: slot })
   Object.defineProperty(ssl, 'session', {
     // enumerable to copy into tls.connect options
     enumerable: true,
     configurable: true,
-    get: () => getTlsSession(key),
+    get: () => peekTlsSession(slot),
   })
 }
 
-export function attachTlsSessionCapture(stream: unknown, key: string): void {
+export function attachTlsSessionCapture(stream: unknown, slot: TlsSessionSlot): void {
   const socket = stream as
     | { on?: (event: string, listener: (arg: Buffer) => void) => unknown }
     | undefined
@@ -86,14 +86,12 @@ export function attachTlsSessionCapture(stream: unknown, key: string): void {
   }
 
   socket.on('session', (session: Buffer) => {
-    storeTlsSession(key, session)
+    storeTlsSession(slot, session)
   })
 }
 
-const disabledMetrics = { recordMetrics: false } as const
-
 // Record whether the server actually resumed the offered session
-export function observeTlsSessionResumption(stream: unknown, key: string): void {
+export function observeTlsSessionResumption(stream: unknown, slot: TlsSessionSlot): void {
   const socket = stream as
     | {
         once?: (event: string, listener: () => void) => unknown
@@ -108,7 +106,7 @@ export function observeTlsSessionResumption(stream: unknown, key: string): void 
     return
   }
 
-  const offered = getSessionCache().get(key, disabledMetrics) !== undefined
+  const offered = peekTlsSession(slot) !== undefined
 
   socket.once('secureConnect', () => {
     const reused = socket.isSessionReused?.() === true
@@ -118,7 +116,7 @@ export function observeTlsSessionResumption(stream: unknown, key: string): void 
 
 // Dependency contract to fail in CI if pg changes between upgrades.
 type PgClientInternals = {
-  connectionParameters?: { host?: string; port?: number; ssl?: unknown }
+  connectionParameters?: { ssl?: unknown }
   connection?: {
     once?: (event: string, listener: () => void) => unknown
     stream?: unknown
@@ -131,7 +129,7 @@ type TlsSessionResumptionClientCtor = new (
 
 let cachedClientClass: TlsSessionResumptionClientCtor | undefined
 
-// Client that resumes TLS sessions per host:port.
+// Client that resumes TLS sessions from the slot installed on the pool's ssl options.
 export function getTlsSessionResumptionClient(): TlsSessionResumptionClientCtor {
   if (!cachedClientClass) {
     cachedClientClass = class TlsSessionResumptionClient extends Client {
@@ -144,13 +142,15 @@ export function getTlsSessionResumptionClient(): TlsSessionResumptionClientCtor 
           return
         }
 
-        const key = `${internals.connectionParameters?.host}:${internals.connectionParameters?.port}`
-        installTlsSessionInjection(ssl as ConnectionOptions, key)
+        const slot = getTlsSessionSlot(ssl)
+        if (!slot) {
+          return
+        }
 
         const connection = internals.connection
         connection?.once?.('sslconnect', () => {
-          attachTlsSessionCapture(connection.stream, key)
-          observeTlsSessionResumption(connection.stream, key)
+          attachTlsSessionCapture(connection.stream, slot)
+          observeTlsSessionResumption(connection.stream, slot)
         })
       }
     }

--- a/src/internal/database/tls-session-resumption.ts
+++ b/src/internal/database/tls-session-resumption.ts
@@ -127,34 +127,30 @@ type TlsSessionResumptionClientCtor = new (
   config?: ConstructorParameters<typeof Client>[0]
 ) => Client
 
-let cachedClientClass: TlsSessionResumptionClientCtor | undefined
-
-// Client that resumes TLS sessions from the slot installed on the pool's ssl options.
-export function getTlsSessionResumptionClient(): TlsSessionResumptionClientCtor {
-  if (!cachedClientClass) {
-    cachedClientClass = class TlsSessionResumptionClient extends Client {
-      constructor(config?: ConstructorParameters<typeof Client>[0]) {
-        super(config)
-
-        const internals = this as unknown as PgClientInternals
-        const ssl = internals.connectionParameters?.ssl
-        if (!ssl || typeof ssl !== 'object') {
-          return
-        }
-
-        const slot = getTlsSessionSlot(ssl)
-        if (!slot) {
-          return
-        }
-
-        const connection = internals.connection
-        connection?.once?.('sslconnect', () => {
-          attachTlsSessionCapture(connection.stream, slot)
-          observeTlsSessionResumption(connection.stream, slot)
-        })
-      }
-    }
+function attachTlsSessionResumption(client: Client): void {
+  const internals = client as unknown as PgClientInternals
+  const ssl = internals.connectionParameters?.ssl
+  if (!ssl || typeof ssl !== 'object') {
+    return
   }
 
-  return cachedClientClass
+  const slot = getTlsSessionSlot(ssl)
+  if (!slot) {
+    return
+  }
+
+  const connection = internals.connection
+  connection?.once?.('sslconnect', () => {
+    attachTlsSessionCapture(connection.stream, slot)
+    observeTlsSessionResumption(connection.stream, slot)
+  })
 }
+
+// Client constructor that resumes TLS sessions from the slot installed on the pool's ssl options.
+export const TlsSessionResumptionClient = class TlsSessionResumptionClient {
+  constructor(config?: ConstructorParameters<typeof Client>[0]) {
+    const client = new Client(config)
+    attachTlsSessionResumption(client)
+    return client
+  }
+} as unknown as TlsSessionResumptionClientCtor

--- a/src/internal/database/tls-session-resumption.ts
+++ b/src/internal/database/tls-session-resumption.ts
@@ -1,0 +1,160 @@
+import {
+  createLruCache,
+  DisposableCache,
+  LruCacheSetOptions,
+  TLS_SESSION_CACHE_NAME,
+} from '@internal/cache'
+import { recordTlsSessionResumption } from '@internal/monitoring/metrics'
+import { Client } from 'pg'
+import type { ConnectionOptions } from 'tls'
+import { TENANT_CONFIG_CACHE_MAX_ITEMS } from './tenant'
+
+/**
+ * Client-side TLS session cache for tenant DB connections.
+ *
+ * Node skips the per-handshake certificate extraction and identity verification work
+ * only when a session is resumed and resumed handshakes are also cheaper on the wire.
+ * pg implements no client session cache, so every reconnect pays the full handshake.
+ * Pass a getter in ssl options of the pool which is reevaluated on every physical
+ * connection and capture the session from the TLS socket. There can be multiple session
+ * tickets per host but last one wins. Finally, a stale or rejected ticket downgrades to
+ * a full handshake inside the same connection attempt and resumption failure is never
+ * a connection error. If the server issues no tickets the cache, cache simply stays empty.
+ */
+
+export const TLS_SESSION_CACHE_MAX_SIZE_BYTES = 100 * 1024 * 1024 // 100MB
+export const TLS_SESSION_CACHE_MAX_AGE_MS = 60 * 60 * 1000
+export function getTlsSessionCacheMaxEntries(): number {
+  // 4x tenant config cache max entries due to longer TTL
+  return 4 * TENANT_CONFIG_CACHE_MAX_ITEMS
+}
+
+type SessionCache = DisposableCache<string, Buffer, LruCacheSetOptions<string, Buffer>>
+
+let sessionCache: SessionCache | undefined
+
+// Lazy initialization to avoid metric observables if feature is unused.
+function getSessionCache(): SessionCache {
+  if (!sessionCache) {
+    sessionCache = createLruCache<string, Buffer>(TLS_SESSION_CACHE_NAME, {
+      max: getTlsSessionCacheMaxEntries(),
+      maxSize: TLS_SESSION_CACHE_MAX_SIZE_BYTES,
+      sizeCalculation: (session) => Math.max(session.length, 1),
+      ttl: TLS_SESSION_CACHE_MAX_AGE_MS,
+    })
+  }
+
+  return sessionCache
+}
+
+export function storeTlsSession(key: string, session: Buffer): void {
+  getSessionCache().set(key, session)
+}
+
+export function getTlsSession(key: string): Buffer | undefined {
+  return getSessionCache().get(key)
+}
+
+export function clearTlsSessionCache(): void {
+  sessionCache?.dispose()
+  sessionCache = undefined
+}
+
+export function getTlsSessionCacheSize(): number {
+  return sessionCache?.getStats().entries ?? 0
+}
+
+export function installTlsSessionInjection(ssl: ConnectionOptions, key: string): void {
+  if (Object.getOwnPropertyDescriptor(ssl, 'session')) {
+    return
+  }
+
+  Object.defineProperty(ssl, 'session', {
+    // enumerable to copy into tls.connect options
+    enumerable: true,
+    configurable: true,
+    get: () => getTlsSession(key),
+  })
+}
+
+export function attachTlsSessionCapture(stream: unknown, key: string): void {
+  const socket = stream as
+    | { on?: (event: string, listener: (arg: Buffer) => void) => unknown }
+    | undefined
+  if (!socket || typeof socket.on !== 'function') {
+    return
+  }
+
+  socket.on('session', (session: Buffer) => {
+    storeTlsSession(key, session)
+  })
+}
+
+const disabledMetrics = { recordMetrics: false } as const
+
+// Record whether the server actually resumed the offered session
+export function observeTlsSessionResumption(stream: unknown, key: string): void {
+  const socket = stream as
+    | {
+        once?: (event: string, listener: () => void) => unknown
+        isSessionReused?: () => boolean
+      }
+    | undefined
+  if (
+    !socket ||
+    typeof socket.once !== 'function' ||
+    typeof socket.isSessionReused !== 'function'
+  ) {
+    return
+  }
+
+  const offered = getSessionCache().get(key, disabledMetrics) !== undefined
+
+  socket.once('secureConnect', () => {
+    const reused = socket.isSessionReused?.() === true
+    recordTlsSessionResumption(reused ? 'resumed' : offered ? 'rejected' : 'uncached')
+  })
+}
+
+// Dependency contract to fail in CI if pg changes between upgrades.
+type PgClientInternals = {
+  connectionParameters?: { host?: string; port?: number; ssl?: unknown }
+  connection?: {
+    once?: (event: string, listener: () => void) => unknown
+    stream?: unknown
+  }
+}
+
+type TlsSessionResumptionClientCtor = new (
+  config?: ConstructorParameters<typeof Client>[0]
+) => Client
+
+let cachedClientClass: TlsSessionResumptionClientCtor | undefined
+
+// Client that resumes TLS sessions per host:port.
+export function getTlsSessionResumptionClient(): TlsSessionResumptionClientCtor {
+  if (!cachedClientClass) {
+    cachedClientClass = class TlsSessionResumptionClient extends Client {
+      constructor(config?: ConstructorParameters<typeof Client>[0]) {
+        super(config)
+
+        const internals = this as unknown as PgClientInternals
+        const ssl = internals.connectionParameters?.ssl
+        if (!ssl || typeof ssl !== 'object') {
+          return
+        }
+
+        const key = `${internals.connectionParameters?.host}:${internals.connectionParameters?.port}`
+        installTlsSessionInjection(ssl as ConnectionOptions, key)
+
+        const connection = internals.connection
+        connection?.once?.('sslconnect', () => {
+          attachTlsSessionCapture(connection.stream, key)
+          observeTlsSessionResumption(connection.stream, key)
+        })
+      }
+    }
+  }
+
+  return cachedClientClass
+}

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -334,6 +334,45 @@ export const cacheSizeBytes = registerMetric('cache_size_bytes', 'gauge', () =>
 )
 
 // ============================================================================
+// DB TLS Session Resumption Metrics
+//
+// * resumed: the offered session was accepted
+// * rejected: a session was offered but the server completed a full handshake
+//             stale/rotated ticket or no server support
+// * uncached: no session was available to offer (cold host, TTL expiry, eviction)
+// ============================================================================
+export type TlsSessionResumptionOutcome = 'resumed' | 'rejected' | 'uncached'
+
+type TlsSessionResumptionMetricsState = {
+  handshakes: Record<TlsSessionResumptionOutcome, ObservableCounterSeries>
+}
+
+const tlsSessionResumptionMetrics = createBatchObservableCounterGroup({
+  meter,
+  registerMetric,
+  maxStates: 1,
+  counters: {
+    handshakes: {
+      name: 'db_tls_session_resumption_total',
+      description: 'Total DB TLS handshakes by session resumption outcome',
+    },
+  },
+  getKey: (scope: 'db') => scope,
+  createState: (): TlsSessionResumptionMetricsState => ({
+    handshakes: {
+      resumed: { count: 0, attributes: { outcome: 'resumed' } },
+      rejected: { count: 0, attributes: { outcome: 'rejected' } },
+      uncached: { count: 0, attributes: { outcome: 'uncached' } },
+    },
+  }),
+})
+
+/** Records the resumption outcome of one DB TLS handshake. */
+export function recordTlsSessionResumption(outcome: TlsSessionResumptionOutcome): void {
+  tlsSessionResumptionMetrics.addHandshakes('db', outcome)
+}
+
+// ============================================================================
 // Database Metrics
 // ============================================================================
 export const dbQueryPerformance = registerMetric(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feat 

## What is the current behavior?

There is no client-side TLS session cache in pg. 

## What is the new behavior?

Cache TLS session tickets in pool strategy for faster handshake.
Using higher value for `TENANT_POOL_CACHE_TTL_MS` to benefit.

## Additional context

Feature can be controlled via `DATABASE_TLS_SESSION_RESUMPTION`.
Add a counter to check if offered sessions are really used or rejected. 