### PR TITLE
fix: precompile projection columns

### DIFF
--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -1,3 +1,4 @@
+import { defineBucketColumns } from '@storage/database'
 import { isClientVersionBefore } from '@storage/limits'
 import { bucketSchema } from '@storage/schemas'
 import { FastifyInstance } from 'fastify'
@@ -5,6 +6,28 @@ import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
+
+const BUCKET_LIST_COLUMNS = defineBucketColumns(
+  'id',
+  'name',
+  'public',
+  'owner',
+  'created_at',
+  'updated_at',
+  'file_size_limit',
+  'allowed_mime_types',
+  'type'
+)
+const LEGACY_BUCKET_LIST_COLUMNS = defineBucketColumns(
+  'id',
+  'name',
+  'public',
+  'owner',
+  'created_at',
+  'updated_at',
+  'file_size_limit',
+  'allowed_mime_types'
+)
 
 const successResponseSchema = {
   type: 'array',
@@ -71,8 +94,7 @@ export default async function routes(fastify: FastifyInstance) {
         isClientVersionBefore('storage3', userAgent, '0.12.1')
 
       const results = await request.storage.listBuckets(
-        'id, name, public, owner, created_at, updated_at, file_size_limit, allowed_mime_types' +
-          (omitBucketType ? '' : ', type'),
+        omitBucketType ? LEGACY_BUCKET_LIST_COLUMNS : BUCKET_LIST_COLUMNS,
         { limit, offset, sortColumn, sortOrder, search }
       )
 

--- a/src/http/routes/bucket/getAllBuckets.ts
+++ b/src/http/routes/bucket/getAllBuckets.ts
@@ -1,4 +1,4 @@
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { isClientVersionBefore } from '@storage/limits'
 import { bucketSchema } from '@storage/schemas'
 import { FastifyInstance } from 'fastify'
@@ -7,7 +7,17 @@ import { createDefaultSchema } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
-const BUCKET_LIST_COLUMNS = defineBucketColumns(
+const LEGACY_BUCKET_LIST_COLUMNS = bucketColumns.select(
+  'id',
+  'name',
+  'public',
+  'owner',
+  'created_at',
+  'updated_at',
+  'file_size_limit',
+  'allowed_mime_types'
+)
+const BUCKET_LIST_COLUMNS = bucketColumns.select(
   'id',
   'name',
   'public',
@@ -17,16 +27,6 @@ const BUCKET_LIST_COLUMNS = defineBucketColumns(
   'file_size_limit',
   'allowed_mime_types',
   'type'
-)
-const LEGACY_BUCKET_LIST_COLUMNS = defineBucketColumns(
-  'id',
-  'name',
-  'public',
-  'owner',
-  'created_at',
-  'updated_at',
-  'file_size_limit',
-  'allowed_mime_types'
 )
 
 const successResponseSchema = {

--- a/src/http/routes/bucket/getBucket.ts
+++ b/src/http/routes/bucket/getBucket.ts
@@ -1,9 +1,21 @@
+import { defineBucketColumns } from '@storage/database'
 import { bucketSchema } from '@storage/schemas'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createDefaultSchema } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
+
+const BUCKET_DETAILS_COLUMNS = defineBucketColumns(
+  'id',
+  'name',
+  'owner',
+  'public',
+  'created_at',
+  'updated_at',
+  'file_size_limit',
+  'allowed_mime_types'
+)
 
 const getBucketParamsSchema = {
   type: 'object',
@@ -36,10 +48,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketId } = request.params
 
-      const results = await request.storage.findBucket(
-        bucketId,
-        'id, name, owner, public, created_at, updated_at, file_size_limit, allowed_mime_types'
-      )
+      const results = await request.storage.findBucket(bucketId, BUCKET_DETAILS_COLUMNS)
 
       return response.send(results)
     }

--- a/src/http/routes/bucket/getBucket.ts
+++ b/src/http/routes/bucket/getBucket.ts
@@ -1,4 +1,4 @@
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { bucketSchema } from '@storage/schemas'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -6,7 +6,7 @@ import { createDefaultSchema } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
-const BUCKET_DETAILS_COLUMNS = defineBucketColumns(
+const BUCKET_DETAILS_COLUMNS = bucketColumns.select(
   'id',
   'name',
   'owner',

--- a/src/http/routes/iceberg/bucket.ts
+++ b/src/http/routes/iceberg/bucket.ts
@@ -1,8 +1,11 @@
+import { defineAnalyticsColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createResponse } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
+
+const ANALYTICS_BUCKET_LIST_COLUMNS = defineAnalyticsColumns('name', 'created_at', 'updated_at')
 
 const deleteBucketParamsSchema = {
   type: 'object',
@@ -112,7 +115,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const query = request.query
 
-      const bucket = await request.storage.listAnalyticsBuckets('name,created_at,updated_at', {
+      const bucket = await request.storage.listAnalyticsBuckets(ANALYTICS_BUCKET_LIST_COLUMNS, {
         limit: query.limit,
         offset: query.offset,
         sortColumn: query.sortColumn,

--- a/src/http/routes/iceberg/bucket.ts
+++ b/src/http/routes/iceberg/bucket.ts
@@ -1,11 +1,11 @@
-import { defineAnalyticsColumns } from '@storage/database'
+import { analyticsColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { createResponse } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
-const ANALYTICS_BUCKET_LIST_COLUMNS = defineAnalyticsColumns('name', 'created_at', 'updated_at')
+const ANALYTICS_BUCKET_LIST_COLUMNS = analyticsColumns.select('name', 'created_at', 'updated_at')
 
 const deleteBucketParamsSchema = {
   type: 'object',

--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -1,4 +1,5 @@
 import { ERRORS } from '@internal/errors'
+import { defineBucketColumns, defineObjectColumns } from '@storage/database'
 import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -8,6 +9,8 @@ import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
+const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
+const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const getObjectParamsSchema = {
   type: 'object',
@@ -43,7 +46,7 @@ async function requestHandler(request: GetObjectRequest, response: FastifyReply)
     bucketId: bucketName,
     objectName,
   })
-  const bucket = await request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
+  const bucket = await request.storage.asSuperUser().findBucket(bucketName, PUBLIC_BUCKET_COLUMNS, {
     dontErrorOnEmpty: true,
   })
 
@@ -67,10 +70,10 @@ async function requestHandler(request: GetObjectRequest, response: FastifyReply)
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(objectName, 'id, version, metadata')
+      .findObject(objectName, OBJECT_DOWNLOAD_COLUMNS)
   } else {
     // request is authenticated use RLS
-    obj = await request.storage.from(bucketName).findObject(objectName, 'id, version, metadata')
+    obj = await request.storage.from(bucketName).findObject(objectName, OBJECT_DOWNLOAD_COLUMNS)
   }
 
   return request.storage.renderer('asset').render(request, response, {

--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -1,5 +1,5 @@
 import { ERRORS } from '@internal/errors'
-import { defineBucketColumns, defineObjectColumns } from '@storage/database'
+import { bucketColumns, objectColumns } from '@storage/database'
 import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -9,8 +9,8 @@ import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
-const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
-const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const PUBLIC_BUCKET_COLUMNS = bucketColumns.select('id', 'public')
+const OBJECT_DOWNLOAD_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const getObjectParamsSchema = {
   type: 'object',

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -1,4 +1,5 @@
 import { ERRORS } from '@internal/errors'
+import { defineBucketColumns, defineObjectColumns } from '@storage/database'
 import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -9,6 +10,17 @@ import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
+const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
+const OBJECT_INFO_COLUMNS = defineObjectColumns(
+  'id',
+  'name',
+  'version',
+  'bucket_id',
+  'metadata',
+  'user_metadata',
+  'updated_at',
+  'created_at'
+)
 
 const getObjectParamsSchema = {
   type: 'object',
@@ -46,7 +58,7 @@ async function requestHandler(
     objectName,
   })
 
-  const bucket = await request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
+  const bucket = await request.storage.asSuperUser().findBucket(bucketName, PUBLIC_BUCKET_COLUMNS, {
     dontErrorOnEmpty: true,
   })
 
@@ -68,17 +80,9 @@ async function requestHandler(
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(
-        objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
-      )
+      .findObject(objectName, OBJECT_INFO_COLUMNS)
   } else {
-    obj = await request.storage
-      .from(bucketName)
-      .findObject(
-        objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
-      )
+    obj = await request.storage.from(bucketName).findObject(objectName, OBJECT_INFO_COLUMNS)
   }
 
   return request.storage.renderer(method).render(request, response, {

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -1,5 +1,5 @@
 import { ERRORS } from '@internal/errors'
-import { defineBucketColumns, defineObjectColumns } from '@storage/database'
+import { bucketColumns, objectColumns } from '@storage/database'
 import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -10,8 +10,8 @@ import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
-const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
-const OBJECT_INFO_COLUMNS = defineObjectColumns(
+const PUBLIC_BUCKET_COLUMNS = bucketColumns.select('id', 'public')
+const OBJECT_INFO_COLUMNS = objectColumns.select(
   'id',
   'name',
   'version',

--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -1,3 +1,4 @@
+import { defineBucketColumns, defineObjectColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
@@ -5,6 +6,8 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
+const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
+const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const getPublicObjectParamsSchema = {
   type: 'object',
@@ -55,10 +58,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       const bucketRef = request.storage.asSuperUser().from(bucketName)
       const [, obj] = await Promise.all([
-        request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
+        request.storage.asSuperUser().findBucket(bucketName, PUBLIC_BUCKET_COLUMNS, {
           isPublic: true,
         }),
-        bucketRef.findObject(objectName, 'id,version,metadata'),
+        bucketRef.findObject(objectName, OBJECT_DOWNLOAD_COLUMNS),
       ])
 
       // send the object from s3

--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -1,4 +1,4 @@
-import { defineBucketColumns, defineObjectColumns } from '@storage/database'
+import { bucketColumns, objectColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
@@ -6,8 +6,8 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
-const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
-const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const PUBLIC_BUCKET_COLUMNS = bucketColumns.select('id', 'public')
+const OBJECT_DOWNLOAD_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const getPublicObjectParamsSchema = {
   type: 'object',

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -1,4 +1,4 @@
-import { defineObjectColumns } from '@storage/database'
+import { objectColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
@@ -7,7 +7,7 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
-const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const OBJECT_DOWNLOAD_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const getSignedObjectParamsSchema = {
   type: 'object',

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -1,3 +1,4 @@
+import { defineObjectColumns } from '@storage/database'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
@@ -6,6 +7,7 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
+const OBJECT_DOWNLOAD_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const getSignedObjectParamsSchema = {
   type: 'object',
@@ -69,7 +71,7 @@ export default async function routes(fastify: FastifyInstance) {
       const obj = await request.storage
         .asSuperUser()
         .from(bucketName)
-        .findObject(objParts.join('/'), 'id,version,metadata')
+        .findObject(objParts.join('/'), OBJECT_DOWNLOAD_COLUMNS)
 
       return request.storage.renderer('asset').render(request, response, {
         bucket: storageS3Bucket,

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -1,5 +1,5 @@
 import { getTenantConfig } from '@internal/database'
-import { defineObjectColumns } from '@storage/database'
+import { objectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -9,7 +9,7 @@ import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
-const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const OBJECT_RENDER_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const renderAuthenticatedImageParamsSchema = {
   type: 'object',

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -1,4 +1,5 @@
 import { getTenantConfig } from '@internal/database'
+import { defineObjectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -8,6 +9,7 @@ import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
+const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const renderAuthenticatedImageParamsSchema = {
   type: 'object',
@@ -54,7 +56,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       const obj = await request.storage
         .from(bucketName)
-        .findObject(objectName, 'id,version,metadata')
+        .findObject(objectName, OBJECT_RENDER_COLUMNS)
 
       const s3Key = request.storage.location.getKeyLocation({
         tenantId: request.tenantId,

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -1,5 +1,5 @@
 import { getTenantConfig } from '@internal/database'
-import { defineBucketColumns, defineObjectColumns } from '@storage/database'
+import { bucketColumns, objectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -9,8 +9,8 @@ import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
-const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
-const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const PUBLIC_BUCKET_COLUMNS = bucketColumns.select('id', 'public')
+const OBJECT_RENDER_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const renderPublicImageParamsSchema = {
   type: 'object',

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -1,4 +1,5 @@
 import { getTenantConfig } from '@internal/database'
+import { defineBucketColumns, defineObjectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -8,6 +9,8 @@ import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
+const PUBLIC_BUCKET_COLUMNS = defineBucketColumns('id', 'public')
+const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const renderPublicImageParamsSchema = {
   type: 'object',
@@ -54,10 +57,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       const bucketRef = request.storage.asSuperUser().from(bucketName)
       const [, obj] = await Promise.all([
-        request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
+        request.storage.asSuperUser().findBucket(bucketName, PUBLIC_BUCKET_COLUMNS, {
           isPublic: true,
         }),
-        bucketRef.findObject(objectName, 'id,version,metadata'),
+        bucketRef.findObject(objectName, OBJECT_RENDER_COLUMNS),
       ])
 
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -1,6 +1,6 @@
 import { SIGNED_URL_SCOPE_DOWNLOAD } from '@internal/auth'
 import { getTenantConfig } from '@internal/database'
-import { defineObjectColumns } from '@storage/database'
+import { objectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -9,7 +9,7 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
-const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const OBJECT_RENDER_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 const renderAuthenticatedImageParamsSchema = {
   type: 'object',

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -1,5 +1,6 @@
 import { SIGNED_URL_SCOPE_DOWNLOAD } from '@internal/auth'
 import { getTenantConfig } from '@internal/database'
+import { defineObjectColumns } from '@storage/database'
 import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
@@ -8,6 +9,7 @@ import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
+const OBJECT_RENDER_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 const renderAuthenticatedImageParamsSchema = {
   type: 'object',
@@ -67,7 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
       const obj = await request.storage
         .asSuperUser()
         .from(bucketName)
-        .findObject(objParts.join('/'), 'id,version,metadata')
+        .findObject(objParts.join('/'), OBJECT_RENDER_COLUMNS)
 
       const renderer = request.storage.renderer('image') as ImageRenderer
 

--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -1,5 +1,6 @@
 import { MultipartFields } from '@fastify/multipart'
 import { ERRORS } from '@internal/errors'
+import { defineBucketColumns } from '@storage/database'
 import { ByteLimitTransformStream } from '@storage/protocols/s3/byte-limit-stream'
 import { MAX_PART_SIZE, S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { fileUploadFromRequest, getStandardMaxFileSizeLimit } from '@storage/uploader'
@@ -7,6 +8,8 @@ import stream, { Readable, Transform } from 'stream'
 import { pipeline } from 'stream/promises'
 import { ROUTE_OPERATIONS } from '../../operations'
 import { S3Router } from '../router'
+
+const UPLOAD_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
 
 const PutObjectInput = {
   summary: 'Put Object',
@@ -158,7 +161,7 @@ export default function PutObject(s3Router: S3Router) {
 
       const bucket = await ctx.storage
         .asSuperUser()
-        .findBucket(req.Params.Bucket, 'id,file_size_limit,allowed_mime_types')
+        .findBucket(req.Params.Bucket, UPLOAD_BUCKET_COLUMNS)
 
       const uploadRequest = await fileUploadFromRequest(ctx.req, {
         objectName: key,
@@ -212,7 +215,7 @@ export default function PutObject(s3Router: S3Router) {
 
       const bucket = await ctx.storage
         .asSuperUser()
-        .findBucket(req.Params.Bucket, 'id,file_size_limit,allowed_mime_types')
+        .findBucket(req.Params.Bucket, UPLOAD_BUCKET_COLUMNS)
 
       const fieldsObject = fieldsToObject(file?.fields || {})
       const metadata = s3Protocol.parseMetadataHeaders(fieldsObject)

--- a/src/http/routes/s3/commands/put-object.ts
+++ b/src/http/routes/s3/commands/put-object.ts
@@ -1,6 +1,6 @@
 import { MultipartFields } from '@fastify/multipart'
 import { ERRORS } from '@internal/errors'
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { ByteLimitTransformStream } from '@storage/protocols/s3/byte-limit-stream'
 import { MAX_PART_SIZE, S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import { fileUploadFromRequest, getStandardMaxFileSizeLimit } from '@storage/uploader'
@@ -9,7 +9,7 @@ import { pipeline } from 'stream/promises'
 import { ROUTE_OPERATIONS } from '../../operations'
 import { S3Router } from '../router'
 
-const UPLOAD_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
+const UPLOAD_BUCKET_COLUMNS = bucketColumns.select('id', 'file_size_limit', 'allowed_mime_types')
 
 const PutObjectInput = {
   summary: 'Put Object',

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -5,6 +5,7 @@ import { ERRORS } from '@internal/errors'
 import { createAgent } from '@internal/http'
 import { logSchema } from '@internal/monitoring'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { defineBucketColumns } from '@storage/database'
 import { getFileSizeLimit } from '@storage/limits'
 import {
   AlsMemoryKV,
@@ -39,6 +40,8 @@ import {
   onUploadFinish,
   SIGNED_URL_SUFFIX,
 } from './lifecycle'
+
+const TUS_BUCKET_LIMIT_COLUMNS = defineBucketColumns('id', 'file_size_limit')
 
 const {
   storageS3MaxSockets,
@@ -164,7 +167,7 @@ function createTusServer(
 
       const bucket = await req.upload.storage
         .asSuperUser()
-        .findBucket(resourceId.bucket, 'id,file_size_limit')
+        .findBucket(resourceId.bucket, TUS_BUCKET_LIMIT_COLUMNS)
 
       const globalFileLimit = await getFileSizeLimit(req.upload.tenantId)
 

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -5,7 +5,7 @@ import { ERRORS } from '@internal/errors'
 import { createAgent } from '@internal/http'
 import { logSchema } from '@internal/monitoring'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { getFileSizeLimit } from '@storage/limits'
 import {
   AlsMemoryKV,
@@ -41,7 +41,7 @@ import {
   SIGNED_URL_SUFFIX,
 } from './lifecycle'
 
-const TUS_BUCKET_LIMIT_COLUMNS = defineBucketColumns('id', 'file_size_limit')
+const TUS_BUCKET_LIMIT_COLUMNS = bucketColumns.select('id', 'file_size_limit')
 
 const {
   storageS3MaxSockets,

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -2,6 +2,7 @@ import { SIGNED_URL_SCOPE_UPLOAD } from '@internal/auth'
 import type { TenantConnection } from '@internal/database'
 import { ERRORS, isRenderableError } from '@internal/errors'
 import { logSchema, RequestLogContext } from '@internal/monitoring'
+import { defineBucketColumns } from '@storage/database'
 import { UploadId } from '@storage/protocols/tus'
 import { Storage } from '@storage/storage'
 import { Uploader, validateMimeType } from '@storage/uploader'
@@ -14,6 +15,7 @@ import type { ServerRequest as Request } from 'srvx'
 import { getConfig } from '../../../config'
 
 const { storageS3Bucket, tusPath, requestAllowXForwardedPrefix, storagePublicUrl } = getConfig()
+const TUS_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
 const parsedPublicUrl = storagePublicUrl ? new URL(storagePublicUrl) : undefined
 const reExtractFileID = /([^/]+)\/?$/
 
@@ -272,9 +274,7 @@ export async function onCreate(
 
   const storage = req.upload.storage
 
-  const bucket = await storage
-    .asSuperUser()
-    .findBucket(uploadID.bucket, 'id, file_size_limit, allowed_mime_types')
+  const bucket = await storage.asSuperUser().findBucket(uploadID.bucket, TUS_BUCKET_COLUMNS)
 
   const metadata = {
     ...(upload.metadata ? upload.metadata : {}),

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -2,7 +2,7 @@ import { SIGNED_URL_SCOPE_UPLOAD } from '@internal/auth'
 import type { TenantConnection } from '@internal/database'
 import { ERRORS, isRenderableError } from '@internal/errors'
 import { logSchema, RequestLogContext } from '@internal/monitoring'
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { UploadId } from '@storage/protocols/tus'
 import { Storage } from '@storage/storage'
 import { Uploader, validateMimeType } from '@storage/uploader'
@@ -15,7 +15,7 @@ import type { ServerRequest as Request } from 'srvx'
 import { getConfig } from '../../../config'
 
 const { storageS3Bucket, tusPath, requestAllowXForwardedPrefix, storagePublicUrl } = getConfig()
-const TUS_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
+const TUS_BUCKET_COLUMNS = bucketColumns.select('id', 'file_size_limit', 'allowed_mime_types')
 const parsedPublicUrl = storagePublicUrl ? new URL(storagePublicUrl) : undefined
 const reExtractFileID = /([^/]+)\/?$/
 

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -2,6 +2,12 @@ import type { TenantConnection, TransactionOptions } from '@internal/database'
 import { DBMigration } from '@internal/database/migrations'
 import { ObjectMetadata } from '../backend'
 import { Bucket, IcebergCatalog, Obj, S3MultipartUpload, S3PartUpload } from '../schemas'
+import {
+  AnalyticsColumnSelection,
+  BucketColumnSelection,
+  MultipartColumnSelection,
+  ObjectColumnSelection,
+} from './columns'
 
 export interface SearchObjectOption {
   search?: string
@@ -85,7 +91,7 @@ export interface Database {
 
   findBucketById<Filters extends FindBucketFilters = FindObjectFilters>(
     bucketId: string,
-    columns: string,
+    columns: BucketColumnSelection,
     filters?: Filters
   ): Promise<Filters['dontErrorOnEmpty'] extends true ? Bucket | undefined : Bucket>
 
@@ -95,7 +101,7 @@ export interface Database {
 
   listObjects(
     bucketId: string,
-    columns: string,
+    columns: ObjectColumnSelection,
     limit: number,
     before?: Date,
     nextToken?: string
@@ -128,7 +134,7 @@ export interface Database {
     }
   ): Promise<S3MultipartUpload[]>
 
-  listBuckets(columns: string, options?: ListBucketOptions): Promise<Bucket[]>
+  listBuckets(columns: BucketColumnSelection, options?: ListBucketOptions): Promise<Bucket[]>
   mustLockObject(bucketId: string, objectName: string, version?: string): Promise<boolean>
 
   waitObjectLock(
@@ -169,18 +175,21 @@ export interface Database {
 
   updateObjectOwner(bucketId: string, objectName: string, owner?: string): Promise<Obj>
 
-  findObjects(bucketId: string, objectNames: string[], columns: string): Promise<Obj[]>
+  findObjects(
+    bucketId: string,
+    objectNames: string[],
+    columns: ObjectColumnSelection
+  ): Promise<Obj[]>
 
   findObjectVersions(
     bucketId: string,
-    objectNames: { name: string; version: string }[],
-    columns: string
+    objectNames: { name: string; version: string }[]
   ): Promise<Obj[]>
 
   findObject<Filters extends FindObjectFilters = FindObjectFilters>(
     bucketId: string,
     objectName: string,
-    columns: string,
+    columns: ObjectColumnSelection,
     filters?: Filters
   ): Promise<Filters['dontErrorOnEmpty'] extends true ? Obj | undefined : Obj>
 
@@ -203,7 +212,7 @@ export interface Database {
 
   findMultipartUpload(
     uploadId: string,
-    columns: string,
+    columns: MultipartColumnSelection,
     options?: { forUpdate?: boolean }
   ): Promise<S3MultipartUpload>
 
@@ -224,7 +233,7 @@ export interface Database {
 
   deleteAnalyticsBucket(id: string, opts?: { soft: boolean }): Promise<IcebergCatalog>
   listAnalyticsBuckets(
-    columns: string,
+    columns: AnalyticsColumnSelection,
     options: ListBucketOptions | undefined
   ): Promise<IcebergCatalog[]>
   findAnalyticsBucketByName(name: string): Promise<IcebergCatalog>

--- a/src/storage/database/column-set.ts
+++ b/src/storage/database/column-set.ts
@@ -1,0 +1,271 @@
+import { DBMigration } from '@internal/database/migrations/types'
+import { quoteIdentifier } from '@internal/database/sql'
+
+type MigrationName = keyof typeof DBMigration
+type ProjectionMode = 'physical' | 'synthetic'
+
+const columnSelectionRuntimeKey: unique symbol = Symbol.for('storage.columnSelection')
+const columnSetBrand: unique symbol = Symbol('storage.columnSet')
+const staticSqlLiteralBrand: unique symbol = Symbol('storage.staticSqlLiteral')
+
+declare const columnSelectionBrand: unique symbol
+declare const columnStateBrand: unique symbol
+
+export type ColumnName<Row> = Extract<keyof Row, string>
+type Invariant<Value> = (value: Value) => Value
+
+// An immutable, precompiled SQL projection token for one row family.
+export interface ColumnSelection<Row, SetId extends symbol> {
+  readonly [columnSelectionBrand]: Invariant<readonly [Row, SetId]>
+}
+
+export type ColumnState<Row, SetId extends symbol> = number & {
+  readonly [columnStateBrand]: Invariant<readonly [Row, SetId]>
+}
+
+// Selects named projection tokens at module initialization.
+export interface ColumnSet<Row, Column extends string, SetId extends symbol> {
+  select(...columns: readonly [Column | '*', ...(Column | '*')[]]): ColumnSelection<Row, SetId>
+}
+
+// Derives the opaque state without exposing a set's identity token.
+export type ColumnSetState<Set> =
+  Set extends ColumnSet<infer Row, infer _Column extends string, infer SetId extends symbol>
+    ? ColumnState<Row, SetId>
+    : never
+
+export interface StaticSqlLiteral {
+  readonly [staticSqlLiteralBrand]: true
+}
+
+export interface ColumnSetDefinition<Column extends string> {
+  // Baseline column selected when compatibility filtering removes everything requested.
+  readonly fallback: Column
+  // Exceptional columns that do not exist before the named migration.
+  readonly availableFrom?: Readonly<Partial<Record<Column, MigrationName>>>
+  // Encoded values that replace requested columns in synthetic mode.
+  readonly synthetic?: Readonly<Partial<Record<Column, StaticSqlLiteral>>>
+}
+
+interface CompiledStaticSqlLiteral extends StaticSqlLiteral {
+  readonly sql: string
+}
+
+interface CompiledColumn {
+  readonly name: string
+  readonly sql: string
+}
+
+interface ColumnSetRuntime {
+  readonly thresholds: readonly number[]
+  readonly availableEpoch: Readonly<Record<string, number>>
+  readonly syntheticSql: Readonly<Record<string, string>>
+  readonly epochCount: number
+  readonly syntheticOffset?: number
+  readonly fallbackSql: string
+}
+
+interface CompiledColumnSet<Row, Column extends string, SetId extends symbol>
+  extends ColumnSet<Row, Column, SetId> {
+  readonly [columnSetBrand]: ColumnSetRuntime
+}
+
+interface CompiledColumnSelection {
+  readonly [columnSelectionRuntimeKey]: readonly string[]
+}
+
+// Encodes a string value so table policies never accept arbitrary SQL fragments.
+export function staticSqlLiteral(value: string): StaticSqlLiteral {
+  return Object.freeze({
+    [staticSqlLiteralBrand]: true as const,
+    sql: `'${value.replace(/'/g, "''")}'`,
+  })
+}
+
+export function defineColumnSet<Row, SetId extends symbol>(
+  definition: ColumnSetDefinition<ColumnName<Row>>
+): ColumnSet<Row, ColumnName<Row>, SetId> {
+  const fallbackSql = quoteIdentifier(definition.fallback)
+  const availableFrom: Record<string, number> = Object.create(null)
+  const thresholdSet = new Set<number>()
+
+  for (const [column, migration] of Object.entries(definition.availableFrom ?? {})) {
+    quoteIdentifier(column)
+
+    const ordinal = DBMigration[migration as MigrationName]
+    if (typeof ordinal !== 'number') {
+      throw new Error(`Unknown database migration: ${String(migration)}`)
+    }
+
+    availableFrom[column] = ordinal
+    thresholdSet.add(ordinal)
+  }
+
+  if (availableFrom[definition.fallback] !== undefined) {
+    throw new Error(`Fallback column must be available in every migration: ${definition.fallback}`)
+  }
+
+  const thresholds = Object.freeze(Array.from(thresholdSet).sort((left, right) => left - right))
+  const availableEpoch: Record<string, number> = Object.create(null)
+
+  for (const [column, ordinal] of Object.entries(availableFrom)) {
+    availableEpoch[column] = thresholds.indexOf(ordinal) + 1
+  }
+
+  const syntheticSql: Record<string, string> = Object.create(null)
+  for (const [column, literal] of Object.entries(definition.synthetic ?? {})) {
+    const quotedColumn = quoteIdentifier(column)
+
+    if (!isStaticSqlLiteral(literal)) {
+      throw new Error(`Invalid static SQL literal for column: ${column}`)
+    }
+
+    syntheticSql[column] = `${literal.sql} AS ${quotedColumn}`
+  }
+
+  const epochCount = thresholds.length + 1
+  const hasSyntheticColumns = Object.keys(syntheticSql).length > 0
+  const runtime: ColumnSetRuntime = Object.freeze({
+    thresholds,
+    availableEpoch: Object.freeze(availableEpoch),
+    syntheticSql: Object.freeze(syntheticSql),
+    epochCount,
+    syntheticOffset: hasSyntheticColumns ? epochCount : undefined,
+    fallbackSql,
+  })
+
+  function compileSelection(columns: readonly string[]): ColumnSelection<Row, SetId> {
+    const compiledColumns = compileColumns(columns)
+
+    const variants = new Array<string>(
+      runtime.epochCount * (runtime.syntheticOffset === undefined ? 1 : 2)
+    )
+
+    for (let epoch = 0; epoch < runtime.epochCount; epoch++) {
+      variants[epoch] = compileVariant(compiledColumns, runtime, epoch, 'physical')
+
+      if (runtime.syntheticOffset !== undefined) {
+        variants[runtime.syntheticOffset + epoch] = compileVariant(
+          compiledColumns,
+          runtime,
+          epoch,
+          'synthetic'
+        )
+      }
+    }
+
+    return Object.freeze({
+      [columnSelectionRuntimeKey]: Object.freeze(variants),
+    }) as unknown as ColumnSelection<Row, SetId>
+  }
+
+  const set: CompiledColumnSet<Row, ColumnName<Row>, SetId> = {
+    select(...columns) {
+      return compileSelection(columns)
+    },
+    [columnSetBrand]: runtime,
+  }
+
+  return Object.freeze(set)
+}
+
+// Maps a verified migration ordinal to a compact table state outside the query path.
+export function prepareColumnState<Row, Column extends string, SetId extends symbol>(
+  set: ColumnSet<Row, Column, SetId>,
+  migrationOrdinal: number,
+  mode: ProjectionMode = 'physical'
+): ColumnState<Row, SetId> {
+  if (!Number.isSafeInteger(migrationOrdinal) || migrationOrdinal < 0) {
+    throw new Error(`Invalid database migration ordinal: ${migrationOrdinal}`)
+  }
+
+  const runtime = (set as CompiledColumnSet<Row, Column, SetId>)[columnSetBrand]
+  let epoch = 0
+
+  while (epoch < runtime.thresholds.length && migrationOrdinal >= runtime.thresholds[epoch]) {
+    epoch++
+  }
+
+  let state = epoch
+
+  if (mode === 'synthetic' && runtime.syntheticOffset !== undefined) {
+    state += runtime.syntheticOffset
+  }
+
+  return state as ColumnState<Row, SetId>
+}
+
+// Hot path: one symbol-property read and one array lookup.
+export function resolveColumns<Row, SetId extends symbol>(
+  selection: ColumnSelection<Row, SetId>,
+  state: ColumnState<Row, SetId>
+): string {
+  return (selection as unknown as CompiledColumnSelection)[columnSelectionRuntimeKey][state]
+}
+
+function compileVariant(
+  columns: readonly CompiledColumn[],
+  runtime: ColumnSetRuntime,
+  epoch: number,
+  mode: ProjectionMode
+): string {
+  if (columns.length === 1 && columns[0].name === '*') {
+    return '*'
+  }
+
+  const physical: string[] = []
+  const synthetic: string[] = []
+
+  for (const column of columns) {
+    const syntheticColumn = mode === 'synthetic' ? runtime.syntheticSql[column.name] : undefined
+    if (syntheticColumn !== undefined) {
+      synthetic.push(syntheticColumn)
+      continue
+    }
+
+    const availableEpoch = runtime.availableEpoch[column.name]
+    if (availableEpoch !== undefined && epoch < availableEpoch) {
+      continue
+    }
+
+    physical.push(column.sql)
+  }
+
+  if (physical.length === 0 && synthetic.length === 0) {
+    return runtime.fallbackSql
+  }
+
+  return physical.concat(synthetic).join(', ')
+}
+
+function compileColumns(columns: readonly string[]): readonly CompiledColumn[] {
+  if (columns.length === 0) {
+    throw new Error('Column selection cannot be empty')
+  }
+
+  const seen = new Set<string>()
+  return columns.map((column) => {
+    if (seen.has(column)) {
+      throw new Error(`Duplicate column in selection: ${column}`)
+    }
+    seen.add(column)
+
+    if (column === '*') {
+      if (columns.length !== 1) {
+        throw new Error('Wildcard cannot be combined with named columns')
+      }
+      return { name: column, sql: column }
+    }
+
+    return { name: column, sql: quoteIdentifier(column) }
+  })
+}
+
+function isStaticSqlLiteral(value: unknown): value is CompiledStaticSqlLiteral {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Partial<CompiledStaticSqlLiteral>)[staticSqlLiteralBrand] === true &&
+    typeof (value as Partial<CompiledStaticSqlLiteral>).sql === 'string'
+  )
+}

--- a/src/storage/database/columns.test.ts
+++ b/src/storage/database/columns.test.ts
@@ -1,0 +1,110 @@
+import {
+  defineAnalyticsColumns,
+  defineBucketColumns,
+  defineMultipartColumns,
+  defineObjectColumns,
+  resolveColumns,
+  SelectColumnOptions,
+  type SelectColumnOptionsMask,
+} from './columns'
+
+describe('compiled column selections', () => {
+  test('compiles and quotes columns once in declaration order', () => {
+    const columns = defineObjectColumns('name', 'bucket_id', 'user_metadata')
+
+    expect(resolveColumns(columns)).toBe('"name", "bucket_id", "user_metadata"')
+  })
+
+  test('preserves the wildcard', () => {
+    expect(resolveColumns(defineObjectColumns('*'))).toBe('*')
+  })
+
+  test('precompiles migration-compatible object columns', () => {
+    const columns = defineObjectColumns('name', 'user_metadata', 'metadata')
+
+    expect(resolveColumns(columns, SelectColumnOptions.excludeUserMetadata)).toBe(
+      '"name", "metadata"'
+    )
+  })
+
+  test('precompiles every multipart migration combination', () => {
+    const columns = defineMultipartColumns('id', 'user_metadata', 'metadata')
+
+    expect(resolveColumns(columns, SelectColumnOptions.excludeUserMetadata)).toBe(
+      '"id", "metadata"'
+    )
+    expect(resolveColumns(columns, SelectColumnOptions.excludeMultipartMetadata)).toBe(
+      '"id", "user_metadata"'
+    )
+    expect(
+      resolveColumns(
+        columns,
+        (SelectColumnOptions.excludeUserMetadata |
+          SelectColumnOptions.excludeMultipartMetadata) as SelectColumnOptionsMask
+      )
+    ).toBe('"id"')
+  })
+
+  test('precompiles physical and synthetic bucket type variants', () => {
+    const columns = defineBucketColumns('id', 'type', 'name')
+
+    expect(resolveColumns(columns, SelectColumnOptions.excludeBucketType)).toBe('"id", "name"')
+    expect(resolveColumns(columns, SelectColumnOptions.syntheticBucketType)).toBe(
+      '"id", "name", \'STANDARD\' AS "type"'
+    )
+  })
+
+  test('precompiles the maximum declared option mask', () => {
+    const allOptions = Object.values(SelectColumnOptions).reduce(
+      (mask, option) => mask | option,
+      0
+    ) as SelectColumnOptionsMask
+
+    expect(resolveColumns(defineObjectColumns('id'), allOptions)).toBe('"id"')
+  })
+
+  test('accepts declared option masks but not arbitrary numbers', () => {
+    expectTypeOf<SelectColumnOptionsMask>().toExtend<number>()
+    expectTypeOf<number>().not.toExtend<SelectColumnOptionsMask>()
+    expectTypeOf(resolveColumns).parameter(1).toEqualTypeOf<SelectColumnOptionsMask | undefined>()
+  })
+
+  test('falls back to id if a migration removes every selected physical column', () => {
+    const objectColumns = defineObjectColumns('user_metadata')
+    const bucketColumns = defineBucketColumns('type')
+
+    expect(resolveColumns(objectColumns, SelectColumnOptions.excludeUserMetadata)).toBe('"id"')
+    expect(resolveColumns(bucketColumns, SelectColumnOptions.excludeBucketType)).toBe('"id"')
+    expect(resolveColumns(bucketColumns, SelectColumnOptions.syntheticBucketType)).toBe(
+      '\'STANDARD\' AS "type"'
+    )
+  })
+
+  test('supports analytics columns independently from storage buckets', () => {
+    expect(resolveColumns(defineAnalyticsColumns('name', 'deleted_at'))).toBe(
+      '"name", "deleted_at"'
+    )
+  })
+
+  test('rejects invalid identifiers while defining a token', () => {
+    expect(() => defineObjectColumns('name; DROP TABLE objects' as 'name')).toThrow(
+      'Invalid PostgreSQL identifier'
+    )
+  })
+
+  test('returns immutable tokens', () => {
+    const columns = defineObjectColumns('id')
+
+    expect(Object.isFrozen(columns)).toBe(true)
+    expect(Object.keys(columns)).toEqual([])
+  })
+
+  test('resolves tokens created by another module instance', async () => {
+    const columns = defineObjectColumns('id', 'name')
+
+    vi.resetModules()
+    const reloadedColumns = await import('./columns')
+
+    expect(reloadedColumns.resolveColumns(columns)).toBe('"id", "name"')
+  })
+})

--- a/src/storage/database/columns.test.ts
+++ b/src/storage/database/columns.test.ts
@@ -1,110 +1,232 @@
+import { DBMigration } from '@internal/database/migrations/types'
 import {
-  defineAnalyticsColumns,
-  defineBucketColumns,
-  defineMultipartColumns,
-  defineObjectColumns,
+  type ColumnSetState,
+  defineColumnSet,
+  prepareColumnState,
   resolveColumns,
-  SelectColumnOptions,
-  type SelectColumnOptionsMask,
-} from './columns'
+  staticSqlLiteral,
+} from './column-set'
+import { analyticsColumns, bucketColumns, multipartColumns, objectColumns } from './columns'
+
+declare const firstColumnSetId: unique symbol
+declare const secondColumnSetId: unique symbol
 
 describe('compiled column selections', () => {
   test('compiles and quotes columns once in declaration order', () => {
-    const columns = defineObjectColumns('name', 'bucket_id', 'user_metadata')
+    const columns = objectColumns.select('name', 'bucket_id', 'user_metadata')
+    const state = prepareColumnState(objectColumns, DBMigration['custom-metadata'])
 
-    expect(resolveColumns(columns)).toBe('"name", "bucket_id", "user_metadata"')
+    expect(resolveColumns(columns, state)).toBe('"name", "bucket_id", "user_metadata"')
   })
 
   test('preserves the wildcard', () => {
-    expect(resolveColumns(defineObjectColumns('*'))).toBe('*')
+    const columns = objectColumns.select('*')
+    const state = prepareColumnState(objectColumns, DBMigration['operation-function'])
+
+    expect(resolveColumns(columns, state)).toBe('*')
   })
 
-  test('precompiles migration-compatible object columns', () => {
-    const columns = defineObjectColumns('name', 'user_metadata', 'metadata')
+  test('applies object rules without affecting same-named columns', () => {
+    const columns = objectColumns.select('name', 'user_metadata', 'metadata')
+    const legacyState = prepareColumnState(objectColumns, DBMigration['operation-function'])
+    const currentState = prepareColumnState(objectColumns, DBMigration['custom-metadata'])
 
-    expect(resolveColumns(columns, SelectColumnOptions.excludeUserMetadata)).toBe(
-      '"name", "metadata"'
+    expect(resolveColumns(columns, legacyState)).toBe('"name", "metadata"')
+    expect(resolveColumns(columns, currentState)).toBe('"name", "user_metadata", "metadata"')
+  })
+
+  test('derives only the ordered multipart migration layouts', () => {
+    const columns = multipartColumns.select('id', 'user_metadata', 'metadata')
+    const baselineState = prepareColumnState(multipartColumns, DBMigration['operation-function'])
+    const customMetadataState = prepareColumnState(multipartColumns, DBMigration['custom-metadata'])
+    const multipartMetadataState = prepareColumnState(
+      multipartColumns,
+      DBMigration['s3-multipart-uploads-metadata']
+    )
+
+    expect(resolveColumns(columns, baselineState)).toBe('"id"')
+    expect(resolveColumns(columns, customMetadataState)).toBe('"id", "user_metadata"')
+    expect(resolveColumns(columns, multipartMetadataState)).toBe(
+      '"id", "user_metadata", "metadata"'
     )
   })
 
-  test('precompiles every multipart migration combination', () => {
-    const columns = defineMultipartColumns('id', 'user_metadata', 'metadata')
+  test('keeps object metadata independent from multipart metadata', () => {
+    const objectSelection = objectColumns.select('metadata')
+    const multipartSelection = multipartColumns.select('metadata')
+    const migration = DBMigration['custom-metadata']
 
-    expect(resolveColumns(columns, SelectColumnOptions.excludeUserMetadata)).toBe(
-      '"id", "metadata"'
-    )
-    expect(resolveColumns(columns, SelectColumnOptions.excludeMultipartMetadata)).toBe(
-      '"id", "user_metadata"'
+    expect(resolveColumns(objectSelection, prepareColumnState(objectColumns, migration))).toBe(
+      '"metadata"'
     )
     expect(
-      resolveColumns(
-        columns,
-        (SelectColumnOptions.excludeUserMetadata |
-          SelectColumnOptions.excludeMultipartMetadata) as SelectColumnOptionsMask
-      )
+      resolveColumns(multipartSelection, prepareColumnState(multipartColumns, migration))
     ).toBe('"id"')
   })
 
-  test('precompiles physical and synthetic bucket type variants', () => {
-    const columns = defineBucketColumns('id', 'type', 'name')
-
-    expect(resolveColumns(columns, SelectColumnOptions.excludeBucketType)).toBe('"id", "name"')
-    expect(resolveColumns(columns, SelectColumnOptions.syntheticBucketType)).toBe(
-      '"id", "name", \'STANDARD\' AS "type"'
+  test('precompiles physical and synthetic bucket layouts', () => {
+    const columns = bucketColumns.select('id', 'type', 'name')
+    const legacyPhysical = prepareColumnState(bucketColumns, DBMigration['operation-function'])
+    const currentPhysical = prepareColumnState(
+      bucketColumns,
+      DBMigration['iceberg-catalog-flag-on-buckets']
     )
-  })
-
-  test('precompiles the maximum declared option mask', () => {
-    const allOptions = Object.values(SelectColumnOptions).reduce(
-      (mask, option) => mask | option,
-      0
-    ) as SelectColumnOptionsMask
-
-    expect(resolveColumns(defineObjectColumns('id'), allOptions)).toBe('"id"')
-  })
-
-  test('accepts declared option masks but not arbitrary numbers', () => {
-    expectTypeOf<SelectColumnOptionsMask>().toExtend<number>()
-    expectTypeOf<number>().not.toExtend<SelectColumnOptionsMask>()
-    expectTypeOf(resolveColumns).parameter(1).toEqualTypeOf<SelectColumnOptionsMask | undefined>()
-  })
-
-  test('falls back to id if a migration removes every selected physical column', () => {
-    const objectColumns = defineObjectColumns('user_metadata')
-    const bucketColumns = defineBucketColumns('type')
-
-    expect(resolveColumns(objectColumns, SelectColumnOptions.excludeUserMetadata)).toBe('"id"')
-    expect(resolveColumns(bucketColumns, SelectColumnOptions.excludeBucketType)).toBe('"id"')
-    expect(resolveColumns(bucketColumns, SelectColumnOptions.syntheticBucketType)).toBe(
-      '\'STANDARD\' AS "type"'
+    const legacySynthetic = prepareColumnState(
+      bucketColumns,
+      DBMigration['operation-function'],
+      'synthetic'
     )
+    const currentSynthetic = prepareColumnState(
+      bucketColumns,
+      DBMigration['iceberg-catalog-flag-on-buckets'],
+      'synthetic'
+    )
+
+    expect(resolveColumns(columns, legacyPhysical)).toBe('"id", "name"')
+    expect(resolveColumns(columns, currentPhysical)).toBe('"id", "type", "name"')
+    expect(resolveColumns(columns, legacySynthetic)).toBe('"id", "name", \'STANDARD\' AS "type"')
+    expect(resolveColumns(columns, currentSynthetic)).toBe('"id", "name", \'STANDARD\' AS "type"')
+  })
+
+  test('falls back to the table fallback if a migration removes every selected column', () => {
+    const objectSelection = objectColumns.select('user_metadata')
+    const bucketSelection = bucketColumns.select('type')
+    const migration = DBMigration['operation-function']
+
+    expect(resolveColumns(objectSelection, prepareColumnState(objectColumns, migration))).toBe(
+      '"id"'
+    )
+    expect(resolveColumns(bucketSelection, prepareColumnState(bucketColumns, migration))).toBe(
+      '"id"'
+    )
+    expect(
+      resolveColumns(bucketSelection, prepareColumnState(bucketColumns, migration, 'synthetic'))
+    ).toBe('\'STANDARD\' AS "type"')
   })
 
   test('supports analytics columns independently from storage buckets', () => {
-    expect(resolveColumns(defineAnalyticsColumns('name', 'deleted_at'))).toBe(
-      '"name", "deleted_at"'
-    )
+    const columns = analyticsColumns.select('name', 'deleted_at')
+    const state = prepareColumnState(analyticsColumns, DBMigration['operation-function'])
+
+    expect(resolveColumns(columns, state)).toBe('"name", "deleted_at"')
   })
 
-  test('rejects invalid identifiers while defining a token', () => {
-    expect(() => defineObjectColumns('name; DROP TABLE objects' as 'name')).toThrow(
+  test('adds a new table-local gate without a global option', () => {
+    type ChecksummedRow = { id: string; checksum: string }
+
+    const checksummedColumns = defineColumnSet<ChecksummedRow, typeof firstColumnSetId>({
+      fallback: 'id',
+      availableFrom: {
+        checksum: 'custom-metadata',
+      },
+    })
+    const columns = checksummedColumns.select('checksum')
+
+    expect(
+      resolveColumns(
+        columns,
+        prepareColumnState(checksummedColumns, DBMigration['operation-function'])
+      )
+    ).toBe('"id"')
+    expect(
+      resolveColumns(
+        columns,
+        prepareColumnState(checksummedColumns, DBMigration['custom-metadata'])
+      )
+    ).toBe('"checksum"')
+  })
+
+  test('encodes static synthetic literals instead of accepting raw SQL', () => {
+    type LabelledRow = { id: string; label: string }
+
+    const labelledColumns = defineColumnSet<LabelledRow, typeof firstColumnSetId>({
+      fallback: 'id',
+      synthetic: {
+        label: staticSqlLiteral("O'Reilly"),
+      },
+    })
+    const columns = labelledColumns.select('label')
+    const state = prepareColumnState(labelledColumns, 0, 'synthetic')
+
+    expect(resolveColumns(columns, state)).toBe("'O''Reilly' AS \"label\"")
+  })
+
+  test('rejects invalid and ambiguous declarations at module initialization', () => {
+    expect(() => objectColumns.select('name; DROP TABLE objects' as 'name')).toThrow(
       'Invalid PostgreSQL identifier'
     )
+    expect(() => objectColumns.select('id', 'id')).toThrow('Duplicate column')
+    expect(() => objectColumns.select('*', 'id')).toThrow('Wildcard')
   })
 
-  test('returns immutable tokens', () => {
-    const columns = defineObjectColumns('id')
+  test('rejects table policies with an unavailable fallback or an unencoded literal', () => {
+    type VersionedRow = { id: string; version: string }
+
+    expect(() =>
+      defineColumnSet<VersionedRow, typeof firstColumnSetId>({
+        fallback: 'version',
+        availableFrom: { version: 'custom-metadata' },
+      })
+    ).toThrow('Fallback column must be available in every migration')
+
+    expect(() =>
+      defineColumnSet<VersionedRow, typeof firstColumnSetId>({
+        fallback: 'id',
+        synthetic: { version: {} as never },
+      })
+    ).toThrow('Invalid static SQL literal')
+  })
+
+  test('returns immutable opaque tokens', () => {
+    const columns = objectColumns.select('id')
 
     expect(Object.isFrozen(columns)).toBe(true)
     expect(Object.keys(columns)).toEqual([])
+    expect(Object.getOwnPropertySymbols(columns)).toHaveLength(1)
+  })
+
+  test('brands table states instead of accepting arbitrary numbers', () => {
+    expectTypeOf<ColumnSetState<typeof objectColumns>>().toExtend<number>()
+    expectTypeOf<number>().not.toExtend<ColumnSetState<typeof objectColumns>>()
+  })
+
+  test('keeps selections and states tied to their originating set', () => {
+    type SharedRow = { id: string; gated: string }
+
+    const firstColumns = defineColumnSet<SharedRow, typeof firstColumnSetId>({ fallback: 'id' })
+    const secondColumns = defineColumnSet<SharedRow, typeof secondColumnSetId>({
+      fallback: 'id',
+      availableFrom: { gated: 'custom-metadata' },
+    })
+
+    const firstSelection = firstColumns.select('id')
+    const secondState = prepareColumnState(secondColumns, DBMigration['custom-metadata'])
+
+    expectTypeOf(secondState).not.toExtend<ColumnSetState<typeof firstColumns>>()
+
+    const resolveMismatchedSet = () => {
+      // @ts-expect-error A state can resolve only selections from its originating set.
+      return resolveColumns(firstSelection, secondState)
+    }
+    expectTypeOf(resolveMismatchedSet).returns.toBeString()
+  })
+
+  test('rejects invalid migration ordinals', () => {
+    expect(() => prepareColumnState(objectColumns, -1)).toThrow(
+      'Invalid database migration ordinal: -1'
+    )
+    expect(() => prepareColumnState(objectColumns, Number.NaN)).toThrow(
+      'Invalid database migration ordinal: NaN'
+    )
   })
 
   test('resolves tokens created by another module instance', async () => {
-    const columns = defineObjectColumns('id', 'name')
+    const columns = objectColumns.select('id', 'name')
+    const state = prepareColumnState(objectColumns, DBMigration['operation-function'])
 
     vi.resetModules()
-    const reloadedColumns = await import('./columns')
+    const reloadedColumnSet = await import('./column-set')
 
-    expect(reloadedColumns.resolveColumns(columns)).toBe('"id", "name"')
+    expect(reloadedColumnSet.resolveColumns(columns, state)).toBe('"id", "name"')
   })
 })

--- a/src/storage/database/columns.ts
+++ b/src/storage/database/columns.ts
@@ -1,0 +1,136 @@
+import { quoteIdentifier } from '@internal/database/sql'
+import type { Bucket, IcebergCatalog, Obj, S3MultipartUpload } from '../schemas'
+
+declare const selectColumnOptionsBrand: unique symbol
+
+// A bitmask composed exclusively from declared select-column options.
+export type SelectColumnOptionsMask = number & {
+  readonly [selectColumnOptionsBrand]: true
+}
+
+export const SelectColumnOptions = Object.freeze({
+  none: 0 as SelectColumnOptionsMask,
+  excludeUserMetadata: (1 << 0) as SelectColumnOptionsMask,
+  excludeMultipartMetadata: (1 << 1) as SelectColumnOptionsMask,
+  excludeBucketType: (1 << 2) as SelectColumnOptionsMask,
+  syntheticBucketType: (1 << 3) as SelectColumnOptionsMask,
+} as const)
+
+// Keep tokens interoperable when a test runner reloads this module in a second module registry.
+const columnSelectionBrand: unique symbol = Symbol.for('storage.columnSelection')
+
+// An immutable, precompiled SQL column selection for a specific row type.
+export interface ColumnSelection<Row> {
+  readonly [columnSelectionBrand]: (row: Row) => Row
+}
+
+export type ObjectColumnSelection = ColumnSelection<Obj>
+export type BucketColumnSelection = ColumnSelection<Bucket>
+export type MultipartColumnSelection = ColumnSelection<S3MultipartUpload>
+export type AnalyticsColumnSelection = ColumnSelection<IcebergCatalog>
+
+export type ObjectColumn = Exclude<keyof Obj, 'buckets'> | '*'
+export type BucketColumn = keyof Bucket | '*'
+export type MultipartColumn = keyof S3MultipartUpload | '*'
+export type AnalyticsColumn = keyof IcebergCatalog | '*'
+
+interface CompiledColumnSelection {
+  readonly [columnSelectionBrand]: readonly string[]
+}
+
+interface CompiledColumn {
+  readonly name: string
+  readonly sql: string
+}
+
+const COLUMN_VARIANT_COUNT =
+  Object.values(SelectColumnOptions).reduce((mask, option) => mask | option, 0) + 1
+
+function defineColumns<Row>(columns: readonly string[]): ColumnSelection<Row> {
+  // Exclusion options are matched by column name, not row type.
+  // Callers must mask options to the relevant row type.
+  // For example, excludeMultipartMetadata would also remove an object's metadata.
+  const compiledColumns = columns.map<CompiledColumn>((name) => ({
+    name,
+    sql: name === '*' ? '*' : quoteIdentifier(name),
+  }))
+  const variants = new Array<string>(COLUMN_VARIANT_COUNT)
+
+  for (let options = 0; options < COLUMN_VARIANT_COUNT; options++) {
+    const selected: string[] = []
+    let synthesizeBucketType = false
+
+    for (const column of compiledColumns) {
+      if (
+        column.name === 'user_metadata' &&
+        (options & SelectColumnOptions.excludeUserMetadata) !== 0
+      ) {
+        continue
+      }
+      if (
+        column.name === 'metadata' &&
+        (options & SelectColumnOptions.excludeMultipartMetadata) !== 0
+      ) {
+        continue
+      }
+      if (column.name === 'type') {
+        if ((options & SelectColumnOptions.syntheticBucketType) !== 0) {
+          synthesizeBucketType = true
+          continue
+        }
+        if ((options & SelectColumnOptions.excludeBucketType) !== 0) {
+          continue
+        }
+      }
+
+      selected.push(column.sql)
+    }
+
+    if (synthesizeBucketType) {
+      selected.push(`'STANDARD' AS "type"`)
+    }
+
+    variants[options] = selected.length === 0 ? quoteIdentifier('id') : selected.join(', ')
+  }
+
+  return Object.freeze({
+    [columnSelectionBrand]: Object.freeze(variants),
+  }) as unknown as ColumnSelection<Row>
+}
+
+export function defineObjectColumns<
+  const Columns extends readonly [ObjectColumn, ...ObjectColumn[]],
+>(...columns: Columns): ObjectColumnSelection {
+  return defineColumns<Obj>(columns)
+}
+
+export function defineBucketColumns<
+  const Columns extends readonly [BucketColumn, ...BucketColumn[]],
+>(...columns: Columns): BucketColumnSelection {
+  return defineColumns<Bucket>(columns)
+}
+
+export function defineMultipartColumns<
+  const Columns extends readonly [MultipartColumn, ...MultipartColumn[]],
+>(...columns: Columns): MultipartColumnSelection {
+  return defineColumns<S3MultipartUpload>(columns)
+}
+
+export function defineAnalyticsColumns<
+  const Columns extends readonly [AnalyticsColumn, ...AnalyticsColumn[]],
+>(...columns: Columns): AnalyticsColumnSelection {
+  return defineColumns<IcebergCatalog>(columns)
+}
+
+export function resolveColumns<Row>(
+  selection: ColumnSelection<Row>,
+  options: SelectColumnOptionsMask = 0 as SelectColumnOptionsMask
+): string {
+  return (selection as unknown as CompiledColumnSelection)[columnSelectionBrand][options]
+}
+
+export const OBJECT_ID_COLUMNS = defineObjectColumns('id')
+export const OBJECT_ALL_COLUMNS = defineObjectColumns('*')
+export const BUCKET_ID_COLUMNS = defineBucketColumns('id')
+export const MULTIPART_ID_COLUMNS = defineMultipartColumns('id')
+export const ANALYTICS_NAME_COLUMNS = defineAnalyticsColumns('name')

--- a/src/storage/database/columns.ts
+++ b/src/storage/database/columns.ts
@@ -1,136 +1,50 @@
-import { quoteIdentifier } from '@internal/database/sql'
 import type { Bucket, IcebergCatalog, Obj, S3MultipartUpload } from '../schemas'
+import { defineColumnSet, staticSqlLiteral } from './column-set'
 
-declare const selectColumnOptionsBrand: unique symbol
+export type { ColumnSelection } from './column-set'
 
-// A bitmask composed exclusively from declared select-column options.
-export type SelectColumnOptionsMask = number & {
-  readonly [selectColumnOptionsBrand]: true
-}
+// type-only set brands
+declare const objectColumnSetId: unique symbol
+declare const bucketColumnSetId: unique symbol
+declare const multipartColumnSetId: unique symbol
+declare const analyticsColumnSetId: unique symbol
 
-export const SelectColumnOptions = Object.freeze({
-  none: 0 as SelectColumnOptionsMask,
-  excludeUserMetadata: (1 << 0) as SelectColumnOptionsMask,
-  excludeMultipartMetadata: (1 << 1) as SelectColumnOptionsMask,
-  excludeBucketType: (1 << 2) as SelectColumnOptionsMask,
-  syntheticBucketType: (1 << 3) as SelectColumnOptionsMask,
-} as const)
+export const objectColumns = defineColumnSet<Obj, typeof objectColumnSetId>({
+  fallback: 'id',
+  availableFrom: {
+    user_metadata: 'custom-metadata',
+  },
+})
 
-// Keep tokens interoperable when a test runner reloads this module in a second module registry.
-const columnSelectionBrand: unique symbol = Symbol.for('storage.columnSelection')
+export const bucketColumns = defineColumnSet<Bucket, typeof bucketColumnSetId>({
+  fallback: 'id',
+  availableFrom: {
+    type: 'iceberg-catalog-flag-on-buckets',
+  },
+  synthetic: {
+    type: staticSqlLiteral('STANDARD'),
+  },
+})
 
-// An immutable, precompiled SQL column selection for a specific row type.
-export interface ColumnSelection<Row> {
-  readonly [columnSelectionBrand]: (row: Row) => Row
-}
+export const multipartColumns = defineColumnSet<S3MultipartUpload, typeof multipartColumnSetId>({
+  fallback: 'id',
+  availableFrom: {
+    user_metadata: 'custom-metadata',
+    metadata: 's3-multipart-uploads-metadata',
+  },
+})
 
-export type ObjectColumnSelection = ColumnSelection<Obj>
-export type BucketColumnSelection = ColumnSelection<Bucket>
-export type MultipartColumnSelection = ColumnSelection<S3MultipartUpload>
-export type AnalyticsColumnSelection = ColumnSelection<IcebergCatalog>
+export const analyticsColumns = defineColumnSet<IcebergCatalog, typeof analyticsColumnSetId>({
+  fallback: 'id',
+})
 
-export type ObjectColumn = Exclude<keyof Obj, 'buckets'> | '*'
-export type BucketColumn = keyof Bucket | '*'
-export type MultipartColumn = keyof S3MultipartUpload | '*'
-export type AnalyticsColumn = keyof IcebergCatalog | '*'
+export type ObjectColumnSelection = ReturnType<typeof objectColumns.select>
+export type BucketColumnSelection = ReturnType<typeof bucketColumns.select>
+export type MultipartColumnSelection = ReturnType<typeof multipartColumns.select>
+export type AnalyticsColumnSelection = ReturnType<typeof analyticsColumns.select>
 
-interface CompiledColumnSelection {
-  readonly [columnSelectionBrand]: readonly string[]
-}
-
-interface CompiledColumn {
-  readonly name: string
-  readonly sql: string
-}
-
-const COLUMN_VARIANT_COUNT =
-  Object.values(SelectColumnOptions).reduce((mask, option) => mask | option, 0) + 1
-
-function defineColumns<Row>(columns: readonly string[]): ColumnSelection<Row> {
-  // Exclusion options are matched by column name, not row type.
-  // Callers must mask options to the relevant row type.
-  // For example, excludeMultipartMetadata would also remove an object's metadata.
-  const compiledColumns = columns.map<CompiledColumn>((name) => ({
-    name,
-    sql: name === '*' ? '*' : quoteIdentifier(name),
-  }))
-  const variants = new Array<string>(COLUMN_VARIANT_COUNT)
-
-  for (let options = 0; options < COLUMN_VARIANT_COUNT; options++) {
-    const selected: string[] = []
-    let synthesizeBucketType = false
-
-    for (const column of compiledColumns) {
-      if (
-        column.name === 'user_metadata' &&
-        (options & SelectColumnOptions.excludeUserMetadata) !== 0
-      ) {
-        continue
-      }
-      if (
-        column.name === 'metadata' &&
-        (options & SelectColumnOptions.excludeMultipartMetadata) !== 0
-      ) {
-        continue
-      }
-      if (column.name === 'type') {
-        if ((options & SelectColumnOptions.syntheticBucketType) !== 0) {
-          synthesizeBucketType = true
-          continue
-        }
-        if ((options & SelectColumnOptions.excludeBucketType) !== 0) {
-          continue
-        }
-      }
-
-      selected.push(column.sql)
-    }
-
-    if (synthesizeBucketType) {
-      selected.push(`'STANDARD' AS "type"`)
-    }
-
-    variants[options] = selected.length === 0 ? quoteIdentifier('id') : selected.join(', ')
-  }
-
-  return Object.freeze({
-    [columnSelectionBrand]: Object.freeze(variants),
-  }) as unknown as ColumnSelection<Row>
-}
-
-export function defineObjectColumns<
-  const Columns extends readonly [ObjectColumn, ...ObjectColumn[]],
->(...columns: Columns): ObjectColumnSelection {
-  return defineColumns<Obj>(columns)
-}
-
-export function defineBucketColumns<
-  const Columns extends readonly [BucketColumn, ...BucketColumn[]],
->(...columns: Columns): BucketColumnSelection {
-  return defineColumns<Bucket>(columns)
-}
-
-export function defineMultipartColumns<
-  const Columns extends readonly [MultipartColumn, ...MultipartColumn[]],
->(...columns: Columns): MultipartColumnSelection {
-  return defineColumns<S3MultipartUpload>(columns)
-}
-
-export function defineAnalyticsColumns<
-  const Columns extends readonly [AnalyticsColumn, ...AnalyticsColumn[]],
->(...columns: Columns): AnalyticsColumnSelection {
-  return defineColumns<IcebergCatalog>(columns)
-}
-
-export function resolveColumns<Row>(
-  selection: ColumnSelection<Row>,
-  options: SelectColumnOptionsMask = 0 as SelectColumnOptionsMask
-): string {
-  return (selection as unknown as CompiledColumnSelection)[columnSelectionBrand][options]
-}
-
-export const OBJECT_ID_COLUMNS = defineObjectColumns('id')
-export const OBJECT_ALL_COLUMNS = defineObjectColumns('*')
-export const BUCKET_ID_COLUMNS = defineBucketColumns('id')
-export const MULTIPART_ID_COLUMNS = defineMultipartColumns('id')
-export const ANALYTICS_NAME_COLUMNS = defineAnalyticsColumns('name')
+export const OBJECT_ID_COLUMNS = objectColumns.select('id')
+export const OBJECT_ALL_COLUMNS = objectColumns.select('*')
+export const BUCKET_ID_COLUMNS = bucketColumns.select('id')
+export const MULTIPART_ID_COLUMNS = multipartColumns.select('id')
+export const ANALYTICS_NAME_COLUMNS = analyticsColumns.select('name')

--- a/src/storage/database/index.ts
+++ b/src/storage/database/index.ts
@@ -1,3 +1,4 @@
 export * from './adapter'
+export * from './columns'
 export * from './errors'
 export * from './pg'

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -1,14 +1,17 @@
 import {
   type DatabaseExecutor,
+  type DatabaseStatement,
   type DatabaseTransaction,
   PgPoolExecutor,
   PgTenantConnection,
 } from '@internal/database'
+import { DBMigration } from '@internal/database/migrations'
 import { normalizeRawError } from '@internal/errors'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
 import { EventEmitter } from 'events'
 import { DatabaseError, type Pool, type PoolClient } from 'pg'
 import { vi } from 'vitest'
+import { defineBucketColumns, defineMultipartColumns, defineObjectColumns } from './columns'
 import { escapeLike, StoragePgDB } from './pg'
 
 class TestStoragePgDB extends StoragePgDB {
@@ -209,6 +212,78 @@ describe('StoragePgDB testPermission', () => {
     )
     expect(transaction.rollback).not.toHaveBeenCalled()
     expect(transaction.commit).not.toHaveBeenCalled()
+  })
+})
+
+describe('StoragePgDB compiled column selections', () => {
+  function createQueryCaptureStorage(latestMigration?: keyof typeof DBMigration) {
+    const transaction = {
+      commit: vi.fn(),
+      rollback: vi.fn(),
+      isCompleted: vi.fn().mockReturnValue(false),
+      query: vi.fn().mockResolvedValue({ rows: [{ id: 'row' }], rowCount: 1 }),
+    }
+    const connection = {
+      getAbortSignal: vi.fn().mockReturnValue(undefined),
+      transaction: vi.fn().mockResolvedValue(transaction),
+      setScope: vi.fn(),
+    } as unknown as PgTenantConnection
+    const storage = new StoragePgDB(connection, {
+      tenantId: 'compiled-columns-tenant',
+      host: 'localhost',
+      latestMigration,
+    })
+
+    return { storage, transaction }
+  }
+
+  function capturedSql(transaction: { query: ReturnType<typeof vi.fn> }): string {
+    const statement = transaction.query.mock.calls[0]?.[0] as DatabaseStatement
+    return statement.text.replace(/\s+/g, ' ').trim()
+  }
+
+  test('uses the current object projection without runtime compilation', async () => {
+    const fixture = createQueryCaptureStorage()
+    const columns = defineObjectColumns('id', 'metadata', 'user_metadata')
+
+    await fixture.storage.findObject('bucket', 'object', columns)
+
+    expect(capturedSql(fixture.transaction)).toContain(
+      'SELECT "id", "metadata", "user_metadata" FROM storage.objects'
+    )
+  })
+
+  test('selects the precompiled object variant before custom metadata exists', async () => {
+    const fixture = createQueryCaptureStorage('operation-function')
+    const columns = defineObjectColumns('id', 'metadata', 'user_metadata')
+
+    await fixture.storage.findObject('bucket', 'object', columns)
+
+    expect(capturedSql(fixture.transaction)).toContain(
+      'SELECT "id", "metadata" FROM storage.objects'
+    )
+  })
+
+  test('selects the multipart variant for its exact migration state', async () => {
+    const fixture = createQueryCaptureStorage('custom-metadata')
+    const columns = defineMultipartColumns('id', 'user_metadata', 'metadata')
+
+    await fixture.storage.findMultipartUpload('upload', columns)
+
+    expect(capturedSql(fixture.transaction)).toContain(
+      'SELECT "id", "user_metadata" FROM storage.s3_multipart_uploads'
+    )
+  })
+
+  test('selects synthetic bucket type without per-query column rewriting', async () => {
+    const fixture = createQueryCaptureStorage()
+    const columns = defineBucketColumns('id', 'type', 'name')
+
+    await fixture.storage.listBuckets(columns)
+
+    expect(capturedSql(fixture.transaction)).toContain(
+      `SELECT "id", "name", 'STANDARD' AS "type" FROM storage.buckets`
+    )
   })
 })
 

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -11,7 +11,7 @@ import { dbQueryPerformance } from '@internal/monitoring/metrics'
 import { EventEmitter } from 'events'
 import { DatabaseError, type Pool, type PoolClient } from 'pg'
 import { vi } from 'vitest'
-import { defineBucketColumns, defineMultipartColumns, defineObjectColumns } from './columns'
+import { bucketColumns, multipartColumns, objectColumns } from './columns'
 import { escapeLike, StoragePgDB } from './pg'
 
 class TestStoragePgDB extends StoragePgDB {
@@ -216,7 +216,7 @@ describe('StoragePgDB testPermission', () => {
 })
 
 describe('StoragePgDB compiled column selections', () => {
-  function createQueryCaptureStorage(latestMigration?: keyof typeof DBMigration) {
+  function createQueryCaptureStorage(latestMigration?: keyof typeof DBMigration | null | string) {
     const transaction = {
       commit: vi.fn(),
       rollback: vi.fn(),
@@ -232,7 +232,7 @@ describe('StoragePgDB compiled column selections', () => {
       tenantId: 'compiled-columns-tenant',
       host: 'localhost',
       latestMigration,
-    })
+    } as ConstructorParameters<typeof StoragePgDB>[1])
 
     return { storage, transaction }
   }
@@ -244,7 +244,7 @@ describe('StoragePgDB compiled column selections', () => {
 
   test('uses the current object projection without runtime compilation', async () => {
     const fixture = createQueryCaptureStorage()
-    const columns = defineObjectColumns('id', 'metadata', 'user_metadata')
+    const columns = objectColumns.select('id', 'metadata', 'user_metadata')
 
     await fixture.storage.findObject('bucket', 'object', columns)
 
@@ -255,7 +255,7 @@ describe('StoragePgDB compiled column selections', () => {
 
   test('selects the precompiled object variant before custom metadata exists', async () => {
     const fixture = createQueryCaptureStorage('operation-function')
-    const columns = defineObjectColumns('id', 'metadata', 'user_metadata')
+    const columns = objectColumns.select('id', 'metadata', 'user_metadata')
 
     await fixture.storage.findObject('bucket', 'object', columns)
 
@@ -264,9 +264,20 @@ describe('StoragePgDB compiled column selections', () => {
     )
   })
 
+  test('applies the object table policy to list projections', async () => {
+    const fixture = createQueryCaptureStorage('operation-function')
+    const columns = objectColumns.select('name', 'metadata', 'user_metadata')
+
+    await fixture.storage.listObjects('bucket', columns)
+
+    expect(capturedSql(fixture.transaction)).toContain(
+      'SELECT "name", "metadata" FROM storage.objects'
+    )
+  })
+
   test('selects the multipart variant for its exact migration state', async () => {
     const fixture = createQueryCaptureStorage('custom-metadata')
-    const columns = defineMultipartColumns('id', 'user_metadata', 'metadata')
+    const columns = multipartColumns.select('id', 'user_metadata', 'metadata')
 
     await fixture.storage.findMultipartUpload('upload', columns)
 
@@ -277,12 +288,45 @@ describe('StoragePgDB compiled column selections', () => {
 
   test('selects synthetic bucket type without per-query column rewriting', async () => {
     const fixture = createQueryCaptureStorage()
-    const columns = defineBucketColumns('id', 'type', 'name')
+    const columns = bucketColumns.select('id', 'type', 'name')
 
     await fixture.storage.listBuckets(columns)
 
     expect(capturedSql(fixture.transaction)).toContain(
       `SELECT "id", "name", 'STANDARD' AS "type" FROM storage.buckets`
+    )
+  })
+
+  test('uses the bucket table policy for physical projections', async () => {
+    const legacyFixture = createQueryCaptureStorage('operation-function')
+    const currentFixture = createQueryCaptureStorage('iceberg-catalog-flag-on-buckets')
+    const columns = bucketColumns.select('id', 'type', 'name')
+
+    await legacyFixture.storage.findBucketById('bucket', columns)
+    await currentFixture.storage.findBucketById('bucket', columns)
+
+    expect(capturedSql(legacyFixture.transaction)).toContain(
+      'SELECT "id", "name" FROM storage.buckets'
+    )
+    expect(capturedSql(currentFixture.transaction)).toContain(
+      'SELECT "id", "type", "name" FROM storage.buckets'
+    )
+  })
+
+  test.each([
+    undefined,
+    null,
+    'unknown-migration',
+  ])('uses the current bucket projection without probing for migration snapshot: %s', async (latestMigration) => {
+    const fixture = createQueryCaptureStorage(latestMigration)
+    const columns = bucketColumns.select('id', 'type', 'name')
+    const hasMigration = vi.spyOn(fixture.storage, 'hasMigration')
+
+    await fixture.storage.findBucketById('bucket', columns)
+
+    expect(hasMigration).not.toHaveBeenCalled()
+    expect(capturedSql(fixture.transaction)).toContain(
+      'SELECT "id", "type", "name" FROM storage.buckets'
     )
   })
 })

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -8,7 +8,8 @@ import {
   type TenantConnection,
   type TransactionOptions,
 } from '@internal/database'
-import { DBMigration, tenantHasMigrations } from '@internal/database/migrations'
+import { tenantHasMigrations } from '@internal/database/migrations'
+import { DBMigration } from '@internal/database/migrations/types'
 import { ERRORS, ErrorCode, isStorageError, StorageBackendError } from '@internal/errors'
 import { hashStringToInt } from '@internal/hashing'
 import { logger, logSchema } from '@internal/monitoring'
@@ -26,18 +27,20 @@ import {
   ScannerS3Key,
   SearchObjectOption,
 } from './adapter'
+import { type ColumnSetState, prepareColumnState, resolveColumns } from './column-set'
 import {
   ANALYTICS_NAME_COLUMNS,
-  AnalyticsColumnSelection,
+  type AnalyticsColumnSelection,
+  analyticsColumns,
   BUCKET_ID_COLUMNS,
-  BucketColumnSelection,
+  type BucketColumnSelection,
+  bucketColumns,
   MULTIPART_ID_COLUMNS,
-  MultipartColumnSelection,
+  type MultipartColumnSelection,
+  multipartColumns,
   OBJECT_ID_COLUMNS,
-  ObjectColumnSelection,
-  resolveColumns,
-  SelectColumnOptions,
-  type SelectColumnOptionsMask,
+  type ObjectColumnSelection,
+  objectColumns,
 } from './columns'
 import { DBError, mapPgTransactionAbortedError, PgErrorContext } from './errors'
 
@@ -74,6 +77,13 @@ const HEALTHCHECK_SQL = 'SELECT id from storage.buckets limit 1'
 const HEALTHCHECK_QUERY_OPTIONS: UnscopedQueryOptions = Object.freeze({
   timeoutMs: databaseStatementTimeout,
 })
+const CURRENT_MIGRATION_ORDINAL = Number.MAX_SAFE_INTEGER
+const ANALYTICS_COLUMN_STATE = prepareColumnState(analyticsColumns, CURRENT_MIGRATION_ORDINAL)
+const BUCKET_LIST_COLUMN_STATE = prepareColumnState(
+  bucketColumns,
+  CURRENT_MIGRATION_ORDINAL,
+  'synthetic'
+)
 
 async function executeQuery<T extends QueryResultRow = QueryResultRow>(
   db: DatabaseExecutor,
@@ -113,7 +123,11 @@ export class StoragePgDB implements Database {
   public readonly sbReqId: string | undefined
   public readonly role?: string
   public readonly latestMigration?: keyof typeof DBMigration
-  private readonly unavailableSelectColumns: SelectColumnOptionsMask
+  private readonly objectColumnState: ColumnSetState<typeof objectColumns>
+  private readonly multipartColumnState: ColumnSetState<typeof multipartColumns>
+  private readonly bucketColumnState: ColumnSetState<typeof bucketColumns>
+  private readonly supportsCustomMetadataColumns: boolean
+  private readonly supportsMultipartMetadataColumn: boolean
 
   constructor(
     public readonly connection: TenantConnection,
@@ -125,7 +139,13 @@ export class StoragePgDB implements Database {
     this.sbReqId = options.sbReqId
     this.role = connection.role
     this.latestMigration = options.latestMigration
-    this.unavailableSelectColumns = unavailableSelectColumnOptions(options.latestMigration)
+    const migrationOrdinal = migrationOrdinalOrCurrent(options.latestMigration)
+    this.supportsCustomMetadataColumns = migrationOrdinal >= DBMigration['custom-metadata']
+    this.supportsMultipartMetadataColumn =
+      migrationOrdinal >= DBMigration['s3-multipart-uploads-metadata']
+    this.objectColumnState = prepareColumnState(objectColumns, migrationOrdinal)
+    this.multipartColumnState = prepareColumnState(multipartColumns, migrationOrdinal)
+    this.bucketColumnState = prepareColumnState(bucketColumns, migrationOrdinal)
   }
 
   async withTransaction<T>(
@@ -287,7 +307,7 @@ export class StoragePgDB implements Database {
     columns: AnalyticsColumnSelection = ANALYTICS_NAME_COLUMNS,
     options: ListBucketOptions | undefined
   ): Promise<IcebergCatalog[]> {
-    const selectedColumns = resolveColumns(columns)
+    const selectedColumns = resolveColumns(columns, ANALYTICS_COLUMN_STATE)
 
     return this.runQuery('ListIcebergBuckets', async (db, signal) => {
       const values: unknown[] = []
@@ -437,10 +457,7 @@ export class StoragePgDB implements Database {
     columns: BucketColumnSelection = BUCKET_ID_COLUMNS,
     filters?: FindBucketFilters
   ) {
-    const columnOptions = (await this.hasMigration('iceberg-catalog-flag-on-buckets'))
-      ? SelectColumnOptions.none
-      : SelectColumnOptions.excludeBucketType
-    const selectedColumns = resolveColumns(columns, columnOptions)
+    const selectedColumns = resolveColumns(columns, this.bucketColumnState)
 
     const result = await this.runQuery('FindBucketById', async (db, signal) => {
       const conditions = ['id = $1']
@@ -522,7 +539,7 @@ export class StoragePgDB implements Database {
     before?: Date,
     nextToken?: string
   ) {
-    const selectedColumns = resolveColumns(columns)
+    const selectedColumns = resolveColumns(columns, this.objectColumnState)
 
     const result = await this.runQuery('ListObjects', async (db, signal) => {
       const conditions = ['bucket_id = $1']
@@ -728,7 +745,7 @@ export class StoragePgDB implements Database {
     columns: BucketColumnSelection = BUCKET_ID_COLUMNS,
     options?: ListBucketOptions
   ) {
-    const selectedColumns = resolveColumns(columns, SelectColumnOptions.syntheticBucketType)
+    const selectedColumns = resolveColumns(columns, BUCKET_LIST_COLUMN_STATE)
 
     return this.runQuery('ListBuckets', async (db, signal) => {
       const conditions: string[] = []
@@ -1156,11 +1173,7 @@ export class StoragePgDB implements Database {
     columns: ObjectColumnSelection = OBJECT_ID_COLUMNS,
     filters?: FindObjectFilters
   ) {
-    const selectedColumns = resolveColumns(
-      columns,
-      (this.unavailableSelectColumns &
-        SelectColumnOptions.excludeUserMetadata) as SelectColumnOptionsMask
-    )
+    const selectedColumns = resolveColumns(columns, this.objectColumnState)
 
     const result = await this.runQuery('FindObject', async (db, signal) => {
       return this.query<Obj>(
@@ -1197,11 +1210,7 @@ export class StoragePgDB implements Database {
       return []
     }
 
-    const selectedColumns = resolveColumns(
-      columns,
-      (this.unavailableSelectColumns &
-        SelectColumnOptions.excludeUserMetadata) as SelectColumnOptionsMask
-    )
+    const selectedColumns = resolveColumns(columns, this.objectColumnState)
     const result = await this.runQuery('FindObjects', async (db, signal) => {
       return this.query<Obj>(
         db,
@@ -1495,7 +1504,7 @@ export class StoragePgDB implements Database {
     columns: MultipartColumnSelection = MULTIPART_ID_COLUMNS,
     options?: { forUpdate?: boolean }
   ) {
-    const selectedColumns = resolveColumns(columns, this.unavailableSelectColumns)
+    const selectedColumns = resolveColumns(columns, this.multipartColumnState)
 
     const result = await this.runQuery('FindMultipartUpload', async (db, signal) => {
       return this.query<S3MultipartUpload>(
@@ -1771,10 +1780,7 @@ export class StoragePgDB implements Database {
   }
 
   protected normalizeRecordColumns<T extends Record<string, unknown>>(columns: T): T {
-    if (
-      (this.unavailableSelectColumns & SelectColumnOptions.excludeUserMetadata) ===
-      SelectColumnOptions.none
-    ) {
+    if (this.supportsCustomMetadataColumns) {
       return columns
     }
 
@@ -1790,10 +1796,7 @@ export class StoragePgDB implements Database {
   }
 
   protected hasMultipartMetadataColumn(): boolean {
-    return (
-      (this.unavailableSelectColumns & SelectColumnOptions.excludeMultipartMetadata) ===
-      SelectColumnOptions.none
-    )
+    return this.supportsMultipartMetadataColumn
   }
 
   protected async runQuery<T>(
@@ -2002,24 +2005,10 @@ export class StoragePgDB implements Database {
   }
 }
 
-function unavailableSelectColumnOptions(
-  latestMigration?: keyof typeof DBMigration
-): SelectColumnOptionsMask {
-  if (!latestMigration) {
-    return SelectColumnOptions.none
-  }
-
-  let options = 0
-  const migration = DBMigration[latestMigration]
-
-  if (migration < DBMigration['custom-metadata']) {
-    options |= SelectColumnOptions.excludeUserMetadata
-  }
-  if (migration < DBMigration['s3-multipart-uploads-metadata']) {
-    options |= SelectColumnOptions.excludeMultipartMetadata
-  }
-
-  return options as SelectColumnOptionsMask
+function migrationOrdinalOrCurrent(latestMigration?: keyof typeof DBMigration): number {
+  return latestMigration === undefined
+    ? CURRENT_MIGRATION_ORDINAL
+    : (DBMigration[latestMigration] ?? CURRENT_MIGRATION_ORDINAL)
 }
 
 function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -26,6 +26,19 @@ import {
   ScannerS3Key,
   SearchObjectOption,
 } from './adapter'
+import {
+  ANALYTICS_NAME_COLUMNS,
+  AnalyticsColumnSelection,
+  BUCKET_ID_COLUMNS,
+  BucketColumnSelection,
+  MULTIPART_ID_COLUMNS,
+  MultipartColumnSelection,
+  OBJECT_ID_COLUMNS,
+  ObjectColumnSelection,
+  resolveColumns,
+  SelectColumnOptions,
+  type SelectColumnOptionsMask,
+} from './columns'
 import { DBError, mapPgTransactionAbortedError, PgErrorContext } from './errors'
 
 const { databaseEngine, databaseStatementTimeout, isMultitenant, databaseHealthcheckUnscoped } =
@@ -100,6 +113,7 @@ export class StoragePgDB implements Database {
   public readonly sbReqId: string | undefined
   public readonly role?: string
   public readonly latestMigration?: keyof typeof DBMigration
+  private readonly unavailableSelectColumns: SelectColumnOptionsMask
 
   constructor(
     public readonly connection: TenantConnection,
@@ -111,6 +125,7 @@ export class StoragePgDB implements Database {
     this.sbReqId = options.sbReqId
     this.role = connection.role
     this.latestMigration = options.latestMigration
+    this.unavailableSelectColumns = unavailableSelectColumnOptions(options.latestMigration)
   }
 
   async withTransaction<T>(
@@ -269,9 +284,11 @@ export class StoragePgDB implements Database {
   }
 
   listAnalyticsBuckets(
-    columns: string,
+    columns: AnalyticsColumnSelection = ANALYTICS_NAME_COLUMNS,
     options: ListBucketOptions | undefined
   ): Promise<IcebergCatalog[]> {
+    const selectedColumns = resolveColumns(columns)
+
     return this.runQuery('ListIcebergBuckets', async (db, signal) => {
       const values: unknown[] = []
       const conditions = ['deleted_at IS NULL']
@@ -299,7 +316,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(columns)}
+            SELECT ${selectedColumns}
             FROM storage.buckets_analytics
             WHERE ${conditions.join(' AND ')}
             ORDER BY ${orderBy}
@@ -415,16 +432,17 @@ export class StoragePgDB implements Database {
     }
   }
 
-  async findBucketById(bucketId: string, columns = 'id', filters?: FindBucketFilters) {
-    const hasBucketType = await this.hasMigration('iceberg-catalog-flag-on-buckets')
+  async findBucketById(
+    bucketId: string,
+    columns: BucketColumnSelection = BUCKET_ID_COLUMNS,
+    filters?: FindBucketFilters
+  ) {
+    const columnOptions = (await this.hasMigration('iceberg-catalog-flag-on-buckets'))
+      ? SelectColumnOptions.none
+      : SelectColumnOptions.excludeBucketType
+    const selectedColumns = resolveColumns(columns, columnOptions)
 
     const result = await this.runQuery('FindBucketById', async (db, signal) => {
-      let columnNames = columns.split(',').map((column) => column.trim())
-
-      if (!hasBucketType) {
-        columnNames = columnNames.filter((name) => name !== 'type')
-      }
-
       const conditions = ['id = $1']
       const values: unknown[] = [bucketId]
 
@@ -437,7 +455,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(columnNames)}
+            SELECT ${selectedColumns}
             FROM storage.buckets
             WHERE ${conditions.join(' AND ')}
             LIMIT 1
@@ -499,11 +517,13 @@ export class StoragePgDB implements Database {
 
   async listObjects(
     bucketId: string,
-    columns = 'id',
+    columns: ObjectColumnSelection = OBJECT_ID_COLUMNS,
     limit = 10,
     before?: Date,
     nextToken?: string
   ) {
+    const selectedColumns = resolveColumns(columns)
+
     const result = await this.runQuery('ListObjects', async (db, signal) => {
       const conditions = ['bucket_id = $1']
       const values: unknown[] = [bucketId]
@@ -524,7 +544,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(columns)}
+            SELECT ${selectedColumns}
             FROM storage.objects
             WHERE ${conditions.join(' AND ')}
             ORDER BY name COLLATE "C"
@@ -704,15 +724,13 @@ export class StoragePgDB implements Database {
     return result.rowCount || 0
   }
 
-  async listBuckets(columns = 'id', options?: ListBucketOptions) {
-    return this.runQuery('ListBuckets', async (db, signal) => {
-      const columnNames = columns.split(',').map((column) => column.trim())
-      const selectColumnNames = columnNames.filter((name) => name !== 'type')
-      const selectedColumns = selectColumnNames.length ? selectColumns(selectColumnNames) : ''
-      const selectClause = columnNames.includes('type')
-        ? [selectedColumns, `'STANDARD' AS "type"`].filter(Boolean).join(', ')
-        : selectedColumns || quoteIdentifier('id')
+  async listBuckets(
+    columns: BucketColumnSelection = BUCKET_ID_COLUMNS,
+    options?: ListBucketOptions
+  ) {
+    const selectedColumns = resolveColumns(columns, SelectColumnOptions.syntheticBucketType)
 
+    return this.runQuery('ListBuckets', async (db, signal) => {
       const conditions: string[] = []
       const values: unknown[] = []
 
@@ -741,7 +759,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectClause}
+            SELECT ${selectedColumns}
             FROM storage.buckets
             ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
             ${orderBy}
@@ -871,7 +889,7 @@ export class StoragePgDB implements Database {
   async upsertObject(
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'user_metadata' | 'version'>
   ) {
-    const objectData = this.normalizeColumns({
+    const objectData = this.normalizeRecordColumns({
       name: data.name,
       owner: isUuid(data.owner || '') ? data.owner : undefined,
       owner_id: data.owner,
@@ -880,7 +898,7 @@ export class StoragePgDB implements Database {
       user_metadata: data.user_metadata,
       version: data.version,
     })
-    const updateData = this.normalizeColumns({
+    const updateData = this.normalizeRecordColumns({
       metadata: data.metadata,
       user_metadata: data.user_metadata,
       version: data.version,
@@ -931,7 +949,7 @@ export class StoragePgDB implements Database {
     name: string,
     data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>
   ) {
-    const objectData = this.normalizeColumns({
+    const objectData = this.normalizeRecordColumns({
       name: data.name,
       bucket_id: data.bucket_id,
       owner: isUuid(data.owner || '') ? data.owner : undefined,
@@ -971,7 +989,7 @@ export class StoragePgDB implements Database {
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'version' | 'user_metadata'>
   ) {
     try {
-      const object = this.normalizeColumns({
+      const object = this.normalizeRecordColumns({
         name: data.name,
         owner: isUuid(data.owner || '') ? data.owner : undefined,
         owner_id: data.owner,
@@ -1135,15 +1153,21 @@ export class StoragePgDB implements Database {
   async findObject(
     bucketId: string,
     objectName: string,
-    columns = 'id',
+    columns: ObjectColumnSelection = OBJECT_ID_COLUMNS,
     filters?: FindObjectFilters
   ) {
+    const selectedColumns = resolveColumns(
+      columns,
+      (this.unavailableSelectColumns &
+        SelectColumnOptions.excludeUserMetadata) as SelectColumnOptionsMask
+    )
+
     const result = await this.runQuery('FindObject', async (db, signal) => {
       return this.query<Obj>(
         db,
         {
           text: `
-            SELECT ${selectColumns(this.normalizeColumns(columns))}
+            SELECT ${selectedColumns}
             FROM storage.objects
             WHERE name = $1
               AND bucket_id = $2
@@ -1164,17 +1188,26 @@ export class StoragePgDB implements Database {
     return object
   }
 
-  async findObjects(bucketId: string, objectNames: string[], columns = 'id') {
+  async findObjects(
+    bucketId: string,
+    objectNames: string[],
+    columns: ObjectColumnSelection = OBJECT_ID_COLUMNS
+  ) {
     if (objectNames.length === 0) {
       return []
     }
 
+    const selectedColumns = resolveColumns(
+      columns,
+      (this.unavailableSelectColumns &
+        SelectColumnOptions.excludeUserMetadata) as SelectColumnOptionsMask
+    )
     const result = await this.runQuery('FindObjects', async (db, signal) => {
       return this.query<Obj>(
         db,
         {
           text: `
-            SELECT ${selectColumns(this.normalizeColumns(columns))}
+            SELECT ${selectedColumns}
             FROM storage.objects
             WHERE bucket_id = $1
               AND name = ANY($2::text[])
@@ -1439,7 +1472,7 @@ export class StoragePgDB implements Database {
         data.metadata = metadata
       }
 
-      const insert = buildInsert(this.normalizeColumns(data))
+      const insert = buildInsert(this.normalizeRecordColumns(data))
       const result = await this.query<S3MultipartUpload>(
         db,
         {
@@ -1457,15 +1490,19 @@ export class StoragePgDB implements Database {
     })
   }
 
-  async findMultipartUpload(uploadId: string, columns = 'id', options?: { forUpdate?: boolean }) {
-    const result = await this.runQuery('FindMultipartUpload', async (db, signal) => {
-      const normalizedColumns = this.normalizeMultipartUploadColumns(columns)
+  async findMultipartUpload(
+    uploadId: string,
+    columns: MultipartColumnSelection = MULTIPART_ID_COLUMNS,
+    options?: { forUpdate?: boolean }
+  ) {
+    const selectedColumns = resolveColumns(columns, this.unavailableSelectColumns)
 
+    const result = await this.runQuery('FindMultipartUpload', async (db, signal) => {
       return this.query<S3MultipartUpload>(
         db,
         {
           text: `
-            SELECT ${selectColumns(normalizedColumns)}
+            SELECT ${selectedColumns}
             FROM storage.s3_multipart_uploads
             WHERE id = $1
             LIMIT 1
@@ -1733,78 +1770,29 @@ export class StoragePgDB implements Database {
     this.connection.dispose()
   }
 
-  /**
-   * Excludes columns selection if a specific migration wasn't run.
-   */
-  protected normalizeColumns<T extends string | Record<string, unknown>>(columns: T): T {
-    const latestMigration = this.latestMigration
-
-    if (!latestMigration) {
+  protected normalizeRecordColumns<T extends Record<string, unknown>>(columns: T): T {
+    if (
+      (this.unavailableSelectColumns & SelectColumnOptions.excludeUserMetadata) ===
+      SelectColumnOptions.none
+    ) {
       return columns
     }
 
-    const rules = [{ migration: 'custom-metadata', newColumns: ['user_metadata'] }]
+    const normalizedColumns: Record<string, unknown> = {}
 
-    for (const rule of rules) {
-      if (DBMigration[latestMigration] >= DBMigration[rule.migration as keyof typeof DBMigration]) {
-        continue
+    for (const column in columns) {
+      if (Object.prototype.hasOwnProperty.call(columns, column) && column !== 'user_metadata') {
+        normalizedColumns[column] = columns[column]
       }
-
-      if (typeof columns === 'string') {
-        const normalizedColumns: string[] = []
-        for (const column of columns.split(',')) {
-          const trimmed = column.trim()
-          if (rule.newColumns.includes(trimmed)) {
-            continue
-          }
-
-          normalizedColumns.push(trimmed)
-        }
-
-        return normalizedColumns.join(',') as T
-      }
-
-      const normalizedColumns: Record<string, unknown> = {}
-      const sourceColumns = columns as Record<string, unknown>
-
-      for (const column in sourceColumns) {
-        if (!Object.prototype.hasOwnProperty.call(sourceColumns, column)) {
-          continue
-        }
-
-        if (rule.newColumns.includes(column)) {
-          continue
-        }
-
-        normalizedColumns[column] = sourceColumns[column]
-      }
-
-      return normalizedColumns as T
     }
 
-    return columns
-  }
-
-  protected normalizeMultipartUploadColumns(columns: string): string[] {
-    const normalizedColumns: string[] = []
-    const hasMetadataColumn = this.hasMultipartMetadataColumn()
-
-    for (const column of this.normalizeColumns(columns).split(',')) {
-      const trimmed = column.trim()
-      if (!trimmed || (!hasMetadataColumn && trimmed === 'metadata')) {
-        continue
-      }
-
-      normalizedColumns.push(trimmed)
-    }
-
-    return normalizedColumns
+    return normalizedColumns as T
   }
 
   protected hasMultipartMetadataColumn(): boolean {
     return (
-      !this.latestMigration ||
-      DBMigration[this.latestMigration] >= DBMigration['s3-multipart-uploads-metadata']
+      (this.unavailableSelectColumns & SelectColumnOptions.excludeMultipartMetadata) ===
+      SelectColumnOptions.none
     )
   }
 
@@ -2014,6 +2002,26 @@ export class StoragePgDB implements Database {
   }
 }
 
+function unavailableSelectColumnOptions(
+  latestMigration?: keyof typeof DBMigration
+): SelectColumnOptionsMask {
+  if (!latestMigration) {
+    return SelectColumnOptions.none
+  }
+
+  let options = 0
+  const migration = DBMigration[latestMigration]
+
+  if (migration < DBMigration['custom-metadata']) {
+    options |= SelectColumnOptions.excludeUserMetadata
+  }
+  if (migration < DBMigration['s3-multipart-uploads-metadata']) {
+    options |= SelectColumnOptions.excludeMultipartMetadata
+  }
+
+  return options as SelectColumnOptionsMask
+}
+
 function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return undefined
@@ -2026,39 +2034,6 @@ function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
 // so arming the deadline allocates no closure.
 function abortFromTimer(controller: AbortController): void {
   controller.abort()
-}
-
-function selectColumns(columns: string | string[]): string {
-  const selected: string[] = []
-
-  if (Array.isArray(columns)) {
-    for (const column of columns) {
-      if (column.length === 0) {
-        continue
-      }
-
-      if (column === '*') {
-        selected.push('*')
-      } else {
-        selected.push(quoteIdentifier(column))
-      }
-    }
-  } else {
-    for (const column of columns.split(',')) {
-      const trimmed = column.trim()
-      if (trimmed.length === 0) {
-        continue
-      }
-
-      if (trimmed === '*') {
-        selected.push('*')
-      } else {
-        selected.push(quoteIdentifier(trimmed))
-      }
-    }
-  }
-
-  return selected.length ? selected.join(', ') : quoteIdentifier('id')
 }
 
 function normalizeSortOrder(sortOrder?: string): 'ASC' | 'DESC' {

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -3,6 +3,7 @@ import { BasePayload } from '@internal/queue'
 import { withOptionalVersion } from '@storage/backend'
 import { Job, SendOptions, WorkOptions } from 'pg-boss'
 import { getConfig } from '../../../config'
+import { defineObjectColumns } from '../../database'
 import { Storage } from '../../index'
 import { MAX_OBJECTS_PER_DELETE_BATCH } from '../../limits'
 import { BaseEvent } from '../base-event'
@@ -16,6 +17,7 @@ export interface ObjectDeleteAllBeforeEvent extends BasePayload {
 }
 
 const { storageS3Bucket } = getConfig()
+const DELETE_BATCH_COLUMNS = defineObjectColumns('id', 'name')
 
 export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeEvent> {
   static queueName = 'object:admin:delete-all-before'
@@ -64,7 +66,12 @@ export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeE
       const start = Date.now()
       while (Date.now() - start < DELETE_JOB_TIME_LIMIT_MS) {
         moreObjectsToDelete = false
-        const objects = await storage.db.listObjects(bucketId, 'id, name', batchLimit + 1, before)
+        const objects = await storage.db.listObjects(
+          bucketId,
+          DELETE_BATCH_COLUMNS,
+          batchLimit + 1,
+          before
+        )
 
         const backend = storage.backend
         if (objects && objects.length > 0) {

--- a/src/storage/events/objects/object-admin-delete-all-before.ts
+++ b/src/storage/events/objects/object-admin-delete-all-before.ts
@@ -3,7 +3,7 @@ import { BasePayload } from '@internal/queue'
 import { withOptionalVersion } from '@storage/backend'
 import { Job, SendOptions, WorkOptions } from 'pg-boss'
 import { getConfig } from '../../../config'
-import { defineObjectColumns } from '../../database'
+import { objectColumns } from '../../database'
 import { Storage } from '../../index'
 import { MAX_OBJECTS_PER_DELETE_BATCH } from '../../limits'
 import { BaseEvent } from '../base-event'
@@ -17,7 +17,7 @@ export interface ObjectDeleteAllBeforeEvent extends BasePayload {
 }
 
 const { storageS3Bucket } = getConfig()
-const DELETE_BATCH_COLUMNS = defineObjectColumns('id', 'name')
+const DELETE_BATCH_COLUMNS = objectColumns.select('id', 'name')
 
 export class ObjectAdminDeleteAllBefore extends BaseEvent<ObjectDeleteAllBeforeEvent> {
   static queueName = 'object:admin:delete-all-before'

--- a/src/storage/events/upgrades/sync-catalog-ids.ts
+++ b/src/storage/events/upgrades/sync-catalog-ids.ts
@@ -1,6 +1,7 @@
 import { getTenantConfig } from '@internal/database'
 import { runMigrationsOnTenant } from '@internal/database/migrations'
 import { logger, logSchema } from '@internal/monitoring'
+import { defineAnalyticsColumns } from '@storage/database'
 import type { Storage } from '@storage/storage'
 import { getConfig } from '../../../config'
 import { UpgradeBaseEvent, UpgradeBaseEventPayload, UpgradeTransaction } from './base-event'
@@ -8,6 +9,7 @@ import { UpgradeBaseEvent, UpgradeBaseEventPayload, UpgradeTransaction } from '.
 type SyncCatalogIdsPayload = UpgradeBaseEventPayload
 
 const { icebergShards } = getConfig()
+const CATALOG_ID_COLUMNS = defineAnalyticsColumns('id', 'name')
 
 export class SyncCatalogIds extends UpgradeBaseEvent<SyncCatalogIdsPayload> {
   static queueName = 'sync-iceberg-catalog-ids'
@@ -46,7 +48,7 @@ export class SyncCatalogIds extends UpgradeBaseEvent<SyncCatalogIdsPayload> {
             },
           })
 
-          const tenantBuckets = await storage.listAnalyticsBuckets('id,name', {
+          const tenantBuckets = await storage.listAnalyticsBuckets(CATALOG_ID_COLUMNS, {
             limit: 1000,
           })
 

--- a/src/storage/events/upgrades/sync-catalog-ids.ts
+++ b/src/storage/events/upgrades/sync-catalog-ids.ts
@@ -1,7 +1,7 @@
 import { getTenantConfig } from '@internal/database'
 import { runMigrationsOnTenant } from '@internal/database/migrations'
 import { logger, logSchema } from '@internal/monitoring'
-import { defineAnalyticsColumns } from '@storage/database'
+import { analyticsColumns } from '@storage/database'
 import type { Storage } from '@storage/storage'
 import { getConfig } from '../../../config'
 import { UpgradeBaseEvent, UpgradeBaseEventPayload, UpgradeTransaction } from './base-event'
@@ -9,7 +9,7 @@ import { UpgradeBaseEvent, UpgradeBaseEventPayload, UpgradeTransaction } from '.
 type SyncCatalogIdsPayload = UpgradeBaseEventPayload
 
 const { icebergShards } = getConfig()
-const CATALOG_ID_COLUMNS = defineAnalyticsColumns('id', 'name')
+const CATALOG_ID_COLUMNS = analyticsColumns.select('id', 'name')
 
 export class SyncCatalogIds extends UpgradeBaseEvent<SyncCatalogIdsPayload> {
   static queueName = 'sync-iceberg-catalog-ids'

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -1,7 +1,7 @@
 import { ERRORS, ErrorCode } from '@internal/errors'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { StorageBackendAdapter } from './backend'
-import { Database } from './database'
+import { Database, resolveColumns } from './database'
 import { ObjectRemoved } from './events'
 import {
   MAX_KEYS_PER_S3_DELETE,
@@ -65,9 +65,10 @@ describe('ObjectStorage.deleteObject', () => {
       message: 'Access denied',
     })
 
-    expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', 'id,version,metadata', {
+    expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', expect.anything(), {
       forUpdate: true,
     })
+    expect(resolveColumns(findObject.mock.calls[0][2])).toBe('"id", "version", "metadata"')
     expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt')
     expect(backend.deleteObject).not.toHaveBeenCalled()
   })

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -1,7 +1,8 @@
 import { ERRORS, ErrorCode } from '@internal/errors'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { StorageBackendAdapter } from './backend'
-import { Database, resolveColumns } from './database'
+import { Database, objectColumns } from './database'
+import { prepareColumnState, resolveColumns } from './database/column-set'
 import { ObjectRemoved } from './events'
 import {
   MAX_KEYS_PER_S3_DELETE,
@@ -10,6 +11,8 @@ import {
 } from './limits'
 import { StorageObjectLocator } from './locator'
 import { ObjectStorage } from './object'
+
+const OBJECT_COLUMN_STATE = prepareColumnState(objectColumns, Number.MAX_SAFE_INTEGER)
 
 function createObjectStorage({
   findObject = vi.fn().mockResolvedValue({
@@ -68,7 +71,9 @@ describe('ObjectStorage.deleteObject', () => {
     expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', expect.anything(), {
       forUpdate: true,
     })
-    expect(resolveColumns(findObject.mock.calls[0][2])).toBe('"id", "version", "metadata"')
+    expect(resolveColumns(findObject.mock.calls[0][2], OBJECT_COLUMN_STATE)).toBe(
+      '"id", "version", "metadata"'
+    )
     expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt')
     expect(backend.deleteObject).not.toHaveBeenCalled()
   })

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -16,7 +16,15 @@ import { StorageObjectLocator } from '@storage/locator'
 import { Obj } from '@storage/schemas'
 import { FastifyRequest } from 'fastify/types/request'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
-import { Database, FindObjectFilters, SearchObjectOption } from './database'
+import {
+  Database,
+  defineBucketColumns,
+  defineObjectColumns,
+  FindObjectFilters,
+  OBJECT_ID_COLUMNS,
+  ObjectColumnSelection,
+  SearchObjectOption,
+} from './database'
 import {
   ObjectAdminDelete,
   ObjectCreatedCopyEvent,
@@ -31,6 +39,20 @@ import {
   mustBeValidKey,
 } from './limits'
 import { CanUploadMetadata, fileUploadFromRequest, Uploader, UploadRequest } from './uploader'
+
+const UPLOAD_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
+const DELETE_OBJECT_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const COPY_SOURCE_COLUMNS = defineObjectColumns('bucket_id', 'metadata', 'user_metadata', 'version')
+const COPY_DESTINATION_COLUMNS = defineObjectColumns(
+  'id',
+  'name',
+  'metadata',
+  'version',
+  'bucket_id'
+)
+const MOVE_SOURCE_COLUMNS = defineObjectColumns('id', 'version', 'user_metadata')
+const MOVE_LOCKED_SOURCE_COLUMNS = defineObjectColumns('id', 'version', 'metadata', 'user_metadata')
+const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
 
 interface CopyObjectParams {
   sourceKey: string
@@ -94,9 +116,7 @@ export class ObjectStorage {
       signal?: AbortSignal
     }
   ) {
-    const bucket = await this.db
-      .asSuperUser()
-      .findBucketById(this.bucketId, 'id, file_size_limit, allowed_mime_types')
+    const bucket = await this.db.asSuperUser().findBucketById(this.bucketId, UPLOAD_BUCKET_COLUMNS)
 
     const uploadRequest = await fileUploadFromRequest(request, {
       objectName: file.objectName,
@@ -141,7 +161,7 @@ export class ObjectStorage {
     const obj = await this.db.withTransaction(async (db) => {
       const obj = await db
         .asSuperUser()
-        .findObject(this.bucketId, objectName, 'id,version,metadata', {
+        .findObject(this.bucketId, objectName, DELETE_OBJECT_COLUMNS, {
           forUpdate: true,
         })
 
@@ -270,7 +290,11 @@ export class ObjectStorage {
    * @param columns
    * @param filters
    */
-  async findObject(objectName: string, columns = 'id', filters?: FindObjectFilters) {
+  async findObject(
+    objectName: string,
+    columns: ObjectColumnSelection = OBJECT_ID_COLUMNS,
+    filters?: FindObjectFilters
+  ) {
     mustBeValidKey(objectName)
 
     return this.db.findObject(this.bucketId, objectName, columns, filters)
@@ -281,7 +305,7 @@ export class ObjectStorage {
    * @param objectNames
    * @param columns
    */
-  async findObjects(objectNames: string[], columns = 'id') {
+  async findObjects(objectNames: string[], columns: ObjectColumnSelection = OBJECT_ID_COLUMNS) {
     return this.db.findObjects(this.bucketId, objectNames, columns)
   }
 
@@ -326,11 +350,7 @@ export class ObjectStorage {
     })
 
     // We check if the user has permission to copy the object to the destination key
-    const originObject = await this.db.findObject(
-      this.bucketId,
-      sourceKey,
-      'bucket_id,metadata,user_metadata,version'
-    )
+    const originObject = await this.db.findObject(this.bucketId, sourceKey, COPY_SOURCE_COLUMNS)
 
     const baseMetadata = originObject.metadata || {}
     const destinationMetadata = { ...baseMetadata }
@@ -386,7 +406,7 @@ export class ObjectStorage {
         const existingDestObject = await db.findObject(
           destinationBucket,
           destinationKey,
-          'id,name,metadata,version,bucket_id',
+          COPY_DESTINATION_COLUMNS,
           {
             dontErrorOnEmpty: true,
             forUpdate: true,
@@ -482,7 +502,7 @@ export class ObjectStorage {
 
     await this.db.testPermission((db) => {
       return Promise.all([
-        db.findObject(this.bucketId, sourceObjectName, 'id'),
+        db.findObject(this.bucketId, sourceObjectName, OBJECT_ID_COLUMNS),
         db.updateObject(this.bucketId, sourceObjectName, {
           name: destinationObjectName,
           version: newVersion,
@@ -494,7 +514,7 @@ export class ObjectStorage {
 
     const sourceObj = await this.db
       .asSuperUser()
-      .findObject(this.bucketId, sourceObjectName, 'id, version,user_metadata')
+      .findObject(this.bucketId, sourceObjectName, MOVE_SOURCE_COLUMNS)
 
     if (s3SourceKey === s3DestinationKey) {
       return {
@@ -525,7 +545,7 @@ export class ObjectStorage {
         const sourceObject = await db.findObject(
           this.bucketId,
           sourceObjectName,
-          'id,version,metadata,user_metadata',
+          MOVE_LOCKED_SOURCE_COLUMNS,
           {
             forUpdate: true,
             dontErrorOnEmpty: false,
@@ -784,14 +804,14 @@ export class ObjectStorage {
     let results: { name: string }[]
 
     if (paths.length <= MAX_OBJECTS_PER_LOOKUP_BATCH) {
-      results = await this.findObjects(paths, 'name')
+      results = await this.findObjects(paths, OBJECT_NAME_COLUMNS)
     } else {
       results = []
 
       for (let i = 0; i < paths.length; i += MAX_OBJECTS_PER_LOOKUP_BATCH) {
         const pathsSubset = paths.slice(i, i + MAX_OBJECTS_PER_LOOKUP_BATCH)
 
-        const objects = await this.findObjects(pathsSubset, 'name')
+        const objects = await this.findObjects(pathsSubset, OBJECT_NAME_COLUMNS)
         results.push(...objects)
       }
     }

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -17,12 +17,12 @@ import { Obj } from '@storage/schemas'
 import { FastifyRequest } from 'fastify/types/request'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
 import {
+  bucketColumns,
   Database,
-  defineBucketColumns,
-  defineObjectColumns,
   FindObjectFilters,
   OBJECT_ID_COLUMNS,
   ObjectColumnSelection,
+  objectColumns,
   SearchObjectOption,
 } from './database'
 import {
@@ -40,19 +40,29 @@ import {
 } from './limits'
 import { CanUploadMetadata, fileUploadFromRequest, Uploader, UploadRequest } from './uploader'
 
-const UPLOAD_BUCKET_COLUMNS = defineBucketColumns('id', 'file_size_limit', 'allowed_mime_types')
-const DELETE_OBJECT_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
-const COPY_SOURCE_COLUMNS = defineObjectColumns('bucket_id', 'metadata', 'user_metadata', 'version')
-const COPY_DESTINATION_COLUMNS = defineObjectColumns(
+const UPLOAD_BUCKET_COLUMNS = bucketColumns.select('id', 'file_size_limit', 'allowed_mime_types')
+const DELETE_OBJECT_COLUMNS = objectColumns.select('id', 'version', 'metadata')
+const COPY_SOURCE_COLUMNS = objectColumns.select(
+  'bucket_id',
+  'metadata',
+  'user_metadata',
+  'version'
+)
+const COPY_DESTINATION_COLUMNS = objectColumns.select(
   'id',
   'name',
   'metadata',
   'version',
   'bucket_id'
 )
-const MOVE_SOURCE_COLUMNS = defineObjectColumns('id', 'version', 'user_metadata')
-const MOVE_LOCKED_SOURCE_COLUMNS = defineObjectColumns('id', 'version', 'metadata', 'user_metadata')
-const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
+const MOVE_SOURCE_COLUMNS = objectColumns.select('id', 'version', 'user_metadata')
+const MOVE_LOCKED_SOURCE_COLUMNS = objectColumns.select(
+  'id',
+  'version',
+  'metadata',
+  'user_metadata'
+)
+const OBJECT_NAME_COLUMNS = objectColumns.select('name')
 
 interface CopyObjectParams {
   sourceKey: string

--- a/src/storage/protocols/s3/s3-handler-delete.test.ts
+++ b/src/storage/protocols/s3/s3-handler-delete.test.ts
@@ -1,5 +1,6 @@
 import { ERRORS, ErrorCode } from '@internal/errors'
 import { describe, expect, it, vi } from 'vitest'
+import { resolveColumns } from '../../database'
 import { S3ProtocolHandler } from './s3-handler'
 
 function createHandler(
@@ -52,7 +53,8 @@ describe('S3ProtocolHandler.deleteObjects', () => {
 
     expect(findBucket).not.toHaveBeenCalled()
     expect(deleteObjects).toHaveBeenCalledWith(['allowed.txt', 'missing.txt', 'denied.txt'])
-    expect(findObjects).toHaveBeenCalledWith(['missing.txt', 'denied.txt'], 'name')
+    expect(findObjects).toHaveBeenCalledWith(['missing.txt', 'denied.txt'], expect.anything())
+    expect(resolveColumns(findObjects.mock.calls[0][1])).toBe('"name"')
     expect(response.responseBody).toEqual({
       DeleteResult: {
         Deleted: [{ Key: 'allowed.txt' }, { Key: 'missing.txt' }],
@@ -103,6 +105,7 @@ describe('S3ProtocolHandler.deleteObjects', () => {
 
     expect(findBucket).toHaveBeenCalledWith('missing-bucket')
     expect(deleteObjects).toHaveBeenCalledWith(['missing.txt'])
-    expect(findObjects).toHaveBeenCalledWith(['missing.txt'], 'name')
+    expect(findObjects).toHaveBeenCalledWith(['missing.txt'], expect.anything())
+    expect(resolveColumns(findObjects.mock.calls[0][1])).toBe('"name"')
   })
 })

--- a/src/storage/protocols/s3/s3-handler-delete.test.ts
+++ b/src/storage/protocols/s3/s3-handler-delete.test.ts
@@ -1,7 +1,10 @@
 import { ERRORS, ErrorCode } from '@internal/errors'
 import { describe, expect, it, vi } from 'vitest'
-import { resolveColumns } from '../../database'
+import { objectColumns } from '../../database'
+import { prepareColumnState, resolveColumns } from '../../database/column-set'
 import { S3ProtocolHandler } from './s3-handler'
+
+const OBJECT_COLUMN_STATE = prepareColumnState(objectColumns, Number.MAX_SAFE_INTEGER)
 
 function createHandler(
   remainingKeys: string[] = [],
@@ -54,7 +57,7 @@ describe('S3ProtocolHandler.deleteObjects', () => {
     expect(findBucket).not.toHaveBeenCalled()
     expect(deleteObjects).toHaveBeenCalledWith(['allowed.txt', 'missing.txt', 'denied.txt'])
     expect(findObjects).toHaveBeenCalledWith(['missing.txt', 'denied.txt'], expect.anything())
-    expect(resolveColumns(findObjects.mock.calls[0][1])).toBe('"name"')
+    expect(resolveColumns(findObjects.mock.calls[0][1], OBJECT_COLUMN_STATE)).toBe('"name"')
     expect(response.responseBody).toEqual({
       DeleteResult: {
         Deleted: [{ Key: 'allowed.txt' }, { Key: 'missing.txt' }],
@@ -106,6 +109,6 @@ describe('S3ProtocolHandler.deleteObjects', () => {
     expect(findBucket).toHaveBeenCalledWith('missing-bucket')
     expect(deleteObjects).toHaveBeenCalledWith(['missing.txt'])
     expect(findObjects).toHaveBeenCalledWith(['missing.txt'], expect.anything())
-    expect(resolveColumns(findObjects.mock.calls[0][1])).toBe('"name"')
+    expect(resolveColumns(findObjects.mock.calls[0][1], OBJECT_COLUMN_STATE)).toBe('"name"')
   })
 })

--- a/src/storage/protocols/s3/s3-handler.test.ts
+++ b/src/storage/protocols/s3/s3-handler.test.ts
@@ -1,4 +1,5 @@
 import { MAX_HEADER_NAME_LENGTH } from '@internal/http/header'
+import { resolveColumns } from '@storage/database'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import * as config from '../../../config'
 
@@ -269,7 +270,10 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
     })
 
     expect(response).toEqual({})
-    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, 'id,version,user_metadata,metadata')
+    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+      '"id", "version", "user_metadata", "metadata"'
+    )
     expect(abortMultipartUpload).toHaveBeenCalled()
     expect(deleteMultipartUpload).toHaveBeenCalledWith(uploadId)
   })
@@ -318,7 +322,10 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
     })
 
     expect(response).toEqual({})
-    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, 'id,version,user_metadata,metadata')
+    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+      '"id", "version", "user_metadata", "metadata"'
+    )
     expect(abortMultipartUpload).toHaveBeenCalled()
     expect(deleteMultipartUpload).toHaveBeenCalledWith(uploadId)
   })
@@ -368,7 +375,10 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
       })
     ).rejects.toEqual(otherError)
 
-    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, 'id,version,user_metadata,metadata')
+    expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+      '"id", "version", "user_metadata", "metadata"'
+    )
     expect(abortMultipartUpload).toHaveBeenCalled()
     expect(deleteMultipartUpload).not.toHaveBeenCalled()
   })

--- a/src/storage/protocols/s3/s3-handler.test.ts
+++ b/src/storage/protocols/s3/s3-handler.test.ts
@@ -1,7 +1,10 @@
 import { MAX_HEADER_NAME_LENGTH } from '@internal/http/header'
-import { resolveColumns } from '@storage/database'
+import { multipartColumns } from '@storage/database'
+import { prepareColumnState, resolveColumns } from '@storage/database/column-set'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
 import * as config from '../../../config'
+
+const MULTIPART_COLUMN_STATE = prepareColumnState(multipartColumns, Number.MAX_SAFE_INTEGER)
 
 describe('S3ProtocolHandler.getBucketLocation', () => {
   it('returns an empty location constraint when the storage region is not configured', async () => {
@@ -271,7 +274,7 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
 
     expect(response).toEqual({})
     expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
-    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1], MULTIPART_COLUMN_STATE)).toBe(
       '"id", "version", "user_metadata", "metadata"'
     )
     expect(abortMultipartUpload).toHaveBeenCalled()
@@ -323,7 +326,7 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
 
     expect(response).toEqual({})
     expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
-    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1], MULTIPART_COLUMN_STATE)).toBe(
       '"id", "version", "user_metadata", "metadata"'
     )
     expect(abortMultipartUpload).toHaveBeenCalled()
@@ -376,7 +379,7 @@ describe('S3ProtocolHandler.abortMultipartUpload', () => {
     ).rejects.toEqual(otherError)
 
     expect(findMultipartUpload).toHaveBeenCalledWith(uploadId, expect.anything())
-    expect(resolveColumns(findMultipartUpload.mock.calls[0][1])).toBe(
+    expect(resolveColumns(findMultipartUpload.mock.calls[0][1], MULTIPART_COLUMN_STATE)).toBe(
       '"id", "version", "user_metadata", "metadata"'
     )
     expect(abortMultipartUpload).toHaveBeenCalled()

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -24,6 +24,14 @@ import { logger, logSchema } from '@internal/monitoring'
 import { PassThrough, Readable } from 'stream'
 import stream from 'stream/promises'
 import { getConfig } from '../../../config'
+import {
+  BUCKET_ID_COLUMNS,
+  defineBucketColumns,
+  defineMultipartColumns,
+  defineObjectColumns,
+  MULTIPART_ID_COLUMNS,
+  OBJECT_ID_COLUMNS,
+} from '../../database'
 import { getFileSizeLimit, mustBeValidBucketName, mustBeValidKey } from '../../limits'
 import { parseCopySourceRangeHeader } from '../../range'
 import { S3MultipartUpload } from '../../schemas'
@@ -32,6 +40,33 @@ import { Uploader, validateMimeType } from '../../uploader'
 import { ByteLimitTransformStream } from './byte-limit-stream'
 
 const { storageS3Region, storageS3Bucket } = getConfig()
+const MULTIPART_COMPLETE_COLUMNS = defineMultipartColumns(
+  'id',
+  'version',
+  'user_metadata',
+  'metadata'
+)
+const MULTIPART_UPLOAD_COLUMNS = defineMultipartColumns('version', 'user_metadata', 'metadata')
+const MULTIPART_PROGRESS_COLUMNS = defineMultipartColumns('in_progress_size')
+const MULTIPART_LOCK_COLUMNS = defineMultipartColumns(
+  'in_progress_size',
+  'version',
+  'upload_signature',
+  'user_metadata',
+  'metadata'
+)
+const S3_OBJECT_INFO_COLUMNS = defineObjectColumns(
+  'metadata',
+  'user_metadata',
+  'created_at',
+  'updated_at'
+)
+const S3_OBJECT_VERSION_COLUMNS = defineObjectColumns('version', 'user_metadata')
+const COPY_SOURCE_COLUMNS = defineObjectColumns('id', 'name', 'version', 'metadata')
+const BUCKET_FILE_SIZE_COLUMNS = defineBucketColumns('file_size_limit')
+const BUCKET_MIME_TYPE_COLUMNS = defineBucketColumns('id', 'allowed_mime_types')
+const S3_BUCKET_LIST_COLUMNS = defineBucketColumns('name', 'created_at')
+const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
 
 export const MAX_PART_SIZE = 5 * 1024 * 1024 * 1024 // 5GB
 
@@ -78,7 +113,7 @@ export class S3ProtocolHandler {
    * Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html
    */
   async listBuckets() {
-    const buckets = await this.storage.listBuckets('name,created_at')
+    const buckets = await this.storage.listBuckets(S3_BUCKET_LIST_COLUMNS)
 
     return {
       responseBody: {
@@ -420,7 +455,7 @@ export class S3ProtocolHandler {
     mustBeValidBucketName(Bucket)
     mustBeValidKey(Key)
 
-    const bucket = await this.storage.asSuperUser().findBucket(Bucket, 'id,allowed_mime_types')
+    const bucket = await this.storage.asSuperUser().findBucket(Bucket, BUCKET_MIME_TYPE_COLUMNS)
 
     if (command.ContentType && bucket.allowed_mime_types && bucket.allowed_mime_types.length > 0) {
       validateMimeType(command.ContentType, bucket.allowed_mime_types || [])
@@ -497,7 +532,7 @@ export class S3ProtocolHandler {
 
     const multiPartUpload = await this.storage.db
       .asSuperUser()
-      .findMultipartUpload(UploadId, 'id,version,user_metadata,metadata')
+      .findMultipartUpload(UploadId, MULTIPART_COMPLETE_COLUMNS)
 
     await uploader.canUpload({
       bucketId: Bucket as string,
@@ -601,14 +636,14 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingContentLength()
     }
 
-    const bucket = await this.storage.asSuperUser().findBucket(Bucket, 'file_size_limit')
+    const bucket = await this.storage.asSuperUser().findBucket(Bucket, BUCKET_FILE_SIZE_COLUMNS)
     const maxFileSize = await getFileSizeLimit(this.storage.db.tenantId, bucket?.file_size_limit)
 
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)
 
     const multipartData = await this.storage.db
       .asSuperUser()
-      .findMultipartUpload(UploadId, 'version,user_metadata,metadata')
+      .findMultipartUpload(UploadId, MULTIPART_UPLOAD_COLUMNS)
 
     await uploader.canUpload({
       bucketId: Bucket as string,
@@ -682,7 +717,7 @@ export class S3ProtocolHandler {
     } catch (e) {
       try {
         await this.storage.db.asSuperUser().withTransaction(async (db) => {
-          const multipart = await db.findMultipartUpload(UploadId, 'in_progress_size', {
+          const multipart = await db.findMultipartUpload(UploadId, MULTIPART_PROGRESS_COLUMNS, {
             forUpdate: true,
           })
 
@@ -775,7 +810,7 @@ export class S3ProtocolHandler {
 
     const multipart = await this.storage.db
       .asSuperUser()
-      .findMultipartUpload(UploadId, 'id,version,user_metadata,metadata')
+      .findMultipartUpload(UploadId, MULTIPART_COMPLETE_COLUMNS)
 
     const uploader = new Uploader(this.storage.backend, this.storage.db, this.storage.location)
     await uploader.canUpload({
@@ -855,9 +890,7 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingParameter('Key')
     }
 
-    const object = await this.storage
-      .from(Bucket)
-      .findObject(Key, 'metadata,user_metadata,created_at,updated_at')
+    const object = await this.storage.from(Bucket).findObject(Key, S3_OBJECT_INFO_COLUMNS)
 
     if (!object) {
       throw ERRORS.NoSuchKey(Key)
@@ -894,7 +927,7 @@ export class S3ProtocolHandler {
       throw ERRORS.MissingParameter('Key')
     }
 
-    const object = await this.storage.from(Bucket).findObject(Key, 'id')
+    const object = await this.storage.from(Bucket).findObject(Key, OBJECT_ID_COLUMNS)
 
     if (!object) {
       throw ERRORS.NoSuchKey(Key)
@@ -929,7 +962,7 @@ export class S3ProtocolHandler {
     let userMetadata: Record<string, unknown> | undefined | null
 
     if (!options?.skipDbCheck) {
-      const object = await this.storage.from(bucket).findObject(key, 'version,user_metadata')
+      const object = await this.storage.from(bucket).findObject(key, S3_OBJECT_VERSION_COLUMNS)
       version = object.version
       userMetadata = object.user_metadata
     }
@@ -1087,7 +1120,10 @@ export class S3ProtocolHandler {
 
     const remainingObjects =
       unresolvedKeys.length > 0
-        ? await this.storage.asSuperUser().from(Bucket).findObjects(unresolvedKeys, 'name')
+        ? await this.storage
+            .asSuperUser()
+            .from(Bucket)
+            .findObjects(unresolvedKeys, OBJECT_NAME_COLUMNS)
         : []
 
     if (deletedObjects.length === 0 && remainingObjects.length === 0) {
@@ -1215,7 +1251,7 @@ export class S3ProtocolHandler {
     }
 
     // check if multipart exists
-    await this.storage.db.asSuperUser().findMultipartUpload(command.UploadId, 'id')
+    await this.storage.db.asSuperUser().findMultipartUpload(command.UploadId, MULTIPART_ID_COLUMNS)
 
     const maxParts = Math.min(command.MaxParts || 1000, 1000)
 
@@ -1308,7 +1344,7 @@ export class S3ProtocolHandler {
     const copySource = await this.storage.db.findObject(
       sourceBucketName,
       sourceKey,
-      'id,name,version,metadata'
+      COPY_SOURCE_COLUMNS
     )
 
     const sourceSize = Number(copySource.metadata?.size ?? 0)
@@ -1325,8 +1361,8 @@ export class S3ProtocolHandler {
 
     const [destinationBucket] = await this.storage.db.asSuperUser().withTransaction(async (db) => {
       return Promise.all([
-        db.findBucketById(Bucket, 'file_size_limit'),
-        db.findBucketById(sourceBucketName, 'id'),
+        db.findBucketById(Bucket, BUCKET_FILE_SIZE_COLUMNS),
+        db.findBucketById(sourceBucketName, BUCKET_ID_COLUMNS),
       ])
     })
     const maxFileSize = await getFileSizeLimit(
@@ -1336,7 +1372,7 @@ export class S3ProtocolHandler {
 
     const multipartData = await this.storage.db
       .asSuperUser()
-      .findMultipartUpload(UploadId, 'version,user_metadata,metadata')
+      .findMultipartUpload(UploadId, MULTIPART_UPLOAD_COLUMNS)
 
     await uploader.canUpload({
       bucketId: Bucket,
@@ -1435,13 +1471,9 @@ export class S3ProtocolHandler {
     maxFileSize: number
   ) {
     return this.storage.db.asSuperUser().withTransaction(async (db) => {
-      const multipart = await db.findMultipartUpload(
-        uploadId,
-        'in_progress_size,version,upload_signature,user_metadata,metadata',
-        {
-          forUpdate: true,
-        }
-      )
+      const multipart = await db.findMultipartUpload(uploadId, MULTIPART_LOCK_COLUMNS, {
+        forUpdate: true,
+      })
 
       const { progress } = this.decryptUploadSignature(multipart.upload_signature)
 

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -26,11 +26,11 @@ import stream from 'stream/promises'
 import { getConfig } from '../../../config'
 import {
   BUCKET_ID_COLUMNS,
-  defineBucketColumns,
-  defineMultipartColumns,
-  defineObjectColumns,
+  bucketColumns,
   MULTIPART_ID_COLUMNS,
+  multipartColumns,
   OBJECT_ID_COLUMNS,
+  objectColumns,
 } from '../../database'
 import { getFileSizeLimit, mustBeValidBucketName, mustBeValidKey } from '../../limits'
 import { parseCopySourceRangeHeader } from '../../range'
@@ -40,33 +40,33 @@ import { Uploader, validateMimeType } from '../../uploader'
 import { ByteLimitTransformStream } from './byte-limit-stream'
 
 const { storageS3Region, storageS3Bucket } = getConfig()
-const MULTIPART_COMPLETE_COLUMNS = defineMultipartColumns(
+const MULTIPART_COMPLETE_COLUMNS = multipartColumns.select(
   'id',
   'version',
   'user_metadata',
   'metadata'
 )
-const MULTIPART_UPLOAD_COLUMNS = defineMultipartColumns('version', 'user_metadata', 'metadata')
-const MULTIPART_PROGRESS_COLUMNS = defineMultipartColumns('in_progress_size')
-const MULTIPART_LOCK_COLUMNS = defineMultipartColumns(
+const MULTIPART_UPLOAD_COLUMNS = multipartColumns.select('version', 'user_metadata', 'metadata')
+const MULTIPART_PROGRESS_COLUMNS = multipartColumns.select('in_progress_size')
+const MULTIPART_LOCK_COLUMNS = multipartColumns.select(
   'in_progress_size',
   'version',
   'upload_signature',
   'user_metadata',
   'metadata'
 )
-const S3_OBJECT_INFO_COLUMNS = defineObjectColumns(
+const S3_OBJECT_INFO_COLUMNS = objectColumns.select(
   'metadata',
   'user_metadata',
   'created_at',
   'updated_at'
 )
-const S3_OBJECT_VERSION_COLUMNS = defineObjectColumns('version', 'user_metadata')
-const COPY_SOURCE_COLUMNS = defineObjectColumns('id', 'name', 'version', 'metadata')
-const BUCKET_FILE_SIZE_COLUMNS = defineBucketColumns('file_size_limit')
-const BUCKET_MIME_TYPE_COLUMNS = defineBucketColumns('id', 'allowed_mime_types')
-const S3_BUCKET_LIST_COLUMNS = defineBucketColumns('name', 'created_at')
-const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
+const S3_OBJECT_VERSION_COLUMNS = objectColumns.select('version', 'user_metadata')
+const COPY_SOURCE_COLUMNS = objectColumns.select('id', 'name', 'version', 'metadata')
+const BUCKET_FILE_SIZE_COLUMNS = bucketColumns.select('file_size_limit')
+const BUCKET_MIME_TYPE_COLUMNS = bucketColumns.select('id', 'allowed_mime_types')
+const S3_BUCKET_LIST_COLUMNS = bucketColumns.select('name', 'created_at')
+const OBJECT_NAME_COLUMNS = objectColumns.select('name')
 
 export const MAX_PART_SIZE = 5 * 1024 * 1024 * 1024 // 5GB
 

--- a/src/storage/scanner/scanner.ts
+++ b/src/storage/scanner/scanner.ts
@@ -4,8 +4,10 @@ import { withOptionalVersion } from '@storage/backend'
 import { BackupObjectEvent } from '@storage/events/objects/backup-object'
 import { Storage } from '@storage/storage'
 import { getConfig } from '../../config'
+import { defineObjectColumns } from '../database'
 
 const { storageS3Bucket } = getConfig()
+const SCANNER_OBJECT_COLUMNS = defineObjectColumns('id', 'name', 'version', 'metadata')
 
 const S3_KEYS_TMP_TABLE_NAME = 'storage._s3_remote_keys'
 
@@ -153,7 +155,7 @@ export class ObjectScanner {
     for (; !options.signal.aborted; ) {
       const storageObjects = await this.storage.db.listObjects(
         bucket,
-        'id,name,version,metadata',
+        SCANNER_OBJECT_COLUMNS,
         1000,
         options.before,
         nextToken
@@ -344,11 +346,7 @@ export class ObjectScanner {
         continue
       }
 
-      const dbObjects = await this.storage.db.findObjectVersions(
-        options.bucket,
-        localObjs,
-        'name,version'
-      )
+      const dbObjects = await this.storage.db.findObjectVersions(options.bucket, localObjs)
 
       const s3OrphanedKeys = tmpS3Objects.filter(
         (key) =>

--- a/src/storage/scanner/scanner.ts
+++ b/src/storage/scanner/scanner.ts
@@ -4,10 +4,10 @@ import { withOptionalVersion } from '@storage/backend'
 import { BackupObjectEvent } from '@storage/events/objects/backup-object'
 import { Storage } from '@storage/storage'
 import { getConfig } from '../../config'
-import { defineObjectColumns } from '../database'
+import { objectColumns } from '../database'
 
 const { storageS3Bucket } = getConfig()
-const SCANNER_OBJECT_COLUMNS = defineObjectColumns('id', 'name', 'version', 'metadata')
+const SCANNER_OBJECT_COLUMNS = objectColumns.select('id', 'name', 'version', 'metadata')
 
 const S3_KEYS_TMP_TABLE_NAME = 'storage._s3_remote_keys'
 

--- a/src/storage/schemas/object.ts
+++ b/src/storage/schemas/object.ts
@@ -1,5 +1,4 @@
 import { FromSchema } from 'json-schema-to-ts'
-import { bucketSchema } from './bucket'
 
 export const objectSchema = {
   $id: 'objectSchema',
@@ -20,7 +19,6 @@ export const objectSchema = {
     user_metadata: {
       anyOf: [{ type: 'object', additionalProperties: true }, { type: 'null' }],
     },
-    buckets: bucketSchema,
   },
   required: ['name'],
   additionalProperties: false,

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -6,7 +6,17 @@ import { StorageObjectLocator } from '@storage/locator'
 import { InfoRenderer } from '@storage/renderer/info'
 import { getConfig } from '../config'
 import { StorageBackendAdapter } from './backend'
-import { Database, FindBucketFilters, ListBucketOptions } from './database'
+import {
+  ANALYTICS_NAME_COLUMNS,
+  AnalyticsColumnSelection,
+  BUCKET_ID_COLUMNS,
+  BucketColumnSelection,
+  Database,
+  defineBucketColumns,
+  defineObjectColumns,
+  FindBucketFilters,
+  ListBucketOptions,
+} from './database'
 import { ObjectAdminDeleteAllBefore } from './events'
 import {
   BucketType,
@@ -19,6 +29,8 @@ import { ObjectStorage } from './object'
 import { AssetRenderer, HeadRenderer, ImageRenderer } from './renderer'
 
 const { emptyBucketMax } = getConfig()
+const BUCKET_NAME_COLUMNS = defineBucketColumns('name')
+const EMPTY_BUCKET_OBJECT_COLUMNS = defineObjectColumns('id', 'name')
 
 function assertNever(value: never): never {
   throw new Error(`Unexpected renderer type: ${String(value)}`)
@@ -79,7 +91,11 @@ export class Storage {
    * @param columns
    * @param filters
    */
-  findBucket(id: string, columns = 'id', filters?: FindBucketFilters) {
+  findBucket(
+    id: string,
+    columns: BucketColumnSelection = BUCKET_ID_COLUMNS,
+    filters?: FindBucketFilters
+  ) {
     return this.db.findBucketById(id, columns, filters)
   }
 
@@ -88,11 +104,14 @@ export class Storage {
    * @param columns
    * @param options
    */
-  listBuckets(columns = 'id', options?: ListBucketOptions) {
+  listBuckets(columns: BucketColumnSelection = BUCKET_ID_COLUMNS, options?: ListBucketOptions) {
     return this.db.listBuckets(columns, options)
   }
 
-  listAnalyticsBuckets(columns = 'name', options?: ListBucketOptions) {
+  listAnalyticsBuckets(
+    columns: AnalyticsColumnSelection = ANALYTICS_NAME_COLUMNS,
+    options?: ListBucketOptions
+  ) {
     return this.db.listAnalyticsBuckets(columns, options)
   }
 
@@ -246,7 +265,7 @@ export class Storage {
    */
   async deleteBucket(id: string) {
     const deleted = await this.db.withTransaction(async (db) => {
-      await db.asSuperUser().findBucketById(id, 'id', {
+      await db.asSuperUser().findBucketById(id, BUCKET_ID_COLUMNS, {
         forUpdate: true,
       })
 
@@ -324,7 +343,7 @@ export class Storage {
    * @param before limit to files before the specified time (defaults to now)
    */
   async emptyBucket(bucketId: string, before: Date = new Date()) {
-    await this.findBucket(bucketId, 'name')
+    await this.findBucket(bucketId, BUCKET_NAME_COLUMNS)
 
     const count = await this.db.countObjectsInBucket(bucketId, emptyBucketMax + 1)
     if (count > emptyBucketMax) {
@@ -334,7 +353,7 @@ export class Storage {
       )
     }
 
-    const objects = await this.db.listObjects(bucketId, 'id, name', 1, before)
+    const objects = await this.db.listObjects(bucketId, EMPTY_BUCKET_OBJECT_COLUMNS, 1, before)
     if (!objects || objects.length < 1) {
       // the bucket is already empty
       return

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -11,11 +11,11 @@ import {
   AnalyticsColumnSelection,
   BUCKET_ID_COLUMNS,
   BucketColumnSelection,
+  bucketColumns,
   Database,
-  defineBucketColumns,
-  defineObjectColumns,
   FindBucketFilters,
   ListBucketOptions,
+  objectColumns,
 } from './database'
 import { ObjectAdminDeleteAllBefore } from './events'
 import {
@@ -29,8 +29,8 @@ import { ObjectStorage } from './object'
 import { AssetRenderer, HeadRenderer, ImageRenderer } from './renderer'
 
 const { emptyBucketMax } = getConfig()
-const BUCKET_NAME_COLUMNS = defineBucketColumns('name')
-const EMPTY_BUCKET_OBJECT_COLUMNS = defineObjectColumns('id', 'name')
+const BUCKET_NAME_COLUMNS = bucketColumns.select('name')
+const EMPTY_BUCKET_OBJECT_COLUMNS = objectColumns.select('id', 'name')
 
 function assertNever(value: never): never {
   throw new Error(`Unexpected renderer type: ${String(value)}`)

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -7,12 +7,13 @@ import { FastifyRequest } from 'fastify'
 import { PassThrough, Readable } from 'stream'
 import { getConfig } from '../config'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
-import { Database } from './database'
+import { Database, defineObjectColumns } from './database'
 import { ObjectAdminDelete, ObjectCreatedPostEvent, ObjectCreatedPutEvent } from './events'
 import { getFileSizeLimit, isEmptyFolder } from './limits'
 import { validateXRobotsTag } from './validators/x-robots-tag'
 
 const { storageS3Bucket, uploadFileSizeLimitStandard } = getConfig()
+const CURRENT_OBJECT_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
 
 type UploadType = 'standard' | 's3' | 'resumable'
 
@@ -213,7 +214,7 @@ export class Uploader {
           timeout: 5000,
         })
 
-        const currentObj = await db.findObject(bucketId, objectName, 'id, version, metadata', {
+        const currentObj = await db.findObject(bucketId, objectName, CURRENT_OBJECT_COLUMNS, {
           forUpdate: true,
           dontErrorOnEmpty: true,
         })

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -7,13 +7,13 @@ import { FastifyRequest } from 'fastify'
 import { PassThrough, Readable } from 'stream'
 import { getConfig } from '../config'
 import { ObjectMetadata, StorageBackendAdapter } from './backend'
-import { Database, defineObjectColumns } from './database'
+import { Database, objectColumns } from './database'
 import { ObjectAdminDelete, ObjectCreatedPostEvent, ObjectCreatedPutEvent } from './events'
 import { getFileSizeLimit, isEmptyFolder } from './limits'
 import { validateXRobotsTag } from './validators/x-robots-tag'
 
 const { storageS3Bucket, uploadFileSizeLimitStandard } = getConfig()
-const CURRENT_OBJECT_COLUMNS = defineObjectColumns('id', 'version', 'metadata')
+const CURRENT_OBJECT_COLUMNS = objectColumns.select('id', 'version', 'metadata')
 
 type UploadType = 'standard' | 's3' | 'resumable'
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -33,7 +33,7 @@ import { wait } from '@internal/concurrency'
 import { getPostgresConnection, getServiceKeyUser, type TenantConnection } from '@internal/database'
 import { DBMigration } from '@internal/database/migrations'
 import { ERRORS } from '@internal/errors'
-import { defineMultipartColumns, StoragePgDB } from '@storage/database'
+import { multipartColumns, StoragePgDB } from '@storage/database'
 import { Uploader } from '@storage/uploader'
 import { createHash, createHmac, randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
@@ -65,7 +65,7 @@ const {
 } = getConfig()
 const STREAMING_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
 const STREAMING_TRAILER_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER'
-const MULTIPART_METADATA_COLUMNS = defineMultipartColumns('id', 'version', 'metadata')
+const MULTIPART_METADATA_COLUMNS = multipartColumns.select('id', 'version', 'metadata')
 async function createBucket(client: S3Client, name?: string, publicRead = true) {
   let bucketName: string
   if (!name) {

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -33,7 +33,7 @@ import { wait } from '@internal/concurrency'
 import { getPostgresConnection, getServiceKeyUser, type TenantConnection } from '@internal/database'
 import { DBMigration } from '@internal/database/migrations'
 import { ERRORS } from '@internal/errors'
-import { StoragePgDB } from '@storage/database'
+import { defineMultipartColumns, StoragePgDB } from '@storage/database'
 import { Uploader } from '@storage/uploader'
 import { createHash, createHmac, randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
@@ -65,6 +65,7 @@ const {
 } = getConfig()
 const STREAMING_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
 const STREAMING_TRAILER_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER'
+const MULTIPART_METADATA_COLUMNS = defineMultipartColumns('id', 'version', 'metadata')
 async function createBucket(client: S3Client, name?: string, publicRead = true) {
   let bucketName: string
   if (!name) {
@@ -3725,13 +3726,13 @@ describe('Migration compatibility', () => {
 
       it('excludes metadata from result when latestMigration is before s3-multipart-uploads-metadata', async () => {
         const db = makeDB('fix-optimized-search-function') // migration 56
-        const result = await db.findMultipartUpload(uploadId, 'id,version,metadata')
+        const result = await db.findMultipartUpload(uploadId, MULTIPART_METADATA_COLUMNS)
         expect(result).not.toHaveProperty('metadata')
       })
 
       it('includes metadata in result when latestMigration is s3-multipart-uploads-metadata', async () => {
         const db = makeDB('s3-multipart-uploads-metadata') // migration 57
-        const result = await db.findMultipartUpload(uploadId, 'id,version,metadata')
+        const result = await db.findMultipartUpload(uploadId, MULTIPART_METADATA_COLUMNS)
         expect(result).toHaveProperty('metadata')
       })
     })

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,11 +1,13 @@
 import { eachParallel } from '@internal/testing/generators/array'
 import { withOptionalVersion } from '@storage/backend'
+import { defineObjectColumns } from '@storage/database'
 import { randomUUID } from 'crypto'
 import { Readable } from 'stream'
 import { getConfig } from '../config'
 import { useStorage } from './utils/storage'
 
 const { storageS3Bucket, tenantId } = getConfig()
+const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
 
 describe('ObjectScanner', () => {
   const storage = useStorage()
@@ -50,7 +52,11 @@ describe('ObjectScanner', () => {
       s3ToDelete.map((o) => `${tenantId}/${bucket.id}/${o.name}/${o.version}`)
     )
 
-    const objectsAfterDel = await storage.database.listObjects(bucket.id, 'name', 10000)
+    const objectsAfterDel = await storage.database.listObjects(
+      bucket.id,
+      OBJECT_NAME_COLUMNS,
+      10000
+    )
     expect(objectsAfterDel).toHaveLength(maxUploads - numToDelete)
 
     const orphaned = storage.scanner.listOrphaned(bucket.id, {
@@ -110,7 +116,11 @@ describe('ObjectScanner', () => {
       'name'
     )
 
-    const objectsAfterDel = await storage.database.listObjects(bucket.id, 'name', 10000)
+    const objectsAfterDel = await storage.database.listObjects(
+      bucket.id,
+      OBJECT_NAME_COLUMNS,
+      10000
+    )
     expect(objectsAfterDel).toHaveLength(maxUploads - numToDelete)
 
     const orphaned = storage.scanner.deleteOrphans(bucket.id, options)

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,13 +1,13 @@
 import { eachParallel } from '@internal/testing/generators/array'
 import { withOptionalVersion } from '@storage/backend'
-import { defineObjectColumns } from '@storage/database'
+import { objectColumns } from '@storage/database'
 import { randomUUID } from 'crypto'
 import { Readable } from 'stream'
 import { getConfig } from '../config'
 import { useStorage } from './utils/storage'
 
 const { storageS3Bucket, tenantId } = getConfig()
-const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
+const OBJECT_NAME_COLUMNS = objectColumns.select('name')
 
 describe('ObjectScanner', () => {
   const storage = useStorage()

--- a/src/test/storage-pg-db.test.ts
+++ b/src/test/storage-pg-db.test.ts
@@ -10,13 +10,73 @@ import { runMigrationsOnTenant } from '@internal/database/migrations'
 import type { TenantConnectionOptions } from '@internal/database/pool'
 import { logger, logSchema } from '@internal/monitoring'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
-import { StoragePgDB } from '@storage/database'
+import {
+  BUCKET_ID_COLUMNS,
+  defineAnalyticsColumns,
+  defineBucketColumns,
+  defineMultipartColumns,
+  defineObjectColumns,
+  MULTIPART_ID_COLUMNS,
+  OBJECT_ID_COLUMNS,
+  StoragePgDB,
+} from '@storage/database'
 import { PgMetastore } from '@storage/protocols/iceberg/pg'
 import { randomUUID } from 'crypto'
 import { DatabaseError, type PoolClient } from 'pg'
 import { getConfig } from '../config'
 
 const { databaseURL, tenantId } = getConfig()
+const BUCKET_DETAILS_COLUMNS = defineBucketColumns(
+  'id',
+  'name',
+  'owner',
+  'owner_id',
+  'public',
+  'file_size_limit',
+  'allowed_mime_types',
+  'type'
+)
+const BUCKET_LIST_COLUMNS = defineBucketColumns(
+  'id',
+  'name',
+  'public',
+  'file_size_limit',
+  'allowed_mime_types',
+  'type'
+)
+const BUCKET_TYPE_COLUMNS = defineBucketColumns('type')
+const BUCKET_UPDATE_COLUMNS = defineBucketColumns(
+  'id',
+  'public',
+  'file_size_limit',
+  'allowed_mime_types'
+)
+const OBJECT_DETAILS_COLUMNS = defineObjectColumns(
+  'name',
+  'bucket_id',
+  'owner',
+  'owner_id',
+  'metadata',
+  'user_metadata',
+  'version'
+)
+const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
+const OBJECT_NAME_VERSION_COLUMNS = defineObjectColumns('name', 'version')
+const MULTIPART_DETAILS_COLUMNS = defineMultipartColumns(
+  'id',
+  'key',
+  'version',
+  'upload_signature',
+  'user_metadata',
+  'metadata'
+)
+const MULTIPART_PROGRESS_COLUMNS = defineMultipartColumns('id', 'in_progress_size')
+const MULTIPART_SIGNATURE_COLUMNS = defineMultipartColumns(
+  'id',
+  'in_progress_size',
+  'upload_signature'
+)
+const ANALYTICS_DETAILS_COLUMNS = defineAnalyticsColumns('id', 'name', 'created_at', 'updated_at')
 
 describe('StoragePgDB bucket metadata', () => {
   let pool: PgPoolStrategy
@@ -89,12 +149,7 @@ describe('StoragePgDB bucket metadata', () => {
       type: 'STANDARD',
     })
 
-    await expect(
-      db.findBucketById(
-        bucketId,
-        'id, name, owner, owner_id, public, file_size_limit, allowed_mime_types, type'
-      )
-    ).resolves.toMatchObject({
+    await expect(db.findBucketById(bucketId, BUCKET_DETAILS_COLUMNS)).resolves.toMatchObject({
       id: bucketId,
       name: bucketId,
       owner,
@@ -106,7 +161,7 @@ describe('StoragePgDB bucket metadata', () => {
     })
 
     await expect(
-      db.listBuckets('id, name, public, file_size_limit, allowed_mime_types, type', {
+      db.listBuckets(BUCKET_LIST_COLUMNS, {
         search: runId,
         sortColumn: 'name',
         sortOrder: 'asc',
@@ -122,7 +177,7 @@ describe('StoragePgDB bucket metadata', () => {
     ])
 
     await expect(
-      db.listBuckets('type', {
+      db.listBuckets(BUCKET_TYPE_COLUMNS, {
         search: runId,
         limit: 1,
       })
@@ -133,7 +188,9 @@ describe('StoragePgDB bucket metadata', () => {
     ])
 
     await db.withTransaction(async (tx) => {
-      await expect(tx.findBucketById(bucketId, 'id', { forUpdate: true })).resolves.toEqual({
+      await expect(
+        tx.findBucketById(bucketId, BUCKET_ID_COLUMNS, { forUpdate: true })
+      ).resolves.toEqual({
         id: bucketId,
       })
     })
@@ -144,9 +201,7 @@ describe('StoragePgDB bucket metadata', () => {
       allowed_mime_types: ['image/jpeg'],
     })
 
-    await expect(
-      db.findBucketById(bucketId, 'id, public, file_size_limit, allowed_mime_types')
-    ).resolves.toMatchObject({
+    await expect(db.findBucketById(bucketId, BUCKET_UPDATE_COLUMNS)).resolves.toMatchObject({
       id: bucketId,
       public: true,
       file_size_limit: null,
@@ -162,7 +217,7 @@ describe('StoragePgDB bucket metadata', () => {
     await deleteObjects(bucketId)
     await expect(db.deleteBucket(bucketId)).resolves.toBe(1)
     await expect(
-      db.findBucketById(bucketId, 'id', { dontErrorOnEmpty: true })
+      db.findBucketById(bucketId, BUCKET_ID_COLUMNS, { dontErrorOnEmpty: true })
     ).resolves.toBeUndefined()
   })
 
@@ -198,7 +253,9 @@ describe('StoragePgDB bucket metadata', () => {
       })
 
       expect(Date.now() - start).toBeLessThan(2_000)
-      await expect(db.listBuckets('id', { limit: 1 })).resolves.toEqual(expect.any(Array))
+      await expect(db.listBuckets(BUCKET_ID_COLUMNS, { limit: 1 })).resolves.toEqual(
+        expect.any(Array)
+      )
     } finally {
       clearTimeout(releaseTimer)
       releaseLock?.()
@@ -321,7 +378,7 @@ describe('StoragePgDB bucket metadata', () => {
     ).rejects.toThrow('rollback pg bucket transaction')
 
     await expect(
-      db.findBucketById(bucketId, 'id', { dontErrorOnEmpty: true })
+      db.findBucketById(bucketId, BUCKET_ID_COLUMNS, { dontErrorOnEmpty: true })
     ).resolves.toBeUndefined()
   })
 
@@ -338,7 +395,7 @@ describe('StoragePgDB bucket metadata', () => {
           })
         })
 
-        await expect(tx.findBucketById(bucketId, 'id')).resolves.toEqual({
+        await expect(tx.findBucketById(bucketId, BUCKET_ID_COLUMNS)).resolves.toEqual({
           id: bucketId,
         })
 
@@ -347,7 +404,7 @@ describe('StoragePgDB bucket metadata', () => {
     ).rejects.toThrow('rollback parent transaction')
 
     await expect(
-      db.findBucketById(bucketId, 'id', { dontErrorOnEmpty: true })
+      db.findBucketById(bucketId, BUCKET_ID_COLUMNS, { dontErrorOnEmpty: true })
     ).resolves.toBeUndefined()
   })
 
@@ -1172,13 +1229,7 @@ describe('StoragePgDB bucket metadata', () => {
       version: 'v1',
     })
 
-    await expect(
-      db.findObject(
-        bucketId,
-        objectA,
-        'name,bucket_id,owner,owner_id,metadata,user_metadata,version'
-      )
-    ).resolves.toMatchObject({
+    await expect(db.findObject(bucketId, objectA, OBJECT_DETAILS_COLUMNS)).resolves.toMatchObject({
       bucket_id: bucketId,
       name: objectA,
       owner,
@@ -1189,9 +1240,9 @@ describe('StoragePgDB bucket metadata', () => {
     })
 
     await db.withTransaction(async (tx) => {
-      await expect(tx.findObject(bucketId, objectA, 'name', { forShare: true })).resolves.toEqual({
-        name: objectA,
-      })
+      await expect(
+        tx.findObject(bucketId, objectA, OBJECT_NAME_COLUMNS, { forShare: true })
+      ).resolves.toEqual({ name: objectA })
       await expect(tx.waitObjectLock(bucketId, `${runId}-wait-lock`)).resolves.toBe(true)
     })
 
@@ -1262,7 +1313,7 @@ describe('StoragePgDB bucket metadata', () => {
     })
 
     await expect(
-      db.findObjects(bucketId, [objectARenamed, objectB], 'name,version')
+      db.findObjects(bucketId, [objectARenamed, objectB], OBJECT_NAME_VERSION_COLUMNS)
     ).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: objectARenamed, version: 'v2' }),
@@ -1282,10 +1333,10 @@ describe('StoragePgDB bucket metadata', () => {
       ])
     )
 
-    const firstPage = await db.listObjects(bucketId, 'name', 2)
+    const firstPage = await db.listObjects(bucketId, OBJECT_NAME_COLUMNS, 2)
     expect(firstPage).toHaveLength(2)
     await expect(
-      db.listObjects(bucketId, 'name', 10, undefined, firstPage[1].name)
+      db.listObjects(bucketId, OBJECT_NAME_COLUMNS, 10, undefined, firstPage[1].name)
     ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ name: objectC })]))
 
     await expect(
@@ -1340,7 +1391,7 @@ describe('StoragePgDB bucket metadata', () => {
     )
 
     await expect(
-      db.findObject(bucketId, objectARenamed, 'id', { dontErrorOnEmpty: true })
+      db.findObject(bucketId, objectARenamed, OBJECT_ID_COLUMNS, { dontErrorOnEmpty: true })
     ).resolves.toBeUndefined()
   })
 
@@ -1383,7 +1434,7 @@ describe('StoragePgDB bucket metadata', () => {
     await db.createMultipartUpload(uploadIdB, bucketId, keyB, 'version-b', 'signature-b', owner)
 
     await expect(
-      db.findMultipartUpload(uploadIdA, 'id,key,version,upload_signature,user_metadata,metadata')
+      db.findMultipartUpload(uploadIdA, MULTIPART_DETAILS_COLUMNS)
     ).resolves.toMatchObject({
       id: uploadIdA,
       key: keyA,
@@ -1395,7 +1446,7 @@ describe('StoragePgDB bucket metadata', () => {
 
     await db.withTransaction(async (tx) => {
       await expect(
-        tx.findMultipartUpload(uploadIdA, 'id,in_progress_size', { forUpdate: true })
+        tx.findMultipartUpload(uploadIdA, MULTIPART_PROGRESS_COLUMNS, { forUpdate: true })
       ).resolves.toMatchObject({
         id: uploadIdA,
         in_progress_size: 0,
@@ -1405,7 +1456,7 @@ describe('StoragePgDB bucket metadata', () => {
     })
 
     await expect(
-      db.findMultipartUpload(uploadIdA, 'id,in_progress_size,upload_signature')
+      db.findMultipartUpload(uploadIdA, MULTIPART_SIGNATURE_COLUMNS)
     ).resolves.toMatchObject({
       id: uploadIdA,
       in_progress_size: 33,
@@ -1466,7 +1517,7 @@ describe('StoragePgDB bucket metadata', () => {
     ])
 
     await db.deleteMultipartUpload(uploadIdA)
-    await expect(db.findMultipartUpload(uploadIdA, 'id')).rejects.toMatchObject({
+    await expect(db.findMultipartUpload(uploadIdA, MULTIPART_ID_COLUMNS)).rejects.toMatchObject({
       code: 'NoSuchUpload',
     })
     await expect(db.listParts(uploadIdA, { maxParts: 10 })).resolves.toEqual([])
@@ -1550,7 +1601,7 @@ describe('StoragePgDB bucket metadata', () => {
     })
 
     await expect(
-      db.listAnalyticsBuckets('id, name, created_at, updated_at', {
+      db.listAnalyticsBuckets(ANALYTICS_DETAILS_COLUMNS, {
         search: runId,
         sortColumn: 'name',
         sortOrder: 'asc',

--- a/src/test/storage-pg-db.test.ts
+++ b/src/test/storage-pg-db.test.ts
@@ -11,13 +11,13 @@ import type { TenantConnectionOptions } from '@internal/database/pool'
 import { logger, logSchema } from '@internal/monitoring'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
 import {
+  analyticsColumns,
   BUCKET_ID_COLUMNS,
-  defineAnalyticsColumns,
-  defineBucketColumns,
-  defineMultipartColumns,
-  defineObjectColumns,
+  bucketColumns,
   MULTIPART_ID_COLUMNS,
+  multipartColumns,
   OBJECT_ID_COLUMNS,
+  objectColumns,
   StoragePgDB,
 } from '@storage/database'
 import { PgMetastore } from '@storage/protocols/iceberg/pg'
@@ -26,7 +26,7 @@ import { DatabaseError, type PoolClient } from 'pg'
 import { getConfig } from '../config'
 
 const { databaseURL, tenantId } = getConfig()
-const BUCKET_DETAILS_COLUMNS = defineBucketColumns(
+const BUCKET_DETAILS_COLUMNS = bucketColumns.select(
   'id',
   'name',
   'owner',
@@ -36,7 +36,7 @@ const BUCKET_DETAILS_COLUMNS = defineBucketColumns(
   'allowed_mime_types',
   'type'
 )
-const BUCKET_LIST_COLUMNS = defineBucketColumns(
+const BUCKET_LIST_COLUMNS = bucketColumns.select(
   'id',
   'name',
   'public',
@@ -44,14 +44,14 @@ const BUCKET_LIST_COLUMNS = defineBucketColumns(
   'allowed_mime_types',
   'type'
 )
-const BUCKET_TYPE_COLUMNS = defineBucketColumns('type')
-const BUCKET_UPDATE_COLUMNS = defineBucketColumns(
+const BUCKET_TYPE_COLUMNS = bucketColumns.select('type')
+const BUCKET_UPDATE_COLUMNS = bucketColumns.select(
   'id',
   'public',
   'file_size_limit',
   'allowed_mime_types'
 )
-const OBJECT_DETAILS_COLUMNS = defineObjectColumns(
+const OBJECT_DETAILS_COLUMNS = objectColumns.select(
   'name',
   'bucket_id',
   'owner',
@@ -60,9 +60,9 @@ const OBJECT_DETAILS_COLUMNS = defineObjectColumns(
   'user_metadata',
   'version'
 )
-const OBJECT_NAME_COLUMNS = defineObjectColumns('name')
-const OBJECT_NAME_VERSION_COLUMNS = defineObjectColumns('name', 'version')
-const MULTIPART_DETAILS_COLUMNS = defineMultipartColumns(
+const OBJECT_NAME_COLUMNS = objectColumns.select('name')
+const OBJECT_NAME_VERSION_COLUMNS = objectColumns.select('name', 'version')
+const MULTIPART_DETAILS_COLUMNS = multipartColumns.select(
   'id',
   'key',
   'version',
@@ -70,13 +70,13 @@ const MULTIPART_DETAILS_COLUMNS = defineMultipartColumns(
   'user_metadata',
   'metadata'
 )
-const MULTIPART_PROGRESS_COLUMNS = defineMultipartColumns('id', 'in_progress_size')
-const MULTIPART_SIGNATURE_COLUMNS = defineMultipartColumns(
+const MULTIPART_PROGRESS_COLUMNS = multipartColumns.select('id', 'in_progress_size')
+const MULTIPART_SIGNATURE_COLUMNS = multipartColumns.select(
   'id',
   'in_progress_size',
   'upload_signature'
 )
-const ANALYTICS_DETAILS_COLUMNS = defineAnalyticsColumns('id', 'name', 'created_at', 'updated_at')
+const ANALYTICS_DETAILS_COLUMNS = analyticsColumns.select('id', 'name', 'created_at', 'updated_at')
 
 describe('StoragePgDB bucket metadata', () => {
   let pool: PgPoolStrategy

--- a/src/test/storage-pg-helper.test.ts
+++ b/src/test/storage-pg-helper.test.ts
@@ -1,4 +1,7 @@
+import { defineBucketColumns } from '@storage/database'
 import { useStorage } from './utils/storage'
+
+const BUCKET_ID_NAME_COLUMNS = defineBucketColumns('id', 'name')
 
 describe('pg storage test helper', () => {
   const t = useStorage()
@@ -11,7 +14,7 @@ describe('pg storage test helper', () => {
       name: bucketId,
     })
 
-    await expect(t.database.findBucketById(bucketId, 'id, name')).resolves.toEqual({
+    await expect(t.database.findBucketById(bucketId, BUCKET_ID_NAME_COLUMNS)).resolves.toEqual({
       id: bucketId,
       name: bucketId,
     })

--- a/src/test/storage-pg-helper.test.ts
+++ b/src/test/storage-pg-helper.test.ts
@@ -1,7 +1,7 @@
-import { defineBucketColumns } from '@storage/database'
+import { bucketColumns } from '@storage/database'
 import { useStorage } from './utils/storage'
 
-const BUCKET_ID_NAME_COLUMNS = defineBucketColumns('id', 'name')
+const BUCKET_ID_NAME_COLUMNS = bucketColumns.select('id', 'name')
 
 describe('pg storage test helper', () => {
   const t = useStorage()

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -10,6 +10,7 @@ import {
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
 import { pathExists, removePath } from '@internal/fs'
 import { logger } from '@internal/monitoring'
+import { OBJECT_ALL_COLUMNS } from '@storage/database'
 import { randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
 import fs from 'fs'
@@ -310,7 +311,7 @@ describe.each([
 
     expect(result).toEqual(true)
 
-    const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+    const dbAsset = await storage.from(bucket.id).findObject(objectName, OBJECT_ALL_COLUMNS)
     expect(dbAsset).toEqual({
       bucket_id: bucket.id,
       created_at: expect.any(Date),
@@ -405,7 +406,7 @@ describe.each([
       },
     ])
 
-    const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+    const dbAsset = await storage.from(bucket.id).findObject(objectName, OBJECT_ALL_COLUMNS)
     expect(dbAsset).toEqual({
       bucket_id: bucket.id,
       created_at: expect.any(Date),
@@ -560,7 +561,7 @@ describe.each([
       upload.start()
     })
 
-    const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+    const dbAsset = await storage.from(bucket.id).findObject(objectName, OBJECT_ALL_COLUMNS)
     expect(dbAsset).toEqual({
       bucket_id: bucket.id,
       created_at: expect.any(Date),
@@ -830,7 +831,7 @@ describe.each([
 
       expect(result).toEqual(true)
 
-      const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+      const dbAsset = await storage.from(bucket.id).findObject(objectName, OBJECT_ALL_COLUMNS)
       expect(dbAsset).toEqual({
         bucket_id: bucket.id,
         created_at: expect.any(Date),
@@ -899,7 +900,7 @@ describe.each([
 
       expect(result).toEqual(true)
 
-      const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
+      const dbAsset = await storage.from(bucket.id).findObject(objectName, OBJECT_ALL_COLUMNS)
       expect(dbAsset).toEqual({
         bucket_id: bucket.id,
         created_at: expect.any(Date),

--- a/src/test/x-forwarded-host.test.ts
+++ b/src/test/x-forwarded-host.test.ts
@@ -48,7 +48,8 @@ vi.spyOn(tenant, 'getTenantConfig').mockImplementation(async () => ({
 }))
 
 // Mock module with inline implementation that doesn't depend on variables
-vi.mock('@storage/database', () => ({
+vi.mock('@storage/database', async (importOriginal) => ({
+  ...(await importOriginal()),
   StoragePgDB: vi.fn(function () {
     return {
       listBuckets: vi.fn().mockResolvedValue([{ id: 'abc123', name: 'def456' }]),


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for performance

## What is the current behavior?

Projection columns are split, parsed, quoted, etc. many times.

## What is the new behavior?

Precompile variants in module load and reuse a variant according to dynamic needs.
Type db layer with branded row type so that wrong columns can't be used (compile error).

## Additional context

It's up to 100 times faster but main benefit is zero garbage.
Dropped postgrest era `buckets` property from object schema.
