### PR TITLE
fix(S3): enforce presigned POST policy conditions

### DIFF
--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -41,6 +41,7 @@ declare module 'fastify' {
     streamingSignatureV4?: ChunkSignatureV4Parser
     multiPartFileStream?: MultipartFile
     bodySha256: string
+    s3PostPolicyContentLengthMax?: number
   }
 }
 
@@ -160,6 +161,13 @@ async function authorizeRequestSignV4(
     )
   }
 
+  if (clientSignature.policy) {
+    request.s3PostPolicyContentLengthMax = signatureV4.validatePostPolicyConditions(
+      clientSignature,
+      { bucket: (request.params as Record<string, string | undefined>)?.Bucket }
+    )
+  }
+
   const wasBodyHashed = allowBodyHash && byteHasherStream && byteHasherStream.writableEnded
 
   const returnStream = wasBodyHashed
@@ -203,7 +211,7 @@ async function authorizeRequestSignV4(
   return returnStream
 }
 
-async function extractSignature(req: AWSRequest) {
+async function extractSignature(req: AWSRequest): Promise<ClientSignature> {
   if (typeof req.headers.authorization === 'string') {
     return SignatureV4.parseAuthorizationHeader(req.headers)
   }

--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -5,7 +5,12 @@ import { getJwtSecret, getTenantConfig, s3CredentialsManager } from '@internal/d
 import { ERRORS } from '@internal/errors'
 import { RequestByteCounterStream } from '@internal/streams'
 import { HashSpillWritable } from '@internal/streams/hash-stream'
-import { ClientSignature, SignatureV4, SignatureV4Service } from '@storage/protocols/s3'
+import {
+  assertPolicyConditionsSatisfied,
+  ClientSignature,
+  SignatureV4,
+  SignatureV4Service,
+} from '@storage/protocols/s3'
 import { ByteLimitTransformStream } from '@storage/protocols/s3/byte-limit-stream'
 import {
   ChunkSignatureV4Parser,
@@ -41,7 +46,6 @@ declare module 'fastify' {
     streamingSignatureV4?: ChunkSignatureV4Parser
     multiPartFileStream?: MultipartFile
     bodySha256: string
-    s3PostPolicyContentLengthMax?: number
   }
 }
 
@@ -162,10 +166,9 @@ async function authorizeRequestSignV4(
   }
 
   if (clientSignature.policy) {
-    request.s3PostPolicyContentLengthMax = signatureV4.validatePostPolicyConditions(
-      clientSignature,
-      { bucket: (request.params as Record<string, string | undefined>)?.Bucket }
-    )
+    assertPolicyConditionsSatisfied(clientSignature.policy.value, clientSignature.policy.fields, {
+      bucket: (request.params as Record<string, string | undefined>)?.Bucket,
+    })
   }
 
   const wasBodyHashed = allowBodyHash && byteHasherStream && byteHasherStream.writableEnded

--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -5,12 +5,7 @@ import { getJwtSecret, getTenantConfig, s3CredentialsManager } from '@internal/d
 import { ERRORS } from '@internal/errors'
 import { RequestByteCounterStream } from '@internal/streams'
 import { HashSpillWritable } from '@internal/streams/hash-stream'
-import {
-  assertPolicyConditionsSatisfied,
-  ClientSignature,
-  SignatureV4,
-  SignatureV4Service,
-} from '@storage/protocols/s3'
+import { ClientSignature, SignatureV4, SignatureV4Service } from '@storage/protocols/s3'
 import { ByteLimitTransformStream } from '@storage/protocols/s3/byte-limit-stream'
 import {
   ChunkSignatureV4Parser,
@@ -150,6 +145,7 @@ async function authorizeRequestSignV4(
     query: request.query as Record<string, string>,
     prefix: storagePrefix,
     payloadHasher: hashStreamComposer,
+    bucket: (request.params as Record<string, string | undefined>)?.Bucket,
   })
 
   if (!isVerified && !sessionToken) {
@@ -163,12 +159,6 @@ async function authorizeRequestSignV4(
       'The request signature we calculated does not match the signature you provided, Check your credentials. ' +
         'The session token should be a valid JWT token'
     )
-  }
-
-  if (clientSignature.policy) {
-    assertPolicyConditionsSatisfied(clientSignature.policy.value, clientSignature.policy.fields, {
-      bucket: (request.params as Record<string, string | undefined>)?.Bucket,
-    })
   }
 
   const wasBodyHashed = allowBodyHash && byteHasherStream && byteHasherStream.writableEnded

--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -220,21 +220,29 @@ export default function PutObject(s3Router: S3Router) {
 
       const maxFileSize = await getStandardMaxFileSizeLimit(ctx.tenantId, bucket.file_size_limit)
 
-      return pipeline(file.file, new ByteLimitTransformStream(maxFileSize), async (fileStream) => {
-        return s3Protocol.putObject(
-          {
-            Body: fileStream as stream.Readable,
-            Bucket: req.Params.Bucket,
-            Key: fieldsObject.key as string,
-            CacheControl: fieldsObject['cache-control'] as string,
-            ContentType: fieldsObject['content-type'] as string,
-            Expires: expiresField ? new Date(expiresField) : undefined,
-            ContentEncoding: fieldsObject['content-encoding'] as string,
-            Metadata: metadata,
-          },
-          { signal: ctx.signals.body, isTruncated: () => file.file.truncated }
-        )
-      })
+      const policyMaxSize = ctx.req.s3PostPolicyContentLengthMax
+      const effectiveMaxFileSize =
+        policyMaxSize !== undefined ? Math.min(maxFileSize, policyMaxSize) : maxFileSize
+
+      return pipeline(
+        file.file,
+        new ByteLimitTransformStream(effectiveMaxFileSize),
+        async (fileStream) => {
+          return s3Protocol.putObject(
+            {
+              Body: fileStream as stream.Readable,
+              Bucket: req.Params.Bucket,
+              Key: fieldsObject.key as string,
+              CacheControl: fieldsObject['cache-control'] as string,
+              ContentType: fieldsObject['content-type'] as string,
+              Expires: expiresField ? new Date(expiresField) : undefined,
+              ContentEncoding: fieldsObject['content-encoding'] as string,
+              Metadata: metadata,
+            },
+            { signal: ctx.signals.body, isTruncated: () => file.file.truncated }
+          )
+        }
+      )
     }
   )
 }

