### PR TITLE
fix: cut down promises from connection create/dispose

### DIFF
--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -14,7 +14,7 @@ async function loadDbPlugins({
   vi.resetModules()
 
   const requestDb = {
-    dispose: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
     setAbortSignal: vi.fn(),
   }
   const getPostgresConnection = vi.fn().mockResolvedValue(requestDb)

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -14,7 +14,6 @@ import {
   updateTenantMigrationsState,
 } from '@internal/database/migrations'
 import { ERRORS } from '@internal/errors'
-import { logSchema } from '@internal/monitoring'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig, MultitenantMigrationStrategy } from '../../config'
 
@@ -65,16 +64,16 @@ export const db = fastifyPlugin(
     })
 
     fastify.addHook('onSend', async (request, reply, payload) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
       return payload
     })
 
     fastify.addHook('onTimeout', async (request) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
     })
 
     fastify.addHook('onRequestAbort', async (request) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
     })
   },
   { name: 'db-init' }
@@ -111,39 +110,20 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
     })
 
     fastify.addHook('onSend', async (request, reply, payload) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
       return payload
     })
 
     fastify.addHook('onTimeout', async (request) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
     })
 
     fastify.addHook('onRequestAbort', async (request) => {
-      disposeRequestConnections(request)
+      request.db?.dispose()
     })
   },
   { name: 'db-superuser-init' }
 )
