### PR TITLE
fix: leverage stateless cdn cache manager

### DIFF
--- a/src/http/plugins/storage.ts
+++ b/src/http/plugins/storage.ts
@@ -1,5 +1,4 @@
 import { createStorageBackend, StorageBackendAdapter } from '@storage/backend'
-import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import type { Database } from '@storage/database'
 import { StoragePgDB } from '@storage/database'
 import { PassThroughLocation, TenantLocation } from '@storage/locator'
@@ -11,7 +10,6 @@ declare module 'fastify' {
   interface FastifyRequest {
     storage: Storage
     backend: StorageBackendAdapter
-    cdnCache: CdnCacheManager
   }
 }
 
@@ -42,7 +40,6 @@ export const storage = fastifyPlugin(
 
       request.backend = storageBackend
       request.storage = new Storage(storageBackend, database, location)
-      request.cdnCache = new CdnCacheManager(request.storage)
     })
 
     fastify.addHook('onClose', async () => {

--- a/src/http/routes/cdn/index.ts
+++ b/src/http/routes/cdn/index.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
-import { db, registerJwtAuth, requireTenantFeature, storage } from '../../plugins'
+import { registerJwtAuth, requireTenantFeature } from '../../plugins'
 import purgeCache from './purgeCache'
 
 const { dbServiceRole } = getConfig()
@@ -11,9 +11,6 @@ export default async function routes(fastify: FastifyInstance) {
       enforceJwtRoles: [dbServiceRole],
     })
     fastify.register(requireTenantFeature('purgeCache'))
-
-    fastify.register(db)
-    fastify.register(storage)
 
     fastify.register(purgeCache)
   })

