### PR TITLE
feat: add heap snapshot into admin

### DIFF
--- a/src/http/routes/admin/pprof.test.ts
+++ b/src/http/routes/admin/pprof.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import fastify, { type FastifyInstance, FastifyReply } from 'fastify'
 import {
   Function as PprofFunction,
@@ -16,6 +17,7 @@ const runtimeApiClient = vi.hoisted(() => ({
   getRuntimeApplications: vi.fn(),
   startApplicationProfiling: vi.fn(),
   stopApplicationProfiling: vi.fn(),
+  takeApplicationHeapSnapshot: vi.fn(),
   close: vi.fn(),
 }))
 const waitForMultipartPprofWindowMock = vi.hoisted(() => vi.fn())
@@ -26,6 +28,7 @@ vi.mock('@platformatic/control', () => ({
     getRuntimeApplications = runtimeApiClient.getRuntimeApplications
     startApplicationProfiling = runtimeApiClient.startApplicationProfiling
     stopApplicationProfiling = runtimeApiClient.stopApplicationProfiling
+    takeApplicationHeapSnapshot = runtimeApiClient.takeApplicationHeapSnapshot
     close = runtimeApiClient.close
   },
 }))
@@ -239,6 +242,7 @@ function createReplyDouble() {
     socket: {
       setKeepAlive: vi.fn(),
     },
+    once: vi.fn(),
     writableEnded: false,
     write: vi.fn(() => true),
     writeHead: vi.fn(),
@@ -249,10 +253,12 @@ function createReplyDouble() {
     raw,
     send: vi.fn(),
     status: vi.fn(),
+    headers: vi.fn(),
   }
 
   reply.status.mockReturnValue(reply)
   reply.send.mockReturnValue(reply)
+  reply.headers.mockReturnValue(reply)
 
   return reply as unknown as FastifyReply
 }
