### PR TITLE
feat: parse traceparent and add to logs

### DIFF
--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -111,6 +111,60 @@ describe('log-request plugin', () => {
     expect(requestLogLine).not.toContain('"request_id"')
   })
 
+  it('threads traceId from a valid traceparent header into the request log data', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log',
+      headers: {
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+    expect(requestLog.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+    expect(requestLog).not.toHaveProperty('trace_id')
+  })
+
+  it('logs an empty traceId when traceparent is malformed', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log',
+      headers: {
+        traceparent: 'malformed-value',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+    expect(requestLog.traceId).toBe('')
+    expect(requestLog).not.toHaveProperty('trace_id')
+  })
+
+  it('logs an empty traceId when traceparent is missing', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/request-log',
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const requestLogLine = lines.find((line) => line.includes('"type":"request"'))
+    expect(requestLogLine).toBeDefined()
+
+    const requestLog = JSON.parse(requestLogLine ?? '{}')
+    expect(requestLog.traceId).toBe('')
+    expect(requestLog).not.toHaveProperty('trace_id')
+  })
+
   it('threads tenant context into the request log data', async () => {
     const response = await app.inject({
       method: 'GET',

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -1,4 +1,9 @@
-import { logSchema, serializeReplyLog, serializeRequestLog } from '@internal/monitoring'
+import {
+  getTraceIdFromTraceparent,
+  logSchema,
+  serializeReplyLog,
+  serializeRequestLog,
+} from '@internal/monitoring'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 
@@ -147,6 +152,7 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
   const statusCode = options.statusCode
   const error = req.raw.executionError || req.executionError
   const tenantId = req.tenantId
+  const traceId = getTraceIdFromTraceparent(req.headers) ?? ''
 
   let reqMetadata = '{}'
 
@@ -193,6 +199,7 @@ function doRequestLog(req: FastifyRequest, options: LogRequestOptions) {
     project: tenantId,
     reqId: rId,
     sbReqId: req.sbReqId,
+    traceId,
     req: requestLog,
     reqMetadata,
     res: replyLog,

--- a/src/internal/monitoring/logflare.test.ts
+++ b/src/internal/monitoring/logflare.test.ts
@@ -20,7 +20,7 @@ describe('logflare helpers', () => {
     vi.resetModules()
   })
 
-  it('promotes project and sbReqId (as request_id) onto the prepared payload', async () => {
+  it('promotes project, sbReqId, and traceId onto the prepared payload', async () => {
     defaultPreparePayloadMock.mockReturnValue({
       log_entry: 'hello',
       metadata: { level: 'info' },
@@ -31,6 +31,7 @@ describe('logflare helpers', () => {
     const payload = {
       project: 'tenant-a',
       sbReqId: 'sb-req-123',
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
       msg: { text: 'hello' },
     }
 
@@ -39,11 +40,12 @@ describe('logflare helpers', () => {
       metadata: { level: 'info' },
       project: 'tenant-a',
       request_id: 'sb-req-123',
+      trace_id: '4bf92f3577b34da6a3ce929d0e0e4736',
     })
     expect(defaultPreparePayloadMock).toHaveBeenCalledWith(payload, meta)
   })
 
-  it('leaves project and request_id undefined when they are missing', async () => {
+  it('leaves project, request_id, and trace_id undefined when they are missing', async () => {
     defaultPreparePayloadMock.mockReturnValue({
       log_entry: 'hello',
       metadata: {},
@@ -59,6 +61,7 @@ describe('logflare helpers', () => {
       metadata: {},
       project: undefined,
       request_id: undefined,
+      trace_id: undefined,
     })
   })
 

--- a/src/internal/monitoring/logflare.ts
+++ b/src/internal/monitoring/logflare.ts
@@ -13,6 +13,7 @@ export function onPreparePayload(payload: Record<string, unknown>, meta: Payload
   const item = defaultPreparePayload(payload, meta)
   item.project = payload.project
   item.request_id = payload.sbReqId
+  item.trace_id = payload.traceId
   return item
 }
 

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -138,6 +138,7 @@ export interface RequestLogContext {
 
 export interface RequestLog extends RequestLogContext {
   type: 'request'
+  traceId: string
   req: SerializedRequestLog
   res?: SerializedReplyLog
   reqMetadata: string

--- a/src/internal/monitoring/request-context.test.ts
+++ b/src/internal/monitoring/request-context.test.ts
@@ -52,10 +52,7 @@ describe('request log context helpers', () => {
   it('extracts trace ids from valid traceparent headers', () => {
     expect(
       getTraceIdFromTraceparent({
-        [TRACEPARENT_HEADER]: [
-          '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          '00-fbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00',
-        ],
+        [TRACEPARENT_HEADER]: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
       })
     ).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
 
@@ -71,6 +68,13 @@ describe('request log context helpers', () => {
     ['missing', undefined],
     ['empty', ''],
     ['malformed', 'malformed-value'],
+    [
+      'multiple values',
+      [
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        '00-fbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00',
+      ],
+    ],
     ['short trace id', '00-4bf92f3577b34da6a3ce929d0e0e47-00f067aa0ba902b7-01'],
     ['short parent id', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902-01'],
     ['uppercase hex', '00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01'],

--- a/src/internal/monitoring/request-context.test.ts
+++ b/src/internal/monitoring/request-context.test.ts
@@ -1,4 +1,10 @@
-import { getSbReqId, getSbReqIdFromPayload, SUPABASE_REQUEST_ID_HEADER } from './request-context'
+import {
+  getSbReqId,
+  getSbReqIdFromPayload,
+  getTraceIdFromTraceparent,
+  SUPABASE_REQUEST_ID_HEADER,
+  TRACEPARENT_HEADER,
+} from './request-context'
 
 describe('request log context helpers', () => {
   it('extracts sbReqId values from request headers', () => {
@@ -41,5 +47,46 @@ describe('request log context helpers', () => {
     ).toBeUndefined()
     expect(getSbReqIdFromPayload({ sbReqId: '' })).toBeUndefined()
     expect(getSbReqIdFromPayload(undefined)).toBeUndefined()
+  })
+
+  it('extracts trace ids from valid traceparent headers', () => {
+    expect(
+      getTraceIdFromTraceparent({
+        [TRACEPARENT_HEADER]: [
+          '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+          '00-fbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00',
+        ],
+      })
+    ).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+
+    expect(
+      getTraceIdFromTraceparent({
+        [TRACEPARENT_HEADER]:
+          '01-fbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00-future-field',
+      })
+    ).toBe('fbf92f3577b34da6a3ce929d0e0e4736')
+  })
+
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['malformed', 'malformed-value'],
+    ['short trace id', '00-4bf92f3577b34da6a3ce929d0e0e47-00f067aa0ba902b7-01'],
+    ['short parent id', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902-01'],
+    ['uppercase hex', '00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01'],
+    ['missing flags', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7'],
+    ['version ff', 'ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'],
+    [
+      'version 00 with extra fields',
+      '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra',
+    ],
+    ['all-zero trace id', '00-00000000000000000000000000000000-00f067aa0ba902b7-01'],
+    ['all-zero parent id', '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01'],
+  ])('ignores %s traceparent headers', (_name, traceparent) => {
+    expect(
+      getTraceIdFromTraceparent({
+        [TRACEPARENT_HEADER]: traceparent,
+      })
+    ).toBeUndefined()
   })
 })

--- a/src/internal/monitoring/request-context.ts
+++ b/src/internal/monitoring/request-context.ts
@@ -18,10 +18,10 @@ export function getSbReqId(headers: IncomingHttpHeaders): string | undefined {
 }
 
 export function getTraceIdFromTraceparent(headers: IncomingHttpHeaders): string | undefined {
-  const traceparent = getNonEmptyString(headers[TRACEPARENT_HEADER])
+  const traceparent = headers[TRACEPARENT_HEADER]
 
   if (
-    !traceparent ||
+    typeof traceparent !== 'string' ||
     (traceparent.length > TRACEPARENT_V0_LENGTH && traceparent.startsWith('00-')) ||
     !TRACEPARENT_PATTERN.test(traceparent)
   ) {

--- a/src/internal/monitoring/request-context.ts
+++ b/src/internal/monitoring/request-context.ts
@@ -1,11 +1,34 @@
 import type { IncomingHttpHeaders } from 'node:http'
 
 export const SUPABASE_REQUEST_ID_HEADER = 'sb-request-id'
+export const TRACEPARENT_HEADER = 'traceparent'
+
+// W3C traceparent: version "-" trace-id "-" parent-id "-" flags, all lowercase hex.
+// Version ff and all-zero ids are invalid; future versions may append extra fields.
+const TRACEPARENT_PATTERN =
+  /^(?!ff)[\da-f]{2}-(?!0{32})[\da-f]{32}-(?!0{16})[\da-f]{16}-[\da-f]{2}(?:-.*)?$/
+const TRACEPARENT_V0_LENGTH = 55
+const TRACE_ID_START = 3
+const TRACE_ID_END = 35
 
 export function getSbReqId(headers: IncomingHttpHeaders): string | undefined {
   const sbReqId = headers[SUPABASE_REQUEST_ID_HEADER]
 
   return getNonEmptyString(sbReqId)
+}
+
+export function getTraceIdFromTraceparent(headers: IncomingHttpHeaders): string | undefined {
+  const traceparent = getNonEmptyString(headers[TRACEPARENT_HEADER])
+
+  if (
+    !traceparent ||
+    (traceparent.length > TRACEPARENT_V0_LENGTH && traceparent.startsWith('00-')) ||
+    !TRACEPARENT_PATTERN.test(traceparent)
+  ) {
+    return undefined
+  }
+
+  return traceparent.slice(TRACE_ID_START, TRACE_ID_END)
 }
 
 export function getSbReqIdFromPayload(payload: unknown): string | undefined {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

API Gateway provides traceparent but storage ignores.

## What is the new behavior?

Storage parses trace id from the given header and logs as top level `trace_id`. Malformed, missing as empty for consistency.

## Additional context

Unlike `request_id`, it's not propagated to other logs and worker. Request id should be used for that correlation.