### PR TITLE
fix: hoist regex and num parser in x-robots-tag

### DIFF
--- a/src/storage/validators/x-robots-tag.test.ts
+++ b/src/storage/validators/x-robots-tag.test.ts
@@ -162,6 +162,12 @@ describe('validateXRobotsTag', () => {
       ).not.toThrow()
     })
 
+    it('should accept extra whitespace before an RFC 822 date followed by another rule', () => {
+      expect(() =>
+        validateXRobotsTag('unavailable_after:  Wed, 03 Dec 2025 13:09:53 GMT, noindex')
+      ).not.toThrow()
+    })
+
     it('should throw for invalid date', () => {
       expect(() => validateXRobotsTag('unavailable_after: not-a-date')).toThrow(
         'X-Robots-Tag "unavailable_after" value must be a valid date'

--- a/src/storage/validators/x-robots-tag.test.ts
+++ b/src/storage/validators/x-robots-tag.test.ts
@@ -97,55 +97,35 @@ describe('validateXRobotsTag', () => {
     })
   })
 
-  describe('max-snippet parametric rule', () => {
-    it('should accept valid max-snippet with number', () => {
-      expect(() => validateXRobotsTag('max-snippet: 50')).not.toThrow()
+  describe.each(['max-snippet', 'max-video-preview'])('%s parametric rule', (ruleName) => {
+    it.each(['50', '0', '-1'])('should accept integer value "%s"', (value) => {
+      expect(() => validateXRobotsTag(`${ruleName}: ${value}`)).not.toThrow()
     })
 
-    it('should accept max-snippet with 0', () => {
-      expect(() => validateXRobotsTag('max-snippet: 0')).not.toThrow()
-    })
-
-    it('should accept max-snippet with -1 (no snippet-length limit)', () => {
-      expect(() => validateXRobotsTag('max-snippet: -1')).not.toThrow()
-    })
-
-    it('should throw for max-snippet below -1', () => {
-      expect(() => validateXRobotsTag('max-snippet: -5')).toThrow(
-        'X-Robots-Tag "max-snippet" value must be a number >= -1'
+    it.each([
+      '-2',
+      'abc',
+      '-0.5',
+      '-1.5',
+      '50a',
+      '0x10',
+      '1e3',
+    ])('should throw for invalid integer value "%s"', (value) => {
+      expect(() => validateXRobotsTag(`${ruleName}: ${value}`)).toThrow(
+        `X-Robots-Tag "${ruleName}" value must be an integer >= -1`
       )
     })
 
-    it('should throw for max-snippet with non-numeric value', () => {
-      expect(() => validateXRobotsTag('max-snippet: abc')).toThrow(
-        'X-Robots-Tag "max-snippet" value must be a number >= -1'
-      )
-    })
-
-    it('should throw for max-snippet without value', () => {
-      expect(() => validateXRobotsTag('max-snippet:')).toThrow(
-        'X-Robots-Tag rule "max-snippet" requires a value'
-      )
-    })
-
-    it('should throw for max-snippet with whitespace-only value', () => {
-      expect(() => validateXRobotsTag('max-snippet:   ')).toThrow(
-        'X-Robots-Tag rule "max-snippet" requires a value'
+    it.each(['', '   '])('should throw for missing value "%s"', (value) => {
+      expect(() => validateXRobotsTag(`${ruleName}: ${value}`)).toThrow(
+        `X-Robots-Tag rule "${ruleName}" requires a value`
       )
     })
   })
 
   describe('max-image-preview parametric rule', () => {
-    it('should accept "none"', () => {
-      expect(() => validateXRobotsTag('max-image-preview: none')).not.toThrow()
-    })
-
-    it('should accept "standard"', () => {
-      expect(() => validateXRobotsTag('max-image-preview: standard')).not.toThrow()
-    })
-
-    it('should accept "large"', () => {
-      expect(() => validateXRobotsTag('max-image-preview: large')).not.toThrow()
+    it.each(['none', 'standard', 'large'])('should accept "%s"', (value) => {
+      expect(() => validateXRobotsTag(`max-image-preview: ${value}`)).not.toThrow()
     })
 
     it('should throw for invalid value', () => {
@@ -157,38 +137,6 @@ describe('validateXRobotsTag', () => {
     it('should throw for missing value', () => {
       expect(() => validateXRobotsTag('max-image-preview:')).toThrow(
         'X-Robots-Tag rule "max-image-preview" requires a value'
-      )
-    })
-  })
-
-  describe('max-video-preview parametric rule', () => {
-    it('should accept positive number', () => {
-      expect(() => validateXRobotsTag('max-video-preview: 30')).not.toThrow()
-    })
-
-    it('should accept 0', () => {
-      expect(() => validateXRobotsTag('max-video-preview: 0')).not.toThrow()
-    })
-
-    it('should accept -1 (no limit)', () => {
-      expect(() => validateXRobotsTag('max-video-preview: -1')).not.toThrow()
-    })
-
-    it('should throw for number less than -1', () => {
-      expect(() => validateXRobotsTag('max-video-preview: -2')).toThrow(
-        'X-Robots-Tag "max-video-preview" value must be a number >= -1'
-      )
-    })
-
-    it('should throw for non-numeric value', () => {
-      expect(() => validateXRobotsTag('max-video-preview: abc')).toThrow(
-        'X-Robots-Tag "max-video-preview" value must be a number >= -1'
-      )
-    })
-
-    it('should throw for missing value', () => {
-      expect(() => validateXRobotsTag('max-video-preview:')).toThrow(
-        'X-Robots-Tag rule "max-video-preview" requires a value'
       )
     })
   })

--- a/src/storage/validators/x-robots-tag.ts
+++ b/src/storage/validators/x-robots-tag.ts
@@ -25,7 +25,7 @@ const PARAMETRIC_RULE_REGEX = new RegExp(`^(${parametricRulesPattern}):\\s*(.*)$
 const PARAMETRIC_RULE_START_REGEX = new RegExp(`^(${parametricRulesPattern}):`)
 const DECIMAL_INTEGER_REGEX = /^-?\d+$/
 const UNAVAILABLE_AFTER_END_REGEX = new RegExp(
-  `unavailable_after:\\s*(.+?)(?:,\\s*(?:${simpleRulesPattern}|${parametricRulesPattern}|[a-zA-Z0-9_-]+:)|$)`
+  `^unavailable_after:\\s*(.+?)(?=,\\s*(?:${simpleRulesPattern}|${parametricRulesPattern}|[a-zA-Z0-9_-]+:)|$)`
 )
 const VALID_IMAGE_PREVIEW_VALUES = new Set(['none', 'standard', 'large'])
 
@@ -110,7 +110,7 @@ function splitRules(value: string): string[] {
         if (dateEndMatch) {
           const fullRule = `unavailable_after: ${dateEndMatch[1].trim()}`
           parts.push(fullRule)
-          remaining = remaining.substring(fullRule.length).replace(/^,\s*/, '').trim()
+          remaining = remaining.substring(dateEndMatch[0].length).replace(/^,\s*/, '').trim()
         } else {
           parts.push(remaining)
           remaining = ''

--- a/src/storage/validators/x-robots-tag.ts
+++ b/src/storage/validators/x-robots-tag.ts
@@ -23,6 +23,10 @@ const parametricRulesPattern = PARAMETRIC_RULES.join('|')
 const SIMPLE_RULE_REGEX = new RegExp(`^(${simpleRulesPattern})$`)
 const PARAMETRIC_RULE_REGEX = new RegExp(`^(${parametricRulesPattern}):\\s*(.*)$`)
 const PARAMETRIC_RULE_START_REGEX = new RegExp(`^(${parametricRulesPattern}):`)
+const DECIMAL_INTEGER_REGEX = /^-?\d+$/
+const UNAVAILABLE_AFTER_END_REGEX = new RegExp(
+  `unavailable_after:\\s*(.+?)(?:,\\s*(?:${simpleRulesPattern}|${parametricRulesPattern}|[a-zA-Z0-9_-]+:)|$)`
+)
 const VALID_IMAGE_PREVIEW_VALUES = new Set(['none', 'standard', 'large'])
 
 /**
@@ -100,11 +104,8 @@ function splitRules(value: string): string[] {
 
       // For unavailable_after, extract date value (may contain commas)
       if (ruleName === 'unavailable_after') {
-        // Build regex to find end of date by looking for comma + known rule or user agent
-        const endPattern = new RegExp(
-          `unavailable_after:\\s*(.+?)(?:,\\s*(?:${simpleRulesPattern}|${parametricRulesPattern}|[a-zA-Z0-9_-]+:)|$)`
-        )
-        const dateEndMatch = remaining.match(endPattern)
+        // Find the end of the date by looking for a comma + known rule or user agent
+        const dateEndMatch = remaining.match(UNAVAILABLE_AFTER_END_REGEX)
 
         if (dateEndMatch) {
           const fullRule = `unavailable_after: ${dateEndMatch[1].trim()}`
@@ -146,12 +147,12 @@ function validateParametricRule(
 
   switch (ruleName) {
     case 'max-snippet': {
-      const num = parseInt(ruleValue, 10)
+      const num = Number(ruleValue)
       // -1 ("no limit", the default) and 0 ("no snippet") are both valid per the
       // robots meta spec, alongside any positive length.
-      if (isNaN(num) || num < -1) {
+      if (!DECIMAL_INTEGER_REGEX.test(ruleValue) || !Number.isInteger(num) || num < -1) {
         throw ERRORS.InvalidXRobotsTag(
-          `X-Robots-Tag "max-snippet" value must be a number >= -1, got: "${ruleValue}"`
+          `X-Robots-Tag "max-snippet" value must be an integer >= -1, got: "${ruleValue}"`
         )
       }
       break
@@ -167,10 +168,10 @@ function validateParametricRule(
     }
 
     case 'max-video-preview': {
-      const num = parseInt(ruleValue, 10)
-      if (isNaN(num) || num < -1) {
+      const num = Number(ruleValue)
+      if (!DECIMAL_INTEGER_REGEX.test(ruleValue) || !Number.isInteger(num) || num < -1) {
         throw ERRORS.InvalidXRobotsTag(
-          `X-Robots-Tag "max-video-preview" value must be a number >= -1, got: "${ruleValue}"`
+          `X-Robots-Tag "max-video-preview" value must be an integer >= -1, got: "${ruleValue}"`
         )
       }
       break


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the current behavior?

Regex is recreated per header.
Num parsing is [permissive](https://github.com/supabase/storage/pull/1227#discussion_r3579064691) and accepts invalid headers.

## What is the new behavior?

Hoist regex to module level.
Replace `parseInt` with `Number.isInteger` to ensure value is an integer.

## Additional context

Reduce boilerplate in tests via each.
Related to #1227
Docs: https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag 