### PR TITLE
fix: drop unused S3 logger middleware

### DIFF
--- a/src/http/routes/tus/index.test.ts
+++ b/src/http/routes/tus/index.test.ts
@@ -1,8 +1,30 @@
+import * as http from 'node:http'
+import * as https from 'node:https'
 import type { Server } from '@tus/server'
 import Fastify, { FastifyInstance } from 'fastify'
 import { requestContext } from '../../plugins/request-context'
-import { publicRoutes } from './index'
+import { createTusLockS3Client, publicRoutes } from './index'
 import type { MultiPartRequest } from './lifecycle'
+
+describe('TUS S3 clients', () => {
+  test('removes the no-op logger middleware from the lock client', () => {
+    const httpAgent = new http.Agent()
+    const httpsAgent = new https.Agent()
+    const client = createTusLockS3Client({ httpAgent, httpsAgent })
+
+    try {
+      expect(
+        client.middlewareStack
+          .identify()
+          .some((middleware) => middleware.includes('loggerMiddleware'))
+      ).toBe(false)
+    } finally {
+      client.destroy()
+      httpAgent.destroy()
+      httpsAgent.destroy()
+    }
+  })
+})
 
 describe('public tus route request context', () => {
   let app: FastifyInstance

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -6,9 +6,15 @@ import { createAgent } from '@internal/http'
 import { logSchema } from '@internal/monitoring'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { getFileSizeLimit } from '@storage/limits'
-import { AlsMemoryKV, FileStore, LockNotifier, PgLocker, UploadId } from '@storage/protocols/tus'
+import {
+  AlsMemoryKV,
+  FileStore,
+  LockNotifier,
+  PgLocker,
+  S3Store,
+  UploadId,
+} from '@storage/protocols/tus'
 import { S3Locker } from '@storage/protocols/tus/s3-locker'
-import { S3Store } from '@tus/s3-store'
 import { DataStore, Server, ServerOptions } from '@tus/server'
 import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
@@ -74,25 +80,27 @@ function createTusStore(agent: { httpsAgent: https.Agent; httpAgent: http.Agent 
   })
 }
 
+export function createTusLockS3Client(agent: { httpsAgent: https.Agent; httpAgent: http.Agent }) {
+  const client = new S3Client({
+    requestHandler: new NodeHttpHandler({
+      ...agent,
+      connectionTimeout: 5000,
+      requestTimeout: storageS3ClientTimeout,
+    }),
+    region: storageS3Region,
+    endpoint: storageS3Endpoint,
+    forcePathStyle: storageS3ForcePathStyle,
+  })
+  client.middlewareStack.remove('loggerMiddleware')
+  return client
+}
+
 function createTusServer(
   lockNotifier: LockNotifier,
   agent: { httpsAgent: https.Agent; httpAgent: http.Agent }
 ) {
   const datastore = createTusStore(agent)
-  const sharedS3Client =
-    tusLockType === 's3'
-      ? new S3Client({
-          requestHandler: new NodeHttpHandler({
-            ...agent,
-            connectionTimeout: 5000,
-            requestTimeout: storageS3ClientTimeout,
-          }),
-          region: storageS3Region,
-          endpoint: storageS3Endpoint,
-          forcePathStyle: storageS3ForcePathStyle,
-        })
-      : undefined
-  sharedS3Client?.middlewareStack.remove('loggerMiddleware')
+  const sharedS3Client = tusLockType === 's3' ? createTusLockS3Client(agent) : undefined
   const serverOptions: ServerOptions & {
     datastore: DataStore
   } = {

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -92,6 +92,7 @@ function createTusServer(
           forcePathStyle: storageS3ForcePathStyle,
         })
       : undefined
+  sharedS3Client?.middlewareStack.remove('loggerMiddleware')
   const serverOptions: ServerOptions & {
     datastore: DataStore
   } = {

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -27,6 +27,9 @@ vi.mock('@aws-sdk/client-s3', async () => {
     ...originalModule,
     S3Client: vi.fn(function () {
       return {
+        middlewareStack: {
+          remove: vi.fn(),
+        },
         send: vi.fn(),
       }
     }),
@@ -85,6 +88,9 @@ describe('S3Backend', () => {
 
     ;(S3Client as unknown as Mock).mockImplementation(function () {
       return {
+        middlewareStack: {
+          remove: vi.fn(),
+        },
         send: mockSend,
       }
     })
@@ -123,6 +129,21 @@ describe('S3Backend', () => {
   }
 
   describe('client config', () => {
+    test('removes the no-op logger middleware from every AWS client', () => {
+      new S3Backend({
+        region: 'us-east-1',
+        endpoint: 'http://127.0.0.1:9000',
+        privateAssetEndpoint: 'http://minio:9000',
+      })
+
+      const s3ClientMock = S3Client as unknown as Mock
+      expect(s3ClientMock).toHaveBeenCalledTimes(2)
+
+      for (const result of s3ClientMock.mock.results) {
+        expect(result.value.middlewareStack.remove).toHaveBeenCalledWith('loggerMiddleware')
+      }
+    })
+
     test('passes split checksum settings independently to the AWS client', async () => {
       const originalRequestChecksum = process.env.STORAGE_S3_REQUEST_CHECKSUM_CALCULATION
       const originalResponseChecksum = process.env.STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -737,6 +737,8 @@ export class S3Backend implements StorageBackendAdapter {
     if (storageS3ResponseChecksumValidation) {
       params.responseChecksumValidation = storageS3ResponseChecksumValidation
     }
-    return new S3Client(params)
+    const client = new S3Client(params)
+    client.middlewareStack.remove('loggerMiddleware')
+    return client
   }
 }

--- a/src/storage/protocols/tus/index.ts
+++ b/src/storage/protocols/tus/index.ts
@@ -1,4 +1,5 @@
 export * from './als-memory-kv'
 export * from './file-store'
 export * from './postgres-locker'
+export * from './s3-store'
 export * from './upload-id'

--- a/src/storage/protocols/tus/s3-store.test.ts
+++ b/src/storage/protocols/tus/s3-store.test.ts
@@ -1,0 +1,70 @@
+import { HttpResponse } from '@smithy/protocol-http'
+import { S3Store } from './s3-store'
+
+class TestS3Store extends S3Store {
+  getClient() {
+    return this.client
+  }
+}
+
+function createStore(
+  handle: (request: unknown, options?: unknown) => Promise<{ response: HttpResponse }>,
+  maxAttempts = 1
+) {
+  return new TestS3Store({
+    s3ClientConfig: {
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      endpoint: 'http://127.0.0.1:9000',
+      credentials: {
+        accessKeyId: 'test',
+        secretAccessKey: 'test',
+      },
+      maxAttempts,
+      requestHandler: { handle },
+    },
+  })
+}
+
+describe('S3Store', () => {
+  test('removes the no-op logger middleware from the internal TUS client', () => {
+    const store = createStore(vi.fn())
+
+    expect(
+      store
+        .getClient()
+        .middlewareStack.identify()
+        .some((middleware) => middleware.includes('loggerMiddleware'))
+    ).toBe(false)
+  })
+
+  test('preserves SDK retries after removing the logger middleware', async () => {
+    const handle = vi
+      .fn()
+      .mockResolvedValueOnce({
+        response: new HttpResponse({ statusCode: 500, headers: {}, body: new Uint8Array() }),
+      })
+      .mockResolvedValueOnce({
+        response: new HttpResponse({ statusCode: 200, headers: {}, body: new Uint8Array() }),
+      })
+    const store = createStore(handle, 2)
+
+    const result = await store.getClient().headBucket({ Bucket: 'test-bucket' })
+
+    expect(handle).toHaveBeenCalledTimes(2)
+    expect(result.$metadata).toMatchObject({ httpStatusCode: 200, attempts: 2 })
+  })
+
+  test('preserves SDK errors after removing the logger middleware', async () => {
+    const expectedError = new Error('request failed')
+    const handle = vi.fn().mockRejectedValue(expectedError)
+    const store = createStore(handle)
+
+    await expect(store.getClient().headBucket({ Bucket: 'test-bucket' })).rejects.toBe(
+      expectedError
+    )
+    expect(expectedError).toMatchObject({
+      $metadata: { attempts: 1, totalRetryDelay: 0 },
+    })
+  })
+})

--- a/src/storage/protocols/tus/s3-store.ts
+++ b/src/storage/protocols/tus/s3-store.ts
@@ -1,0 +1,8 @@
+import { type Options, S3Store as TusS3Store } from '@tus/s3-store'
+
+export class S3Store extends TusS3Store {
+  constructor(options: Options) {
+    super(options)
+    this.client.middlewareStack.remove('loggerMiddleware')
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Perf touch

## What is the current behavior?

S3 logger isn't used so SDK uses no op logger which discards output line but it still runs a filter for sensitive data. 

## What is the new behavior?

No need to pay the price, disable it completely.

