### PR TITLE
fix: copy TLS session ticket from pooled arena

### DIFF
--- a/src/internal/database/tls-session-resumption.test.ts
+++ b/src/internal/database/tls-session-resumption.test.ts
@@ -32,10 +32,25 @@ describe('tls session slot', () => {
     expect(peekTlsSession(slot)).toBeUndefined()
 
     storeTlsSession(slot, first)
-    expect(peekTlsSession(slot)).toBe(first)
+    expect(peekTlsSession(slot)).toEqual(first)
 
     storeTlsSession(slot, second)
-    expect(peekTlsSession(slot)).toBe(second)
+    expect(peekTlsSession(slot)).toEqual(second)
+  })
+
+  test('copies tickets out of pooled buffers so slots never pin pool arenas', () => {
+    const slot = createTlsSessionSlot()
+    // simulate a big pooled buffer arena (256k)
+    const arena = Buffer.allocUnsafeSlow(256 * 1024)
+    const ticket = arena.subarray(0, 1068)
+    ticket.fill(7)
+
+    storeTlsSession(slot, ticket)
+
+    const stored = peekTlsSession(slot)
+    expect(stored).toEqual(ticket)
+    expect(stored!.buffer).not.toBe(arena.buffer)
+    expect(stored!.buffer.byteLength).toBe(ticket.byteLength)
   })
 
   test('expires sessions after the max age', () => {
@@ -64,11 +79,11 @@ describe('tls session slot', () => {
 
     const first = Buffer.from('first')
     storeTlsSession(slot, first)
-    expect(Object.assign({}, ssl).session).toBe(first)
+    expect(Object.assign({}, ssl).session).toEqual(first)
 
     const second = Buffer.from('second')
     storeTlsSession(slot, second)
-    expect(Object.assign({}, ssl).session).toBe(second)
+    expect(Object.assign({}, ssl).session).toEqual(second)
   })
 
   test('slot reference does not leak into tls.connect options', () => {
@@ -104,10 +119,10 @@ describe('tls session slot', () => {
     const first = Buffer.from('first')
     const second = Buffer.from('second')
     socket.emit('session', first)
-    expect(peekTlsSession(slot)).toBe(first)
+    expect(peekTlsSession(slot)).toEqual(first)
 
     socket.emit('session', second)
-    expect(peekTlsSession(slot)).toBe(second)
+    expect(peekTlsSession(slot)).toEqual(second)
   })
 
   test('capture tolerates streams without listener support', () => {
@@ -220,9 +235,9 @@ describe('TlsSessionResumptionClient pg wiring', () => {
 
     const session = Buffer.from('ticket')
     stream.emit('session', session)
-    expect(peekTlsSession(slot)).toBe(session)
+    expect(peekTlsSession(slot)).toEqual(session)
 
-    expect(Object.assign({}, ssl).session).toBe(session)
+    expect(Object.assign({}, ssl).session).toEqual(session)
 
     stream.emit('secureConnect')
     expect(recordSpy).toHaveBeenCalledWith('uncached')

--- a/src/internal/database/tls-session-resumption.ts
+++ b/src/internal/database/tls-session-resumption.ts
@@ -41,7 +41,11 @@ export function createTlsSessionSlot(): TlsSessionSlot {
 }
 
 export function storeTlsSession(slot: TlsSessionSlot, session: Buffer): void {
-  slot.session = session
+  // Copy the ticket out of the pooled arena to avoid pinning the pool's memory.
+  const copy = Buffer.allocUnsafeSlow(session.byteLength)
+  session.copy(copy)
+
+  slot.session = copy
   slot.storedAt = Date.now()
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In [TLS session resumption](https://github.com/supabase/storage/pull/1195), session buffer is cached in tenant pool. Received view is small but backing buffer depends on buffer pool arena size and it's much bigger (for example 256kb in default watt). By keeping a reference, it will use unnecessarily a lot of memory. 

## What is the new behavior?

Copy buffer into a small, exact sized non-pooled buffer (~1kb) and release the bigger pooled buffer. 

## Additional context

Related to https://github.com/supabase/storage/pull/1195