--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -220,29 +220,21 @@ export default function PutObject(s3Router: S3Router) {
 
       const maxFileSize = await getStandardMaxFileSizeLimit(ctx.tenantId, bucket.file_size_limit)
 
-      const policyMaxSize = ctx.req.s3PostPolicyContentLengthMax
-      const effectiveMaxFileSize =
-        policyMaxSize !== undefined ? Math.min(maxFileSize, policyMaxSize) : maxFileSize
-
-      return pipeline(
-        file.file,
-        new ByteLimitTransformStream(effectiveMaxFileSize),
-        async (fileStream) => {
-          return s3Protocol.putObject(
-            {
-              Body: fileStream as stream.Readable,
-              Bucket: req.Params.Bucket,
-              Key: fieldsObject.key as string,
-              CacheControl: fieldsObject['cache-control'] as string,
-              ContentType: fieldsObject['content-type'] as string,
-              Expires: expiresField ? new Date(expiresField) : undefined,
-              ContentEncoding: fieldsObject['content-encoding'] as string,
-              Metadata: metadata,
-            },
-            { signal: ctx.signals.body, isTruncated: () => file.file.truncated }
-          )
-        }
-      )
+      return pipeline(file.file, new ByteLimitTransformStream(maxFileSize), async (fileStream) => {
+        return s3Protocol.putObject(
+          {
+            Body: fileStream as stream.Readable,
+            Bucket: req.Params.Bucket,
+            Key: fieldsObject.key as string,
+            CacheControl: fieldsObject['cache-control'] as string,
+            ContentType: fieldsObject['content-type'] as string,
+            Expires: expiresField ? new Date(expiresField) : undefined,
+            ContentEncoding: fieldsObject['content-encoding'] as string,
+            Metadata: metadata,
+          },
+          { signal: ctx.signals.body, isTruncated: () => file.file.truncated }
+        )
+      })
     }
   )
 }

--- a/src/storage/protocols/s3/index.ts
+++ b/src/storage/protocols/s3/index.ts
@@ -1,1 +1,2 @@
+export * from './policy'
 export * from './signature-v4'

