### PR TITLE
feat: run healthcheck unscoped

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,6 +43,8 @@ AUTH_ENCRYPTION_KEY=encryptionkey
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1/postgres
 DATABASE_POOL_URL=postgresql://postgres:postgres@127.0.0.1:6453/postgres
 DATABASE_CONNECTION_TIMEOUT=3000
+# Set to true to run healthchecks without the scoped transaction path.
+DATABASE_HEALTHCHECK_UNSCOPED=false
 DATABASE_SEARCH_PATH=
 
 DATABASE_APPLICATION_NAME="Supabase Storage API"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -7,6 +7,7 @@ const CONFIG_ENV_KEYS = [
   'TENANT_POOL_CACHE_HIT_LOG_SAMPLE_RATE',
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
   'DATABASE_POOL_DRAIN_TIMEOUT',
+  'DATABASE_HEALTHCHECK_UNSCOPED',
   'REQUEST_HARD_LIMITS_ENABLED',
   'STORAGE_S3_REQUEST_CHECKSUM_CALCULATION',
   'STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION',
@@ -114,6 +115,24 @@ describe('tenant pool cache config parsing', () => {
     const config = getConfig({ reload: true })
 
     expect(config.databasePoolDrainTimeout).toBe(45_000)
+  })
+
+  test('disables unscoped database healthchecks by default', async () => {
+    setConfigEnv({})
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.databaseHealthcheckUnscoped).toBe(false)
+  })
+
+  test('enables unscoped database healthchecks from env', async () => {
+    setConfigEnv({ DATABASE_HEALTHCHECK_UNSCOPED: 'true' })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.databaseHealthcheckUnscoped).toBe(true)
   })
 
   test.each([

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,7 @@ type StorageConfigType = {
   databasePoolDrainTimeout: number
   databaseConnectionTimeout: number
   databaseEnableQueryCancellation: boolean
+  databaseHealthcheckUnscoped: boolean
   databaseStatementTimeout: number
   databaseApplicationName: string
   region: string
@@ -504,6 +505,8 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     ),
     databaseEnableQueryCancellation:
       getOptionalConfigFromEnv('DATABASE_ENABLE_QUERY_CANCELLATION') === 'true',
+    databaseHealthcheckUnscoped:
+      getOptionalConfigFromEnv('DATABASE_HEALTHCHECK_UNSCOPED') === 'true',
     databaseStatementTimeout: parseInt(
       getOptionalConfigFromEnv('DATABASE_STATEMENT_TIMEOUT') || '30000',
       10

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -1,7 +1,8 @@
-import { PgTenantConnection } from '@internal/database'
+import { type PgExecutor, PgPoolExecutor, PgTenantConnection } from '@internal/database'
 import { normalizeRawError } from '@internal/errors'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
-import { DatabaseError } from 'pg'
+import { EventEmitter } from 'events'
+import { DatabaseError, type Pool, type PoolClient } from 'pg'
 import { vi } from 'vitest'
 import { escapeLike, StoragePgDB } from './pg'
 
@@ -106,6 +107,193 @@ describe('StoragePgDB metrics', () => {
       performanceNowSpy.mockRestore()
       recordSpy.mockRestore()
     }
+  })
+})
+
+describe('StoragePgDB healthcheck', () => {
+  const probeSql = 'SELECT id from storage.buckets limit 1'
+  const expectedAbortError = {
+    name: 'AbortError',
+    code: 'ABORT_ERR',
+    message: 'Query was aborted',
+  }
+  let UnscopedStoragePgDB: typeof StoragePgDB
+
+  beforeAll(async () => {
+    vi.resetModules()
+    const configModule = await import('../../config')
+    const { databaseHealthcheckUnscoped } = configModule.getConfig()
+    configModule.mergeConfig({ databaseHealthcheckUnscoped: true })
+
+    try {
+      const pgModule = await import('./pg')
+      UnscopedStoragePgDB = pgModule.StoragePgDB
+    } finally {
+      configModule.mergeConfig({ databaseHealthcheckUnscoped })
+    }
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  function createHealthcheckFixture(
+    executor: PgExecutor,
+    options: {
+      requestSignal?: AbortSignal
+      StorageClass?: typeof StoragePgDB
+    } = {}
+  ) {
+    const { requestSignal, StorageClass = TestStoragePgDB } = options
+    const transaction = {
+      commit: vi.fn(),
+      rollback: vi.fn(),
+      isCompleted: vi.fn().mockReturnValue(false),
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    }
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(requestSignal),
+      pool: {
+        acquire: vi.fn().mockReturnValue(executor),
+      },
+      transaction: vi.fn().mockResolvedValue(transaction),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new StorageClass(connection, {
+      tenantId: 'healthcheck-tenant',
+      host: 'localhost',
+    })
+
+    return { connection, storage, transaction }
+  }
+
+  function createProbe(requestSignal?: AbortSignal) {
+    let finishQuery: (() => void) | undefined
+    const executor = {
+      query: vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finishQuery = () => resolve({ rows: [] })
+          })
+      ),
+    }
+    const fixture = createHealthcheckFixture(executor, {
+      requestSignal,
+      StorageClass: UnscopedStoragePgDB,
+    })
+
+    return {
+      ...fixture,
+      executor,
+      probeSignal: () => executor.query.mock.calls[0]?.[1]?.signal as AbortSignal | undefined,
+      finishQuery: () => {
+        if (!finishQuery) {
+          throw new Error('Probe query has not started')
+        }
+        finishQuery()
+      },
+    }
+  }
+
+  function createPendingPoolExecutor() {
+    const release = vi.fn()
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn(() => new Promise(() => undefined)),
+      release,
+    }) as unknown as PoolClient & EventEmitter
+    const connect = vi.fn().mockResolvedValue(client)
+    const pool = { connect } as unknown as Pool
+
+    return { client, connect, executor: new PgPoolExecutor(pool), release }
+  }
+
+  test('rejects and disposes the client when the healthcheck timeout elapses', async () => {
+    const { client, executor, release } = createPendingPoolExecutor()
+    const fixture = createHealthcheckFixture(executor, {
+      StorageClass: UnscopedStoragePgDB,
+    })
+    const probe = fixture.storage.healthcheck()
+    const rejection = expect(probe).rejects.toMatchObject(expectedAbortError)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(client.query).toHaveBeenCalledWith(probeSql, undefined)
+
+    await vi.advanceTimersToNextTimerAsync()
+
+    await rejection
+    expect(release).toHaveBeenCalledWith(expect.objectContaining(expectedAbortError))
+
+    expect(fixture.connection.pool.acquire).toHaveBeenCalledTimes(1)
+    expect(fixture.connection.transaction).not.toHaveBeenCalled()
+    expect(fixture.connection.setScope).not.toHaveBeenCalled()
+  })
+
+  test('rejects and disposes the client when the request is canceled in flight', async () => {
+    const requestController = new AbortController()
+    const { client, executor, release } = createPendingPoolExecutor()
+    const fixture = createHealthcheckFixture(executor, {
+      requestSignal: requestController.signal,
+      StorageClass: UnscopedStoragePgDB,
+    })
+    const probe = fixture.storage.healthcheck()
+    const rejection = expect(probe).rejects.toMatchObject(expectedAbortError)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(client.query).toHaveBeenCalledWith(probeSql, undefined)
+
+    requestController.abort()
+
+    await rejection
+    expect(release).toHaveBeenCalledWith(expect.objectContaining(expectedAbortError))
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  test('rejects before checkout when the request is already canceled', async () => {
+    const requestController = new AbortController()
+    requestController.abort()
+    const { connect, executor } = createPendingPoolExecutor()
+    const fixture = createHealthcheckFixture(executor, {
+      requestSignal: requestController.signal,
+      StorageClass: UnscopedStoragePgDB,
+    })
+
+    await expect(fixture.storage.healthcheck()).rejects.toMatchObject(expectedAbortError)
+
+    expect(connect).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  test('uses the scoped readiness probe by default', async () => {
+    const executor = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as PgExecutor
+    const fixture = createHealthcheckFixture(executor)
+
+    await expect(fixture.storage.healthcheck()).resolves.toBeUndefined()
+
+    expect(fixture.connection.pool.acquire).not.toHaveBeenCalled()
+    expect(fixture.connection.transaction).toHaveBeenCalledTimes(1)
+    expect(fixture.connection.setScope).toHaveBeenCalledWith(fixture.transaction)
+    expect(fixture.transaction.query).toHaveBeenCalledWith(probeSql, { signal: undefined })
+    expect(fixture.transaction.commit).toHaveBeenCalledTimes(1)
+  })
+
+  test('clears the timeout and stops observing the request signal once the probe settles', async () => {
+    const requestController = new AbortController()
+    const probeFixture = createProbe(requestController.signal)
+    const probe = probeFixture.storage.healthcheck()
+    probeFixture.finishQuery()
+    await expect(probe).resolves.toBeUndefined()
+
+    expect(vi.getTimerCount()).toBe(0)
+
+    requestController.abort()
+    expect(probeFixture.probeSignal()?.aborted).toBe(false)
   })
 })
 

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -28,7 +28,8 @@ import {
 } from './adapter'
 import { DBError, mapPgTransactionAbortedError, PgErrorContext } from './errors'
 
-const { databaseEngine, isMultitenant } = getConfig()
+const { databaseEngine, databaseStatementTimeout, isMultitenant, databaseHealthcheckUnscoped } =
+  getConfig()
 // Scanner cache tables are unlogged scratch tables, not session temp tables.
 // They must survive across pooled pg clients used by separate unscoped queries.
 const S3_KEYS_SCRATCH_TABLE_SCHEMA = 'storage'
@@ -50,6 +51,31 @@ interface PgDatabaseOptions {
   tnx?: PgTransaction
   parentTnx?: PgTransaction
   parentConnection?: PgTenantConnection
+}
+
+interface UnscopedQueryOptions {
+  readonly timeoutMs?: number
+}
+
+const HEALTHCHECK_SQL = 'SELECT id from storage.buckets limit 1'
+const HEALTHCHECK_QUERY_OPTIONS: UnscopedQueryOptions = Object.freeze({
+  timeoutMs: databaseStatementTimeout,
+})
+
+async function executeQuery<T extends QueryResultRow = QueryResultRow>(
+  db: PgExecutor,
+  statement: string | PgStatement,
+  signal?: AbortSignal
+) {
+  try {
+    return await db.query<T>(statement, { signal })
+  } catch (error) {
+    throw mapPgError(error, typeof statement === 'string' ? statement : statement.text)
+  }
+}
+
+function healthcheckProbe(db: PgExecutor, signal?: AbortSignal) {
+  return executeQuery(db, HEALTHCHECK_SQL, signal)
 }
 
 class TestPermissionRollbackError extends Error {
@@ -1666,9 +1692,11 @@ export class StoragePgDB implements Database {
   }
 
   async healthcheck() {
-    await this.runQuery('Healthcheck', (db, signal) => {
-      return this.query(db, 'SELECT id from storage.buckets limit 1', signal)
-    })
+    if (databaseHealthcheckUnscoped) {
+      await this.runUnscopedQuery('Healthcheck', healthcheckProbe, HEALTHCHECK_QUERY_OPTIONS)
+    } else {
+      await this.runQuery('Healthcheck', healthcheckProbe)
+    }
   }
 
   destroyConnection(): void {
@@ -1883,31 +1911,53 @@ export class StoragePgDB implements Database {
 
   protected async runUnscopedQuery<T>(
     queryName: string,
-    fn: (db: PgExecutor, signal?: AbortSignal) => Promise<T>
+    fn: (db: PgExecutor, signal?: AbortSignal) => Promise<T>,
+    options?: UnscopedQueryOptions
   ): Promise<T> {
     const startTime = performance.now()
-    const abortSignal = this.connection.getAbortSignal()
-    const recordDuration = this.createDurationRecorder(queryName, startTime, abortSignal)
+    const requestAbortSignal = this.connection.getAbortSignal()
+    const recordDuration = this.createDurationRecorder(queryName, startTime, requestAbortSignal)
+    const timeoutMs = normalizeTimeoutMs(options?.timeoutMs)
+
+    let controller: AbortController | undefined
+    let timer: NodeJS.Timeout | undefined
+    let onRequestAbort: (() => void) | undefined
+
+    if (timeoutMs !== undefined) {
+      controller = new AbortController()
+      timer = setTimeout(abortFromTimer, timeoutMs, controller)
+      timer.unref()
+
+      if (requestAbortSignal?.aborted) {
+        controller.abort()
+      } else if (requestAbortSignal) {
+        const timedController = controller
+        onRequestAbort = () => timedController.abort()
+        requestAbortSignal.addEventListener('abort', onRequestAbort, { once: true })
+      }
+    }
 
     try {
-      return await fn(this.connection.pool.acquire(), abortSignal)
+      return await fn(this.connection.pool.acquire(), controller?.signal ?? requestAbortSignal)
     } catch (e) {
       throw mapPgErrorWithQueryName(e, queryName)
     } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer)
+      }
+      if (onRequestAbort) {
+        requestAbortSignal?.removeEventListener('abort', onRequestAbort)
+      }
       recordDuration()
     }
   }
 
-  protected async query<T extends QueryResultRow = QueryResultRow>(
+  protected query<T extends QueryResultRow = QueryResultRow>(
     db: PgExecutor,
     statement: string | PgStatement,
     signal?: AbortSignal
   ) {
-    try {
-      return await db.query<T>(statement, { signal })
-    } catch (e) {
-      throw mapPgError(e, typeof statement === 'string' ? statement : statement.text)
-    }
+    return executeQuery<T>(db, statement, signal)
   }
 
   private createDurationRecorder(
@@ -1932,6 +1982,20 @@ export class StoragePgDB implements Database {
       })
     }
   }
+}
+
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return undefined
+  }
+
+  return timeoutMs
+}
+
+// Static setTimeout callback taking the controller as an argument
+// so arming the deadline allocates no closure.
+function abortFromTimer(controller: AbortController): void {
+  controller.abort()
 }
 
 function selectColumns(columns: string | string[]): string {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Healthcheck pays the price for full tx/scope machinery and make 4 round trips. 

## What is the new behavior?

Healthcheck can skip this machinery and make a simpler pooled select.  

## Additional context

It's controlled by `DATABASE_HEALTHCHECK_UNSCOPED=true`, disabled by default.