--- a/src/http/routes/cdn/purgeCache.ts
+++ b/src/http/routes/cdn/purgeCache.ts
@@ -1,3 +1,4 @@
+import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema, createResponse } from '../../routes-helper'
@@ -50,6 +51,8 @@ interface PurgeTenantRequestInterface extends AuthenticatedRequest {
 }
 
 export default async function routes(fastify: FastifyInstance) {
+  const cdnCache = new CdnCacheManager()
+
   // Purge tenant cache
   fastify.delete<PurgeTenantRequestInterface>(
     '/',
@@ -66,7 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { transformations } = request.query
 
-      await request.cdnCache.purge({
+      await cdnCache.purge({
         type: transformations ? 'tenant-transforms' : 'tenant',
         tenant: request.tenantId,
       })
@@ -93,7 +96,7 @@ export default async function routes(fastify: FastifyInstance) {
       const { bucketName } = request.params
       const { transformations } = request.query
 
-      await request.cdnCache.purge({
+      await cdnCache.purge({
         type: transformations ? 'bucket-transforms' : 'bucket',
         bucket: bucketName,
         tenant: request.tenantId,
@@ -122,7 +125,7 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
       const { transformations } = request.query
 
-      await request.cdnCache.purge({
+      await cdnCache.purge({
         type: transformations ? 'object-transforms' : 'object',
         bucket: bucketName,
         objectName,

--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -1,4 +1,3 @@
-import type { Storage } from '@storage/storage'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 
@@ -17,21 +16,6 @@ async function importCdnCacheManager(config: CdnConfig = {}) {
   return import('./cdn-cache-manager')
 }
 
-function createStorageMock(findObject = vi.fn().mockResolvedValue({ id: 'object-id' })) {
-  const storageAsSuperUser = vi.fn(() => ({
-    findBucket: vi.fn().mockResolvedValue({ id: 'object-id' }),
-  }))
-  const asSuperUser = vi.fn(() => ({ findObject }))
-  const from = vi.fn(() => ({ asSuperUser }))
-
-  return {
-    storage: { from, asSuperUser: storageAsSuperUser } as unknown as Storage,
-    from,
-    asSuperUser,
-    findObject,
-  }
-}
-
 describe('CdnCacheManager', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -48,9 +32,8 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'object',
       tenant: 'tenant-ref',
       bucket: 'bucket-id',
@@ -88,9 +71,8 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: undefined,
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'object',
       tenant: 'tenant-ref',
       bucket: 'bucket-id',
@@ -119,10 +101,9 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
     await expect(
-      new CdnCacheManager(storage.storage).purge({
+      new CdnCacheManager().purge({
         type: 'object',
         tenant: 'tenant-ref',
         bucket: 'bucket-id',
@@ -148,10 +129,9 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
     await expect(
-      new CdnCacheManager(storage.storage).purge({
+      new CdnCacheManager().purge({
         type: 'object',
         tenant: 'tenant-ref',
         bucket: 'bucket-id',
@@ -175,10 +155,9 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
     await expect(
-      new CdnCacheManager(storage.storage).purge({
+      new CdnCacheManager().purge({
         type: 'object',
         tenant: 'tenant-ref',
         bucket: 'bucket-id',
@@ -194,17 +173,16 @@ describe('CdnCacheManager', () => {
     })
   })
 
-  it('requires a CDN purge endpoint URL before checking object existence', async () => {
+  it('requires a CDN purge endpoint URL before sending a purge request', async () => {
     const fetchMock = vi.fn<typeof fetch>()
     vi.stubGlobal('fetch', fetchMock)
 
     const { CdnCacheManager } = await importCdnCacheManager({
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
     await expect(
-      new CdnCacheManager(storage.storage).purge({
+      new CdnCacheManager().purge({
         type: 'object',
         tenant: 'tenant-ref',
         bucket: 'bucket-id',
@@ -215,7 +193,6 @@ describe('CdnCacheManager', () => {
       message: 'Missing Required Parameter CDN_PURGE_ENDPOINT_URL is not set',
     })
 
-    expect(storage.from).not.toHaveBeenCalled()
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -227,16 +204,12 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'bucket',
       tenant: 'tenant-ref',
       bucket: 'bucket-id',
     })
-
-    expect(storage.from).not.toHaveBeenCalled()
-    expect(storage.findObject).not.toHaveBeenCalled()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
@@ -264,15 +237,11 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'tenant',
       tenant: 'tenant-ref',
     })
-
-    expect(storage.from).not.toHaveBeenCalled()
-    expect(storage.findObject).not.toHaveBeenCalled()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
@@ -299,9 +268,8 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'object-transforms',
       tenant: 'tenant-ref',
       bucket: 'bucket-id',
@@ -335,16 +303,12 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'bucket-transforms',
       tenant: 'tenant-ref',
       bucket: 'bucket-id',
     })
-
-    expect(storage.from).not.toHaveBeenCalled()
-    expect(storage.findObject).not.toHaveBeenCalled()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
@@ -372,15 +336,11 @@ describe('CdnCacheManager', () => {
       cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
       cdnPurgeEndpointKey: 'test-key',
     })
-    const storage = createStorageMock()
 
-    await new CdnCacheManager(storage.storage).purge({
+    await new CdnCacheManager().purge({
       type: 'tenant-transforms',
       tenant: 'tenant-ref',
     })
-
-    expect(storage.from).not.toHaveBeenCalled()
-    expect(storage.findObject).not.toHaveBeenCalled()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 

--- a/src/storage/cdn/cdn-cache-manager.ts
+++ b/src/storage/cdn/cdn-cache-manager.ts
@@ -1,5 +1,4 @@
 import { ERRORS } from '@internal/errors'
-import { Storage } from '@storage/storage'
 import { Agent } from 'undici'
 
 import { getConfig } from '../../config'
@@ -81,8 +80,6 @@ async function assertOkResponse(response: Response) {
 }
 
 export class CdnCacheManager {
-  constructor(protected readonly storage: Storage) {}
-
   async purge(opts: PurgeCacheInput) {
     if (!cdnPurgeUrl) {
       throw ERRORS.MissingParameter('CDN_PURGE_ENDPOINT_URL is not set')

--- a/src/test/cdn.test.ts
+++ b/src/test/cdn.test.ts
@@ -1,9 +1,7 @@
 import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import { FastifyInstance } from 'fastify'
 import { SignJWT } from 'jose'
-import { Readable } from 'stream'
 import { getConfig, mergeConfig } from '../config'
-import { useStorage } from './utils/storage'
 
 getConfig()
 mergeConfig({
@@ -14,30 +12,21 @@ mergeConfig({
 const { serviceKeyAsync, anonKeyAsync, tenantId, jwtSecret } = getConfig()
 
 describe('CDN Cache Manager', () => {
-  const storageHook = useStorage()
   let appInstance: FastifyInstance
-  let buildApp: typeof import('../app').default
-
   const bucketName = 'cdn-cache-manager-test-' + Date.now()
-  beforeAll(async () => {
-    await storageHook.storage.createBucket({
-      id: bucketName,
-      name: bucketName,
-    })
-    buildApp = (await import('../app')).default
-  })
 
-  beforeEach(() => {
+  beforeAll(async () => {
+    const buildApp = (await import('../app')).default
     appInstance = buildApp()
   })
 
-  afterEach(async () => {
-    await appInstance.close()
+  afterEach(() => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
-  afterAll(() => {
+  afterAll(async () => {
+    await appInstance.close()
     getConfig({ reload: true })
   })
 
@@ -70,20 +59,8 @@ describe('CDN Cache Manager', () => {
     expect(responseAuthenticated.statusCode).toBe(403)
   })
 
-  it('will allow calling the purge endpoint when using service_key', async () => {
+  it('will allow purging an object when using service_key', async () => {
     const objectName = `purge-file-${Date.now()}.txt`
-    await storageHook.storage.from(bucketName).uploadNewObject({
-      isUpsert: true,
-      objectName,
-      userMetadata: {},
-      file: {
-        body: Readable.from(Buffer.from('test')),
-        cacheControl: 'public, max-age=31536000',
-        mimeType: 'text/plain',
-        isTruncated: () => false,
-      },
-    })
-
     const purgeSpy = vi.spyOn(CdnCacheManager.prototype, 'purge').mockResolvedValue(undefined)
 
     const response = await appInstance.inject({
@@ -108,18 +85,6 @@ describe('CDN Cache Manager', () => {
 
   it('will purge object transformations when transformations query param is true', async () => {
     const objectName = `purge-file-transforms-${Date.now()}.txt`
-    await storageHook.storage.from(bucketName).uploadNewObject({
-      isUpsert: true,
-      objectName,
-      userMetadata: {},
-      file: {
-        body: Readable.from(Buffer.from('test')),
-        cacheControl: 'public, max-age=31536000',
-        mimeType: 'text/plain',
-        isTruncated: () => false,
-      },
-    })
-
     const purgeSpy = vi.spyOn(CdnCacheManager.prototype, 'purge').mockResolvedValue(undefined)
 
     const response = await appInstance.inject({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for performance

## What is the current behavior?

Storage plugin attaches a cdn manager but it's stateless at this point. 

## What is the new behavior?

Remove cdn cache manager from storage plugin. Attach it as a singleton only for CDN routes.

## Additional context

It will reduce GC pressure.
