### PR TITLE
fix: unit for execution time and improve onerror handler of logflare

### DIFF
--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -160,6 +160,31 @@ describe('log-request plugin', () => {
     })
   })
 
+  it('logs executionTime as integer milliseconds', async () => {
+    let now = 100.25
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 0.501
+      return now
+    })
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log',
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+
+    expect(requestLog.executionTime).toBeGreaterThan(0)
+    expect(Number.isInteger(requestLog.executionTime)).toBe(true)
+
+    nowSpy.mockRestore()
+  })
+
   it('logs redacted urls without leaking sensitive request data', async () => {
     const response = await app.inject({
       method: 'GET',

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -107,7 +107,7 @@ export const logRequest = (options: RequestLoggerOptions) =>
       })
 
       fastify.addHook('onSend', (req, _reply, payload, done) => {
-        req.executionTime = performance.now() - req.startTime
+        req.executionTime = Math.round(performance.now() - req.startTime)
         done(null, payload)
       })
 

--- a/src/internal/monitoring/logflare.test.ts
+++ b/src/internal/monitoring/logflare.test.ts
@@ -72,4 +72,46 @@ describe('logflare helpers', () => {
 
     expect(errorSpy).toHaveBeenCalledWith('[Logflare][Error] boom - stack-trace')
   })
+
+  it('includes response diagnostics without logging the full batch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { onError } = await import('./logflare')
+    const err = Object.assign(new Error('boom'), {
+      response: { status: 422 },
+      data: { error: 'invalid payload' },
+    })
+    err.stack = 'stack-trace'
+
+    onError(
+      {
+        batch: [
+          { metadata: { context: { type: 'request' } }, sensitive: 'hidden' },
+          { metadata: { context: { type: 'event' } } },
+        ],
+      },
+      err
+    )
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Logflare][Error] boom (status=422 data={"error":"invalid payload"} batchSize=2 batchTypes=request,event) - stack-trace'
+    )
+    expect(errorSpy.mock.calls[0]?.[0]).not.toContain('hidden')
+  })
+
+  it('does not throw when response diagnostics are not serializable', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { onError } = await import('./logflare')
+    const data: { self?: unknown } = {}
+    data.self = data
+    const err = Object.assign(new Error('boom'), {
+      response: { status: 422 },
+      data,
+    })
+    err.stack = 'stack-trace'
+
+    expect(() => onError({}, err)).not.toThrow()
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Logflare][Error] boom (status=422 data=[unserializable]) - stack-trace'
+    )
+  })
 })

--- a/src/internal/monitoring/logflare.ts
+++ b/src/internal/monitoring/logflare.ts
@@ -2,6 +2,13 @@ import { defaultPreparePayload } from 'pino-logflare'
 
 type PayloadMeta = Parameters<typeof defaultPreparePayload>[1]
 
+interface LogflareNetworkError extends Error {
+  response?: {
+    status?: number
+  }
+  data?: unknown
+}
+
 export function onPreparePayload(payload: Record<string, unknown>, meta: PayloadMeta) {
   const item = defaultPreparePayload(payload, meta)
   item.project = payload.project
@@ -9,6 +16,54 @@ export function onPreparePayload(payload: Record<string, unknown>, meta: Payload
   return item
 }
 
-export function onError(_payload: Record<string, unknown>, err: Error) {
-  console.error(`[Logflare][Error] ${err.message} - ${err.stack}`)
+export function onError(payload: Record<string, unknown>, err: Error) {
+  console.error(
+    `[Logflare][Error] ${err.message}${formatErrorDetails(payload, err)} - ${err.stack}`
+  )
+}
+
+function formatErrorDetails(payload: Record<string, unknown>, err: Error): string {
+  const details: string[] = []
+  const networkError = err as LogflareNetworkError
+
+  if (networkError.response?.status !== undefined) {
+    details.push(`status=${networkError.response.status}`)
+  }
+
+  if (networkError.data !== undefined) {
+    details.push(`data=${stringifyLogflareData(networkError.data)}`)
+  }
+
+  if (Array.isArray(payload.batch)) {
+    details.push(`batchSize=${payload.batch.length}`)
+
+    const batchTypes = getBatchTypes(payload.batch)
+    if (batchTypes.length > 0) {
+      details.push(`batchTypes=${batchTypes.join(',')}`)
+    }
+  }
+
+  return details.length > 0 ? ` (${details.join(' ')})` : ''
+}
+
+function stringifyLogflareData(data: unknown): string {
+  try {
+    return JSON.stringify(data)
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+function getBatchTypes(batch: unknown[]): string[] {
+  const types = new Set<string>()
+
+  for (const item of batch) {
+    const type = (item as { metadata?: { context?: { type?: unknown } } } | null)?.metadata?.context
+      ?.type
+    if (typeof type === 'string' && type) {
+      types.add(type)
+    }
+  }
+
+  return Array.from(types)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

As a part of refactoring, unit was changed to float but logflare doesn't accept the batch if a single item doesn't conform to the schema (if schema is locked).

## What is the new behavior?

Round executionTime to conform the schema. Cover it via a regression test.
Improve logflare onError handler to provide more details when failed.

## Additional context

Related to https://github.com/supabase/storage/pull/1220
