### PR TITLE
chore: cleanup logflare onerror edge cases

### DIFF
--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -46,7 +46,11 @@ describe('log-request plugin', () => {
   })
 
   afterEach(async () => {
-    await app.close()
+    try {
+      await app.close()
+    } finally {
+      vi.restoreAllMocks()
+    }
   })
 
   it('derives resources from route params and prefixes them', async () => {
@@ -162,7 +166,7 @@ describe('log-request plugin', () => {
 
   it('logs executionTime as integer milliseconds', async () => {
     let now = 100.25
-    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => {
+    vi.spyOn(performance, 'now').mockImplementation(() => {
       now += 0.501
       return now
     })
@@ -181,8 +185,6 @@ describe('log-request plugin', () => {
 
     expect(requestLog.executionTime).toBeGreaterThan(0)
     expect(Number.isInteger(requestLog.executionTime)).toBe(true)
-
-    nowSpy.mockRestore()
   })
 
   it('logs redacted urls without leaking sensitive request data', async () => {

--- a/src/internal/monitoring/logflare.test.ts
+++ b/src/internal/monitoring/logflare.test.ts
@@ -114,4 +114,38 @@ describe('logflare helpers', () => {
       '[Logflare][Error] boom (status=422 data=[unserializable]) - stack-trace'
     )
   })
+
+  it('falls back when response diagnostics serialize to undefined', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { onError } = await import('./logflare')
+    const err = Object.assign(new Error('boom'), {
+      response: { status: 422 },
+      data: () => {},
+    })
+    err.stack = 'stack-trace'
+
+    onError({}, err)
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Logflare][Error] boom (status=422 data=[unserializable]) - stack-trace'
+    )
+  })
+
+  it('truncates large response diagnostics', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { onError } = await import('./logflare')
+    const err = Object.assign(new Error('boom'), {
+      response: { status: 422 },
+      data: { error: 'x'.repeat(3000) },
+    })
+    err.stack = 'stack-trace'
+
+    onError({}, err)
+
+    const logLine = errorSpy.mock.calls[0]?.[0]
+    expect(logLine).toContain('data={"error":"')
+    expect(logLine).toContain('...[truncated]')
+    expect(logLine).toContain(' - stack-trace')
+    expect(logLine?.length).toBeLessThan(2100)
+  })
 })

--- a/src/internal/monitoring/logflare.ts
+++ b/src/internal/monitoring/logflare.ts
@@ -1,6 +1,8 @@
 import { defaultPreparePayload } from 'pino-logflare'
 
 type PayloadMeta = Parameters<typeof defaultPreparePayload>[1]
+const LOGFLARE_ERROR_DATA_MAX_CHARS = 2000
+const LOGFLARE_ERROR_DATA_TRUNCATED_SUFFIX = '...[truncated]'
 
 interface LogflareNetworkError extends Error {
   response?: {
@@ -48,7 +50,20 @@ function formatErrorDetails(payload: Record<string, unknown>, err: Error): strin
 
 function stringifyLogflareData(data: unknown): string {
   try {
-    return JSON.stringify(data)
+    const serialized = JSON.stringify(data)
+
+    if (!serialized) {
+      return '[unserializable]'
+    }
+
+    if (serialized.length <= LOGFLARE_ERROR_DATA_MAX_CHARS) {
+      return serialized
+    }
+
+    return `${serialized.slice(
+      0,
+      LOGFLARE_ERROR_DATA_MAX_CHARS - LOGFLARE_ERROR_DATA_TRUNCATED_SUFFIX.length
+    )}${LOGFLARE_ERROR_DATA_TRUNCATED_SUFFIX}`
   } catch {
     return '[unserializable]'
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Logflare error payload could be too big and could bloat logs. 
 
## What is the new behavior?

Cap the error body as defense in depth.

## Additional context

Related to #1221 
