### PR TITLE
fix: exclude soft deleted catalogs from count

### DIFF
--- a/src/storage/protocols/iceberg/metastore.ts
+++ b/src/storage/protocols/iceberg/metastore.ts
@@ -91,7 +91,7 @@ export interface Metastore<Tnx = unknown> {
   ): Promise<T>
 
   assignCatalog(param: { bucketName: string; bucketId: string; tenantId: string }): Promise<Catalog>
-  countCatalogs(params: { tenantId: string; limit: number }): Promise<number>
+  countCatalogs(params: { tenantId: string; limit: number; deleted?: boolean }): Promise<number>
   countNamespaces(param: { tenantId: string; limit: number }): Promise<number>
   countTables(params: { namespaceId: string; tenantId?: string; limit: number }): Promise<number>
   countResources(params: {

--- a/src/storage/protocols/iceberg/pg.test.ts
+++ b/src/storage/protocols/iceberg/pg.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { PgMetastore } from './pg'
+
+function createMetastore(query: ReturnType<typeof vi.fn>) {
+  return new PgMetastore({ query } as never, {
+    multiTenant: false,
+    schema: 'storage',
+  })
+}
+
+function getLastStatement(query: ReturnType<typeof vi.fn>): string {
+  const [statement] = query.mock.calls.at(-1) || []
+
+  if (!statement) {
+    throw new Error('No query calls found')
+  }
+
+  if (typeof statement === 'string') {
+    return statement
+  }
+
+  if (typeof statement === 'object' && 'text' in statement) {
+    return String(statement.text)
+  }
+
+  throw new Error('Expected a PgStatement query with text property')
+}
+
+describe('PgMetastore.countCatalogs', () => {
+  it('excludes soft-deleted catalogs by default', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [{ count: 5 }] })
+    const metastore = createMetastore(query)
+
+    await metastore.countCatalogs({
+      tenantId: 'tenant-id',
+      limit: 100,
+    })
+
+    const statement = getLastStatement(query)
+    expect(statement).toContain('deleted_at IS NULL')
+  })
+
+  it('includes soft-deleted catalogs when deleted parameter is true', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [{ count: 10 }] })
+    const metastore = createMetastore(query)
+
+    await metastore.countCatalogs({
+      tenantId: 'tenant-id',
+      limit: 100,
+      deleted: true,
+    })
+
+    const statement = getLastStatement(query)
+    expect(statement).not.toContain('deleted_at IS NULL')
+  })
+})

--- a/src/storage/protocols/iceberg/pg.ts
+++ b/src/storage/protocols/iceberg/pg.ts
@@ -205,10 +205,18 @@ export class PgMetastore implements Metastore<PgTransaction> {
     return catalog
   }
 
-  async countCatalogs(params: { tenantId: string; limit: number }): Promise<number> {
+  async countCatalogs(params: {
+    tenantId: string
+    limit: number
+    deleted?: boolean
+  }): Promise<number> {
     const values: unknown[] = []
     const conditions: string[] = []
     this.addTenantCondition(conditions, values, params.tenantId)
+
+    if (!params.deleted) {
+      conditions.push('deleted_at IS NULL')
+    }
 
     return this.countRows('iceberg_catalogs', conditions, values, params.limit)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Soft deleted catalogs are included in the usage limit. This results in users getting the error `The maximum number of this resource ${limit} is reached` even if they have no active analytics buckets.

## What is the new behavior?

Exclude soft deleted catalogs (deleted_at not null) from the count.
