### PR TITLE
fix: postpone parsing policy until signature verification

### DIFF
--- a/src/storage/protocols/s3/policy.ts
+++ b/src/storage/protocols/s3/policy.ts
@@ -45,12 +45,12 @@ export function assertPolicyNotExpired(expiration: string | undefined): void {
     throw ERRORS.InvalidSignature('Missing policy expiration')
   }
 
-  const expirationDate = new Date(expiration)
-  if (isNaN(expirationDate.getTime())) {
+  const expirationDate = Date.parse(expiration)
+  if (isNaN(expirationDate)) {
     throw ERRORS.InvalidSignature('Invalid policy expiration')
   }
 
-  if (expirationDate < new Date()) {
+  if (expirationDate < Date.now()) {
     throw ERRORS.ExpiredSignature()
   }
 }
@@ -66,12 +66,12 @@ export function assertPolicyNotExpired(expiration: string | undefined): void {
  *
  * @param policy the decoded policy document
  * @param submittedFields the submitted form fields, keyed by lowercased name
- * @param opts.bucket the bucket resolved from the request path
+ * @param bucket the bucket resolved from the request path
  */
 export function assertPolicyConditionsSatisfied(
   policy: Policy,
   submittedFields: Record<string, string>,
-  opts: { bucket?: string }
+  bucket?: string
 ): void {
   const conditions = policy?.conditions
   if (!Array.isArray(conditions)) {
@@ -79,8 +79,8 @@ export function assertPolicyConditionsSatisfied(
   }
 
   const fields: Record<string, string> = { ...submittedFields }
-  if (opts.bucket !== undefined) {
-    fields['bucket'] = opts.bucket
+  if (bucket !== undefined) {
+    fields['bucket'] = bucket
   }
 
   const coveredFields = new Set<string>()
@@ -166,5 +166,19 @@ function assertFieldStartsWith(
   const actual = fields[field]
   if (actual === undefined || !actual.startsWith(String(prefix ?? ''))) {
     throw ERRORS.AccessDenied(`Policy condition failed: "${field}" does not start with "${prefix}"`)
+  }
+}
+
+export function parsePolicy(encoded: string): Policy {
+  try {
+    const value: unknown = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'))
+
+    if (!value || typeof value !== 'object') {
+      throw new Error()
+    }
+
+    return value as Policy
+  } catch {
+    throw ERRORS.InvalidSignature('Invalid POST policy')
   }
 }

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@internal/errors'
 import crypto from 'crypto'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
-import { assertPolicyConditionsSatisfied, assertPolicyNotExpired, Policy } from './policy'
+import { assertPolicyConditionsSatisfied, assertPolicyNotExpired, parsePolicy } from './policy'
 
 export enum SignatureV4Service {
   S3 = 's3',
@@ -29,7 +29,6 @@ export interface ClientSignature {
   contentSha?: string
   policy?: {
     raw: string
-    value: Policy
     fields: Record<string, string>
   }
 }
@@ -211,8 +210,6 @@ export class SignatureV4 {
       throw ERRORS.InvalidSignature('Invalid signature format')
     }
 
-    const xPolicy: Policy = JSON.parse(Buffer.from(policy, 'base64').toString('utf-8'))
-
     const fields: Record<string, string> = Object.create(null)
     form.forEach((value, key) => {
       if (typeof value !== 'string') {
@@ -240,7 +237,6 @@ export class SignatureV4 {
       sessionToken,
       policy: {
         raw: policy,
-        value: xPolicy,
         fields,
       },
     }
@@ -288,12 +284,13 @@ export class SignatureV4 {
         return false
       }
 
-      const { value, fields } = clientSignature.policy
+      const value = parsePolicy(clientSignature.policy.raw)
+
       // A POST policy must declare an expiration; AWS treats a missing one as
       // invalid. Without this check a signed policy with no expiration would never
       // expire and could be replayed forever.
       assertPolicyNotExpired(value.expiration)
-      assertPolicyConditionsSatisfied(value, fields, { bucket: request.bucket })
+      assertPolicyConditionsSatisfied(value, clientSignature.policy.fields, request.bucket)
       return true
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for hardening

## What is the current behavior?

Policy is parsed eagerly before signature is verified.

## What is the new behavior?

Let signature verified first then parse policy json.

## Additional context

Related to #1211 
