### PR TITLE
fix: cache fast path and less allocations for outcome

### DIFF
--- a/src/internal/cache/lru.test.ts
+++ b/src/internal/cache/lru.test.ts
@@ -41,6 +41,78 @@ describe('lru cache wrapper', () => {
     })
   })
 
+  test('plain get returns hits misses and stale values according to allowStale', () => {
+    const staleCache = createLruCache<string, { bytes: number }>({
+      max: 2,
+      ttl: 10,
+      allowStale: true,
+      perf: {
+        now: () => Date.now(),
+      },
+    })
+
+    staleCache.set('entry', { bytes: 1 })
+
+    expect(staleCache.get('entry')).toEqual({ bytes: 1 })
+    expect(staleCache.get('missing')).toBeUndefined()
+
+    vi.advanceTimersByTime(11)
+
+    expect(staleCache.get('entry')).toEqual({ bytes: 1 })
+
+    const expiringCache = createLruCache<string, { bytes: number }>({
+      max: 2,
+      ttl: 10,
+      allowStale: false,
+      perf: {
+        now: () => Date.now(),
+      },
+    })
+
+    expiringCache.set('entry', { bytes: 1 })
+
+    vi.advanceTimersByTime(11)
+
+    expect(expiringCache.get('entry')).toBeUndefined()
+  })
+
+  test('reuses getWithOutcome status without carrying outcomes across lookups', () => {
+    const cache = createLruCache<string, { bytes: number }>({
+      max: 2,
+      ttl: 10,
+      allowStale: true,
+      perf: {
+        now: () => Date.now(),
+      },
+    })
+
+    cache.set('fresh', { bytes: 1 })
+
+    expect(cache.getWithOutcome('fresh')).toEqual({
+      value: { bytes: 1 },
+      outcome: 'hit',
+    })
+    expect(cache.getWithOutcome('missing')).toEqual({
+      value: undefined,
+      outcome: 'miss',
+    })
+
+    cache.set('stale', { bytes: 2 })
+    vi.advanceTimersByTime(11)
+
+    expect(cache.getWithOutcome('stale')).toEqual({
+      value: { bytes: 2 },
+      outcome: 'stale',
+    })
+
+    cache.set('fresh-again', { bytes: 3 })
+
+    expect(cache.getWithOutcome('fresh-again')).toEqual({
+      value: { bytes: 3 },
+      outcome: 'hit',
+    })
+  })
+
   test('purges timer-driven stale entries from raw cache stats', () => {
     const cache = createLruCache<string, { bytes: number }>({
       max: 2,

--- a/src/internal/cache/lru.ts
+++ b/src/internal/cache/lru.ts
@@ -16,6 +16,8 @@ export class LruCache<K extends {}, V extends {}>
 {
   private readonly cache: BaseLruCache<K, V>
   private readonly purgeStaleTimer?: ReturnType<typeof setInterval>
+  private readonly lookupStatus: BaseLruCache.Status<V> = {}
+  private readonly lookupOptions = { status: this.lookupStatus }
 
   constructor(options: LruCacheOptions<K, V>) {
     const { purgeStaleIntervalMs, ...cacheOptions } = options
@@ -33,13 +35,14 @@ export class LruCache<K extends {}, V extends {}>
   }
 
   get(key: K, options?: CacheLookupOptions): V | undefined {
-    return this.getWithOutcome(key).value
+    return this.cache.get(key)
   }
 
   getWithOutcome(key: K) {
-    const status: BaseLruCache.Status<V> = {}
-    const value = this.cache.get(key, { status })
-    const outcome = (status.get || (value === undefined ? 'miss' : 'hit')) as CacheLookupOutcome
+    this.lookupStatus.get = undefined
+    const value = this.cache.get(key, this.lookupOptions)
+    const outcome = (this.lookupStatus.get ||
+      (value === undefined ? 'miss' : 'hit')) as CacheLookupOutcome
 
     return { value, outcome }
   }

--- a/src/internal/cache/monitoring.test.ts
+++ b/src/internal/cache/monitoring.test.ts
@@ -54,6 +54,27 @@ describe('cache telemetry helpers', () => {
     expect(recordSpy).not.toHaveBeenCalled()
   })
 
+  test('recordMetrics false uses plain get without outcome lookup', () => {
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
+    const inner = createLruCache<string, { ok: boolean }>({
+      max: 2,
+    })
+    const outcomeSpy = vi.spyOn(inner, 'getWithOutcome')
+    const cache = monitorCache(TENANT_CONFIG_CACHE_NAME, inner)
+
+    cache.set('hit', { ok: true })
+
+    expect(cache.get('hit', { recordMetrics: false })).toEqual({ ok: true })
+    expect(outcomeSpy).not.toHaveBeenCalled()
+    expect(recordSpy).not.toHaveBeenCalled()
+
+    expect(cache.get('hit')).toEqual({ ok: true })
+    expect(outcomeSpy).toHaveBeenCalledTimes(1)
+    expect(recordSpy).toHaveBeenCalledWith(TENANT_CONFIG_CACHE_NAME, 'hit')
+
+    cache.dispose()
+  })
+
   test('records stale cache reads when allowStale is enabled', () => {
     const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
     const cache = createLruCache(TENANT_CONFIG_CACHE_NAME, {

--- a/src/internal/cache/ttl.test.ts
+++ b/src/internal/cache/ttl.test.ts
@@ -20,6 +20,21 @@ describe('ttl cache wrapper', () => {
     vi.useRealTimers()
   })
 
+  test('plain get returns the value while fresh and undefined after ttl elapses', async () => {
+    const cache = createTtlCache<string, { bytes: number }>({
+      max: 10,
+      ttl: 20,
+    })
+
+    cache.set('entry', { bytes: 4 })
+
+    expect(cache.get('entry')).toEqual({ bytes: 4 })
+
+    await vi.advanceTimersByTimeAsync(40)
+
+    expect(cache.get('entry')).toBeUndefined()
+  })
+
   test('purges stale entries from stats and iteration after ttl elapses', async () => {
     const cache = createTtlCache<string, { bytes: number }>({
       max: 10,

--- a/src/internal/cache/ttl.ts
+++ b/src/internal/cache/ttl.ts
@@ -31,7 +31,7 @@ export class TtlCache<K, V> implements DisposableCache<K, V, TtlCacheSetOptions>
   }
 
   get(key: K, options?: CacheLookupOptions): V | undefined {
-    return this.getWithOutcome(key).value
+    return this.cache.get(key)
   }
 
   getWithOutcome(key: K) {

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -48,6 +48,8 @@ type GetTenantConfigOptions = {
   recordMetrics?: boolean
 }
 
+const GET_TENANT_CONFIG_WITHOUT_METRICS: GetTenantConfigOptions = { recordMetrics: false }
+
 type LegacyJwksConfig = NonNullable<TenantConfig['jwks']>
 
 export interface Features {
@@ -191,9 +193,7 @@ export async function getTenantConfig(
     throw ERRORS.InvalidTenantId()
   }
 
-  const cachedConfig = tenantConfigCache.get(tenantId, {
-    recordMetrics: options?.recordMetrics,
-  })
+  const cachedConfig = tenantConfigCache.get(tenantId, options)
   if (cachedConfig !== undefined) {
     return cachedConfig
   }
@@ -434,7 +434,7 @@ export async function listenForTenantUpdate(pubSub: PubSubAdapter): Promise<void
  * @param cacheKey
  */
 export async function onTenantConfigChange(cacheKey: string) {
-  const oldConfig = tenantConfigCache.get(cacheKey, { recordMetrics: false })
+  const oldConfig = tenantConfigCache.get(cacheKey, GET_TENANT_CONFIG_WITHOUT_METRICS)
   tenantConfigCache.delete(cacheKey)
 
   if (!oldConfig) {
@@ -442,7 +442,7 @@ export async function onTenantConfigChange(cacheKey: string) {
   }
 
   try {
-    const newConfig = await getTenantConfig(cacheKey, { recordMetrics: false })
+    const newConfig = await getTenantConfig(cacheKey, GET_TENANT_CONFIG_WITHOUT_METRICS)
 
     // 1. DB endpoint changed: the cached pool's connection string is stale, and
     //    so are its open sockets. Hard destroy so the next request rebuilds


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

TTL cache doesn't use its outcome because its monitoring is done separately but it pays outcome price.
LRU cache allocates outcomes per getWithOutcome and get goes through outcome but discards it.

## What is the new behavior?

Convert get to no outcome for TTL cache.
Reuse outcome for LRU cache to prevent allocations, safe since LRU cache is sync.

## Additional context

Also cut interim allocation for get tenant config to pass options.
This will help minor GC.
