### PR TITLE
fix: increase jwt timeout for signed url cdn acceptance test

### DIFF
--- a/acceptance/specs/cdn.test.ts
+++ b/acceptance/specs/cdn.test.ts
@@ -51,7 +51,7 @@ const onePixelPng = new Uint8Array(
   )
 )
 
-const SIGNED_EXPIRES_IN_S = 7
+const SIGNED_EXPIRES_IN_S = 10
 const CACHE_RETRIES = 10
 const TEST_CONFIGS: TestConfig[] = [
   { bucketType: 'public', accessMethods: ['public'] },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Singed URLs in acceptance tests expire in 7s

## What is the new behavior?

10s jwt expiration

## Additional context

Test flaky because jwt sometimes expires too quickly