--- a/src/storage/protocols/s3/policy.ts
+++ b/src/storage/protocols/s3/policy.ts
@@ -1,0 +1,170 @@
+import { ERRORS } from '@internal/errors'
+
+/**
+ * A decoded AWS POST policy document: an expiration plus a list of conditions
+ * that the submitted upload form must satisfy.
+ */
+export interface Policy {
+  expiration: string
+  conditions: PolicyCondition[]
+}
+
+/**
+ * An AWS POST policy condition is either:
+ *  - an exact-match object with a single key: `{ "bucket": "my-bucket" }`
+ *  - a tuple: `["eq", "$key", "value"]`, `["starts-with", "$key", "prefix"]`,
+ *    or `["content-length-range", min, max]`
+ */
+export type PolicyCondition = Record<string, string> | (string | number)[]
+
+/**
+ * Submitted form fields that do NOT need to be covered by a policy condition,
+ * keyed by their lowercased name. This mirrors AWS POST semantics: every other
+ * field (including `key`, `bucket`, and every `x-amz-meta-*`) must be constrained
+ * by a condition, otherwise a holder of a signed policy could attach arbitrary
+ * uncovered fields. `file` is stripped before signature parsing; fields prefixed
+ * with `x-ignore-` are AWS's documented escape hatch and are also exempt.
+ */
+const EXEMPT_POLICY_FIELDS = new Set([
+  'policy',
+  'x-amz-signature',
+  'x-amz-algorithm',
+  'x-amz-credential',
+  'x-amz-date',
+  'x-amz-security-token',
+])
+
+/**
+ * Validates a POST policy `expiration`, an absolute ISO8601 timestamp (e.g.
+ * `2025-01-01T00:00:00Z`). Compares it directly to the current time and never
+ * relies on any client-supplied date. The expiration is required: a policy
+ * without one is rejected as invalid.
+ */
+export function assertPolicyNotExpired(expiration: string | undefined): void {
+  if (!expiration) {
+    throw ERRORS.InvalidSignature('Missing policy expiration')
+  }
+
+  const expirationDate = new Date(expiration)
+  if (isNaN(expirationDate.getTime())) {
+    throw ERRORS.InvalidSignature('Invalid policy expiration')
+  }
+
+  if (expirationDate < new Date()) {
+    throw ERRORS.ExpiredSignature()
+  }
+}
+
+/**
+ * Evaluates the signed POST policy conditions against the values the client
+ * actually submitted, in a single pass. Throws if any condition is not
+ * satisfied, or if any submitted field is not covered by a condition (see
+ * {@link EXEMPT_POLICY_FIELDS}).
+ *
+ * The `bucket` value is taken from the request target (the URL), since AWS POST
+ * uploads carry the bucket in the path rather than as a form field.
+ *
+ * @param policy the decoded policy document
+ * @param submittedFields the submitted form fields, keyed by lowercased name
+ * @param opts.bucket the bucket resolved from the request path
+ */
+export function assertPolicyConditionsSatisfied(
+  policy: Policy,
+  submittedFields: Record<string, string>,
+  opts: { bucket?: string }
+): void {
+  const conditions = policy?.conditions
+  if (!Array.isArray(conditions)) {
+    throw ERRORS.InvalidSignature('Invalid policy conditions')
+  }
+
+  const fields: Record<string, string> = { ...submittedFields }
+  if (opts.bucket !== undefined) {
+    fields['bucket'] = opts.bucket
+  }
+
+  const coveredFields = new Set<string>()
+  for (const condition of conditions) {
+    const field = evaluatePolicyCondition(condition, fields)
+    if (field) {
+      coveredFields.add(field)
+    }
+  }
+
+  // Every submitted field must be constrained by a condition
+  for (const field of Object.keys(fields)) {
+    if (EXEMPT_POLICY_FIELDS.has(field) || field.startsWith('x-ignore-')) {
+      continue
+    }
+    if (!coveredFields.has(field)) {
+      throw ERRORS.AccessDenied(
+        `Policy condition failed: field "${field}" is not covered by the policy`
+      )
+    }
+  }
+}
+
+function evaluatePolicyCondition(
+  condition: PolicyCondition,
+  fields: Record<string, string>
+): string | undefined {
+  // Exact-match object form: { "field": "value" } with exactly one key.
+  if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+    const keys = Object.keys(condition)
+    if (keys.length !== 1) {
+      throw ERRORS.InvalidSignature('Invalid policy condition')
+    }
+    const field = keys[0].toLowerCase()
+    assertFieldEquals(field, condition[keys[0]], fields)
+    return field
+  }
+
+  // Tuple form: ["eq" | "starts-with", "$field", value] or
+  // ["content-length-range", min, max].
+  if (Array.isArray(condition)) {
+    const [operator, target, value] = condition
+
+    // TODO: content-length-range (min/max file size) is recognized but NOT
+    // enforce yet. enforcement is tracked as a follow-up).
+    if (operator === 'content-length-range') {
+      return undefined
+    }
+
+    if ((operator === 'eq' || operator === 'starts-with') && typeof target === 'string') {
+      if (!target.startsWith('$')) {
+        throw ERRORS.InvalidSignature('Invalid policy condition')
+      }
+      const field = target.slice(1).toLowerCase()
+      if (operator === 'eq') {
+        assertFieldEquals(field, value, fields)
+      } else {
+        assertFieldStartsWith(field, value, fields)
+      }
+      return field
+    }
+  }
+
+  throw ERRORS.InvalidSignature('Unsupported policy condition')
+}
+
+function assertFieldEquals(
+  field: string,
+  expected: string | number,
+  fields: Record<string, string>
+): void {
+  const actual = fields[field]
+  if (actual === undefined || actual !== String(expected)) {
+    throw ERRORS.AccessDenied(`Policy condition failed: "${field}" does not match`)
+  }
+}
+
+function assertFieldStartsWith(
+  field: string,
+  prefix: string | number,
+  fields: Record<string, string>
+): void {
+  const actual = fields[field]
+  if (actual === undefined || !actual.startsWith(String(prefix ?? ''))) {
+    throw ERRORS.AccessDenied(`Policy condition failed: "${field}" does not start with "${prefix}"`)
+  }
+}

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@internal/errors'
 import crypto from 'crypto'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
