### PR TITLE
fix: lazy retry, handle cases, drop async-retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@tus/server": "2.2.1",
         "agentkeepalive": "^4.6.0",
         "ajv": "^8.18.0",
-        "async-retry": "^1.3.3",
         "aws-sigv4-sign": "^1.2.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "dotenv": "^16.0.0",
@@ -77,7 +76,6 @@
       "devDependencies": {
         "@aws-sdk/s3-presigned-post": "^3.1023.0",
         "@biomejs/biome": "2.5.1",
-        "@types/async-retry": "^1.4.5",
         "@types/js-yaml": "^4.0.5",
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^24.12.0",
@@ -11574,15 +11572,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/async-retry": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.5.tgz",
-      "integrity": "sha512-YrdjSD+yQv7h6d5Ip+PMxh3H6ZxKyQk0Ts+PvaNRInxneG9PFVZjFg77ILAN+N6qYf7g4giSJ1l+ZjQ1zeegvA==",
-      "dev": true,
-      "dependencies": {
-        "@types/retry": "*"
-      }
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -11718,12 +11707,6 @@
       "dependencies": {
         "@types/pg": "*"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true
     },
     "node_modules/@types/stream-buffers": {
       "version": "3.0.7",
@@ -12047,14 +12030,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dependencies": {
-        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -15777,14 +15752,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -25442,15 +25409,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "@types/async-retry": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.5.tgz",
-      "integrity": "sha512-YrdjSD+yQv7h6d5Ip+PMxh3H6ZxKyQk0Ts+PvaNRInxneG9PFVZjFg77ILAN+N6qYf7g4giSJ1l+ZjQ1zeegvA==",
-      "dev": true,
-      "requires": {
-        "@types/retry": "*"
-      }
-    },
     "@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -25574,12 +25532,6 @@
       "requires": {
         "@types/pg": "*"
       }
-    },
-    "@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true
     },
     "@types/stream-buffers": {
       "version": "3.0.7",
@@ -25814,14 +25766,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
-    },
-    "async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "requires": {
-        "retry": "0.13.1"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -28222,11 +28166,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
       "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="
-    },
-    "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@tus/server": "2.2.1",
     "agentkeepalive": "^4.6.0",
     "ajv": "^8.18.0",
-    "async-retry": "^1.3.3",
     "aws-sigv4-sign": "^1.2.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "dotenv": "^16.0.0",
@@ -116,7 +115,6 @@
   "devDependencies": {
     "@aws-sdk/s3-presigned-post": "^3.1023.0",
     "@biomejs/biome": "2.5.1",
-    "@types/async-retry": "^1.4.5",
     "@types/js-yaml": "^4.0.5",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^24.12.0",

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -858,6 +858,340 @@ describe('PgTenantConnection', () => {
     }
   })
 
