### PR TITLE
fix: cut down per request garbage

### DIFF
--- a/src/http/plugins/storage.ts
+++ b/src/http/plugins/storage.ts
@@ -19,6 +19,9 @@ const { storageBackendType, storageS3Bucket } = getConfig()
 
 const storageBackend = createStorageBackend(storageBackendType)
 
+// TenantLocation is immutable so singleton not to allocate per request.
+const tenantLocation = new TenantLocation(storageS3Bucket)
+
 export const storage = fastifyPlugin(
   async function storagePlugin(fastify) {
     fastify.decorateRequest('storage')
@@ -35,7 +38,7 @@ export const storage = fastifyPlugin(
 
       const location = request.isIcebergBucket
         ? new PassThroughLocation(request.internalIcebergBucketName!)
-        : new TenantLocation(storageS3Bucket)
+        : tenantLocation
 
       request.backend = storageBackend
       request.storage = new Storage(storageBackend, database, location)

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -21,6 +21,10 @@ import { AssetRenderer, HeadRenderer, ImageRenderer } from './renderer'
 
 const { emptyBucketMax } = getConfig()
 
+function assertNever(value: never): never {
+  throw new Error(`Unexpected renderer type: ${String(value)}`)
+}
+
 /**
  * Storage
  * interacts with the storage backend of choice and the database
@@ -56,14 +60,18 @@ export class Storage {
    * @param type
    */
   renderer(type: 'asset' | 'head' | 'image' | 'info') {
-    const renderers = {
-      asset: () => new AssetRenderer(this.backend),
-      head: () => new HeadRenderer(),
-      image: () => new ImageRenderer(this.backend),
-      info: () => new InfoRenderer(),
+    switch (type) {
+      case 'asset':
+        return new AssetRenderer(this.backend)
+      case 'head':
+        return new HeadRenderer()
+      case 'image':
+        return new ImageRenderer(this.backend)
+      case 'info':
+        return new InfoRenderer()
+      default:
+        return assertNever(type)
     }
-
-    return renderers[type]()
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Every request creates a new tenant location but it's immutable.
Renderer creates a every version and then discards all except one. 

## What is the new behavior?

Create a singleton tenant location and shared with all requests.
Use switch in renderer so that it only creates what it needs, nothing else. 

## Additional context

This reduces per request garbage.
