### PR TITLE
fix: include resource type in IcebergMaximumResourceLimit error message

### DIFF
--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -72,11 +72,11 @@ export const ERRORS = {
       message: `The bucket you tried to delete is not empty`,
       originalError: e,
     }),
-  IcebergMaximumResourceLimit: (limit: number, e?: Error) =>
+  IcebergMaximumResourceLimit: (resource: string, limit: number, e?: Error) =>
     new StorageBackendError({
       code: ErrorCode.IcebergMaximumResourceLimit,
       httpStatusCode: 409,
-      message: `The maximum number of this resource ${limit} is reached`,
+      message: `The maximum number of this resource (${resource}) ${limit} is reached`,
       originalError: e,
     }),
   IcebergResourceNotEmpty: (resource: string, name: string, e?: Error) =>

--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
@@ -155,7 +155,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       })
 
       if (catalogCount >= this.options.limits.maxCatalogsCount) {
-        throw ERRORS.IcebergMaximumResourceLimit(this.options.limits.maxCatalogsCount)
+        throw ERRORS.IcebergMaximumResourceLimit('catalog', this.options.limits.maxCatalogsCount)
       }
 
       return store.assignCatalog({
@@ -215,7 +215,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       })
 
       if (tableCount >= this.options.limits.maxTableCount) {
-        throw ERRORS.IcebergMaximumResourceLimit(this.options.limits.maxTableCount)
+        throw ERRORS.IcebergMaximumResourceLimit('table', this.options.limits.maxTableCount)
       }
 
       const namespaceName = this.getTenantNamespaceName(dbNamespace.id)
@@ -481,7 +481,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
       })
 
       if (namespaceCount >= this.options.limits.maxNamespaceCount) {
-        throw ERRORS.IcebergMaximumResourceLimit(this.options.limits.maxNamespaceCount)
+        throw ERRORS.IcebergMaximumResourceLimit('namespace', this.options.limits.maxNamespaceCount)
       }
 
       const catalog = await store.findCatalogByName({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The IcebergMaximumResourceLimit error does not indicate which resource is causing the restriction.

This error message could indicate maximum number of catalogs, buckets, or tables and the end user has no way of knowing which resource is causing the restriction: `The maximum number of this resource 10 is reached`

## What is the new behavior?

Include the resource type in the error message text so the error message is more actionable. 