### PR TITLE
fix: root at s3 upload part copy

### DIFF
--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -1382,8 +1382,10 @@ export class S3ProtocolHandler {
 
     return {
       responseBody: {
-        ETag: uploadPart.eTag || '',
-        LastModified: uploadPart.lastModified ? uploadPart.lastModified.toISOString() : undefined,
+        CopyPartResult: {
+          ETag: uploadPart.eTag || '',
+          LastModified: uploadPart.lastModified ? uploadPart.lastModified.toISOString() : undefined,
+        },
       },
     }
   }

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -3063,18 +3063,35 @@ describe('S3 Protocol', () => {
         const resp = await client.send(createMultiPartUpload)
         expect(resp.UploadId).toBeTruthy()
 
-        const copyPart = new UploadPartCopyCommand({
-          Bucket: bucket,
-          Key: newKey,
-          UploadId: resp.UploadId,
-          PartNumber: 1,
-          CopySource: `${bucket}/${sourceKey}`,
-          CopySourceRange: `bytes=0-${1024 * 4}`,
+        const copySource = `${bucket}/${sourceKey}`
+        const copySourceRange = `bytes=0-${1024 * 4}`
+        const signedRequest = await createSignedS3Request({
+          baseUrl,
+          path: `/s3/${bucket}/${newKey}`,
+          method: 'PUT',
+          query: {
+            partNumber: '1',
+            uploadId: resp.UploadId!,
+          },
+          headers: {
+            'x-amz-copy-source': copySource,
+            'x-amz-copy-source-range': copySourceRange,
+          },
         })
+        const rawResponse = await fetch(signedRequest.requestUrl, {
+          method: 'PUT',
+          headers: {
+            ...signedRequest.headers,
+            accept: 'application/xml',
+          },
+        })
+        const rawBody = (await rawResponse.text()).replace(/^<\?xml[^>]*\?>/, '')
 
-        const copyResp = await client.send(copyPart)
-        expect(copyResp.CopyPartResult?.ETag).toBeTruthy()
-        expect(copyResp.CopyPartResult?.LastModified).toBeTruthy()
+        expect(rawResponse.status).toBe(200)
+        expect(rawBody).toMatch(/^<CopyPartResult(?:\s[^>]*)?>/)
+        expect(rawBody).toContain('<ETag>')
+        expect(rawBody).toContain('<LastModified>')
+        expect(rawBody).toMatch(/<\/CopyPartResult>$/)
 
         const listPartsCmd = new ListPartsCommand({
           Bucket: bucket,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 upload part copy response doesn't set root tag name correct. 

## What is the new behavior?

It sets now and regression test validates the wire.
SDK doesn't care about root tag but might not be compatible with strict clients.

## Additional context

[S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html#API_UploadPartCopy_ResponseSyntax)
