### PR TITLE
feat: add admin endpoint to cleanup orphan iceberg resources

### DIFF
--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -60,6 +60,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(routes.tenants, { prefix: 'tenants' })
   app.register(routes.objects, { prefix: 'tenants' })
   app.register(routes.jwks, { prefix: 'tenants' })
+  app.register(routes.icebergAdmin, { prefix: 'tenants' })
   app.register(routes.migrations, { prefix: 'migrations' })
   if (isRunningUnderWatt) {
     app.register(routes.pprof, { prefix: 'debug/pprof' })

--- a/src/http/routes/admin/iceberg-admin.ts
+++ b/src/http/routes/admin/iceberg-admin.ts
@@ -1,0 +1,85 @@
+import { multitenantPgExecutor } from '@internal/database'
+import { DeleteIcebergResources } from '@storage/events/iceberg'
+import { FastifyInstance } from 'fastify'
+import { getConfig } from '../../../config'
+import { registerApiKeyAuth } from '../../plugins/apikey'
+
+const { isMultitenant } = getConfig()
+
+interface IcebergCatalogRow {
+  id: string
+  name: string
+  tenant_id: string
+  deleted_at: string
+}
+
+function getOrphanIcebergCatalogs() {
+  return multitenantPgExecutor.query<IcebergCatalogRow>(
+    `
+      SELECT id, name, tenant_id, deleted_at
+      FROM iceberg_catalogs
+      WHERE deleted_at IS NOT NULL
+        AND deleted_at < NOW() - INTERVAL '24 hours'
+      ORDER BY deleted_at ASC
+    `
+  )
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  registerApiKeyAuth(fastify)
+
+  fastify.get(
+    '/iceberg/orphan-catalogs',
+    { schema: { tags: ['iceberg'] } },
+    async (_request, reply) => {
+      if (!isMultitenant) {
+        return reply.status(400).send({ error: 'This endpoint only supports multitenant mode' })
+      }
+
+      const { rows } = await getOrphanIcebergCatalogs()
+
+      return reply.send({
+        count: rows.length,
+        items: rows,
+      })
+    }
+  )
+
+  fastify.delete(
+    '/iceberg/orphan-catalogs',
+    { schema: { tags: ['iceberg'] } },
+    async (request, reply) => {
+      if (!isMultitenant) {
+        return reply.status(400).send({ error: 'This endpoint only supports multitenant mode' })
+      }
+
+      const { rows } = await getOrphanIcebergCatalogs()
+
+      if (rows.length === 0) {
+        return reply.status(404).send({
+          error: 'No orphan catalogs found to cleanup',
+        })
+      }
+
+      await DeleteIcebergResources.batchSend(
+        rows.map(
+          (catalog) =>
+            new DeleteIcebergResources({
+              catalogId: catalog.id,
+              tenant: {
+                ref: catalog.tenant_id,
+                host: '', // Not needed for cleanup
+              },
+              sbReqId: request.sbReqId,
+            })
+        )
+      )
+
+      return reply.send({
+        message: 'Cleanup jobs scheduled',
+        count: rows.length,
+        items: rows,
+      })
+    }
+  )
+}

--- a/src/http/routes/admin/iceberg-admin.ts
+++ b/src/http/routes/admin/iceberg-admin.ts
@@ -4,7 +4,7 @@ import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
 import { registerApiKeyAuth } from '../../plugins/apikey'
 
-const { isMultitenant } = getConfig()
+const { isMultitenant, pgQueueEnable } = getConfig()
 
 interface IcebergCatalogRow {
   id: string
@@ -32,8 +32,10 @@ export default async function routes(fastify: FastifyInstance) {
     '/iceberg/orphan-catalogs',
     { schema: { tags: ['iceberg'] } },
     async (_request, reply) => {
-      if (!isMultitenant) {
-        return reply.status(400).send({ error: 'This endpoint only supports multitenant mode' })
+      if (!isMultitenant || !pgQueueEnable) {
+        return reply
+          .status(400)
+          .send({ error: 'This endpoint only supports multitenant mode with the queue enabled' })
       }
 
       const { rows } = await getOrphanIcebergCatalogs()
@@ -49,8 +51,10 @@ export default async function routes(fastify: FastifyInstance) {
     '/iceberg/orphan-catalogs',
     { schema: { tags: ['iceberg'] } },
     async (request, reply) => {
-      if (!isMultitenant) {
-        return reply.status(400).send({ error: 'This endpoint only supports multitenant mode' })
+      if (!isMultitenant || !pgQueueEnable) {
+        return reply
+          .status(400)
+          .send({ error: 'This endpoint only supports multitenant mode with the queue enabled' })
       }
 
       const { rows } = await getOrphanIcebergCatalogs()

--- a/src/http/routes/admin/index.ts
+++ b/src/http/routes/admin/index.ts
@@ -1,3 +1,4 @@
+export { default as icebergAdmin } from './iceberg-admin'
 export { default as jwks } from './jwks'
 export { default as migrations } from './migrations'
 export { default as objects } from './objects'


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Introduces an admin endpoint that can be used to clean up orphan iceberg resources. These are items that were "soft deleted" by marking them as "deleted_at" but never actually removed.

- `GET tenants/iceberg/orphan-catalogs` - returns list of orphan catalogs to clean up (dry run)
- `DELETE tenants/iceberg/orphan-catalogs` - queues a `DeleteIcebergResources` job for each item