### PR TITLE
fix(config): vector s3 buckets empty env parsing

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -215,3 +215,53 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheMissLogSampleRate).toBe(0)
   })
 })
+
+describe('vectorS3Buckets config parsing', () => {
+  const originalValue = process.env.VECTOR_S3_BUCKETS
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.VECTOR_S3_BUCKETS
+    } else {
+      process.env.VECTOR_S3_BUCKETS = originalValue
+    }
+
+    vi.resetModules()
+  })
+
+  test('defaults to an empty array when VECTOR_S3_BUCKETS is unset', async () => {
+    delete process.env.VECTOR_S3_BUCKETS
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.vectorS3Buckets).toEqual([])
+  })
+
+  test('defaults to an empty array when VECTOR_S3_BUCKETS is an empty string', async () => {
+    process.env.VECTOR_S3_BUCKETS = ''
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.vectorS3Buckets).toEqual([])
+  })
+
+  test('parses a comma-separated list of bucket names', async () => {
+    process.env.VECTOR_S3_BUCKETS = 'bucket-0,bucket-1,bucket-2'
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.vectorS3Buckets).toEqual(['bucket-0', 'bucket-1', 'bucket-2'])
+  })
+
+  test('ignores a trailing comma', async () => {
+    process.env.VECTOR_S3_BUCKETS = 'bucket-0,bucket-1,'
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.vectorS3Buckets).toEqual(['bucket-0', 'bucket-1'])
+  })
+})

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -257,7 +257,7 @@ describe('vectorS3Buckets config parsing', () => {
   })
 
   test('ignores a trailing comma', async () => {
-    process.env.VECTOR_S3_BUCKETS = 'bucket-0,bucket-1,'
+    process.env.VECTOR_S3_BUCKETS = 'bucket-0, bucket-1,'
 
     const { getConfig } = await import('./config')
     const config = getConfig({ reload: true })

--- a/src/config.ts
+++ b/src/config.ts
@@ -675,7 +675,8 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     vectorEnabled: getOptionalConfigFromEnv('VECTOR_ENABLED') === 'true',
     vectorBucketProvider: (getOptionalConfigFromEnv('VECTOR_BUCKET_PROVIDER') ||
       's3') as VectorBucketProvider,
-    vectorS3Buckets: getOptionalConfigFromEnv('VECTOR_S3_BUCKETS')?.trim()?.split(',') || [],
+    vectorS3Buckets:
+      getOptionalConfigFromEnv('VECTOR_S3_BUCKETS')?.trim()?.split(',').filter(Boolean) || [],
     vectorBucketRegion: getOptionalConfigFromEnv('VECTOR_BUCKET_REGION') || undefined,
     vectorDatabaseURL: getOptionalConfigFromEnv('VECTOR_DATABASE_URL') || undefined,
     vectorDatabaseCreate: getOptionalConfigFromEnv('VECTOR_DATABASE_CREATE') !== 'false',

--- a/src/config.ts
+++ b/src/config.ts
@@ -676,7 +676,10 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     vectorBucketProvider: (getOptionalConfigFromEnv('VECTOR_BUCKET_PROVIDER') ||
       's3') as VectorBucketProvider,
     vectorS3Buckets:
-      getOptionalConfigFromEnv('VECTOR_S3_BUCKETS')?.trim()?.split(',').filter(Boolean) || [],
+      getOptionalConfigFromEnv('VECTOR_S3_BUCKETS')
+        ?.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean) || [],
     vectorBucketRegion: getOptionalConfigFromEnv('VECTOR_BUCKET_REGION') || undefined,
     vectorDatabaseURL: getOptionalConfigFromEnv('VECTOR_DATABASE_URL') || undefined,
     vectorDatabaseCreate: getOptionalConfigFromEnv('VECTOR_DATABASE_CREATE') !== 'false',


### PR DESCRIPTION
## What kind of change does this PR introduce?

`VECTOR_S3_BUCKETS` gets set to an empty string for any region with no vector buckets configured. `''.split(',')` returns `['']` rather than `[]`, so the existing `|| []` fallback never applied. On startup this seeded a `shard_key: ''` row in the shard table for `kind: 'vector'` in every such region. This was harmless while those regions didn't have vector buckets but once a region gets enabled, the empty shard key can still get selected.

This PR filters out empty strings after splitting, so an empty/unset env var always resolves to `[]`.