### PR TITLE
fix: reuse pool executor in strategy

### DIFF
--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -24,6 +24,10 @@ class TestablePgPoolStrategy extends PgPoolStrategy {
   setCurrentPoolForTest(pool: Pool): void {
     this.pool = pool
   }
+
+  getCachedExecutorPoolForTest(): Pool | undefined {
+    return Reflect.get(this, 'executorPool') as Pool | undefined
+  }
 }
 
 function createPoolStrategySettings(
@@ -2139,5 +2143,41 @@ describe('PgTenantConnection payload serialization', () => {
     } finally {
       stringifySpy.mockRestore()
     }
+  })
+})
+
+describe('PgPoolStrategy executor reuse', () => {
+  it('reuses one executor per physical pool and rebuilds it when the pool is replaced', () => {
+    const strategy = new TestablePgPoolStrategy(createPoolStrategySettings())
+    const poolA = { options: { max: 8 } } as unknown as Pool
+    strategy.setCurrentPoolForTest(poolA)
+
+    const first = strategy.acquire()
+    expect(strategy.acquire()).toBe(first)
+
+    strategy.rebalance({ maxConnections: 4 })
+    expect(strategy.acquire()).toBe(first)
+
+    const poolB = { options: { max: 8 } } as unknown as Pool
+    strategy.setCurrentPoolForTest(poolB)
+    const replacement = strategy.acquire()
+    expect(replacement).not.toBe(first)
+    expect(strategy.acquire()).toBe(replacement)
+  })
+
+  it('releases the cached executor pool when the strategy is destroyed', async () => {
+    const strategy = new TestablePgPoolStrategy(createPoolStrategySettings())
+    const pool = {
+      options: { max: 8 },
+      end: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Pool
+    strategy.setCurrentPoolForTest(pool)
+
+    strategy.acquire()
+    expect(strategy.getCachedExecutorPoolForTest()).toBe(pool)
+
+    await strategy.destroy()
+
+    expect(strategy.getCachedExecutorPoolForTest()).toBeUndefined()
   })
 })

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -134,11 +134,18 @@ export type PgCancelConnectionTarget =
 export class PgPoolStrategy {
   protected pool?: Pool
   protected tlsSession?: TlsSessionSlot
+  private executor?: PgPoolExecutor
+  private executorPool?: Pool
 
   constructor(protected readonly options: PoolStrategySettings) {}
 
   acquire(): PgPoolExecutor {
-    return new PgPoolExecutor(this.getPool())
+    const pool = this.getPool()
+    if (!this.executor || this.executorPool !== pool) {
+      this.executor = new PgPoolExecutor(pool)
+      this.executorPool = pool
+    }
+    return this.executor
   }
 
   async destroy(): Promise<void> {
@@ -148,6 +155,10 @@ export class PgPoolStrategy {
       return
     }
 
+    if (this.executorPool === originalPool) {
+      this.executor = undefined
+      this.executorPool = undefined
+    }
     this.pool = undefined
     await this.drainPool(originalPool, 'destroy')
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for performance

## What is the current behavior?

Each acquire creates an interim pool executor.

## What is the new behavior?

Its lifecycle tied to pool itself, create once for the pool and reuse until pool identity changes.

## Additional context

It helps GC in hot path.