### PR TITLE
chore: cleanup multigres workaround for statement timeout

### DIFF
--- a/src/test/pg-connection.test.ts
+++ b/src/test/pg-connection.test.ts
@@ -128,6 +128,7 @@ describe('Pg database foundation', () => {
         request_path: string
         storage_operation: string
         allow_delete: string
+        statement_timeout: string
       }>({
         text: `
           SELECT
@@ -135,14 +136,10 @@ describe('Pg database foundation', () => {
             current_setting('request.jwt.claim.role', true) as jwt_role,
             current_setting('request.path', true) as request_path,
             current_setting('storage.operation', true) as storage_operation,
-            current_setting('storage.allow_delete_query', true) as allow_delete
+            current_setting('storage.allow_delete_query', true) as allow_delete,
+            current_setting('statement_timeout') as statement_timeout
         `,
       })
-      // Multigres enforces statement_timeout here, but current_setting still
-      // reports 0; SHOW reflects the effective transaction-local GUC.
-      const timeout = await transaction.query<{ statement_timeout: string }>(
-        'SHOW statement_timeout'
-      )
 
       expect(result.rows[0]).toEqual(
         expect.objectContaining({
@@ -151,9 +148,9 @@ describe('Pg database foundation', () => {
           request_path: '/pg-foundation',
           storage_operation: 'pg-foundation-test',
           allow_delete: 'true',
+          statement_timeout: '1234ms',
         })
       )
-      expect(timeout.rows[0].statement_timeout).toBe('1234ms')
 
       await transaction.commit()
     } catch (e) {

--- a/src/test/storage-pg-db.test.ts
+++ b/src/test/storage-pg-db.test.ts
@@ -1787,7 +1787,9 @@ describe('StoragePgDB bucket metadata', () => {
   }
 
   async function readCurrentStatementTimeoutMsFromExecutor(pg: PgExecutor): Promise<number> {
-    const result = await pg.query<{ statement_timeout: string }>('SHOW statement_timeout')
+    const result = await pg.query<{ statement_timeout: string }>(`
+      SELECT current_setting('statement_timeout') AS statement_timeout
+    `)
 
     return parseStatementTimeoutMs(result.rows[0].statement_timeout)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Multigres keeps returning zero for statement timeout via `current_setting` and required top level `show` instead.

## What is the new behavior?

https://github.com/multigres/multigres/pull/1258 fixed the problem so dropping the workaround and making it consistent for engines.

## Additional context

Related to https://github.com/supabase/storage/pull/1154#discussion_r3570608315 where the original bug was found.