-
-function disposeRequestConnections(request: {
-  db?: PgTenantConnection
-  log: Parameters<typeof logSchema.error>[0]
-  tenantId: string
-  id: string
-  sbReqId?: string
-}) {
-  request.db?.dispose().catch((e) => {
-    logSchema.error(request.log, 'Error disposing db connection', {
-      type: 'db-connection',
-      tenantId: request.tenantId,
-      project: request.tenantId,
-      reqId: request.id,
-      sbReqId: request.sbReqId,
-      error: e,
-    })
-  })
-}
 
 /**
  * Handle database migration for multitenant applications when a request is made

--- a/src/http/routes/tus/lifecycle.test.ts
+++ b/src/http/routes/tus/lifecycle.test.ts
@@ -21,7 +21,7 @@ function createRawTusRequest({
     error: vi.fn(),
     warn: vi.fn(),
   }
-  const dispose = vi.fn().mockResolvedValue(undefined)
+  const dispose = vi.fn()
 
   const request = {
     headers,
@@ -64,29 +64,16 @@ describe('tus lifecycle logging', () => {
     vi.restoreAllMocks()
   })
 
-  it('logs db dispose failures with sbReqId through logSchema', async () => {
-    const error = new Error('dispose failed')
-    const errorSpy = vi.spyOn(logSchema, 'error').mockImplementation(() => undefined)
-    const { dispose, rawReq, reqLog, response } = createRawTusRequest({
+  it('disposes the db synchronously when the response finishes', async () => {
+    const { dispose, rawReq, response } = createRawTusRequest({
       method: 'HEAD',
     })
-
-    dispose.mockRejectedValueOnce(error)
 
     await onIncomingRequest(rawReq, uploadId, {} as DataStore)
 
     response.emit('finish')
-    await new Promise((resolve) => setImmediate(resolve))
 
-    expect(errorSpy).toHaveBeenCalledWith(reqLog, 'Error disposing db connection', {
-      type: 'db-connection',
-      tenantId: 'tenant-123',
-      project: 'tenant-123',
-      reqId: 'req-123',
-      error,
-      sbReqId: 'sb-req-123',
-    })
-    expect(reqLog.error).not.toHaveBeenCalled()
+    expect(dispose).toHaveBeenCalledOnce()
   })
 
   it('logs upload metadata parse failures with sbReqId through logSchema', async () => {

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -67,16 +67,7 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
   }
 
   res.on('finish', () => {
-    req.upload.db.dispose().catch((e) => {
-      logSchema.error(req.log, 'Error disposing db connection', {
-        type: 'db-connection',
-        tenantId: req.upload.tenantId,
-        project: req.upload.tenantId,
-        reqId: req.upload.reqId,
-        sbReqId: req.upload.sbReqId,
-        error: e,
-      })
-    })
+    req.upload.db.dispose()
   })
 
   const uploadID = UploadId.fromString(id)

--- a/src/internal/database/client.ts
+++ b/src/internal/database/client.ts
@@ -27,7 +27,7 @@ export async function getPgPostgresConnection(
     disableHostCheck: options.disableHostCheck,
   })
 
-  return await PgTenantConnection.create({
+  return PgTenantConnection.create({
     ...dbCredentials,
     ...options,
     clusterSize: Cluster.size,

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -807,7 +807,7 @@ describe('PgTenantConnection', () => {
       })
     )
 
-    await connection.dispose()
+    connection.dispose()
 
     await expect(connection.query('SELECT 1')).rejects.toThrow(
       'Cannot use a disposed PgTenantConnection'
@@ -848,7 +848,7 @@ describe('PgTenantConnection', () => {
       await vi.advanceTimersByTimeAsync(0)
       expect(pool.acquire).toHaveBeenCalledTimes(1)
 
-      await connection.dispose()
+      connection.dispose()
       await vi.advanceTimersByTimeAsync(200)
 
       await expect(transactionErrorPromise).resolves.toMatchObject({

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -653,14 +653,13 @@ export class PgTenantConnection {
     return PgTenantConnection.poolManager.destroyAll()
   }
 
-  static async create(options: TenantConnectionOptions) {
+  static create(options: TenantConnectionOptions): PgTenantConnection {
     const pgPool = PgTenantConnection.poolManager.getPool(options)
     return new this(pgPool, options)
   }
 
-  dispose() {
+  dispose(): void {
     this.disposed = true
-    return Promise.resolve()
   }
 
   setAbortSignal(signal: AbortSignal) {

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -192,7 +192,7 @@ export interface Database {
 
   healthcheck(): Promise<void>
 
-  destroyConnection(): Promise<void>
+  destroyConnection(): void
 
   createMultipartUpload(
     uploadId: string,

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -1671,8 +1671,8 @@ export class StoragePgDB implements Database {
     })
   }
 
-  destroyConnection() {
-    return this.connection.dispose()
+  destroyConnection(): void {
+    this.connection.dispose()
   }
 
   /**

--- a/src/storage/events/iceberg/delete-iceberg-resources.test.ts
+++ b/src/storage/events/iceberg/delete-iceberg-resources.test.ts
@@ -209,7 +209,7 @@ describe('DeleteIcebergResources.handle', () => {
       { name: 'table-1', shard_key: 'shard-key-1', shard_id: 'shard-id-1' },
     ])
     restCatalog.listTables.mockResolvedValue({ identifiers: [] })
-    db.destroyConnection.mockResolvedValue(undefined)
+    db.destroyConnection.mockReturnValue(undefined)
   })
 
   describe('multitenant', () => {

--- a/src/storage/events/iceberg/delete-iceberg-resources.ts
+++ b/src/storage/events/iceberg/delete-iceberg-resources.ts
@@ -1,6 +1,5 @@
 import { multitenantPgExecutor } from '@internal/database'
 import { ERRORS } from '@internal/errors'
-import { logger } from '@internal/monitoring'
 import { BasePayload } from '@internal/queue'
 import { PgShardStoreFactory, ShardCatalog } from '@internal/sharding'
 import { getCatalogAuthStrategy, RestCatalogClient } from '@storage/protocols/iceberg/catalog'
@@ -180,12 +179,7 @@ export class DeleteIcebergResources extends BaseEvent<DeleteIcebergResourcesPayl
       })
     } finally {
       if (eventStorage) {
-        await eventStorage.db.destroyConnection().catch((e) => {
-          logger.error(
-            { error: e, sbReqId: job.data.sbReqId },
-            `[DeleteIcebergResources] ${job.data.tenant.ref} - FAILED DISPOSING CONNECTION`
-          )
-        })
+        eventStorage.db.destroyConnection()
       }
     }
   }

--- a/src/storage/events/lifecycle/bucket-deleted.ts
+++ b/src/storage/events/lifecycle/bucket-deleted.ts
@@ -1,6 +1,5 @@
 import { multitenantPgExecutor } from '@internal/database'
 import { ErrorCode, StorageBackendError } from '@internal/errors'
-import { logger } from '@internal/monitoring'
 import { BasePayload } from '@internal/queue'
 import { DeleteIcebergResources } from '@storage/events/iceberg/delete-iceberg-resources'
 import { BucketType } from '@storage/limits'
@@ -85,12 +84,7 @@ export class BucketDeleted extends BaseEvent<BucketDeletedEvent> {
       })
     } finally {
       if (storage) {
-        await storage.db.destroyConnection().catch((e) => {
-          logger.error(
-            { error: e, sbReqId: job.data.sbReqId },
-            `[BucketDeleted] ${job.data.tenant.ref} - FAILED DISPOSING CONNECTION`
-          )
-        })
+        storage.db.destroyConnection()
       }
     }
   }

--- a/src/storage/events/objects/backup-object.ts
+++ b/src/storage/events/objects/backup-object.ts
@@ -118,17 +118,7 @@ export class BackupObjectEvent extends BaseEvent<BackupObjectEventPayload> {
         `[Admin]: BackupObjectEvent ${s3Key} - FAILED`
       )
     } finally {
-      storage.db
-        .destroyConnection()
-        .then(() => {
-          // no-op
-        })
-        .catch((e) => {
-          logger.error(
-            { error: e, sbReqId: job.data.sbReqId },
-            `[Admin]: BackupObjectEvent ${tenantId} - FAILED DISPOSING CONNECTION`
-          )
-        })
+      storage.db.destroyConnection()
     }
   }
 }

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -142,18 +142,7 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
       throw e
     } finally {
       if (storage) {
-        const tenant = storage.db.tenant()
-        storage.db
-          .destroyConnection()
-          .then(() => {
-            // no-op
-          })
-          .catch((e) => {
-            logger.error(
-              { error: e, sbReqId: job.data.sbReqId },
-              `[Admin]: ObjectAdminDeleteAllBefore ${tenant.ref} - FAILED DISPOSING CONNECTION`
-            )
-          })
+        storage.db.destroyConnection()
       }
     }
   }

--- a/src/storage/events/objects/object-admin-delete.ts
+++ b/src/storage/events/objects/object-admin-delete.ts
@@ -80,18 +80,7 @@ export class ObjectAdminDelete extends BaseEvent<ObjectDeleteEvent> {
       throw e
     } finally {
       if (storage) {
-        const tenant = storage.db.tenant()
-        storage.db
-          .destroyConnection()
-          .then(() => {
-            // no-op
-          })
-          .catch((e) => {
-            logger.error(
-              { error: e, sbReqId: job.data.sbReqId },
-              `[Admin]: ObjectAdminDelete ${tenant.ref} - FAILED DISPOSING CONNECTION`
-            )
-          })
+        storage.db.destroyConnection()
       }
     }
   }

--- a/src/storage/events/upgrades/sync-catalog-ids.ts
+++ b/src/storage/events/upgrades/sync-catalog-ids.ts
@@ -118,12 +118,7 @@ export class SyncCatalogIds extends UpgradeBaseEvent<SyncCatalogIdsPayload> {
           )
         } finally {
           if (storage) {
-            await storage.db.destroyConnection().catch((e) => {
-              logger.error(
-                { error: e },
-                `[Upgrade][SyncCatalogIds] ${catalog.tenant_id} - FAILED DISPOSING CONNECTION`
-              )
-            })
+            storage.db.destroyConnection()
           }
         }
       })

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -61,7 +61,7 @@ afterEach(async () => {
 })
 
 afterAll(async () => {
-  await adminDb.destroyConnection()
+  adminDb.destroyConnection()
 })
 
 async function createBucket(name: string, authorization = authenticatedKey) {
@@ -594,7 +594,7 @@ describe('testing count objects in bucket', () => {
   afterAll(async () => {
     await db.deleteObjects(testBucketId, testObjectNames, 'name')
     await db.deleteBucket(testBucketId)
-    await db.destroyConnection()
+    db.destroyConnection()
   })
 
   it('should return correct object count', async () => {

--- a/src/test/database-protection.test.ts
+++ b/src/test/database-protection.test.ts
@@ -13,7 +13,7 @@ describe('Database Protection Triggers', () => {
   })
 
   afterAll(async () => {
-    await tHelper.database.connection.dispose()
+    tHelper.database.connection.dispose()
   })
 
   describe('Direct DELETE protection (migration 0050)', () => {

--- a/src/test/iceberg.test.ts
+++ b/src/test/iceberg.test.ts
@@ -166,7 +166,7 @@ describe('Iceberg Catalog', () => {
       db: {
         ...t.storage.db,
         connection: t.storage.db.connection,
-        destroyConnection: vi.fn().mockResolvedValue(undefined),
+        destroyConnection: vi.fn(),
       },
     } as unknown as typeof t.storage)
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1163,7 +1163,7 @@ describe('testing POST object via binary upload', () => {
       type: 'STANDARD',
     })
     await setupTx.commit()
-    await db.dispose()
+    db.dispose()
 
     const path = './src/test/assets/sadcat.jpg'
     const { size } = fs.statSync(path)

--- a/src/test/pg-connection.test.ts
+++ b/src/test/pg-connection.test.ts
@@ -213,8 +213,8 @@ describe('Pg database foundation', () => {
       isExternalPool: false,
     })
 
-    const first = await PgTenantConnection.create(settings)
-    const second = await PgTenantConnection.create(settings)
+    const first = PgTenantConnection.create(settings)
+    const second = PgTenantConnection.create(settings)
 
     expect(second.pool).toBe(first.pool)
 
@@ -234,15 +234,15 @@ describe('Pg database foundation', () => {
       isExternalPool: true,
     })
 
-    const first = await PgTenantConnection.create(settings)
-    const second = await PgTenantConnection.create(settings)
+    const first = PgTenantConnection.create(settings)
+    const second = PgTenantConnection.create(settings)
 
     expect(second.pool).toBe(first.pool)
 
     await first.pool.acquire().query('SELECT 1')
     expect(first.pool.getPoolStats()).not.toBeNull()
 
-    await first.dispose()
+    first.dispose()
     expect(first.pool.getPoolStats()).not.toBeNull()
     await expect(first.query('SELECT 1')).rejects.toThrow(
       'Cannot use a disposed PgTenantConnection'
@@ -250,7 +250,7 @@ describe('Pg database foundation', () => {
 
     // The shared pool stays usable for connections that were not disposed.
     await second.pool.acquire().query('SELECT 1')
-    await second.dispose()
+    second.dispose()
     await PgTenantConnection.poolManager.destroy('pg-foundation-external-pool')
   })
 
@@ -267,7 +267,7 @@ describe('Pg database foundation', () => {
       const result = await connection.pool.acquire().query<{ n: number }>('SELECT 1 AS n')
       expect(result.rows[0].n).toBe(1)
     } finally {
-      await connection.dispose()
+      connection.dispose()
     }
   })
 })

--- a/src/test/pg-connection.test.ts
+++ b/src/test/pg-connection.test.ts
@@ -270,4 +270,41 @@ describe('Pg database foundation', () => {
       connection.dispose()
     }
   })
+
+  it('reuses the single-tenant pool after disposing a request-scoped connection', async () => {
+    expect(getConfig().isMultitenant).toBe(false)
+
+    const superUser = await getServiceKeyUser(tenantId)
+    const createRequestConnection = () =>
+      getPgPostgresConnection({
+        tenantId,
+        host: 'localhost',
+        user: superUser,
+        superUser,
+      })
+
+    const first = await createRequestConnection()
+    await first.query('SELECT 1')
+    expect(first.pool.getPoolStats()).toEqual({ total: 1, used: 0 })
+
+    first.dispose()
+    expect(first.pool.getPoolStats()).toEqual({ total: 1, used: 0 })
+
+    const second = await createRequestConnection()
+
+    try {
+      expect(second).not.toBe(first)
+      expect(second.pool).toBe(first.pool)
+      expect(second.pool.getPoolStats()).toEqual({ total: 1, used: 0 })
+      await expect(first.query('SELECT 1')).rejects.toThrow(
+        'Cannot use a disposed PgTenantConnection'
+      )
+      await expect(second.query<{ n: number }>('SELECT 2 AS n')).resolves.toMatchObject({
+        rows: [{ n: 2 }],
+      })
+      expect(second.pool.getPoolStats()).toEqual({ total: 1, used: 0 })
+    } finally {
+      second.dispose()
+    }
+  })
 })

--- a/src/test/rls.test.ts
+++ b/src/test/rls.test.ts
@@ -181,7 +181,7 @@ describe('RLS policies', () => {
 
   afterAll(async () => {
     await db.end()
-    await (currentStorage.db as StoragePgDB).connection.dispose()
+    ;(currentStorage.db as StoragePgDB).connection.dispose()
   })
 
   testSpec.tests.forEach((_test, index) => {

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -2445,7 +2445,7 @@ describe('S3 Protocol', () => {
           anonClient.destroy()
           await db.query(`DROP POLICY IF EXISTS "${policyName}_select" ON storage.objects`)
           await db.query(`DROP POLICY IF EXISTS "${policyName}_delete" ON storage.objects`)
-          await connection.dispose()
+          connection.dispose()
           await client
             .send(
               new DeleteObjectsCommand({
@@ -3374,7 +3374,7 @@ describe('Migration compatibility', () => {
     afterAll(async () => {
       const db = new StoragePgDB(connection, { tenantId, host: 'localhost' })
       await db.deleteBucket(bucketId)
-      await connection.dispose()
+      connection.dispose()
     })
 
     const makeDB = (latestMigration?: keyof typeof DBMigration) =>

--- a/src/test/sharding.test.ts
+++ b/src/test/sharding.test.ts
@@ -23,8 +23,8 @@ describe('Sharding System', () => {
     await runMultitenantMigrations()
   })
 
-  afterAll(async () => {
-    await storageTest.database.connection.dispose()
+  afterAll(() => {
+    storageTest.database.connection.dispose()
   })
 
   beforeEach(async () => {

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -252,7 +252,7 @@ describe.each([
 
   afterEach(async () => {
     vi.useRealTimers()
-    await connection?.dispose()
+    connection?.dispose()
   })
 
   it('advertises TUS protocol headers on OPTIONS preflight', async () => {
@@ -1112,7 +1112,7 @@ describe('File-backed TUS — path traversal', () => {
   })
 
   afterEach(async () => {
-    await connection.dispose()
+    connection.dispose()
   })
 
   it('rejects traversal object names and does not write outside the file-backed TUS root', async () => {

--- a/src/test/utils/storage.ts
+++ b/src/test/utils/storage.ts
@@ -84,7 +84,7 @@ export function useStorage(options: { ensureMigrations?: boolean } = {}) {
   })
 
   afterAll(async () => {
-    await connection.dispose()
+    connection.dispose()
   })
 
   return {

--- a/src/test/vectors.test.ts
+++ b/src/test/vectors.test.ts
@@ -127,7 +127,7 @@ describe('Vectors API', () => {
 
   afterAll(async () => {
     await appInstance.close()
-    await storageTest.database.connection.dispose()
+    storageTest.database.connection.dispose()
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for promises

## What is the current behavior?

Connection creation is async but it's actually sync. 
Dispose is very close to be sync after shared pool manager refactoring but it creates a new promise for API compatibility.

## What is the new behavior?

Make create sync and update callers as relevant.
Make dispose sync and cleanup error handling.

## Additional context

It will help GC in hot path.