### PR TITLE
fix: precompile x-forwarded-host regexp

### DIFF
--- a/src/http/plugins/tenant-id.ts
+++ b/src/http/plugins/tenant-id.ts
@@ -8,12 +8,9 @@ declare module 'fastify' {
   }
 }
 
-const { isMultitenant, tenantId: defaultTenantId, requestXForwardedHostRegExp } = getConfig()
+const { isMultitenant, tenantId: defaultTenantId } = getConfig()
 
-const xForwardedHostRegExp = getXForwardedHostRegExp({
-  isMultitenant,
-  requestXForwardedHostRegExp,
-})
+const xForwardedHostRegExp = getXForwardedHostRegExp()
 
 export const tenantId = fastifyPlugin(
   async (fastify) => {

--- a/src/http/plugins/tenant-id.ts
+++ b/src/http/plugins/tenant-id.ts
@@ -1,3 +1,4 @@
+import { getXForwardedHostRegExp } from '@internal/http/x-forwarded-host'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig } from '../../config'
 
@@ -9,11 +10,16 @@ declare module 'fastify' {
 
 const { isMultitenant, tenantId: defaultTenantId, requestXForwardedHostRegExp } = getConfig()
 
+const xForwardedHostRegExp = getXForwardedHostRegExp({
+  isMultitenant,
+  requestXForwardedHostRegExp,
+})
+
 export const tenantId = fastifyPlugin(
   async (fastify) => {
     fastify.decorateRequest('tenantId', defaultTenantId)
     fastify.addHook('onRequest', (request, _reply, done) => {
-      if (!isMultitenant || !requestXForwardedHostRegExp) {
+      if (!isMultitenant || !xForwardedHostRegExp) {
         done()
         return
       }
@@ -24,7 +30,7 @@ export const tenantId = fastifyPlugin(
         return
       }
 
-      const result = xForwardedHost.match(requestXForwardedHostRegExp)
+      const result = xForwardedHost.match(xForwardedHostRegExp)
       if (!result) {
         done()
         return

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -6,6 +6,8 @@ import { PgTenantConnection } from './pg-connection'
 import { User } from './pool'
 import { getTenantConfig } from './tenant'
 
+const xForwardedHostRegExp = getXForwardedHostRegExp()
+
 interface ConnectionOptions {
   host: string
   tenantId: string
@@ -39,13 +41,7 @@ async function getDbSettings(
   host: string | undefined,
   options?: { disableHostCheck?: boolean }
 ) {
-  const {
-    isMultitenant,
-    databasePoolURL,
-    databaseURL,
-    databaseMaxConnections,
-    requestXForwardedHostRegExp,
-  } = getConfig()
+  const { isMultitenant, databasePoolURL, databaseURL, databaseMaxConnections } = getConfig()
 
   let dbUrl = databasePoolURL || databaseURL
   let maxConnections = databaseMaxConnections
@@ -57,11 +53,6 @@ async function getDbSettings(
     }
 
     if (!options?.disableHostCheck) {
-      const xForwardedHostRegExp = getXForwardedHostRegExp({
-        isMultitenant,
-        requestXForwardedHostRegExp,
-      })
-
       if (xForwardedHostRegExp) {
         const xForwardedHost = host
 

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -1,5 +1,6 @@
 import { Cluster } from '@internal/cluster'
 import { ERRORS } from '@internal/errors'
+import { getXForwardedHostRegExp } from '@internal/http/x-forwarded-host'
 import { getConfig } from '../../config'
 import { PgTenantConnection } from './pg-connection'
 import { User } from './pool'
@@ -55,16 +56,23 @@ async function getDbSettings(
       throw ERRORS.InvalidTenantId()
     }
 
-    if (requestXForwardedHostRegExp && !options?.disableHostCheck) {
-      const xForwardedHost = host
+    if (!options?.disableHostCheck) {
+      const xForwardedHostRegExp = getXForwardedHostRegExp({
+        isMultitenant,
+        requestXForwardedHostRegExp,
+      })
 
-      if (typeof xForwardedHost !== 'string') {
-        throw ERRORS.InvalidXForwardedHeader('X-Forwarded-Host header is not a string')
-      }
-      if (!new RegExp(requestXForwardedHostRegExp).test(xForwardedHost)) {
-        throw ERRORS.InvalidXForwardedHeader(
-          'X-Forwarded-Host header does not match regular expression'
-        )
+      if (xForwardedHostRegExp) {
+        const xForwardedHost = host
+
+        if (typeof xForwardedHost !== 'string') {
+          throw ERRORS.InvalidXForwardedHeader('X-Forwarded-Host header is not a string')
+        }
+        if (!xForwardedHostRegExp.test(xForwardedHost)) {
+          throw ERRORS.InvalidXForwardedHeader(
+            'X-Forwarded-Host header does not match regular expression'
+          )
+        }
       }
     }
 

--- a/src/internal/http/index.ts
+++ b/src/internal/http/index.ts
@@ -1,2 +1,3 @@
 export * from './agent'
 export * from './header'
+export * from './x-forwarded-host'

--- a/src/internal/http/x-forwarded-host.test.ts
+++ b/src/internal/http/x-forwarded-host.test.ts
@@ -1,62 +1,107 @@
-import { getXForwardedHostRegExp } from './x-forwarded-host'
+const xForwardedHostEnvKeys = [
+  'MULTI_TENANT',
+  'IS_MULTITENANT',
+  'REQUEST_X_FORWARDED_HOST_REGEXP',
+  'X_FORWARDED_HOST_REGEXP',
+] as const
+
+const originalEnv = Object.fromEntries(
+  xForwardedHostEnvKeys.map((key) => [key, process.env[key]])
+) as Record<(typeof xForwardedHostEnvKeys)[number], string | undefined>
+
+async function loadXForwardedHostRegExp({
+  isMultitenant,
+  pattern,
+}: {
+  isMultitenant: boolean
+  pattern?: string
+}) {
+  vi.resetModules()
+
+  process.env.MULTI_TENANT = isMultitenant ? 'true' : 'false'
+  process.env.IS_MULTITENANT = isMultitenant ? 'true' : 'false'
+  process.env.X_FORWARDED_HOST_REGEXP = ''
+
+  if (pattern === undefined) {
+    process.env.REQUEST_X_FORWARDED_HOST_REGEXP = ''
+  } else {
+    process.env.REQUEST_X_FORWARDED_HOST_REGEXP = pattern
+  }
+
+  return await import('./x-forwarded-host')
+}
+
+function restoreXForwardedHostEnv() {
+  for (const key of xForwardedHostEnvKeys) {
+    const value = originalEnv[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+afterEach(() => {
+  restoreXForwardedHostEnv()
+  vi.resetModules()
+})
 
 describe('getXForwardedHostRegExp', () => {
-  it('skips compiling the host pattern when multitenancy is disabled', () => {
-    expect(
-      getXForwardedHostRegExp({
-        isMultitenant: false,
-        requestXForwardedHostRegExp: '[',
-      })
-    ).toBeUndefined()
-  })
-
-  it('reuses the compiled regexp for the same pattern', () => {
-    const config = {
-      isMultitenant: true,
-      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
-    }
-
-    expect(getXForwardedHostRegExp(config)).toBe(getXForwardedHostRegExp(config))
-  })
-
-  it('recompiles when the configured pattern changes', () => {
-    const first = getXForwardedHostRegExp({
-      isMultitenant: true,
-      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
-    })
-    const second = getXForwardedHostRegExp({
-      isMultitenant: true,
-      requestXForwardedHostRegExp: '^([0-9]+)\\.local$',
+  it('skips compiling the host pattern when multitenancy is disabled', async () => {
+    const { getXForwardedHostRegExp } = await loadXForwardedHostRegExp({
+      isMultitenant: false,
+      pattern: '[',
     })
 
-    expect(second).not.toBe(first)
-    expect('123.local'.match(second!)).toBeTruthy()
+    expect(getXForwardedHostRegExp()).toBeUndefined()
   })
 
-  it('does not replace the cache when a new pattern is invalid', () => {
-    const previous = getXForwardedHostRegExp({
+  it('returns undefined when no host pattern is configured', async () => {
+    const { getXForwardedHostRegExp } = await loadXForwardedHostRegExp({
       isMultitenant: true,
-      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
     })
 
-    expect(() =>
-      getXForwardedHostRegExp({
-        isMultitenant: true,
-        requestXForwardedHostRegExp: '[',
-      })
-    ).toThrow(SyntaxError)
-    expect(() =>
-      getXForwardedHostRegExp({
-        isMultitenant: true,
-        requestXForwardedHostRegExp: '[',
-      })
-    ).toThrow(SyntaxError)
+    expect(getXForwardedHostRegExp()).toBeUndefined()
+  })
 
-    expect(
-      getXForwardedHostRegExp({
+  it('reuses the compiled regexp from startup config', async () => {
+    const { getXForwardedHostRegExp } = await loadXForwardedHostRegExp({
+      isMultitenant: true,
+      pattern: '^([a-z]+)\\.local$',
+    })
+
+    const first = getXForwardedHostRegExp()
+    const second = getXForwardedHostRegExp()
+
+    expect(second).toBe(first)
+    expect('tenant.local'.match(first!)).toBeTruthy()
+  })
+
+  it('does not recompile when config is reloaded after module load', async () => {
+    const { getXForwardedHostRegExp } = await loadXForwardedHostRegExp({
+      isMultitenant: true,
+      pattern: '^([a-z]+)\\.local$',
+    })
+    const previous = getXForwardedHostRegExp()
+
+    process.env.REQUEST_X_FORWARDED_HOST_REGEXP = '^([0-9]+)\\.local$'
+    const { getConfig } = await import('../../config')
+    getConfig({ reload: true })
+
+    const current = getXForwardedHostRegExp()
+
+    expect(current).toBe(previous)
+    expect('tenant.local'.match(current!)).toBeTruthy()
+    expect('123.local'.match(current!)).toBeFalsy()
+  })
+
+  it('throws while loading the helper when the configured pattern is invalid', async () => {
+    await expect(
+      loadXForwardedHostRegExp({
         isMultitenant: true,
-        requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
+        pattern: '[',
       })
-    ).toBe(previous)
+    ).rejects.toThrow(SyntaxError)
   })
 })

--- a/src/internal/http/x-forwarded-host.test.ts
+++ b/src/internal/http/x-forwarded-host.test.ts
@@ -1,0 +1,62 @@
+import { getXForwardedHostRegExp } from './x-forwarded-host'
+
+describe('getXForwardedHostRegExp', () => {
+  it('skips compiling the host pattern when multitenancy is disabled', () => {
+    expect(
+      getXForwardedHostRegExp({
+        isMultitenant: false,
+        requestXForwardedHostRegExp: '[',
+      })
+    ).toBeUndefined()
+  })
+
+  it('reuses the compiled regexp for the same pattern', () => {
+    const config = {
+      isMultitenant: true,
+      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
+    }
+
+    expect(getXForwardedHostRegExp(config)).toBe(getXForwardedHostRegExp(config))
+  })
+
+  it('recompiles when the configured pattern changes', () => {
+    const first = getXForwardedHostRegExp({
+      isMultitenant: true,
+      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
+    })
+    const second = getXForwardedHostRegExp({
+      isMultitenant: true,
+      requestXForwardedHostRegExp: '^([0-9]+)\\.local$',
+    })
+
+    expect(second).not.toBe(first)
+    expect('123.local'.match(second!)).toBeTruthy()
+  })
+
+  it('does not replace the cache when a new pattern is invalid', () => {
+    const previous = getXForwardedHostRegExp({
+      isMultitenant: true,
+      requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
+    })
+
+    expect(() =>
+      getXForwardedHostRegExp({
+        isMultitenant: true,
+        requestXForwardedHostRegExp: '[',
+      })
+    ).toThrow(SyntaxError)
+    expect(() =>
+      getXForwardedHostRegExp({
+        isMultitenant: true,
+        requestXForwardedHostRegExp: '[',
+      })
+    ).toThrow(SyntaxError)
+
+    expect(
+      getXForwardedHostRegExp({
+        isMultitenant: true,
+        requestXForwardedHostRegExp: '^([a-z]+)\\.local$',
+      })
+    ).toBe(previous)
+  })
+})

--- a/src/internal/http/x-forwarded-host.ts
+++ b/src/internal/http/x-forwarded-host.ts
@@ -1,25 +1,16 @@
-interface XForwardedHostRegExpConfig {
-  isMultitenant: boolean
-  requestXForwardedHostRegExp?: string
-}
+import { getConfig } from '../../config'
 
-let cachedPattern: string | undefined
-let cachedRegExp: RegExp | undefined
+const xForwardedHostRegExp = createXForwardedHostRegExp()
 
-export function getXForwardedHostRegExp({
-  isMultitenant,
-  requestXForwardedHostRegExp,
-}: XForwardedHostRegExpConfig): RegExp | undefined {
+function createXForwardedHostRegExp(): RegExp | undefined {
+  const { isMultitenant, requestXForwardedHostRegExp } = getConfig()
   if (!isMultitenant || !requestXForwardedHostRegExp) {
     return undefined
   }
 
-  if (requestXForwardedHostRegExp !== cachedPattern) {
-    const nextRegExp = new RegExp(requestXForwardedHostRegExp)
+  return new RegExp(requestXForwardedHostRegExp)
+}
 
-    cachedPattern = requestXForwardedHostRegExp
-    cachedRegExp = nextRegExp
-  }
-
-  return cachedRegExp
+export function getXForwardedHostRegExp(): RegExp | undefined {
+  return xForwardedHostRegExp
 }

--- a/src/internal/http/x-forwarded-host.ts
+++ b/src/internal/http/x-forwarded-host.ts
@@ -1,0 +1,25 @@
+interface XForwardedHostRegExpConfig {
+  isMultitenant: boolean
+  requestXForwardedHostRegExp?: string
+}
+
+let cachedPattern: string | undefined
+let cachedRegExp: RegExp | undefined
+
+export function getXForwardedHostRegExp({
+  isMultitenant,
+  requestXForwardedHostRegExp,
+}: XForwardedHostRegExpConfig): RegExp | undefined {
+  if (!isMultitenant || !requestXForwardedHostRegExp) {
+    return undefined
+  }
+
+  if (requestXForwardedHostRegExp !== cachedPattern) {
+    const nextRegExp = new RegExp(requestXForwardedHostRegExp)
+
+    cachedPattern = requestXForwardedHostRegExp
+    cachedRegExp = nextRegExp
+  }
+
+  return cachedRegExp
+}

--- a/src/internal/monitoring/otel-tracing.ts
+++ b/src/internal/monitoring/otel-tracing.ts
@@ -5,17 +5,13 @@ const {
   version,
   requestTraceHeader,
   isMultitenant,
-  requestXForwardedHostRegExp,
   tenantId: defaultTenantId,
   region,
   serviceName,
   storageS3InternalTracesEnabled,
 } = getConfig()
 
-const xForwardedHostRegExp = getXForwardedHostRegExp({
-  isMultitenant,
-  requestXForwardedHostRegExp,
-})
+const xForwardedHostRegExp = getXForwardedHostRegExp()
 
 import { FastifyOtelInstrumentation } from '@fastify/otel'
 import * as grpc from '@grpc/grpc-js'

--- a/src/internal/monitoring/otel-tracing.ts
+++ b/src/internal/monitoring/otel-tracing.ts
@@ -1,3 +1,4 @@
+import { getXForwardedHostRegExp } from '@internal/http/x-forwarded-host'
 import { getConfig } from '../../config'
 
 const {
@@ -10,6 +11,11 @@ const {
   serviceName,
   storageS3InternalTracesEnabled,
 } = getConfig()
+
+const xForwardedHostRegExp = getXForwardedHostRegExp({
+  isMultitenant,
+  requestXForwardedHostRegExp,
+})
 
 import { FastifyOtelInstrumentation } from '@fastify/otel'
 import * as grpc from '@grpc/grpc-js'
@@ -154,11 +160,11 @@ if (tracingEnabled && traceExporter && spanProcessors.length > 0) {
         startIncomingSpanHook: (req) => {
           let tenantId = ''
           if (isMultitenant) {
-            if (requestXForwardedHostRegExp) {
+            if (xForwardedHostRegExp) {
               const serverRequest = req
               const xForwardedHost = serverRequest.headers['x-forwarded-host']
               if (typeof xForwardedHost !== 'string') return {}
-              const result = xForwardedHost.match(requestXForwardedHostRegExp)
+              const result = xForwardedHost.match(xForwardedHostRegExp)
               if (!result) return {}
               tenantId = result[1]
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In multitenant, if x-forwarded-host regex is given, it's compiled twice per request.

## What is the new behavior?

Precompile it once and cache module level to cut down two compilation in hot path.
