### PR TITLE
fix(x-robots-tag): allow max-snippet -1 (no snippet-length limit)

### DIFF
--- a/src/storage/validators/x-robots-tag.test.ts
+++ b/src/storage/validators/x-robots-tag.test.ts
@@ -106,15 +106,19 @@ describe('validateXRobotsTag', () => {
       expect(() => validateXRobotsTag('max-snippet: 0')).not.toThrow()
     })
 
-    it('should throw for max-snippet with negative number', () => {
+    it('should accept max-snippet with -1 (no snippet-length limit)', () => {
+      expect(() => validateXRobotsTag('max-snippet: -1')).not.toThrow()
+    })
+
+    it('should throw for max-snippet below -1', () => {
       expect(() => validateXRobotsTag('max-snippet: -5')).toThrow(
-        'X-Robots-Tag "max-snippet" value must be a non-negative number'
+        'X-Robots-Tag "max-snippet" value must be a number >= -1'
       )
     })
 
     it('should throw for max-snippet with non-numeric value', () => {
       expect(() => validateXRobotsTag('max-snippet: abc')).toThrow(
-        'X-Robots-Tag "max-snippet" value must be a non-negative number'
+        'X-Robots-Tag "max-snippet" value must be a number >= -1'
       )
     })
 

--- a/src/storage/validators/x-robots-tag.ts
+++ b/src/storage/validators/x-robots-tag.ts
@@ -147,9 +147,11 @@ function validateParametricRule(
   switch (ruleName) {
     case 'max-snippet': {
       const num = parseInt(ruleValue, 10)
-      if (isNaN(num) || num < 0) {
+      // -1 ("no limit", the default) and 0 ("no snippet") are both valid per the
+      // robots meta spec, alongside any positive length.
+      if (isNaN(num) || num < -1) {
         throw ERRORS.InvalidXRobotsTag(
-          `X-Robots-Tag "max-snippet" value must be a non-negative number, got: "${ruleValue}"`
+          `X-Robots-Tag "max-snippet" value must be a number >= -1, got: "${ruleValue}"`
         )
       }
       break


### PR DESCRIPTION
## Problem

The `max-snippet` X-Robots-Tag validator (`src/storage/validators/x-robots-tag.ts`) rejects `-1`:

```ts
case 'max-snippet': {
  const num = parseInt(ruleValue, 10)
  if (isNaN(num) || num < 0) {   // rejects -1
```

Per the [robots meta tag spec](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag), `max-snippet: -1` means "no snippet-length limit" and is a valid value (alongside `0` and any positive integer) — in fact it's the recommended default (`max-snippet:-1, max-image-preview:large, max-video-preview:-1`). The sibling `max-video-preview` case in the same file already handles this correctly with `num < -1`; `max-snippet` was an inconsistent oversight.

So a user setting the spec-recommended `X-Robots-Tag: max-snippet:-1` gets a `400 InvalidXRobotsTag` error.

## Fix

Loosen the guard to `num < -1` and align the error message with `max-video-preview` (`"must be a number >= -1"`). Update the existing negative-value test to `-5` (still rejected) and add a case asserting `-1` is accepted.

## Tests

`src/storage/validators/x-robots-tag.test.ts`: adds "accepts `max-snippet: -1`", keeps "throws below -1" (`-5`) and "throws for non-numeric" (`abc`).

Note on verification: I confirmed the edited validator logic directly (`-1` accepted; `-5`/`abc` still rejected; `max-video-preview` unchanged), but couldn't run the full `vitest` suite locally — `supabase/storage` doesn't install on Windows (`fs-xattr` is `os: "!win32"` and the repo requires Node ≥ 24). The change is a one-line guard + test, so CI should confirm.
