### PR TITLE
fix: do not allocate log options for excluded urls

### DIFF
--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -56,7 +56,9 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(plugins.requestContext)
   app.register(plugins.signals)
   app.register(plugins.adminTenantId)
-  app.register(plugins.logRequest({ excludeUrls: ['/status', '/metrics', '/health', '/version'] }))
+  app.register(
+    plugins.logRequest({ excludeUrls: new Set(['/status', '/metrics', '/health', '/version']) })
+  )
   app.register(routes.tenants, { prefix: 'tenants' })
   app.register(routes.objects, { prefix: 'tenants' })
   app.register(routes.jwks, { prefix: 'tenants' })

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,14 +60,14 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
     })
   }
 
-  const excludedRoutesFromMonitoring = [
+  const excludedRoutesFromMonitoring = new Set([
     '/status',
     '/metrics',
     '/health',
     '/healthcheck',
     '/version',
     '/documentation',
-  ]
+  ])
 
   // add in common schemas
   app.addSchema(schemas.authSchema)

--- a/src/http/plugins/header-validator.ts
+++ b/src/http/plugins/header-validator.ts
@@ -4,7 +4,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 
 interface HeaderValidatorOptions {
-  excludeUrls?: string[]
+  excludeUrls?: Set<string>
 }
 
 /**
@@ -16,8 +16,10 @@ interface HeaderValidatorOptions {
 export const headerValidator = (options: HeaderValidatorOptions = {}) =>
   fastifyPlugin(
     async function headerValidatorPlugin(fastify: FastifyInstance) {
+      const excludeUrls = options.excludeUrls?.size ? options.excludeUrls : undefined
+
       fastify.addHook('onSend', (request: FastifyRequest, reply: FastifyReply, payload, done) => {
-        if (options.excludeUrls?.includes(request.url.toLowerCase())) {
+        if (excludeUrls?.has(request.url)) {
           done(null, payload)
           return
         }

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -3,7 +3,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 
 interface RequestLoggerOptions {
-  excludeUrls?: string[]
+  excludeUrls?: Set<string>
 }
 
 type BivariantHandler<Args extends unknown[], Return> = {
@@ -40,24 +40,29 @@ declare module 'fastify' {
 export const logRequest = (options: RequestLoggerOptions) =>
   fastifyPlugin(
     async (fastify) => {
+      const excludeUrls = options.excludeUrls?.size ? options.excludeUrls : undefined
+
       fastify.addHook('onRequest', (req, res, done) => {
-        req.startTime = Date.now()
+        req.startTime = performance.now()
+
+        if (excludeUrls?.has(req.url)) {
+          done()
+          return
+        }
 
         res.raw.once('close', () => {
           if (req.raw.aborted) {
             doRequestLog(req, {
-              excludeUrls: options.excludeUrls,
               statusCode: 'ABORTED REQ',
-              responseTime: (Date.now() - req.startTime) / 1000,
+              responseTime: performance.now() - req.startTime,
             })
             return
           }
 
           if (!res.raw.writableFinished) {
             doRequestLog(req, {
-              excludeUrls: options.excludeUrls,
               statusCode: 'ABORTED RES',
-              responseTime: (Date.now() - req.startTime) / 1000,
+              responseTime: performance.now() - req.startTime,
             })
           }
         })
@@ -102,14 +107,18 @@ export const logRequest = (options: RequestLoggerOptions) =>
       })
 
       fastify.addHook('onSend', (req, _reply, payload, done) => {
-        req.executionTime = Date.now() - req.startTime
+        req.executionTime = performance.now() - req.startTime
         done(null, payload)
       })
 
       fastify.addHook('onResponse', (req, reply, done) => {
+        if (excludeUrls?.has(req.url)) {
+          done()
+          return
+        }
+
         doRequestLog(req, {
           reply,
-          excludeUrls: options.excludeUrls,
           statusCode: reply.statusCode,
           responseTime: reply.elapsedTime,
           executionTime: req.executionTime,
@@ -122,17 +131,12 @@ export const logRequest = (options: RequestLoggerOptions) =>
 
 interface LogRequestOptions {
   reply?: FastifyReply
-  excludeUrls?: string[]
   statusCode: number | 'ABORTED REQ' | 'ABORTED RES'
   responseTime: number
   executionTime?: number
 }
 
 function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
-  if (options.excludeUrls?.includes(req.url)) {
-    return
-  }
-
   const requestLog = serializeRequestLog(req)
   const replyLog = serializeReplyLog(options.reply)
   const rMeth = requestLog.method

--- a/src/http/plugins/metrics.ts
+++ b/src/http/plugins/metrics.ts
@@ -19,7 +19,7 @@ function parseMetricSizeHeader(value: number | string | string[] | undefined): n
 
 interface MetricsOptions {
   enabledEndpoint?: boolean
-  excludeRoutes?: string[]
+  excludeRoutes?: Set<string>
 }
 
 export const metrics = (options: MetricsOptions = {}) =>
@@ -47,7 +47,7 @@ export const metricsEndpoint = ({ enabledEndpoint }: MetricsOptions) => {
 
 interface HttpMetricsOptions {
   /** Routes to exclude from metrics collection */
-  excludeRoutes?: string[]
+  excludeRoutes?: Set<string>
 }
 
 /**
@@ -58,12 +58,10 @@ interface HttpMetricsOptions {
 export const httpMetrics = (options: HttpMetricsOptions = {}) =>
   fastifyPlugin(
     async (fastify) => {
-      const excludeRoutes = options.excludeRoutes || [
-        '/metrics',
-        '/status',
-        '/health',
-        '/healthcheck',
-      ]
+      const excludeRoutes = options.excludeRoutes?.size
+        ? options.excludeRoutes
+        : new Set(['/metrics', '/status', '/health', '/healthcheck'])
+      const excludePrefixes = Array.from(excludeRoutes, (route) => route + '/')
 
       // Hook into request lifecycle to measure duration
       fastify.addHook('onRequest', (request, _reply, done) => {
@@ -75,10 +73,16 @@ export const httpMetrics = (options: HttpMetricsOptions = {}) =>
       fastify.addHook('onResponse', (request, reply, done) => {
         const route = request.routeOptions?.url || 'unknown'
 
-        // Skip excluded routes (match start of path)
-        if (excludeRoutes.some((r) => route === r || route.startsWith(r + '/'))) {
+        // Skip excluded routes (exact match or subpath)
+        if (excludeRoutes.has(route)) {
           done()
           return
+        }
+        for (let i = 0; i < excludePrefixes.length; i++) {
+          if (route.startsWith(excludePrefixes[i])) {
+            done()
+            return
+          }
         }
 
         const startTime = request.metricsStartTime


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for performance

## What is the current behavior?

* logRequest options is allocated to be ignored for excluded urls
* headerValidator lowercases url and allocates unnecessarily
* httpMetrics allocates exclude prefix unnecessarily

## What is the new behavior?

* hoist exclude check in logRequest to prevent allocation
* remove lowercasing in headerValidator
* precompile prefix exclude array in httpMetrics

## Additional context

Use `performance.now` (since we checking diff, not absolute) and fix unit for failed requests.
It will help minor GC.