@@ -306,6 +312,9 @@ describe('admin pprof routes', () => {
     runtimeApiClient.startApplicationProfiling.mockResolvedValue(undefined)
     runtimeApiClient.stopApplicationProfiling.mockResolvedValue(
       buildProfile('default-worker', 3).buffer
+    )
+    runtimeApiClient.takeApplicationHeapSnapshot.mockResolvedValue(
+      Readable.from(['{"snapshot":true}'])
     )
     runtimeApiClient.close.mockResolvedValue(undefined)
     installMultipartWindowMock()
@@ -619,6 +628,193 @@ describe('admin pprof routes', () => {
           .map((sample) => sample.value[0])
           .sort((left, right) => Number(left) - Number(right))
       ).toEqual([11, 22])
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('streams a full heap snapshot for the requested worker via Watt control', async () => {
+    runtimeApiClient.takeApplicationHeapSnapshot.mockResolvedValue(
+      Readable.from(['{"snapshot":', 'true}'])
+    )
+
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/heap-snapshot?workerId=7',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('application/octet-stream')
+      expect(response.headers['cache-control']).toBe('no-store')
+      expect(response.headers['x-platformatic-application-id']).toBe('storage')
+      expect(response.headers['x-platformatic-worker-id']).toBe('7')
+      expect(response.headers['content-disposition']).toContain('storage-worker-7.heapsnapshot')
+      expect(response.body).toBe('{"snapshot":true}')
+      expect(runtimeApiClient.takeApplicationHeapSnapshot).toHaveBeenCalledWith(
+        process.pid,
+        'storage:7'
+      )
+      expect(runtimeApiClient.close).toHaveBeenCalledTimes(1)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('requires workerId for full heap snapshots and lists discovered workers', async () => {
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/heap-snapshot',
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({
+        message:
+          'Full heap snapshots are per V8 isolate; pass workerId to capture exactly one worker. Available workerIds: 0, 1.',
+      })
+      expect(runtimeApiClient.takeApplicationHeapSnapshot).not.toHaveBeenCalled()
+      expect(runtimeApiClient.close).toHaveBeenCalledTimes(1)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('requires workerId for full heap snapshots even when worker discovery degrades to one target', async () => {
+    runtimeApiClient.getRuntimeApplications.mockResolvedValue({
+      applications: [{ id: 'storage' }],
+    })
+
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/heap-snapshot',
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({
+        message:
+          'Full heap snapshots are per V8 isolate; pass workerId to capture exactly one worker. Available workerIds: 2.',
+      })
+      expect(runtimeApiClient.takeApplicationHeapSnapshot).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('rejects overlapping full heap snapshots for the same worker', async () => {
+    const harness = await buildRouteHarness()
+    const firstReply = createReplyDouble()
+    const secondReply = createReplyDouble()
+    const snapshotHandler = harness.getHandler('/heap-snapshot')
+    const openSnapshot = new Readable({
+      read() {},
+    })
+
+    runtimeApiClient.takeApplicationHeapSnapshot.mockResolvedValueOnce(openSnapshot)
+
+    await expect(
+      snapshotHandler(
+        {
+          query: {
+            workerId: 7,
+          },
+          signals: {
+            disconnect: new AbortController(),
+          },
+        },
+        firstReply
+      )
+    ).resolves.toBe(firstReply)
+
+    await expect(
+      snapshotHandler(
+        {
+          query: {
+            workerId: 7,
+          },
+          signals: {
+            disconnect: new AbortController(),
+          },
+        },
+        secondReply
+      )
+    ).resolves.toBe(secondReply)
+
+    expect(secondReply.status).toHaveBeenCalledWith(409)
+    expect(secondReply.send).toHaveBeenCalledWith({
+      message: 'Heap snapshot capture is already running for service "storage:7".',
+    })
+    expect(runtimeApiClient.takeApplicationHeapSnapshot).toHaveBeenCalledTimes(1)
+
+    openSnapshot.destroy()
+    await harness.onClose()
+  })
+
+  it('destroys the heap snapshot stream and closes the control client on disconnect', async () => {
+    const harness = await buildRouteHarness()
+    const reply = createReplyDouble()
+    const controller = new AbortController()
+    const snapshotHandler = harness.getHandler('/heap-snapshot')
+    const snapshot = new Readable({
+      read() {},
+    })
+    const destroySpy = vi.spyOn(snapshot, 'destroy')
+
+    runtimeApiClient.takeApplicationHeapSnapshot.mockResolvedValueOnce(snapshot)
+
+    await expect(
+      snapshotHandler(
+        {
+          query: {
+            workerId: 7,
+          },
+          signals: {
+            disconnect: controller,
+          },
+        },
+        reply
+      )
+    ).resolves.toBe(reply)
+
+    controller.abort()
+
+    expect(destroySpy).toHaveBeenCalled()
+    expect(runtimeApiClient.close).toHaveBeenCalledTimes(1)
+
+    await harness.onClose()
+  })
+
+  it('returns live worker ids when a requested snapshot worker is stale', async () => {
+    runtimeApiClient.takeApplicationHeapSnapshot.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          'Failed to take heap snapshot for service "storage:0": Worker 0 of application storage not found. Available applications are: 4, 5'
+        ),
+        {
+          code: 'PLT_CTR_FAILED_TO_TAKE_HEAP_SNAPSHOT',
+        }
+      )
+    )
+
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/heap-snapshot?workerId=0',
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({
+        message: 'Worker 0 is not available. Available workerIds: 4, 5.',
+      })
     } finally {
       await app.close()
     }

--- a/src/http/routes/admin/pprof.ts
+++ b/src/http/routes/admin/pprof.ts
@@ -5,6 +5,7 @@ import {
 import { mergeStoppedProfileBuffers } from '@internal/monitoring/pprof/profile'
 import {
   asProfilingRuntimeApiClient,
+  buildHeapSnapshotResponseHeaders,
   buildPprofFilename,
   buildPprofSessionKey,
   buildPprofStartOptions,
@@ -20,6 +21,7 @@ import {
 } from '@internal/monitoring/pprof/runtime'
 import type {
   ActivePprofSession,
+  HeapSnapshotStream,
   MultipartPprofWriter,
   PprofCaptureOptions,
   PprofCaptureType,
@@ -128,7 +130,127 @@ interface HeapProfileRequest extends RequestGenericInterface {
   Querystring: FromSchema<typeof heapProfileSchema.querystring>
 }
 
+const heapSnapshotSchema = {
+  description:
+    'Capture a full V8 heap snapshot for one Watt worker. Returns a streamed .heapsnapshot file.',
+  querystring: {
+    type: 'object',
+    properties: {
+      workerId: {
+        type: 'integer',
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+  tags: ['pprof'],
+} as const
+
+interface HeapSnapshotRequest extends RequestGenericInterface {
+  Querystring: FromSchema<typeof heapSnapshotSchema.querystring>
+}
+
 const activePprofSessions = new Map<string, ActivePprofSession>()
+
+interface ActiveHeapSnapshotSession {
+  closeClient: () => Promise<void>
+  key: string
+  stream?: HeapSnapshotStream
+}
+
+const activeHeapSnapshotSessions = new Map<string, ActiveHeapSnapshotSession>()
+
+function createAbortError(): Error & { code: string } {
+  const error = new Error('The operation was aborted.') as Error & { code: string }
+  error.name = 'AbortError'
+  error.code = 'ABORT_ERR'
+  return error
+}
+
+function formatWorkerIds(workerIds: number[]) {
+  return workerIds.length === 0 ? '' : ` Available workerIds: ${workerIds.join(', ')}.`
+}
+
+function getSelectionWorkerIds(selection: WattPprofSelection) {
+  return [
+    ...new Set(
+      selection.targets
+        .map((target) => target.workerId)
+        .filter((workerId): workerId is number => workerId !== undefined)
+    ),
+  ]
+}
+
+function buildHeapSnapshotSessionKey(selection: WattPprofSelection, target: WattPprofTarget) {
+  return `${selection.applicationId}:heap-snapshot:${target.targetApplicationId}`
+}
+
+function createHeapSnapshotAlreadyStartedError(
+  selection: WattPprofSelection,
+  target: WattPprofTarget
+) {
+  return createControlStyleError(
+    PPROF_CONTROL_ERROR_CODES.profilingAlreadyStarted,
+    `Heap snapshot capture is already running for service "${selection.applicationId}:${target.workerId}".`
+  )
+}
+
+async function withProfilingClient(
+  reply: FastifyReply,
+  options: {
+    client?: ProfilingRuntimeApiClient
+    notAvailableMessage: string
+    workerId?: number
+  },
+  handler: (
+    client: ProfilingRuntimeApiClient,
+    selection: WattPprofSelection,
+    controls: {
+      closeClient: () => Promise<void>
+      keepClientOpen: () => void
+    }
+  ) => Promise<FastifyReply>
+) {
+  const client = options.client ?? asProfilingRuntimeApiClient(new RuntimeApiClient())
+  let shouldCloseClient = true
+  let closePromise: Promise<void> | undefined
+
+  const closeClient = () => {
+    closePromise ??= client.close().catch(() => {})
+    return closePromise
+  }
+
+  try {
+    const selection = await resolveWattPprofSelection(client, options.workerId)
+
+    if (!selection) {
+      return reply.status(501).send({
+        message: options.notAvailableMessage,
+      })
+    }
+
+    return await handler(client, selection, {
+      closeClient,
+      keepClientOpen() {
+        shouldCloseClient = false
+      },
+    })
+  } catch (error) {
+    const knownError = getKnownPprofError(error)
+
+    if (knownError) {
+      return reply.status(knownError.statusCode).send({
+        message: knownError.message,
+      })
+    }
+
+    throw error
+  } finally {
+    if (shouldCloseClient) {
+      await closeClient()
+    }
+  }
+}
 
 async function stopProfilingTargets(
   client: ProfilingRuntimeApiClient,
@@ -237,85 +359,207 @@ async function captureAndSendPprof(
   options: PprofCaptureOptions,
   client: ProfilingRuntimeApiClient = asProfilingRuntimeApiClient(new RuntimeApiClient())
 ) {
-  try {
-    let selection: WattPprofSelection | null = await resolveWattPprofSelection(
+  return withProfilingClient(
+    reply,
+    {
       client,
-      options.workerId
-    )
+      notAvailableMessage: 'pprof capture is only available when running under Platformatic Watt.',
+      workerId: options.workerId,
+    },
+    async (client, selection) => {
+      let selectedTargets = selection
+      let session: ActivePprofSession | undefined
+      let writer: MultipartPprofWriter | undefined
 
-    if (!selection) {
-      return reply.status(501).send({
-        message: 'pprof capture is only available when running under Platformatic Watt.',
-      })
-    }
+      try {
+        session = await startPprofSessionWithLiveWorkerRetry(client, selectedTargets, options)
+        selectedTargets = session
+        writer = createMultipartPprofWriter(reply, selectedTargets, options.type, options.seconds)
+        await waitForMultipartPprofWindow(reply, writer, options.seconds, options.signal)
 
-    let session: ActivePprofSession | undefined
-    let writer: MultipartPprofWriter | undefined
+        if (!activePprofSessions.has(session.key)) {
+          writer.close()
+          session = undefined
+          return reply
+        }
 
-    try {
-      session = await startPprofSessionWithLiveWorkerRetry(client, selection, options)
-      selection = session
-      writer = createMultipartPprofWriter(reply, selection, options.type, options.seconds)
-      await waitForMultipartPprofWindow(reply, writer, options.seconds, options.signal)
-
-      if (!activePprofSessions.has(session.key)) {
-        writer.close()
+        const profile = await stopPprofSession(client, session)
         session = undefined
-        return reply
-      }
 
-      const profile = await stopPprofSession(client, session)
-      session = undefined
-
-      writer.writeBinaryPart(
-        {
-          'Content-Disposition': `attachment; filename="${buildPprofFilename(resolvePprofFilenameTarget(selection), options.type)}"`,
-          'Content-Type': 'application/octet-stream',
-        },
-        profile
-      )
-      writer.close()
-      return reply
-    } catch (error) {
-      if (options.signal.aborted && isAbortError(error)) {
-        writer?.close()
-        return reply
-      }
-
-      const knownError = getKnownPprofError(error)
-      if (writer) {
-        writer.writeJsonPart({
-          event: 'error',
-          error: {
-            code: knownError?.code,
-            message:
-              error instanceof Error
-                ? error.message
-                : 'Failed to capture a pprof profile from the Watt runtime.',
-            statusCode: knownError?.statusCode ?? 500,
+        writer.writeBinaryPart(
+          {
+            'Content-Disposition': `attachment; filename="${buildPprofFilename(resolvePprofFilenameTarget(selectedTargets), options.type)}"`,
+            'Content-Type': 'application/octet-stream',
           },
-        })
+          profile
+        )
         writer.close()
         return reply
-      }
+      } catch (error) {
+        if (options.signal.aborted && isAbortError(error)) {
+          writer?.close()
+          return reply
+        }
 
-      if (knownError) {
-        return reply.status(knownError.statusCode).send({
-          message: knownError.message,
+        const knownError = getKnownPprofError(error)
+        if (writer) {
+          writer.writeJsonPart({
+            event: 'error',
+            error: {
+              code: knownError?.code,
+              message:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to capture a pprof profile from the Watt runtime.',
+              statusCode: knownError?.statusCode ?? 500,
+            },
+          })
+          writer.close()
+          return reply
+        }
+
+        if (knownError) {
+          return reply.status(knownError.statusCode).send({
+            message: knownError.message,
+          })
+        }
+
+        throw error
+      } finally {
+        // onClose clears the shared session registry before it stops any in-flight captures, so
+        // only the code path that still owns the registry entry should perform the final stop here.
+        if (session && activePprofSessions.has(session.key)) {
+          await stopPprofSession(client, session).catch(() => {})
+        }
+      }
+    }
+  )
+}
+
+function cleanupHeapSnapshotSession(
+  session: ActiveHeapSnapshotSession,
+  abortSignal: AbortSignal,
+  abortHandler: () => void
+) {
+  activeHeapSnapshotSessions.delete(session.key)
+  abortSignal.removeEventListener('abort', abortHandler)
+  void session.closeClient()
+}
+
+function closeHeapSnapshotSessionWhenStreamEnds(
+  reply: FastifyReply,
+  session: ActiveHeapSnapshotSession,
+  abortSignal: AbortSignal,
+  abortHandler: () => void
+) {
+  let cleaned = false
+  const cleanup = () => {
+    if (cleaned) {
+      return
+    }
+
+    cleaned = true
+    cleanupHeapSnapshotSession(session, abortSignal, abortHandler)
+  }
+
+  session.stream?.once('end', cleanup)
+  session.stream?.once('error', cleanup)
+  session.stream?.once('close', cleanup)
+  reply.raw.once('close', cleanup)
+}
+
+async function captureAndSendHeapSnapshot(
+  reply: FastifyReply,
+  options: {
+    signal: AbortSignal
+    workerId?: number
+  },
+  client: ProfilingRuntimeApiClient = asProfilingRuntimeApiClient(new RuntimeApiClient())
+) {
+  return withProfilingClient(
+    reply,
+    {
+      client,
+      notAvailableMessage:
+        'heap snapshot capture is only available when running under Platformatic Watt.',
+      workerId: options.workerId,
+    },
+    async (client, selection, controls) => {
+      if (options.workerId === undefined) {
+        return reply.status(400).send({
+          message:
+            'Full heap snapshots are per V8 isolate; pass workerId to capture exactly one worker.' +
+            formatWorkerIds(getSelectionWorkerIds(selection)),
         })
       }
 
-      throw error
-    } finally {
-      // onClose clears the shared session registry before it stops any in-flight captures, so
-      // only the code path that still owns the registry entry should perform the final stop here.
-      if (session && activePprofSessions.has(session.key)) {
-        await stopPprofSession(client, session).catch(() => {})
+      const target = selection.targets[0]
+      const session: ActiveHeapSnapshotSession = {
+        closeClient: controls.closeClient,
+        key: buildHeapSnapshotSessionKey(selection, target),
+      }
+
+      if (activeHeapSnapshotSessions.has(session.key)) {
+        throw createHeapSnapshotAlreadyStartedError(selection, target)
+      }
+
+      activeHeapSnapshotSessions.set(session.key, session)
+
+      const abortHandler = () => {
+        session.stream?.destroy(createAbortError())
+        void controls.closeClient()
+      }
+      options.signal.addEventListener('abort', abortHandler, { once: true })
+
+      try {
+        const snapshot = await client.takeApplicationHeapSnapshot(
+          target.runtimePid,
+          target.targetApplicationId
+        )
+        session.stream = snapshot
+
+        if (options.signal.aborted) {
+          snapshot.destroy(createAbortError())
+          return reply
+        }
+
+        closeHeapSnapshotSessionWhenStreamEnds(reply, session, options.signal, abortHandler)
+        controls.keepClientOpen()
+
+        return reply.headers(buildHeapSnapshotResponseHeaders(selection, target)).send(snapshot)
+      } catch (error) {
+        const workerIds = resolveRuntimeWorkerIdsFromError(error)
+
+        if (workerIds && workerIds.length > 0) {
+          return reply.status(400).send({
+            message: `Worker ${options.workerId} is not available.${formatWorkerIds(workerIds)}`,
+          })
+        }
+
+        if (options.signal.aborted) {
+          return reply
+        }
+
+        throw error
+      } finally {
+        if (!session.stream || options.signal.aborted) {
+          cleanupHeapSnapshotSession(session, options.signal, abortHandler)
+        }
       }
     }
-  } finally {
-    await client.close().catch(() => {})
-  }
+  )
+}
+
+async function stopActiveHeapSnapshotSessions() {
+  const pendingSessions = [...activeHeapSnapshotSessions.values()]
+  activeHeapSnapshotSessions.clear()
+
+  await Promise.allSettled(
+    pendingSessions.map(async (session) => {
+      session.stream?.destroy(createAbortError())
+      await session.closeClient()
+    })
+  )
 }
 
 async function stopActivePprofSessions(client: ProfilingRuntimeApiClient) {
@@ -331,20 +575,35 @@ async function stopActivePprofSessions(client: ProfilingRuntimeApiClient) {
   )
 }
 
+async function stopActiveSessions() {
+  const pendingSnapshotCount = activeHeapSnapshotSessions.size
+  const pendingPprofCount = activePprofSessions.size
+
+  if (pendingSnapshotCount > 0) {
+    await stopActiveHeapSnapshotSessions()
+  }
+
+  if (pendingPprofCount === 0) {
+    return
+  }
+
+  const client = asProfilingRuntimeApiClient(new RuntimeApiClient())
+
+  try {
+    await stopActivePprofSessions(client)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
 export default async function routes(fastify: FastifyInstance) {
   registerApiKeyAuth(fastify)
   fastify.addHook('onClose', async () => {
-    if (activePprofSessions.size === 0) {
+    if (activePprofSessions.size === 0 && activeHeapSnapshotSessions.size === 0) {
       return
     }
 
-    const client = asProfilingRuntimeApiClient(new RuntimeApiClient())
-
-    try {
-      await stopActivePprofSessions(client)
-    } finally {
-      await client.close().catch(() => {})
-    }
+    await stopActiveSessions()
   })
 
   fastify.get<CpuProfileRequest>(
@@ -378,6 +637,17 @@ export default async function routes(fastify: FastifyInstance) {
       }
 
       return captureAndSendPprof(reply, options)
+    }
+  )
+
+  fastify.get<HeapSnapshotRequest>(
+    '/heap-snapshot',
+    { schema: heapSnapshotSchema },
+    async (request, reply) => {
+      return captureAndSendHeapSnapshot(reply, {
+        signal: request.signals.disconnect.signal,
+        workerId: request.query.workerId,
+      })
     }
   )
 }

--- a/src/internal/monitoring/pprof/client-http.ts
+++ b/src/internal/monitoring/pprof/client-http.ts
@@ -6,6 +6,22 @@ const PPROF_ERROR_BODY_MAX_BYTES = 4 * 1024
 
 type PprofQueryValue = boolean | number | string | undefined
 
+type FetchPprofStreamOptions = {
+  adminUrl: string
+  apiKey: string
+  workerId?: number
+} & (
+  | {
+      nodeModulesSourceMaps?: string
+      seconds: number
+      sourceMaps?: boolean
+      type: Exclude<PprofRequestTargetType, 'heap-snapshot'>
+    }
+  | {
+      type: 'heap-snapshot'
+    }
+)
+
 export function resolvePprofAdminUrl(
   baseUrl: string,
   requestPath: string,
@@ -75,25 +91,24 @@ async function readResponseBody(response: Response) {
   return truncated ? `: ${bodyText}… [truncated]` : `: ${bodyText}`
 }
 
-export async function fetchPprofStream(options: {
-  adminUrl: string
-  apiKey: string
-  nodeModulesSourceMaps?: string
-  seconds: number
-  sourceMaps?: boolean
-  type: PprofRequestTargetType
-  workerId?: number
-}) {
+export async function fetchPprofStream(options: FetchPprofStreamOptions) {
+  const isHeapSnapshot = options.type === 'heap-snapshot'
+  const pprofParams =
+    options.type === 'heap-snapshot'
+      ? {}
+      : {
+          nodeModulesSourceMaps: options.nodeModulesSourceMaps,
+          seconds: options.seconds,
+          sourceMaps: options.sourceMaps,
+        }
   const response = await fetch(
     resolvePprofAdminUrl(options.adminUrl, `/debug/pprof/${options.type}`, {
-      nodeModulesSourceMaps: options.nodeModulesSourceMaps,
-      seconds: options.seconds,
-      sourceMaps: options.sourceMaps,
+      ...pprofParams,
       workerId: options.workerId,
     }),
     {
       headers: {
-        Accept: 'multipart/mixed',
+        Accept: isHeapSnapshot ? 'application/octet-stream' : 'multipart/mixed',
         ApiKey: options.apiKey,
       },
       method: 'GET',
@@ -112,6 +127,7 @@ export async function fetchPprofStream(options: {
   }
 
   return {
+    contentDisposition: response.headers.get('content-disposition') ?? undefined,
     contentType: response.headers.get('content-type') ?? undefined,
     // Node's Readable.fromWeb expects the stream/web type, while fetch exposes the DOM shape.
     stream: Readable.fromWeb(response.body as unknown as NodeReadableStream),

--- a/src/internal/monitoring/pprof/client.test.ts
+++ b/src/internal/monitoring/pprof/client.test.ts
@@ -80,6 +80,39 @@ describe('fetchPprofStream', () => {
     expect(await readStream(response.stream)).toBe('profile-data')
   })
 
+  it('requests full heap snapshots as raw binary output without pprof query params', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('{"snapshot":true}', {
+        headers: {
+          'content-disposition': 'attachment; filename="storage-worker-7.heapsnapshot"',
+          'content-type': 'application/octet-stream',
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await fetchPprofStream({
+      adminUrl: 'https://example.com/admin',
+      apiKey: 'secret',
+      type: 'heap-snapshot',
+      workerId: 7,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/admin/debug/pprof/heap-snapshot?workerId=7',
+      {
+        headers: {
+          Accept: 'application/octet-stream',
+          ApiKey: 'secret',
+        },
+        method: 'GET',
+      }
+    )
+    expect(response.contentDisposition).toBe('attachment; filename="storage-worker-7.heapsnapshot"')
+    expect(response.contentType).toBe('application/octet-stream')
+    expect(await readStream(response.stream)).toBe('{"snapshot":true}')
+  })
+
   it('surfaces non-2xx responses with the response body', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('upstream failure', {

--- a/src/internal/monitoring/pprof/download.test.ts
+++ b/src/internal/monitoring/pprof/download.test.ts
@@ -1,9 +1,10 @@
+import nodeFs from 'fs'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { Readable } from 'stream'
+import { Readable, Writable } from 'stream'
 import { vi } from 'vitest'
-import { writeMultipartPprofToFile } from './download'
+import { writeMultipartPprofToFile, writePprofCaptureToFile } from './download'
 
 function buildMultipartBody(
   boundary: string,
@@ -48,6 +49,31 @@ function splitBuffer(buffer: Buffer, chunkSize: number) {
   }
 
   return chunks
+}
+
+function createIndexedAccessCountingChunk(content: Buffer) {
+  let indexedAccesses = 0
+  const bytes = new Uint8Array(content)
+  const chunk = new Proxy(bytes, {
+    get(target, property, receiver) {
+      if (typeof property === 'string' && /^\d+$/.test(property)) {
+        indexedAccesses += 1
+      }
+
+      if (property === 'byteLength' || property === 'length' || property === 'buffer') {
+        return Reflect.get(target, property, target)
+      }
+
+      return Reflect.get(target, property, receiver)
+    },
+  })
+
+  return {
+    chunk,
+    get indexedAccesses() {
+      return indexedAccesses
+    },
+  }
 }
 
 describe('writeMultipartPprofToFile', () => {
@@ -458,5 +484,204 @@ describe('writeMultipartPprofToFile', () => {
         'Pprof capture stream ended before the profile was delivered for storage (cpu, 45s).'
       ),
     })
+  })
+
+  it('does not add an error listener per backpressured profile write', async () => {
+    const boundary = 'pprof-test-boundary'
+    const profile = Buffer.alloc(24, 0x1)
+    const outputPath = path.join(tempDir, 'profile.pprof')
+    const writeStream = new Writable({
+      highWaterMark: 1,
+      write(_chunk, _encoding, callback) {
+        setImmediate(callback)
+      },
+    })
+    vi.spyOn(nodeFs, 'createWriteStream').mockReturnValue(writeStream as nodeFs.WriteStream)
+
+    const body = buildMultipartBody(boundary, [
+      {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            applicationId: 'storage',
+            event: 'started',
+            filename: 'storage-cpu.pprof',
+            seconds: 60,
+            servingWorkerId: 2,
+            type: 'cpu',
+          }),
+          'utf8'
+        ),
+      },
+      {
+        headers: {
+          'Content-Disposition': 'attachment; filename="storage-cpu.pprof"',
+          'Content-Type': 'application/octet-stream',
+        },
+        body: profile,
+      },
+    ])
+
+    await writeMultipartPprofToFile(
+      Readable.from(splitBuffer(body, 1)),
+      `multipart/mixed; boundary="${boundary}"`,
+      {
+        outputPath,
+      }
+    )
+
+    expect(writeStream.listenerCount('error')).toBeLessThan(6)
+  })
+})
+
+describe('writePprofCaptureToFile', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pprof-download-'))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('writes raw full heap snapshot streams using the response filename', async () => {
+    const snapshot = Buffer.from('{"snapshot":true}')
+    vi.spyOn(process, 'cwd').mockReturnValue(tempDir)
+
+    const result = await writePprofCaptureToFile(Readable.from(splitBuffer(snapshot, 5)), {
+      contentDisposition: 'attachment; filename="..\\\\storage-worker-7.heapsnapshot"',
+      contentType: 'application/octet-stream',
+      type: 'heap-snapshot',
+    })
+
+    const expectedOutputPath = path.join(tempDir, 'dist', 'storage-worker-7.heapsnapshot')
+    expect(result.outputPath).toBe(expectedOutputPath)
+    expect(result).not.toHaveProperty('startedEvent')
+    await expect(fs.readFile(expectedOutputPath)).resolves.toEqual(snapshot)
+  })
+
+  it('uses a heap-snapshot fallback filename for malformed raw capture filenames', async () => {
+    const snapshot = Buffer.from('{"snapshot":true}')
+    vi.spyOn(process, 'cwd').mockReturnValue(tempDir)
+
+    const result = await writePprofCaptureToFile(Readable.from([snapshot]), {
+      contentDisposition: 'attachment; filename=".."',
+      contentType: 'application/octet-stream',
+      type: 'heap-snapshot',
+    })
+
+    const expectedOutputPath = path.join(tempDir, 'dist', 'heap-snapshot.heapsnapshot')
+    expect(result.outputPath).toBe(expectedOutputPath)
+    await expect(fs.readFile(expectedOutputPath)).resolves.toEqual(snapshot)
+  })
+
+  it('rejects empty raw full heap snapshot responses', async () => {
+    await expect(
+      writePprofCaptureToFile(Readable.from([]), {
+        contentDisposition: 'attachment; filename="empty.heapsnapshot"',
+        contentType: 'application/octet-stream',
+        type: 'heap-snapshot',
+      })
+    ).rejects.toThrow('Heap snapshot response was empty.')
+  })
+
+  it('rejects truncated raw full heap snapshot responses', async () => {
+    await expect(
+      writePprofCaptureToFile(Readable.from(['{"snapshot":true']), {
+        contentDisposition: 'attachment; filename="truncated.heapsnapshot"',
+        contentType: 'application/octet-stream',
+        type: 'heap-snapshot',
+      })
+    ).rejects.toThrow('Heap snapshot response is not a complete JSON object.')
+  })
+
+  it('does not scan every byte in heap snapshot chunks after finding the opening brace', async () => {
+    const writeStream = new Writable({
+      objectMode: true,
+      write(_chunk, _encoding, callback) {
+        callback()
+      },
+    })
+    vi.spyOn(nodeFs, 'createWriteStream').mockReturnValue(writeStream as nodeFs.WriteStream)
+
+    const firstChunk = createIndexedAccessCountingChunk(Buffer.from('{'))
+    const middleChunk = createIndexedAccessCountingChunk(Buffer.alloc(10_000, 0x78))
+    const lastChunk = createIndexedAccessCountingChunk(Buffer.from('}'))
+
+    await writePprofCaptureToFile(
+      Readable.from([firstChunk.chunk, middleChunk.chunk, lastChunk.chunk]),
+      {
+        contentDisposition: 'attachment; filename="profile.heapsnapshot"',
+        contentType: 'application/octet-stream',
+        type: 'heap-snapshot',
+      },
+      {
+        outputPath: path.join(tempDir, 'profile.heapsnapshot'),
+      }
+    )
+
+    expect(middleChunk.indexedAccesses).toBeLessThan(10)
+  })
+
+  it('keeps pprof captures on the multipart parser even with malformed response content-type', async () => {
+    await expect(
+      writePprofCaptureToFile(Readable.from(['profile-data']), {
+        contentType: 'application/octet-stream',
+        type: 'heap',
+      })
+    ).rejects.toThrow('Expected a multipart/mixed pprof response with a boundary parameter.')
+  })
+
+  it('keeps multipart pprof behavior behind the generic capture writer', async () => {
+    const boundary = 'pprof-test-boundary'
+    const profile = Buffer.from([1, 2, 3])
+    const outputPath = path.join(tempDir, 'profile.pprof')
+    const body = buildMultipartBody(boundary, [
+      {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            applicationId: 'storage',
+            event: 'started',
+            filename: 'storage-cpu.pprof',
+            seconds: 60,
+            type: 'cpu',
+          }),
+          'utf8'
+        ),
+      },
+      {
+        headers: {
+          'Content-Disposition': 'attachment; filename="storage-cpu.pprof"',
+          'Content-Type': 'application/octet-stream',
+        },
+        body: profile,
+      },
+    ])
+
+    const result = await writePprofCaptureToFile(
+      Readable.from(splitBuffer(body, 7)),
+      {
+        contentType: `multipart/mixed; boundary=${boundary}`,
+        type: 'profile',
+      },
+      {
+        outputPath,
+      }
+    )
+
+    expect(result.outputPath).toBe(outputPath)
+    expect(result.startedEvent).toMatchObject({
+      applicationId: 'storage',
+      type: 'cpu',
+    })
+    await expect(fs.readFile(outputPath)).resolves.toEqual(profile)
   })
 })

--- a/src/internal/monitoring/pprof/download.ts
+++ b/src/internal/monitoring/pprof/download.ts
@@ -1,6 +1,10 @@
+import { once } from 'events'
 import fs from 'fs'
 import { mkdir } from 'fs/promises'
 import path from 'path'
+import { PassThrough } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { PprofRequestTargetType } from './types'
 
 export interface MultipartPprofStartedEvent {
   applicationId: string
@@ -11,6 +15,11 @@ export interface MultipartPprofStartedEvent {
   type: 'cpu' | 'heap'
   workerCount?: number
   workerId?: number
+}
+
+export interface PprofCaptureFileResult {
+  outputPath: string
+  startedEvent?: MultipartPprofStartedEvent
 }
 
 export interface MultipartPprofPingEvent {
@@ -42,6 +51,7 @@ enum MultipartState {
 }
 
 const DEFAULT_PPROF_FILENAME = 'profile.pprof'
+const DEFAULT_HEAP_SNAPSHOT_FILENAME = 'heap-snapshot.heapsnapshot'
 
 export function extractMultipartBoundary(contentType: string | undefined) {
   if (!contentType) {
@@ -107,11 +117,11 @@ function parseMultipartFilename(headers: MultipartHeaders) {
   return plainMatch?.[1]?.trim()
 }
 
-function sanitizeMultipartFilename(filename: string) {
+function sanitizeMultipartFilename(filename: string, fallback = DEFAULT_PPROF_FILENAME) {
   const sanitized = path.posix.basename(filename.trim().replaceAll('\\', '/'))
 
   if (!sanitized || sanitized === '.' || sanitized === '..') {
-    return DEFAULT_PPROF_FILENAME
+    return fallback
   }
 
   return sanitized
@@ -122,16 +132,84 @@ async function openOutputFile(filePath: string) {
   return fs.createWriteStream(filePath)
 }
 
-async function closeOutputFile(stream: fs.WriteStream | undefined) {
-  if (!stream) {
-    return
+function isJsonWhitespace(byte: number) {
+  return byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d
+}
+
+type HeapSnapshotChunk = Buffer | string | Uint8Array
+
+function getChunkByteLength(chunk: HeapSnapshotChunk) {
+  return typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength
+}
+
+function getChunkLength(chunk: HeapSnapshotChunk) {
+  return chunk.length
+}
+
+function getChunkByte(chunk: HeapSnapshotChunk, index: number) {
+  return typeof chunk === 'string' ? chunk.charCodeAt(index) : chunk[index]
+}
+
+function findFirstNonWhitespaceByte(chunk: HeapSnapshotChunk) {
+  for (let index = 0; index < getChunkLength(chunk); index += 1) {
+    const byte = getChunkByte(chunk, index)
+    if (!isJsonWhitespace(byte)) {
+      return byte
+    }
   }
 
-  await new Promise<void>((resolve, reject) => {
-    stream.once('finish', resolve)
-    stream.once('error', reject)
-    stream.end()
-  })
+  return undefined
+}
+
+function findLastNonWhitespaceByte(chunk: HeapSnapshotChunk) {
+  for (let index = getChunkLength(chunk) - 1; index >= 0; index -= 1) {
+    const byte = getChunkByte(chunk, index)
+    if (!isJsonWhitespace(byte)) {
+      return byte
+    }
+  }
+
+  return undefined
+}
+
+async function* validateHeapSnapshotChunks(source: AsyncIterable<Buffer | string | Uint8Array>) {
+  let bytes = 0
+  let firstNonWhitespace: number | undefined
+  let lastNonWhitespace: number | undefined
+
+  for await (const chunk of source) {
+    const byteLength = getChunkByteLength(chunk)
+    bytes += byteLength
+
+    if (byteLength > 0) {
+      if (firstNonWhitespace === undefined) {
+        firstNonWhitespace = findFirstNonWhitespaceByte(chunk)
+      }
+
+      const chunkLastNonWhitespace = findLastNonWhitespaceByte(chunk)
+      if (chunkLastNonWhitespace !== undefined) {
+        lastNonWhitespace = chunkLastNonWhitespace
+      }
+    }
+
+    yield chunk
+  }
+
+  if (bytes === 0) {
+    throw new Error('Heap snapshot response was empty.')
+  }
+
+  if (firstNonWhitespace !== 0x7b || lastNonWhitespace !== 0x7d) {
+    throw new Error('Heap snapshot response is not a complete JSON object.')
+  }
+}
+
+async function writeHeapSnapshotStreamToFile(stream: NodeJS.ReadableStream, outputPath: string) {
+  await pipeline(
+    stream as AsyncIterable<Buffer | string | Uint8Array>,
+    validateHeapSnapshotChunks,
+    fs.createWriteStream(outputPath)
+  )
 }
 
 function getErrorCause(error: unknown) {
@@ -218,7 +296,7 @@ export async function writeMultipartPprofToFile(
   options?: {
     outputPath?: string
   }
-) {
+): Promise<PprofCaptureFileResult> {
   const boundary = extractMultipartBoundary(contentType)
   if (!boundary) {
     throw new Error('Expected a multipart/mixed pprof response with a boundary parameter.')
@@ -230,8 +308,9 @@ export async function writeMultipartPprofToFile(
   let currentHeaders: MultipartHeaders = {}
   let currentLength = 0
   let jsonChunks: Buffer[] = []
-  let outputFile: fs.WriteStream | undefined
   let outputPath = options?.outputPath ? path.resolve(options.outputPath) : undefined
+  let profileBodyStream: PassThrough | undefined
+  let profileOutputPipeline: Promise<void> | undefined
   let receivedProfile = false
   let startedEvent: MultipartPprofStartedEvent | undefined
   let lastHeartbeatAt: string | undefined
@@ -265,8 +344,8 @@ export async function writeMultipartPprofToFile(
   }
 
   const openProfileOutput = async () => {
-    if (outputFile) {
-      return outputFile
+    if (profileBodyStream) {
+      return profileBodyStream
     }
 
     const filename = sanitizeMultipartFilename(
@@ -274,8 +353,53 @@ export async function writeMultipartPprofToFile(
     )
 
     outputPath ??= path.resolve(process.cwd(), 'dist', filename)
-    outputFile = await openOutputFile(outputPath)
-    return outputFile
+    const outputFile = await openOutputFile(outputPath)
+    profileBodyStream = new PassThrough()
+    profileOutputPipeline = pipeline(profileBodyStream, outputFile)
+    void profileOutputPipeline.catch(() => {})
+    return profileBodyStream
+  }
+
+  const getProfileOutputPipeline = () => {
+    if (!profileOutputPipeline) {
+      throw new Error('Profile output pipeline was not initialized.')
+    }
+
+    return profileOutputPipeline
+  }
+
+  const writeProfileChunk = async (chunk: Buffer) => {
+    const profileBody = await openProfileOutput()
+    if (profileBody.write(chunk)) {
+      return
+    }
+
+    await Promise.race([
+      once(profileBody, 'drain').then(() => undefined),
+      getProfileOutputPipeline(),
+    ])
+  }
+
+  const finishProfileOutput = async () => {
+    if (!profileBodyStream) {
+      return
+    }
+
+    profileBodyStream.end()
+    await getProfileOutputPipeline()
+    profileBodyStream = undefined
+    profileOutputPipeline = undefined
+  }
+
+  const abortProfileOutput = async () => {
+    if (!profileBodyStream) {
+      return
+    }
+
+    profileBodyStream.destroy()
+    await profileOutputPipeline?.catch(() => {})
+    profileBodyStream = undefined
+    profileOutputPipeline = undefined
   }
 
   const consumeBoundaryLine = () => {
@@ -331,20 +455,13 @@ export async function writeMultipartPprofToFile(
   }
 
   const consumeProfileBody = async () => {
-    const file = await openProfileOutput()
     const bytesToWrite = Math.min(currentLength, buffer.length)
 
     if (bytesToWrite > 0) {
       const chunk = buffer.subarray(0, bytesToWrite)
       buffer = buffer.subarray(bytesToWrite)
       currentLength -= bytesToWrite
-
-      if (!file.write(chunk)) {
-        await new Promise<void>((resolve, reject) => {
-          file.once('drain', resolve)
-          file.once('error', reject)
-        })
-      }
+      await writeProfileChunk(chunk)
     }
 
     if (currentLength > 0) {
@@ -360,6 +477,7 @@ export async function writeMultipartPprofToFile(
     }
 
     buffer = buffer.subarray(2)
+    await finishProfileOutput()
     receivedProfile = true
     parserState.value = MultipartState.Boundary
     return true
@@ -423,7 +541,7 @@ export async function writeMultipartPprofToFile(
       throw error
     }
   } finally {
-    await closeOutputFile(outputFile)
+    await abortProfileOutput()
   }
 
   if (parserState.value !== MultipartState.Done) {
@@ -446,5 +564,39 @@ export async function writeMultipartPprofToFile(
   return {
     outputPath,
     startedEvent,
+  }
+}
+
+export async function writePprofCaptureToFile(
+  stream: NodeJS.ReadableStream,
+  response: {
+    contentDisposition?: string
+    contentType?: string
+    type: PprofRequestTargetType
+  },
+  options?: {
+    outputPath?: string
+  }
+): Promise<PprofCaptureFileResult> {
+  if (response.type !== 'heap-snapshot') {
+    return writeMultipartPprofToFile(stream, response.contentType, options)
+  }
+
+  const filename = sanitizeMultipartFilename(
+    parseMultipartFilename({
+      'content-disposition': response.contentDisposition ?? '',
+    }) ?? DEFAULT_HEAP_SNAPSHOT_FILENAME,
+    DEFAULT_HEAP_SNAPSHOT_FILENAME
+  )
+  const outputPath = options?.outputPath
+    ? path.resolve(options.outputPath)
+    : path.resolve(process.cwd(), 'dist', filename)
+
+  await mkdir(path.dirname(outputPath), { recursive: true })
+  await writeHeapSnapshotStreamToFile(stream, outputPath)
+  console.log(`Saved pprof capture to ${outputPath}.`)
+
+  return {
+    outputPath,
   }
 }

--- a/src/internal/monitoring/pprof/runtime.test.ts
+++ b/src/internal/monitoring/pprof/runtime.test.ts
@@ -13,6 +13,7 @@ import { FailedToStartProfiling } from '@platformatic/control'
 import { WorkerNotFoundError } from '@platformatic/runtime/lib/errors.js'
 import {
   asProfilingRuntimeApiClient,
+  buildHeapSnapshotFilename,
   buildPprofFilename,
   buildPprofResponseHeaders,
   buildPprofSessionKey,
@@ -40,6 +41,7 @@ function createClient(overrides?: {
   getRuntimeApplications?: ProfilingRuntimeApiClient['getRuntimeApplications']
   startApplicationProfiling?: ProfilingRuntimeApiClient['startApplicationProfiling']
   stopApplicationProfiling?: ProfilingRuntimeApiClient['stopApplicationProfiling']
+  takeApplicationHeapSnapshot?: ProfilingRuntimeApiClient['takeApplicationHeapSnapshot']
 }) {
   return {
     close: overrides?.close ?? vi.fn().mockResolvedValue(undefined),
@@ -52,6 +54,8 @@ function createClient(overrides?: {
       overrides?.startApplicationProfiling ?? vi.fn().mockResolvedValue(undefined),
     stopApplicationProfiling:
       overrides?.stopApplicationProfiling ?? vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+    takeApplicationHeapSnapshot:
+      overrides?.takeApplicationHeapSnapshot ?? vi.fn().mockResolvedValue(undefined),
   } satisfies ProfilingRuntimeApiClient
 }
 
@@ -87,6 +91,19 @@ describe('pprof runtime helpers', () => {
           'cpu'
         )
       ).toBe('storage-api-v1-worker-3-cpu.pprof')
+    })
+  })
+
+  describe('buildHeapSnapshotFilename', () => {
+    it('sanitizes application ids and includes worker ids when present', () => {
+      expect(
+        buildHeapSnapshotFilename({
+          applicationId: 'storage/api v1',
+          runtimePid: process.pid,
+          targetApplicationId: 'storage/api v1:3',
+          workerId: 3,
+        })
+      ).toBe('storage-api-v1-worker-3.heapsnapshot')
     })
   })
 
@@ -220,6 +237,18 @@ describe('pprof runtime helpers', () => {
       ).toEqual({
         code: PPROF_CONTROL_ERROR_CODES.failedToStart,
         message: 'missing @platformatic/wattpm-pprof-capture dependency',
+        statusCode: 502,
+      })
+
+      expect(
+        getKnownPprofError(
+          Object.assign(new Error('snapshot failed'), {
+            code: PPROF_CONTROL_ERROR_CODES.failedToTakeHeapSnapshot,
+          })
+        )
+      ).toEqual({
+        code: PPROF_CONTROL_ERROR_CODES.failedToTakeHeapSnapshot,
+        message: 'snapshot failed',
         statusCode: 502,
       })
 

--- a/src/internal/monitoring/pprof/runtime.ts
+++ b/src/internal/monitoring/pprof/runtime.ts
@@ -15,6 +15,7 @@ export const PPROF_CONTROL_ERROR_CODES = {
   applicationNotFound: 'PLT_CTR_APPLICATION_NOT_FOUND',
   failedToStart: 'PLT_CTR_FAILED_TO_START_PROFILING',
   failedToStop: 'PLT_CTR_FAILED_TO_STOP_PROFILING',
+  failedToTakeHeapSnapshot: 'PLT_CTR_FAILED_TO_TAKE_HEAP_SNAPSHOT',
   profilingAlreadyStarted: 'PLT_CTR_PROFILING_ALREADY_STARTED',
   profilingNotStarted: 'PLT_CTR_PROFILING_NOT_STARTED',
   runtimeNotFound: 'PLT_CTR_RUNTIME_NOT_FOUND',
@@ -171,6 +172,13 @@ export function buildPprofFilename(target: WattPprofTarget, type: PprofCaptureTy
   return `${safeApplicationId}${workerSuffix}-${type}.pprof`
 }
 
+export function buildHeapSnapshotFilename(target: WattPprofTarget) {
+  const safeApplicationId = target.applicationId.replace(/[^A-Za-z0-9._-]+/g, '-')
+  const workerSuffix = target.workerId === undefined ? '' : `-worker-${target.workerId}`
+
+  return `${safeApplicationId}${workerSuffix}.heapsnapshot`
+}
+
 export function resolvePprofFilenameTarget(selection: WattPprofSelection) {
   return selection.requestedWorkerId === undefined
     ? { ...selection.targets[0], workerId: undefined }
@@ -185,6 +193,19 @@ export function buildPprofResponseHeaders(selection: WattPprofSelection, content
     ...(selection.requestedWorkerId !== undefined
       ? { 'x-platformatic-worker-id': `${selection.requestedWorkerId}` }
       : { 'x-platformatic-worker-count': `${selection.targets.length}` }),
+  }
+}
+
+export function buildHeapSnapshotResponseHeaders(
+  selection: WattPprofSelection,
+  target: WattPprofTarget
+) {
+  return {
+    'cache-control': 'no-store',
+    'content-disposition': `attachment; filename="${buildHeapSnapshotFilename(target)}"`,
+    'content-type': 'application/octet-stream',
+    'x-platformatic-application-id': selection.applicationId,
+    ...(target.workerId !== undefined ? { 'x-platformatic-worker-id': `${target.workerId}` } : {}),
   }
 }
 
@@ -314,6 +335,12 @@ export function getKnownPprofError(error: unknown): PprofKnownError | undefined 
         message,
         statusCode: isMissingPprofCaptureDependency(error) ? 501 : 502,
       }
+    case PPROF_CONTROL_ERROR_CODES.failedToTakeHeapSnapshot:
+      return {
+        code,
+        message,
+        statusCode: 502,
+      }
     default:
       return undefined
   }
@@ -330,7 +357,9 @@ export function asProfilingRuntimeApiClient(value: unknown): ProfilingRuntimeApi
     'startApplicationProfiling' in value &&
     typeof value.startApplicationProfiling === 'function' &&
     'stopApplicationProfiling' in value &&
-    typeof value.stopApplicationProfiling === 'function'
+    typeof value.stopApplicationProfiling === 'function' &&
+    'takeApplicationHeapSnapshot' in value &&
+    typeof value.takeApplicationHeapSnapshot === 'function'
   ) {
     return value as ProfilingRuntimeApiClient
   }

--- a/src/internal/monitoring/pprof/types.ts
+++ b/src/internal/monitoring/pprof/types.ts
@@ -1,5 +1,8 @@
+import type { Readable } from 'stream'
+
 export type PprofCaptureType = 'cpu' | 'heap'
-export type PprofRequestTargetType = 'heap' | 'profile'
+export type PprofRequestTargetType = 'heap' | 'heap-snapshot' | 'profile'
+export type HeapSnapshotStream = Readable
 
 export interface WattPprofTarget {
   applicationId: string
@@ -72,6 +75,7 @@ export interface ProfilingRuntimeApiClient {
       type: PprofCaptureType
     }
   ): Promise<ArrayBuffer>
+  takeApplicationHeapSnapshot(pid: number, applicationId: string): Promise<HeapSnapshotStream>
 }
 
 export type RuntimeApplicationWorkersShape = {

--- a/src/scripts/pprof-client.test.ts
+++ b/src/scripts/pprof-client.test.ts
@@ -4,6 +4,7 @@ import {
   parseNonNegativeIntegerEnv,
   parsePositiveIntegerEnv,
   parsePprofTarget,
+  resolvePprofClientFlameMdFormat,
 } from './pprof-client'
 
 describe('parsePprofTarget', () => {
@@ -15,6 +16,9 @@ describe('parsePprofTarget', () => {
     expect(parsePprofTarget('heap', 30)).toEqual({
       seconds: 30,
       type: 'heap',
+    })
+    expect(parsePprofTarget('heap-snapshot', 30)).toEqual({
+      type: 'heap-snapshot',
     })
   })
 
@@ -32,6 +36,7 @@ describe('parsePprofTarget', () => {
   it('rejects invalid targets', () => {
     expect(() => parsePprofTarget(undefined, 60)).toThrow('Usage:')
     expect(() => parsePprofTarget('cpu', 60)).toThrow('Usage:')
+    expect(() => parsePprofTarget('heap-snapshot:10', 60)).toThrow('Usage:')
     expect(() => parsePprofTarget('profile:abc', 60)).toThrow('seconds must be a positive integer')
     expect(() => parsePprofTarget('heap:0', 60)).toThrow('seconds must be a positive integer')
     expect(() => parsePprofTarget('profile:10abc', 60)).toThrow(
@@ -76,5 +81,22 @@ describe('pprof client env parsing', () => {
     expect(() => parseNonNegativeIntegerEnv('7x', 'PPROF_WORKER_ID')).toThrow(
       'PPROF_WORKER_ID must be a non-negative integer'
     )
+  })
+})
+
+describe('resolvePprofClientFlameMdFormat', () => {
+  it('only resolves the flame markdown format when flame generation will run', () => {
+    expect(
+      resolvePprofClientFlameMdFormat(false, { type: 'profile', seconds: 60 }, 'invalid')
+    ).toBeUndefined()
+    expect(
+      resolvePprofClientFlameMdFormat(true, { type: 'heap-snapshot' }, 'invalid')
+    ).toBeUndefined()
+    expect(resolvePprofClientFlameMdFormat(true, { type: 'profile', seconds: 60 }, 'summary')).toBe(
+      'summary'
+    )
+    expect(() =>
+      resolvePprofClientFlameMdFormat(true, { type: 'heap', seconds: 60 }, 'invalid')
+    ).toThrow('Invalid PPROF_FLAME_MD_FORMAT')
   })
 })

--- a/src/scripts/pprof-client.ts
+++ b/src/scripts/pprof-client.ts
@@ -1,5 +1,5 @@
 import { fetchPprofStream } from '@internal/monitoring/pprof/client-http'
-import { writeMultipartPprofToFile } from '@internal/monitoring/pprof/download'
+import { writePprofCaptureToFile } from '@internal/monitoring/pprof/download'
 import { generateFlameArtifacts, resolveFlameMdFormat } from '@internal/monitoring/pprof/flame'
 import type { PprofRequestTargetType } from '@internal/monitoring/pprof/types'
 import path from 'path'
@@ -13,6 +13,8 @@ const PPROF_WORKER_ID = process.env.PPROF_WORKER_ID
 const PPROF_SOURCE_MAPS = process.env.PPROF_SOURCE_MAPS
 const PPROF_NODE_MODULES_SOURCE_MAPS = process.env.PPROF_NODE_MODULES_SOURCE_MAPS
 const PPROF_OUTPUT = process.env.PPROF_OUTPUT
+const PPROF_USAGE =
+  'Usage: tsx src/scripts/pprof-client.ts <profile[:seconds]|heap[:seconds]|heap-snapshot> [output-file]'
 
 export function parseBooleanEnv(value: string | undefined) {
   if (value === undefined) {
@@ -82,19 +84,29 @@ export function parseNonNegativeIntegerEnv(value: string | undefined, envName: s
 export function parsePprofTarget(
   value: string | undefined,
   defaultSeconds: number
-): { seconds: number; type: PprofRequestTargetType } {
+):
+  | { seconds: number; type: Exclude<PprofRequestTargetType, 'heap-snapshot'> }
+  | {
+      type: 'heap-snapshot'
+    } {
   if (!value) {
-    throw new Error(
-      'Usage: tsx src/scripts/pprof-client.ts <profile[:seconds]|heap[:seconds]> [output-file]'
-    )
+    throw new Error(PPROF_USAGE)
   }
 
   const [type, secondsValue, ...rest] = value.split(':')
 
-  if (rest.length > 0 || (type !== 'profile' && type !== 'heap')) {
-    throw new Error(
-      'Usage: tsx src/scripts/pprof-client.ts <profile[:seconds]|heap[:seconds]> [output-file]'
-    )
+  if (rest.length > 0 || (type !== 'profile' && type !== 'heap' && type !== 'heap-snapshot')) {
+    throw new Error(PPROF_USAGE)
+  }
+
+  if (type === 'heap-snapshot') {
+    if (secondsValue !== undefined) {
+      throw new Error(PPROF_USAGE)
+    }
+
+    return {
+      type,
+    }
   }
 
   if (secondsValue === undefined || secondsValue === '') {
@@ -113,6 +125,18 @@ export function parsePprofTarget(
     seconds,
     type,
   }
+}
+
+export function resolvePprofClientFlameMdFormat(
+  generateFlame: boolean,
+  target: ReturnType<typeof parsePprofTarget>,
+  value: string | undefined
+) {
+  if (!generateFlame || target.type === 'heap-snapshot') {
+    return undefined
+  }
+
+  return resolveFlameMdFormat(value)
 }
 
 function fail(message: string) {
@@ -151,17 +175,29 @@ async function main() {
     return
   }
 
-  const flameMdFormat = resolveFlameMdFormat(PPROF_FLAME_MD_FORMAT)
+  const flameMdFormat = resolvePprofClientFlameMdFormat(
+    generateFlame,
+    parsedTarget,
+    PPROF_FLAME_MD_FORMAT
+  )
 
-  const response = await fetchPprofStream({
-    adminUrl: ADMIN_URL,
-    apiKey: ADMIN_API_KEY,
-    nodeModulesSourceMaps: PPROF_NODE_MODULES_SOURCE_MAPS || undefined,
-    seconds: parsedTarget.seconds,
-    sourceMaps,
-    type: parsedTarget.type,
-    workerId,
-  })
+  const response =
+    parsedTarget.type === 'heap-snapshot'
+      ? await fetchPprofStream({
+          adminUrl: ADMIN_URL,
+          apiKey: ADMIN_API_KEY,
+          type: 'heap-snapshot',
+          workerId,
+        })
+      : await fetchPprofStream({
+          adminUrl: ADMIN_URL,
+          apiKey: ADMIN_API_KEY,
+          nodeModulesSourceMaps: PPROF_NODE_MODULES_SOURCE_MAPS || undefined,
+          seconds: parsedTarget.seconds,
+          sourceMaps,
+          type: parsedTarget.type,
+          workerId,
+        })
 
   const outputPath = outputArg
     ? path.resolve(outputArg)
@@ -169,15 +205,19 @@ async function main() {
       ? path.resolve(PPROF_OUTPUT)
       : undefined
 
-  const { outputPath: capturedProfilePath } = await writeMultipartPprofToFile(
+  const { outputPath: capturedProfilePath } = await writePprofCaptureToFile(
     response.stream,
-    response.contentType,
+    {
+      contentDisposition: response.contentDisposition,
+      contentType: response.contentType,
+      type: parsedTarget.type,
+    },
     {
       outputPath,
     }
   )
 
-  if (!generateFlame) {
+  if (!generateFlame || parsedTarget.type === 'heap-snapshot') {
     return
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Existing heap profile is sampled and only for profile duration. We can't take full heap snapshots. 

## What is the new behavior?

Add an admin endpoint to trigger heap snapshot and extend existing pprof client to download it.

## Additional context

Related to #1212 