+  it('starts successful transactions without scheduling retry timers', async () => {
+    vi.useFakeTimers()
+
+    const transaction = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgTransaction
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction: vi.fn().mockResolvedValue(transaction),
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      await expect(connection.transaction()).resolves.toBe(transaction)
+
+      expect(pool.acquire).toHaveBeenCalledTimes(1)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries transaction setup after connection-state errors', async () => {
+    vi.useFakeTimers()
+
+    const connectionStateError = createDatabaseError('08006', 'connection failure')
+    const transaction = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgTransaction
+    const beginTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(connectionStateError)
+      .mockResolvedValue(transaction)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      const transactionPromise = connection.transaction()
+      const transactionResult = transactionPromise.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100) // max of jitter
+
+      await expect(transactionResult).resolves.toEqual({
+        status: 'resolved',
+        value: transaction,
+      })
+      expect(pool.acquire).toHaveBeenCalledTimes(2)
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries transaction setup after socket-level connection errors', async () => {
+    vi.useFakeTimers()
+
+    const socketError = new Error('Connection terminated unexpectedly')
+    const transaction = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgTransaction
+    const beginTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(socketError)
+      .mockResolvedValue(transaction)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      const transactionPromise = connection.transaction()
+      const transactionResult = transactionPromise.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(transactionResult).resolves.toEqual({
+        status: 'resolved',
+        value: transaction,
+      })
+      expect(pool.acquire).toHaveBeenCalledTimes(2)
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries transaction setup after coded socket errors', async () => {
+    vi.useFakeTimers()
+
+    try {
+      for (const code of ['ECONNRESET', 'EPIPE']) {
+        const socketError = Object.assign(new Error(`write ${code}`), { code })
+        const transaction = {
+          query: vi.fn().mockResolvedValue({ rows: [] }),
+        } as unknown as PgTransaction
+        const beginTransaction = vi
+          .fn()
+          .mockRejectedValueOnce(socketError)
+          .mockResolvedValue(transaction)
+        const pool = {
+          acquire: vi.fn().mockReturnValue({
+            beginTransaction,
+          }),
+        } as unknown as PgPoolStrategy
+        const connection = new PgTenantConnection(
+          pool,
+          createPoolStrategySettings({
+            isExternalPool: false,
+          })
+        )
+
+        const transactionPromise = connection.transaction()
+        const transactionResult = transactionPromise.then(
+          (value) => ({ status: 'resolved' as const, value }),
+          (error) => ({ status: 'rejected' as const, error })
+        )
+
+        await vi.advanceTimersByTimeAsync(100)
+
+        await expect(transactionResult).resolves.toEqual({
+          status: 'resolved',
+          value: transaction,
+        })
+        expect(pool.acquire).toHaveBeenCalledTimes(2)
+        expect(beginTransaction).toHaveBeenCalledTimes(2)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries public beginTransaction on connection-state errors', async () => {
+    vi.useFakeTimers()
+
+    const connectionStateError = createDatabaseError('08006', 'connection failure')
+    const transaction = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgTransaction
+    const beginTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(connectionStateError)
+      .mockResolvedValue(transaction)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      const transactionPromise = connection.beginTransaction()
+      const transactionResult = transactionPromise.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(transactionResult).resolves.toEqual({
+        status: 'resolved',
+        value: transaction,
+      })
+      expect(pool.acquire).toHaveBeenCalledTimes(2)
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not retry when the eager attempt consumed the setup budget', async () => {
+    vi.useFakeTimers()
+
+    const connectionStateError = createDatabaseError('08006', 'connection failure')
+    const beginTransaction = vi.fn().mockImplementationOnce(async () => {
+      vi.advanceTimersByTime(3500)
+      throw connectionStateError
+    })
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      await expect(connection.transaction()).rejects.toBe(connectionStateError)
+      expect(pool.acquire).toHaveBeenCalledTimes(1)
+      expect(beginTransaction).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries transaction setup after connection-limit errors', async () => {
+    vi.useFakeTimers()
+
+    const connectionLimitError = createDatabaseError(undefined, 'Max client connections reached')
+    const transaction = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgTransaction
+    const beginTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(connectionLimitError)
+      .mockResolvedValue(transaction)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    try {
+      const transactionPromise = connection.transaction()
+      const transactionResult = transactionPromise.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(transactionResult).resolves.toEqual({
+        status: 'resolved',
+        value: transaction,
+      })
+      expect(pool.acquire).toHaveBeenCalledTimes(2)
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails transaction setup fast on non-retryable errors', async () => {
+    const permissionError = createDatabaseError('42501', 'permission denied')
+    const beginTransaction = vi.fn().mockRejectedValue(permissionError)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+
+    await expect(connection.transaction()).rejects.toBe(permissionError)
+    expect(pool.acquire).toHaveBeenCalledTimes(1)
+    expect(beginTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops transaction retries once the abort signal fires', async () => {
+    vi.useFakeTimers()
+
+    const connectionStateError = createDatabaseError('08006', 'connection failure')
+    const beginTransaction = vi.fn().mockRejectedValue(connectionStateError)
+    const pool = {
+      acquire: vi.fn().mockReturnValue({
+        beginTransaction,
+      }),
+    } as unknown as PgPoolStrategy
+    const connection = new PgTenantConnection(
+      pool,
+      createPoolStrategySettings({
+        isExternalPool: false,
+      })
+    )
+    const abortController = new AbortController()
+    connection.setAbortSignal(abortController.signal)
+
+    try {
+      const transactionPromise = connection.transaction()
+      const transactionErrorPromise = transactionPromise.catch((error) => error)
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(pool.acquire).toHaveBeenCalledTimes(1)
+
+      abortController.abort()
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(transactionErrorPromise).resolves.toMatchObject({
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+      })
+      expect(pool.acquire).toHaveBeenCalledTimes(1)
+      expect(beginTransaction).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('maps pg-pool acquisition timeouts to DatabaseTimeout', async () => {
     const timeoutError = new Error('timeout exceeded when trying to connect')
     const pool = {

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -1,7 +1,6 @@
 import { ERRORS } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import { TransactionOptions } from '@storage/database'
-import retry from 'async-retry'
 import pg, { DatabaseError, Pool, PoolClient, QueryResult, QueryResultRow } from 'pg'
 import PgConnection from 'pg/lib/connection'
 import { getConfig } from '../../config'
@@ -116,6 +115,10 @@ type DisposableQueryError = Error & {
 }
 
 const poolDrainCheckIntervalMs = 200
+const transactionSetupMaxAttempts = 11
+const transactionSetupTotalBudgetMs = 3000
+const transactionSetupRetryMinDelayMs = 50
+const transactionSetupRetryMaxDelayMs = 200
 
 export type PgCancelConnectionTarget =
   | {
@@ -655,9 +658,7 @@ export class PgTenantConnection {
   }
 
   async beginTransaction(options?: TransactionOptions): Promise<PgTransaction> {
-    this.assertNotDisposed()
-    // PgPoolExecutor derives the deferred statement_timeout from options.timeout.
-    return this.pool.acquire().beginTransaction(options)
+    return this.beginTransactionWithRetry(options)
   }
 
   asSuperUser() {
@@ -680,32 +681,7 @@ export class PgTenantConnection {
 
     try {
       const beginOptions = withDefaultStatementTimeout(opts)
-      const transaction = await retry<PgTransaction>(
-        async (bail) => {
-          if (this.disposed) {
-            bail(createDisposedTenantConnectionError())
-            return undefined as never
-          }
-
-          try {
-            return await this.pool.acquire().beginTransaction(beginOptions)
-          } catch (e) {
-            if (isConnectionLimitError(e)) {
-              throw e
-            }
-
-            bail(e as Error)
-            // bail rejects the retry promise; this return only satisfies the callback type.
-            return undefined as never
-          }
-        },
-        {
-          minTimeout: 50,
-          maxTimeout: 200,
-          maxRetryTime: 3000,
-          retries: 10,
-        }
-      )
+      const transaction = await this.beginTransactionWithRetry(beginOptions)
 
       if (this.options.isExternalPool) {
         try {
@@ -727,6 +703,43 @@ export class PgTenantConnection {
 
       throw e
     }
+  }
+
+  private async beginTransactionWithRetry(
+    opts?: PgBeginTransactionOptions
+  ): Promise<PgTransaction> {
+    const startedAt = performance.now()
+    let delayMs = transactionSetupRetryMinDelayMs
+
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.beginTransactionForRequest(opts)
+      } catch (e) {
+        // Full jitter with exponential backoff: 50-100, 100-200, then 200ms.
+        const sleepMs = Math.min(delayMs * (1 + Math.random()), transactionSetupRetryMaxDelayMs)
+        const elapsedMs = performance.now() - startedAt
+
+        if (
+          !isRetryableTransactionSetupError(e) ||
+          attempt >= transactionSetupMaxAttempts ||
+          elapsedMs + sleepMs >= transactionSetupTotalBudgetMs
+        ) {
+          throw e
+        }
+
+        await wait(sleepMs)
+        delayMs = Math.min(delayMs * 2, transactionSetupRetryMaxDelayMs)
+      }
+    }
+  }
+
+  private beginTransactionForRequest(opts?: PgBeginTransactionOptions): Promise<PgTransaction> {
+    this.assertNotDisposed()
+    if (this.abortSignal?.aborted) {
+      throw createAbortError()
+    }
+    // PgPoolExecutor derives the deferred statement_timeout from options.timeout.
+    return this.pool.acquire().beginTransaction(opts)
   }
 
   private assertNotDisposed(): void {
@@ -943,6 +956,33 @@ function isConnectionLimitError(error: unknown): boolean {
     error instanceof DatabaseError &&
     ((error.code === '08P01' && error.message.includes('no more connections allowed')) ||
       error.message.includes('Max client connections reached'))
+  )
+}
+
+function isRetryableTransactionSetupError(error: unknown): boolean {
+  return (
+    isConnectionStateError(error) || isConnectionLimitError(error) || isBrokenClientError(error)
+  )
+}
+
+// Socket-level of a dead pooled connection can surface as a plain Error.
+// No setup is run yet, so a fresh client can safely retry.
+// Connection-establishment failures (ECONNREFUSED, connect timeouts) aren't retried.
+function isBrokenClientError(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name === 'AbortError') {
+    return false
+  }
+
+  if ((error as DisposableQueryError)[disposeClientOnRelease] === true) {
+    return true
+  }
+
+  const code = (error as NodeJS.ErrnoException).code
+  return (
+    code === 'ECONNRESET' ||
+    code === 'EPIPE' ||
+    error.message === 'Connection terminated unexpectedly' ||
+    error.message === 'Client has encountered a connection error and is not queryable'
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for performance

## What is the current behavior?

Currently every transaction pays the price of async retry machinery. Machinery should be bolt on when it fails.

## What is the new behavior?

Replace async-retry with a for loop, which is cheaper (no operation building, no options allocation, no promise, etc.), easier to maintain (no dependency), faster (no next tick).

## Additional context

Start retrying connection state and broken client errors as well.
It's around 7x CPU, 6x GC friendly on success and 1.5x CPU, 3x GC friendly on retries.