-import { assertPolicyNotExpired, Policy } from './policy'
+import { assertPolicyConditionsSatisfied, assertPolicyNotExpired, Policy } from './policy'
 
 export enum SignatureV4Service {
   S3 = 's3',
@@ -42,6 +42,7 @@ interface SignatureRequest {
   query?: Record<string, string>
   prefix?: string
   payloadHasher?: Writable & { digestHex: () => string }
+  bucket?: string
 }
 
 interface Credentials {
@@ -212,11 +213,6 @@ export class SignatureV4 {
 
     const xPolicy: Policy = JSON.parse(Buffer.from(policy, 'base64').toString('utf-8'))
 
-    // A POST policy must declare an expiration; AWS treats a missing one as
-    // invalid. Without this check a signed policy with no expiration would never
-    // expire and could be replayed forever.
-    assertPolicyNotExpired(xPolicy.expiration)
-
     const fields: Record<string, string> = Object.create(null)
     form.forEach((value, key) => {
       if (typeof value !== 'string') {
@@ -287,7 +283,18 @@ export class SignatureV4 {
    */
   async verify(clientSignature: ClientSignature, request: SignatureRequest) {
     if (typeof clientSignature.policy?.raw === 'string') {
-      return this.verifyPostPolicySignature(clientSignature, clientSignature.policy.raw)
+      const verified = this.verifyPostPolicySignature(clientSignature, clientSignature.policy.raw)
+      if (!verified) {
+        return false
+      }
+
+      const { value, fields } = clientSignature.policy
+      // A POST policy must declare an expiration; AWS treats a missing one as
+      // invalid. Without this check a signed policy with no expiration would never
+      // expire and could be replayed forever.
+      assertPolicyNotExpired(value.expiration)
+      assertPolicyConditionsSatisfied(value, fields, { bucket: request.bucket })
+      return true
     }
 
     const serverSignature = await this.sign(clientSignature, request)

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -29,6 +29,7 @@ export interface ClientSignature {
   policy?: {
     raw: string
     value: Policy
+    fields: Record<string, string>
   }
 }
 
@@ -54,23 +55,16 @@ type SignatureQuery = Record<string, unknown>
 
 export interface Policy {
   expiration: string
-  conditions: PolicyConditions
+  conditions: PolicyCondition[]
 }
 
-interface PolicyConditions {
-  policies: PolicyEntry[]
-  contentLengthRange: {
-    min: number
-    max: number
-    valid: boolean
-  }
-}
-
-interface PolicyEntry {
-  operator: string
-  key: string
-  value: string
-}
+/**
+ * An AWS POST policy condition is either:
+ *  - an exact-match object with a single key: `{ "bucket": "my-bucket" }`
+ *  - a tuple: `["eq", "$key", "value"]`, `["starts-with", "$key", "prefix"]`,
+ *    or `["content-length-range", min, max]`
+ */
+export type PolicyCondition = Record<string, string> | (string | number)[]
 
 /**
  * Lists the headers that should never be included in the
@@ -98,6 +92,21 @@ export const ALWAYS_UNSIGNABLE_QUERY_PARAMS = {
 }
 
 export const EMPTY_SHA256_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+/**
+ * Submitted form fields that do NOT need to be covered by a policy condition,
+ * keyed by their lowercased name. This matches AWS POST semantics: every other
+ * field (including `key`, `bucket`, and every `x-amz-meta-*`) must be constrained
+ * by a condition.
+ */
+const EXEMPT_POLICY_FIELDS = new Set([
+  'policy',
+  'x-amz-signature',
+  'x-amz-algorithm',
+  'x-amz-credential',
+  'x-amz-date',
+  'x-amz-security-token',
+])
 
 export class SignatureV4 {
   public readonly serverCredentials: SignatureV4Options['credentials']
@@ -230,9 +239,22 @@ export class SignatureV4 {
 
     const xPolicy: Policy = JSON.parse(Buffer.from(policy, 'base64').toString('utf-8'))
 
-    if (xPolicy.expiration) {
-      this.checkExpiration(longDate, xPolicy.expiration)
-    }
+    // A POST policy must declare an expiration; AWS treats a missing one as
+    // invalid. Without this check a signed policy with no expiration would never
+    // expire and could be replayed forever.
+    this.checkPolicyExpiration(xPolicy.expiration)
+
+    const fields: Record<string, string> = {}
+    form.forEach((value, key) => {
+      if (typeof value !== 'string') {
+        return
+      }
+      const normalizedKey = key.toLowerCase()
+      if (normalizedKey in fields) {
+        throw ERRORS.InvalidSignature('Duplicate form field in POST policy request')
+      }
+      fields[normalizedKey] = value
+    })
 
     const credentialsPart = credentialPart.split('/')
     if (credentialsPart.length !== 5) {
@@ -250,7 +272,29 @@ export class SignatureV4 {
       policy: {
         raw: policy,
         value: xPolicy,
+        fields,
       },
+    }
+  }
+
+  /**
+   * Validates a POST policy `expiration`, which is an absolute ISO8601 timestamp
+   * (e.g. `2025-01-01T00:00:00Z`). Unlike {@link checkExpiration}, used by
+   * presigned query URLs, where the value is a number of seconds relative to
+   * X-Amz-Date.
+   */
+  protected static checkPolicyExpiration(expiration: string | undefined) {
+    if (!expiration) {
+      throw ERRORS.InvalidSignature('Missing policy expiration')
+    }
+
+    const expirationDate = new Date(expiration)
+    if (isNaN(expirationDate.getTime())) {
+      throw ERRORS.InvalidSignature('Invalid policy expiration')
+    }
+
+    if (expirationDate < new Date()) {
+      throw ERRORS.ExpiredSignature()
     }
   }
 
@@ -299,6 +343,150 @@ export class SignatureV4 {
       Buffer.from(clientSignature.signature),
       Buffer.from(serverSignature.signature)
     )
+  }
+
+  /**
+   * Evaluates the signed POST policy conditions against the values the client
+   * actually submitted, in a single pass, and:
+   *  - throws if any condition is not satisfied;
+   *  - throws if any submitted field is NOT covered by a condition
+   *  - returns the effective `content-length-range` upper bound
+   *
+   * The `bucket` value is taken from the request target (the URL), since AWS
+   * POST uploads carry the bucket in the path rather than as a form field.
+   */
+  validatePostPolicyConditions(
+    clientSignature: ClientSignature,
+    opts: { bucket?: string }
+  ): number | undefined {
+    const policy = clientSignature.policy
+    if (!policy) {
+      return undefined
+    }
+
+    const conditions = policy.value?.conditions
+    if (!Array.isArray(conditions)) {
+      throw ERRORS.InvalidSignature('Invalid policy conditions')
+    }
+
+    const fields: Record<string, string> = { ...policy.fields }
+    if (opts.bucket !== undefined) {
+      fields['bucket'] = opts.bucket
+    }
+
+    const coveredFields = new Set<string>()
+    let max: number | undefined
+
+    for (const condition of conditions) {
+      const result = this.evaluatePolicyCondition(condition, fields)
+      if (result.field) {
+        coveredFields.add(result.field)
+      }
+      if (result.max !== undefined) {
+        // Fold to the most restrictive upper bound across every content-length-range.
+        max = max === undefined ? result.max : Math.min(max, result.max)
+      }
+    }
+
+    // Every submitted field must be constrained by a condition
+    for (const field of Object.keys(fields)) {
+      if (EXEMPT_POLICY_FIELDS.has(field) || field.startsWith('x-ignore-')) {
+        continue
+      }
+      if (!coveredFields.has(field)) {
+        throw ERRORS.AccessDenied(
+          `Policy condition failed: field "${field}" is not covered by the policy`
+        )
+      }
+    }
+
+    return max
+  }
+
+  protected evaluatePolicyCondition(
+    condition: PolicyCondition,
+    fields: Record<string, string>
+  ): { field?: string; max?: number } {
+    const normalized = this.normalizePolicyCondition(condition)
+
+    if (normalized.operator === 'content-length-range') {
+      return { max: normalized.max }
+    }
+
+    if (normalized.operator === 'eq') {
+      this.assertFieldEquals(normalized.field, normalized.value, fields)
+    } else if (normalized.operator === 'starts-with') {
+      this.assertFieldStartsWith(normalized.field, normalized.value, fields)
+    }
+
+    return { field: normalized.field }
+  }
+
+  /**
+   * Normalize a raw policy condition into a single operator form, or throws
+   * if it is malformed. The exact-match object `{ field: value }` is the same
+   * as `["eq", "$field", value]`, so both collapse to the same `eq` shape.
+   */
+  private normalizePolicyCondition(
+    condition: PolicyCondition
+  ):
+    | { operator: 'eq' | 'starts-with'; field: string; value: string | number }
+    | { operator: 'content-length-range'; min: number; max: number } {
+    // Exact-match object form: { "field": "value" } with exactly one key.
+    if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+      const keys = Object.keys(condition)
+      if (keys.length !== 1) {
+        throw ERRORS.InvalidSignature('Invalid policy condition')
+      }
+      return { operator: 'eq', field: keys[0].toLowerCase(), value: condition[keys[0]] }
+    }
+
+    // Tuple form: ["eq" | "starts-with", "$field", value] or
+    // ["content-length-range", min, max].
+    if (Array.isArray(condition)) {
+      const [operator, target, value] = condition
+
+      if (operator === 'content-length-range') {
+        if (typeof target !== 'number' || typeof value !== 'number') {
+          throw ERRORS.InvalidSignature('Invalid content-length-range condition')
+        }
+        return { operator: 'content-length-range', min: target, max: value }
+      }
+
+      if (
+        (operator === 'eq' || operator === 'starts-with') &&
+        typeof target === 'string' &&
+        target.startsWith('$')
+      ) {
+        return { operator, field: target.slice(1).toLowerCase(), value }
+      }
+    }
+
+    throw ERRORS.InvalidSignature('Unsupported policy condition')
+  }
+
+  private assertFieldEquals(
+    field: string,
+    expected: string | number,
+    fields: Record<string, string>
+  ) {
+    const actual = fields[field]
+    if (actual === undefined || actual !== String(expected)) {
+      throw ERRORS.AccessDenied(`Policy condition failed: "${field}" does not match`)
+    }
+  }
+
+  private assertFieldStartsWith(
+    field: string,
+    prefix: string | number,
+    fields: Record<string, string>
+  ) {
+    const actual = fields[field]
+    if (actual === undefined || !actual.startsWith(String(prefix ?? ''))) {
+      throw ERRORS.AccessDenied(
+        `Policy condition failed: "${field}" does not start with "${prefix}"`
+      )
+    }
   }
 
   /**

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -4,6 +4,7 @@ import { ERRORS } from '@internal/errors'
 import crypto from 'crypto'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
+import { assertPolicyNotExpired, Policy } from './policy'
 
 export enum SignatureV4Service {
   S3 = 's3',
@@ -53,19 +54,6 @@ interface Credentials {
 type SignatureHeaders = Record<string, string | string[] | undefined>
 type SignatureQuery = Record<string, unknown>
 
-export interface Policy {
-  expiration: string
-  conditions: PolicyCondition[]
-}
-
-/**
- * An AWS POST policy condition is either:
- *  - an exact-match object with a single key: `{ "bucket": "my-bucket" }`
- *  - a tuple: `["eq", "$key", "value"]`, `["starts-with", "$key", "prefix"]`,
- *    or `["content-length-range", min, max]`
- */
-export type PolicyCondition = Record<string, string> | (string | number)[]
-
 /**
  * Lists the headers that should never be included in the
  * request signature signature process.
@@ -92,21 +80,6 @@ export const ALWAYS_UNSIGNABLE_QUERY_PARAMS = {
 }
 
 export const EMPTY_SHA256_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-
-/**
- * Submitted form fields that do NOT need to be covered by a policy condition,
- * keyed by their lowercased name. This matches AWS POST semantics: every other
- * field (including `key`, `bucket`, and every `x-amz-meta-*`) must be constrained
- * by a condition.
- */
-const EXEMPT_POLICY_FIELDS = new Set([
-  'policy',
-  'x-amz-signature',
-  'x-amz-algorithm',
-  'x-amz-credential',
-  'x-amz-date',
-  'x-amz-security-token',
-])
 
 export class SignatureV4 {
   public readonly serverCredentials: SignatureV4Options['credentials']
@@ -242,15 +215,15 @@ export class SignatureV4 {
     // A POST policy must declare an expiration; AWS treats a missing one as
     // invalid. Without this check a signed policy with no expiration would never
     // expire and could be replayed forever.
-    this.checkPolicyExpiration(xPolicy.expiration)
+    assertPolicyNotExpired(xPolicy.expiration)
 
-    const fields: Record<string, string> = {}
+    const fields: Record<string, string> = Object.create(null)
     form.forEach((value, key) => {
       if (typeof value !== 'string') {
         return
       }
       const normalizedKey = key.toLowerCase()
-      if (normalizedKey in fields) {
+      if (Object.prototype.hasOwnProperty.call(fields, normalizedKey)) {
         throw ERRORS.InvalidSignature('Duplicate form field in POST policy request')
       }
       fields[normalizedKey] = value
@@ -274,27 +247,6 @@ export class SignatureV4 {
         value: xPolicy,
         fields,
       },
-    }
-  }
-
-  /**
-   * Validates a POST policy `expiration`, which is an absolute ISO8601 timestamp
-   * (e.g. `2025-01-01T00:00:00Z`). Unlike {@link checkExpiration}, used by
-   * presigned query URLs, where the value is a number of seconds relative to
-   * X-Amz-Date.
-   */
-  protected static checkPolicyExpiration(expiration: string | undefined) {
-    if (!expiration) {
-      throw ERRORS.InvalidSignature('Missing policy expiration')
-    }
-
-    const expirationDate = new Date(expiration)
-    if (isNaN(expirationDate.getTime())) {
-      throw ERRORS.InvalidSignature('Invalid policy expiration')
-    }
-
-    if (expirationDate < new Date()) {
-      throw ERRORS.ExpiredSignature()
     }
   }
 
@@ -343,150 +295,6 @@ export class SignatureV4 {
       Buffer.from(clientSignature.signature),
       Buffer.from(serverSignature.signature)
     )
-  }
-
-  /**
-   * Evaluates the signed POST policy conditions against the values the client
-   * actually submitted, in a single pass, and:
-   *  - throws if any condition is not satisfied;
-   *  - throws if any submitted field is NOT covered by a condition
-   *  - returns the effective `content-length-range` upper bound
-   *
-   * The `bucket` value is taken from the request target (the URL), since AWS
-   * POST uploads carry the bucket in the path rather than as a form field.
-   */
-  validatePostPolicyConditions(
-    clientSignature: ClientSignature,
-    opts: { bucket?: string }
-  ): number | undefined {
-    const policy = clientSignature.policy
-    if (!policy) {
-      return undefined
-    }
-
-    const conditions = policy.value?.conditions
-    if (!Array.isArray(conditions)) {
-      throw ERRORS.InvalidSignature('Invalid policy conditions')
-    }
-
-    const fields: Record<string, string> = { ...policy.fields }
-    if (opts.bucket !== undefined) {
-      fields['bucket'] = opts.bucket
-    }
-
-    const coveredFields = new Set<string>()
-    let max: number | undefined
-
-    for (const condition of conditions) {
-      const result = this.evaluatePolicyCondition(condition, fields)
-      if (result.field) {
-        coveredFields.add(result.field)
-      }
-      if (result.max !== undefined) {
-        // Fold to the most restrictive upper bound across every content-length-range.
-        max = max === undefined ? result.max : Math.min(max, result.max)
-      }
-    }
-
-    // Every submitted field must be constrained by a condition
-    for (const field of Object.keys(fields)) {
-      if (EXEMPT_POLICY_FIELDS.has(field) || field.startsWith('x-ignore-')) {
-        continue
-      }
-      if (!coveredFields.has(field)) {
-        throw ERRORS.AccessDenied(
-          `Policy condition failed: field "${field}" is not covered by the policy`
-        )
-      }
-    }
-
-    return max
-  }
-
-  protected evaluatePolicyCondition(
-    condition: PolicyCondition,
-    fields: Record<string, string>
-  ): { field?: string; max?: number } {
-    const normalized = this.normalizePolicyCondition(condition)
-
-    if (normalized.operator === 'content-length-range') {
-      return { max: normalized.max }
-    }
-
-    if (normalized.operator === 'eq') {
-      this.assertFieldEquals(normalized.field, normalized.value, fields)
-    } else if (normalized.operator === 'starts-with') {
-      this.assertFieldStartsWith(normalized.field, normalized.value, fields)
-    }
-
-    return { field: normalized.field }
-  }
-
-  /**
-   * Normalize a raw policy condition into a single operator form, or throws
-   * if it is malformed. The exact-match object `{ field: value }` is the same
-   * as `["eq", "$field", value]`, so both collapse to the same `eq` shape.
-   */
-  private normalizePolicyCondition(
-    condition: PolicyCondition
-  ):
-    | { operator: 'eq' | 'starts-with'; field: string; value: string | number }
-    | { operator: 'content-length-range'; min: number; max: number } {
-    // Exact-match object form: { "field": "value" } with exactly one key.
-    if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
-      const keys = Object.keys(condition)
-      if (keys.length !== 1) {
-        throw ERRORS.InvalidSignature('Invalid policy condition')
-      }
-      return { operator: 'eq', field: keys[0].toLowerCase(), value: condition[keys[0]] }
-    }
-
-    // Tuple form: ["eq" | "starts-with", "$field", value] or
-    // ["content-length-range", min, max].
-    if (Array.isArray(condition)) {
-      const [operator, target, value] = condition
-
-      if (operator === 'content-length-range') {
-        if (typeof target !== 'number' || typeof value !== 'number') {
-          throw ERRORS.InvalidSignature('Invalid content-length-range condition')
-        }
-        return { operator: 'content-length-range', min: target, max: value }
-      }
-
-      if (
-        (operator === 'eq' || operator === 'starts-with') &&
-        typeof target === 'string' &&
-        target.startsWith('$')
-      ) {
-        return { operator, field: target.slice(1).toLowerCase(), value }
-      }
-    }
-
-    throw ERRORS.InvalidSignature('Unsupported policy condition')
-  }
-
-  private assertFieldEquals(
-    field: string,
-    expected: string | number,
-    fields: Record<string, string>
-  ) {
-    const actual = fields[field]
-    if (actual === undefined || actual !== String(expected)) {
-      throw ERRORS.AccessDenied(`Policy condition failed: "${field}" does not match`)
-    }
-  }
-
-  private assertFieldStartsWith(
-    field: string,
-    prefix: string | number,
-    fields: Record<string, string>
-  ) {
-    const actual = fields[field]
-    if (actual === undefined || !actual.startsWith(String(prefix ?? ''))) {
-      throw ERRORS.AccessDenied(
-        `Policy condition failed: "${field}" does not start with "${prefix}"`
-      )
-    }
   }
 
   /**

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -1039,7 +1039,6 @@ describe('S3 Protocol', () => {
         Object.keys(signedURL.fields).forEach((key) => {
           formData.set(key, signedURL.fields[key])
         })
-        formData.set('key', 'other/object.txt')
         formData.set('file', new Blob([Buffer.alloc(16)]), 'object.txt')
 
         const otherUrl = signedURL.url.replace(`/s3/${signedBucket}`, `/s3/${otherBucket}`)
@@ -1116,27 +1115,6 @@ describe('S3 Protocol', () => {
         expect(resp.status).toBe(403)
       })
 
-      it('enforces the content-length-range upper bound', async () => {
-        const bucketName = await createBucket(client)
-
-        const signedURL = await createPresignedPost(client, {
-          Bucket: bucketName,
-          Key: 'test.jpg',
-          Expires: 5000,
-          Conditions: [['content-length-range', 0, 1024]],
-        })
-
-        const formData = new FormData()
-        Object.keys(signedURL.fields).forEach((key) => {
-          formData.set(key, signedURL.fields[key])
-        })
-        formData.set('file', new Blob([Buffer.alloc(1024 * 2)]), 'test.jpg')
-
-        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
-
-        expect(resp.status).toBe(413)
-      })
-
       it('accepts (and ignores) a field Storage does not act on, when covered by a condition', async () => {
         const bucketName = await createBucket(client)
 
@@ -1182,6 +1160,31 @@ describe('S3 Protocol', () => {
         const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
 
         expect(resp.status).toBe(403)
+      })
+
+      it('allows an uncovered x-ignore- field (AWS exemption)', async () => {
+        // AWS exempts fields prefixed with `x-ignore-` from the "every field must
+        // be covered by a condition" rule, so an uncovered x-ignore-* field must
+        // NOT be rejected (contrast the x-amz-meta-* case above).
+        const bucketName = await createBucket(client)
+
+        const signedURL = await createPresignedPost(client, {
+          Bucket: bucketName,
+          Key: 'test.jpg',
+          Expires: 5000,
+          Fields: { 'Content-Type': 'image/jpg' },
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        formData.set('x-ignore-toolkit-field', 'anything')
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'test.jpg')
+
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(200)
       })
     })
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -931,6 +931,23 @@ describe('S3 Protocol', () => {
     }
 
     describe('MultiPart Form Data Upload', () => {
+      // Hand-signs a POST policy with the server's S3 credentials, returning the
+      // form fields a client would submit. Lets us craft conditions the AWS SDK
+      // won't generate on its own
+      function signPostPolicy(policy: Record<string, unknown>) {
+        const shortDate = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+        const policyB64 = Buffer.from(JSON.stringify(policy)).toString('base64')
+        const hmac = (key: Buffer | string, data: string) =>
+          createHmac('sha256', key).update(data, 'utf-8').digest()
+        const kDate = hmac('AWS4' + s3ProtocolAccessKeySecret!, shortDate)
+        const kRegion = hmac(kDate, storageS3Region)
+        const kService = hmac(kRegion, 's3')
+        const kSigning = hmac(kService, 'aws4_request')
+        const signature = hmac(kSigning, policyB64).toString('hex')
+        const credential = `${s3ProtocolAccessKeyId}/${shortDate}/${storageS3Region}/s3/aws4_request`
+        return { policyB64, signature, credential }
+      }
+
       it('can upload using multipart/form-data', async () => {
         const webhookSpy = vi
           .spyOn(ObjectCreatedPostEvent, 'sendWebhook')
@@ -1005,6 +1022,166 @@ describe('S3 Protocol', () => {
 
         expect(resp.status).toBe(413)
         expect(resp.statusText).toBe('Payload Too Large')
+      })
+
+      it('rejects a presigned POST replayed against a different bucket', async () => {
+        const signedBucket = await createBucket(client)
+        const otherBucket = await createBucket(client)
+
+        const signedURL = await createPresignedPost(client, {
+          Bucket: signedBucket,
+          Key: 'allowed/test.jpg',
+          Expires: 5000,
+          Fields: { 'Content-Type': 'image/jpg' },
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        formData.set('key', 'other/object.txt')
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'object.txt')
+
+        const otherUrl = signedURL.url.replace(`/s3/${signedBucket}`, `/s3/${otherBucket}`)
+        const resp = await fetch(otherUrl, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(403)
+      })
+
+      it('rejects a presigned POST whose key violates the signed starts-with condition', async () => {
+        const bucketName = await createBucket(client)
+
+        const signedURL = await createPresignedPost(client, {
+          Bucket: bucketName,
+          // ${filename} produces a `["starts-with", "$key", "allowed/"]` condition
+          // biome-ignore lint/suspicious/noTemplateCurlyInString: AWS POST uses a literal ${filename} token
+          Key: 'allowed/${filename}',
+          Expires: 5000,
+          Fields: { 'Content-Type': 'image/jpg' },
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        formData.set('key', 'outside/object.txt')
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'object.txt')
+
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(403)
+      })
+
+      it('rejects an expired policy even with a far-future X-Amz-Date', async () => {
+        const bucketName = await createBucket(client)
+
+        const { policyB64, signature, credential } = signPostPolicy({
+          expiration: '2020-01-01T00:00:00Z',
+          conditions: [{ bucket: bucketName }, ['starts-with', '$key', '']],
+        })
+
+        const formData = new FormData()
+        formData.set('key', 'some-key.txt')
+        formData.set('Policy', policyB64)
+        formData.set('X-Amz-Algorithm', 'AWS4-HMAC-SHA256')
+        formData.set('X-Amz-Credential', credential)
+        formData.set('X-Amz-Date', '99991231T235959Z')
+        formData.set('X-Amz-Signature', signature)
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'some-key.txt')
+
+        const resp = await fetch(`${baseUrl}/s3/${bucketName}`, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(400)
+      })
+
+      it('rejects a key that violates an "eq" key condition', async () => {
+        const bucketName = await createBucket(client)
+
+        const { policyB64, signature, credential } = signPostPolicy({
+          expiration: '2099-01-01T00:00:00Z',
+          conditions: [{ bucket: bucketName }, ['eq', '$key', 'allowed/exact.txt']],
+        })
+
+        const formData = new FormData()
+        formData.set('key', 'allowed/different.txt')
+        formData.set('Policy', policyB64)
+        formData.set('X-Amz-Algorithm', 'AWS4-HMAC-SHA256')
+        formData.set('X-Amz-Credential', credential)
+        formData.set('X-Amz-Date', '99991231T235959Z')
+        formData.set('X-Amz-Signature', signature)
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'object.txt')
+
+        const resp = await fetch(`${baseUrl}/s3/${bucketName}`, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(403)
+      })
+
+      it('enforces the content-length-range upper bound', async () => {
+        const bucketName = await createBucket(client)
+
+        const signedURL = await createPresignedPost(client, {
+          Bucket: bucketName,
+          Key: 'test.jpg',
+          Expires: 5000,
+          Conditions: [['content-length-range', 0, 1024]],
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        formData.set('file', new Blob([Buffer.alloc(1024 * 2)]), 'test.jpg')
+
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(413)
+      })
+
+      it('accepts (and ignores) a field Storage does not act on, when covered by a condition', async () => {
+        const bucketName = await createBucket(client)
+
+        // `acl` is a valid AWS POST field that Storage does not implement. As long
+        // as it is covered by a condition (the SDK adds one for every Fields
+        // entry) it is accepted and ignored, matching AWS-compatible behavior.
+        const signedURL = await createPresignedPost(client, {
+          Bucket: bucketName,
+          Key: 'test.jpg',
+          Expires: 5000,
+          Fields: { acl: 'public-read' },
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'test.jpg')
+
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(200)
+      })
+
+      it('rejects a submitted field that is not covered by any policy condition', async () => {
+        const bucketName = await createBucket(client)
+
+        const signedURL = await createPresignedPost(client, {
+          Bucket: bucketName,
+          Key: 'test.jpg',
+          Expires: 5000,
+          Fields: { 'Content-Type': 'image/jpg' },
+        })
+
+        const formData = new FormData()
+        Object.keys(signedURL.fields).forEach((key) => {
+          formData.set(key, signedURL.fields[key])
+        })
+        // An extra field the signed policy never constrained with a condition.
+        formData.set('x-amz-meta-extra', 'value')
+        formData.set('file', new Blob([Buffer.alloc(16)]), 'test.jpg')
+
+        const resp = await fetch(signedURL.url, { method: 'POST', body: formData })
+
+        expect(resp.status).toBe(403)
       })
     })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix to enforce policy conditions in S3 presigned POST url.

## What is the current behavior?

Currently only verifies the HMAC over the Policy blob 

## What is the new behavior?

Properly validates the conditions

## Additional context

