### PR TITLE
fix: retry for backup object event

### DIFF
--- a/src/storage/events/lifecycle/webhook.ts
+++ b/src/storage/events/lifecycle/webhook.ts
@@ -172,7 +172,7 @@ export class Webhook extends BaseEvent<WebhookEvent> {
       logger.error(
         {
           error: error.message,
-          jodId: job.id,
+          jobId: job.id,
           type: 'event',
           event: job.data.event.type,
           payload: JSON.stringify(job.data.event.payload),

--- a/src/storage/events/objects/backup-object.test.ts
+++ b/src/storage/events/objects/backup-object.test.ts
@@ -1,0 +1,74 @@
+import { vi } from 'vitest'
+
+const { createStorage, loggerError, logEvent, S3Backend } = vi.hoisted(() => ({
+  createStorage: vi.fn(),
+  loggerError: vi.fn(),
+  logEvent: vi.fn(),
+  S3Backend: class {},
+}))
+
+vi.mock('../../../config', () => ({
+  getConfig: () => ({ storageS3Bucket: 'test-storage' }),
+}))
+
+vi.mock('../base-event', () => ({
+  BaseEvent: class {
+    static createStorage = createStorage
+  },
+}))
+
+vi.mock('@internal/monitoring', () => ({
+  logger: { error: loggerError },
+  logSchema: { event: logEvent },
+}))
+
+vi.mock('@storage/backend', () => ({
+  S3Backend,
+}))
+
+import { BackupObjectEvent } from './backup-object'
+
+const job = {
+  id: 'backup-object-job',
+  data: {
+    tenant: { ref: 'tenant-a', host: 'tenant-a.example.test' },
+    bucketId: 'bucket-a',
+    name: 'object-a',
+    version: 'version-a',
+    size: 1,
+  },
+} as never
+
+describe('BackupObjectEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects backup failures after logging them and disposing its database connection', async () => {
+    const failure = new Error('backup failed')
+    const destroyConnection = vi.fn().mockResolvedValue(undefined)
+    const backend = Object.assign(new S3Backend(), {
+      backup: vi.fn().mockRejectedValue(failure),
+    })
+
+    createStorage.mockResolvedValue({
+      backend,
+      db: { destroyConnection },
+      location: {
+        getKeyLocation: vi.fn().mockReturnValue('tenant-a/bucket-a/object-a'),
+      },
+    })
+
+    await expect(BackupObjectEvent.handle(job)).rejects.toBe(failure)
+
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: failure,
+        jobId: 'backup-object-job',
+        event: 'BackupObject',
+      }),
+      '[Admin]: BackupObjectEvent tenant-a/bucket-a/object-a - FAILED'
+    )
+    expect(destroyConnection).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/storage/events/objects/backup-object.ts
+++ b/src/storage/events/objects/backup-object.ts
@@ -104,9 +104,9 @@ export class BackupObjectEvent extends BaseEvent<BackupObjectEventPayload> {
       logger.error(
         {
           error: e,
-          jodId: job.id,
+          jobId: job.id,
           type: 'event',
-          event: 'ObjectAdminDelete',
+          event: 'BackupObject',
           payload: JSON.stringify(job.data),
           objectPath: s3Key,
           objectVersion: job.data.version,
@@ -117,6 +117,7 @@ export class BackupObjectEvent extends BaseEvent<BackupObjectEventPayload> {
         },
         `[Admin]: BackupObjectEvent ${s3Key} - FAILED`
       )
+      throw e
     } finally {
       storage.db
         .destroyConnection()

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -127,7 +127,7 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
       logger.error(
         {
           error: e,
-          jodId: job.id,
+          jobId: job.id,
           type: 'event',
           event: 'ObjectAdminDeleteAllBefore',
           payload: JSON.stringify(job.data),

--- a/src/storage/events/objects/object-admin-delete.ts
+++ b/src/storage/events/objects/object-admin-delete.ts
@@ -64,7 +64,7 @@ export class ObjectAdminDelete extends BaseEvent<ObjectDeleteEvent> {
       logger.error(
         {
           error: e,
-          jodId: job.id,
+          jobId: job.id,
           type: 'event',
           event: 'ObjectAdminDelete',
           payload: JSON.stringify(job.data),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Backup object handler doesn't throw error so failure doesn't retry.
There are some typos in logs fields.

## What is the new behavior?

Rethrow the error so queue can retry (count 5 can work).
Fix typos.

## Additional context

We should extend `logSchema.error` to extend `EventLog` and cut duplication between error and success but it's for another PR.
