### PR TITLE
feat: add migration version admin handler

### DIFF
--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -1,10 +1,21 @@
 import { vi } from 'vitest'
 
 const getGlobal = vi.hoisted(() => vi.fn())
+const lastLocalMigrationName = vi.hoisted(() => vi.fn())
 
 vi.mock('@platformatic/globals', () => ({
   getGlobal,
 }))
+
+vi.mock('@internal/database/migrations', async () => {
+  const actual = await vi.importActual<typeof import('@internal/database/migrations')>(
+    '@internal/database/migrations'
+  )
+  return {
+    ...actual,
+    lastLocalMigrationName,
+  }
+})
 
 async function buildAdminApp() {
   vi.resetModules()
@@ -14,7 +25,11 @@ async function buildAdminApp() {
   return app
 }
 
-describe('admin app pprof registration', () => {
+describe('admin app', () => {
+  beforeEach(() => {
+    lastLocalMigrationName.mockResolvedValue('storage-schema')
+  })
+
   it('does not register pprof endpoints outside Watt', async () => {
     getGlobal.mockReturnValue(undefined)
 
@@ -47,6 +62,27 @@ describe('admin app pprof registration', () => {
       })
 
       expect(response.statusCode).toBe(401)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns the stack migration version', async () => {
+    getGlobal.mockReturnValue(undefined)
+    lastLocalMigrationName.mockResolvedValue('create-migrations-table')
+
+    const app = await buildAdminApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/migration-version',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        migrationVersion: 'create-migrations-table',
+      })
     } finally {
       await app.close()
     }

--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -2,6 +2,8 @@ import { vi } from 'vitest'
 
 const getGlobal = vi.hoisted(() => vi.fn())
 const lastLocalMigrationName = vi.hoisted(() => vi.fn())
+const adminApiKey = 'test-admin-api-key'
+const originalServerAdminApiKeys = process.env.SERVER_ADMIN_API_KEYS
 
 vi.mock('@platformatic/globals', () => ({
   getGlobal,
@@ -27,7 +29,16 @@ async function buildAdminApp() {
 
 describe('admin app', () => {
   beforeEach(() => {
+    process.env.SERVER_ADMIN_API_KEYS = adminApiKey
     lastLocalMigrationName.mockResolvedValue('storage-schema')
+  })
+
+  afterAll(() => {
+    if (originalServerAdminApiKeys === undefined) {
+      delete process.env.SERVER_ADMIN_API_KEYS
+    } else {
+      process.env.SERVER_ADMIN_API_KEYS = originalServerAdminApiKeys
+    }
   })
 
   it('does not register pprof endpoints outside Watt', async () => {
@@ -77,12 +88,32 @@ describe('admin app', () => {
       const response = await app.inject({
         method: 'GET',
         url: '/migration-version',
+        headers: {
+          apikey: adminApiKey,
+        },
       })
 
       expect(response.statusCode).toBe(200)
       expect(response.json()).toEqual({
         migrationVersion: 'create-migrations-table',
       })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('requires the admin API key for the stack migration version', async () => {
+    getGlobal.mockReturnValue(undefined)
+
+    const app = await buildAdminApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/migration-version',
+      })
+
+      expect(response.statusCode).toBe(401)
     } finally {
       await app.close()
     }

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -81,8 +81,15 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.get('/version', (_, reply) => {
     reply.send(version)
   })
-  app.get('/migration-version', { schema: { tags: ['migration'] } }, async (_, reply) => {
-    reply.send({ migrationVersion: await lastLocalMigrationName() })
+  app.register(async (protectedRoutes) => {
+    plugins.registerApiKeyAuth(protectedRoutes)
+    protectedRoutes.get(
+      '/migration-version',
+      { schema: { tags: ['migration'] } },
+      async (_, reply) => {
+        reply.send({ migrationVersion: await lastLocalMigrationName() })
+      }
+    )
   })
   app.get('/status', async (_, response) => response.status(200).send())
 

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -1,5 +1,6 @@
 import fastifySwagger from '@fastify/swagger'
 import fastifySwaggerUi from '@fastify/swagger-ui'
+import { lastLocalMigrationName } from '@internal/database/migrations'
 import { handleMetricsRequest } from '@internal/monitoring/otel-metrics'
 import { getGlobal } from '@platformatic/globals'
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
@@ -57,7 +58,9 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(plugins.signals)
   app.register(plugins.adminTenantId)
   app.register(
-    plugins.logRequest({ excludeUrls: new Set(['/status', '/metrics', '/health', '/version']) })
+    plugins.logRequest({
+      excludeUrls: new Set(['/status', '/metrics', '/health', '/version', '/migration-version']),
+    })
   )
   app.register(routes.tenants, { prefix: 'tenants' })
   app.register(routes.objects, { prefix: 'tenants' })
@@ -77,6 +80,9 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
 
   app.get('/version', (_, reply) => {
     reply.send(version)
+  })
+  app.get('/migration-version', { schema: { tags: ['migration'] } }, async (_, reply) => {
+    reply.send({ migrationVersion: await lastLocalMigrationName() })
   })
   app.get('/status', async (_, response) => response.status(200).send())
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Branching needs to know about migration version of the different stacks.

## What is the new behavior?

Add a new admin endpoint (`/migration-version`) that returns version in the shape of `{"migrationVersion":"some-version"}`.

## Additional context

Exclude new endpoint from logging.
