### PR TITLE
fix: fold search path into set config

### DIFF
--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -14,7 +14,7 @@ import {
   PgTenantConnection,
   PgTransaction,
 } from './pg-connection'
-import type { TenantConnectionOptions } from './pool'
+import { searchPath, type TenantConnectionOptions } from './pool'
 
 class TestablePgPoolStrategy extends PgPoolStrategy {
   getCurrentPoolForTest(): Pool {
@@ -62,6 +62,7 @@ function createDatabaseError(code: string | undefined, message = 'database error
 }
 
 type TestPgBeginTransactionOptions = {
+  searchPath?: string
   timeout?: number
   statementTimeoutMs?: number
 }
@@ -90,6 +91,7 @@ function createMockTenantConnectionWithTransaction(
   const beginTransaction = vi.fn(
     async (options?: TestPgBeginTransactionOptions): Promise<PgTransaction> => {
       transaction = new PgTransaction(client, undefined, {
+        searchPath: options?.searchPath,
         statementTimeoutMs: normalizeTestStatementTimeoutMs(options),
       })
       return transaction
@@ -670,6 +672,72 @@ describe('PgTransaction', () => {
     expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT 2', undefined)
   })
 
+  it('applies a pending search path before the first direct query', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    } as unknown as PoolClient
+    const transaction = new PgTransaction(client, undefined, {
+      searchPath: searchPath.join(','),
+    })
+
+    await transaction.query('SELECT 1')
+    await transaction.query('SELECT 2')
+
+    expect(client.query).toHaveBeenCalledTimes(3)
+    expect(client.query).toHaveBeenNthCalledWith(1, "SELECT set_config('search_path', $1, true)", [
+      searchPath.join(','),
+    ])
+    expect(client.query).toHaveBeenNthCalledWith(2, 'SELECT 1', undefined)
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT 2', undefined)
+  })
+
+  it('applies pending search path and statement timeout together before a direct query', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    } as unknown as PoolClient
+    const transaction = new PgTransaction(client, undefined, {
+      searchPath: searchPath.join(','),
+      statementTimeoutMs: 4321,
+    })
+
+    await transaction.query('SELECT 1')
+    await transaction.query('SELECT 2')
+
+    expect(client.query).toHaveBeenCalledTimes(3)
+    expect(client.query).toHaveBeenNthCalledWith(
+      1,
+      "SELECT set_config('statement_timeout', $1, true), set_config('search_path', $2, true)",
+      ['4321ms', searchPath.join(',')]
+    )
+    expect(client.query).toHaveBeenNthCalledWith(2, 'SELECT 1', undefined)
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT 2', undefined)
+  })
+
+  it('keeps pending settings across setup queries until a direct query applies them', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    } as unknown as PoolClient
+    const transaction = new PgTransaction(client, undefined, {
+      searchPath: searchPath.join(','),
+      statementTimeoutMs: 4321,
+    })
+
+    await transaction.runSetupQuery('BEGIN')
+    await transaction.query('SELECT 1')
+
+    expect(client.query).toHaveBeenCalledTimes(3)
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN', undefined)
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      "SELECT set_config('statement_timeout', $1, true), set_config('search_path', $2, true)",
+      ['4321ms', searchPath.join(',')]
+    )
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT 1', undefined)
+  })
+
   it('normalizes invalid constructor statement timeouts as disabled', async () => {
     for (const statementTimeoutMs of [-5, Number.NaN, Number.POSITIVE_INFINITY, 0]) {
       const client = {
@@ -683,6 +751,20 @@ describe('PgTransaction', () => {
       expect(client.query).toHaveBeenCalledTimes(1)
       expect(client.query).toHaveBeenNthCalledWith(1, 'SELECT 1', undefined)
     }
+  })
+
+  it('normalizes an empty constructor search path as disabled', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    } as unknown as PoolClient
+    const transaction = new PgTransaction(client, undefined, { searchPath: '' })
+
+    const queryPromise = transaction.query('SELECT 1')
+
+    expect(client.query).toHaveBeenCalledTimes(1)
+    expect(client.query).toHaveBeenNthCalledWith(1, 'SELECT 1', undefined)
+    await queryPromise
   })
 
   it('rejects a pre-aborted direct query before applying a pending statement timeout', async () => {
@@ -1298,6 +1380,7 @@ describe('PgTenantConnection', () => {
     const beginTransaction = vi.fn(
       async (options?: TestPgBeginTransactionOptions): Promise<PgTransaction> => {
         transaction = new PgTransaction(client, undefined, {
+          searchPath: options?.searchPath,
           statementTimeoutMs: normalizeTestStatementTimeoutMs(options),
         })
         return transaction
@@ -1339,7 +1422,7 @@ describe('PgTenantConnection', () => {
     ])
   })
 
-  it('keeps external-pool search_path setup before deferring statement_timeout', async () => {
+  it('folds external-pool search_path and statement_timeout into scope setup', async () => {
     const query = vi.fn().mockResolvedValue({ rows: [] })
     const client = {
       query,
@@ -1349,6 +1432,7 @@ describe('PgTenantConnection', () => {
     const beginTransaction = vi.fn(
       async (options?: TestPgBeginTransactionOptions): Promise<PgTransaction> => {
         transaction = new PgTransaction(client, undefined, {
+          searchPath: options?.searchPath,
           statementTimeoutMs: normalizeTestStatementTimeoutMs(options),
         })
         return transaction
@@ -1367,21 +1451,19 @@ describe('PgTenantConnection', () => {
     )
 
     await expect(connection.transaction({ timeout: 4321 })).resolves.toBe(transaction!)
-    expect(beginTransaction).toHaveBeenCalledWith({ timeout: 4321 })
-
-    expect(query).toHaveBeenCalledTimes(1)
-    expect(query).toHaveBeenNthCalledWith(
-      1,
-      "SELECT set_config('search_path', $1, true)",
-      expect.any(Array)
-    )
+    expect(beginTransaction).toHaveBeenCalledWith({
+      timeout: 4321,
+      searchPath: searchPath.join(','),
+    })
+    expect(query).not.toHaveBeenCalled()
 
     await connection.setScope(transaction!)
 
-    expect(query).toHaveBeenCalledTimes(2)
-    const [scopeStatement, scopeValues] = query.mock.calls[1]
+    expect(query).toHaveBeenCalledTimes(1)
+    const [scopeStatement, scopeValues] = query.mock.calls[0]
     expect(scopeStatement).toContain("set_config('role', $1, true)")
     expect(scopeStatement).toContain("set_config('statement_timeout', $10, true)")
+    expect(scopeStatement).toContain("set_config('search_path', $11, true)")
     expect(scopeValues).toEqual([
       'authenticated',
       'authenticated',
@@ -1393,10 +1475,11 @@ describe('PgTenantConnection', () => {
       '',
       '',
       '4321ms',
+      searchPath.join(','),
     ])
   })
 
-  it('folds deferred statement_timeout into scope setup', async () => {
+  it('folds external-pool search_path without a positive statement timeout', async () => {
     const query = vi.fn().mockResolvedValue({ rows: [] })
     const client = {
       query,
@@ -1406,6 +1489,7 @@ describe('PgTenantConnection', () => {
     const beginTransaction = vi.fn(
       async (options?: TestPgBeginTransactionOptions): Promise<PgTransaction> => {
         transaction = new PgTransaction(client, undefined, {
+          searchPath: options?.searchPath,
           statementTimeoutMs: normalizeTestStatementTimeoutMs(options),
         })
         return transaction
@@ -1423,21 +1507,19 @@ describe('PgTenantConnection', () => {
       })
     )
 
-    await expect(connection.transaction({ timeout: 4321 })).resolves.toBe(transaction!)
-    expect(beginTransaction).toHaveBeenCalledWith({ timeout: 4321 })
-
-    expect(query).toHaveBeenCalledTimes(1)
-    expect(query).toHaveBeenNthCalledWith(
-      1,
-      "SELECT set_config('search_path', $1, true)",
-      expect.any(Array)
-    )
+    await expect(connection.transaction({ timeout: 0 })).resolves.toBe(transaction!)
+    expect(beginTransaction).toHaveBeenCalledWith({
+      timeout: 0,
+      searchPath: searchPath.join(','),
+    })
+    expect(query).not.toHaveBeenCalled()
 
     await connection.setScope(transaction!)
 
-    expect(query).toHaveBeenCalledTimes(2)
-    const [scopeStatement, scopeValues] = query.mock.calls[1]
-    expect(scopeStatement).toContain("set_config('statement_timeout', $10, true)")
+    expect(query).toHaveBeenCalledTimes(1)
+    const [scopeStatement, scopeValues] = query.mock.calls[0]
+    expect(scopeStatement).not.toContain("set_config('statement_timeout'")
+    expect(scopeStatement).toContain("set_config('search_path', $10, true)")
     expect(scopeValues).toEqual([
       'authenticated',
       'authenticated',
@@ -1448,7 +1530,7 @@ describe('PgTenantConnection', () => {
       '',
       '',
       '',
-      '4321ms',
+      searchPath.join(','),
     ])
   })
 
@@ -1487,6 +1569,7 @@ describe('PgTenantConnection', () => {
     const beginTransaction = vi.fn(
       async (options?: TestPgBeginTransactionOptions): Promise<PgTransaction> => {
         transaction = new PgTransaction(client, undefined, {
+          searchPath: options?.searchPath,
           statementTimeoutMs: normalizeTestStatementTimeoutMs(options),
         })
         return transaction
@@ -1512,6 +1595,23 @@ describe('PgTenantConnection', () => {
     expect(query).toHaveBeenNthCalledWith(2, 'SELECT 1', undefined)
     expect(
       query.mock.calls.filter(([statement]) => String(statement).includes('statement_timeout'))
+    ).toHaveLength(1)
+  })
+
+  it('does not re-apply search_path after setScope consumes it', async () => {
+    const { connection, query, getTransaction } = createMockTenantConnectionWithTransaction({
+      isExternalPool: true,
+    })
+
+    await connection.transaction({ timeout: 4321 })
+    await connection.setScope(getTransaction())
+    await getTransaction().query('SELECT 1')
+
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(query.mock.calls[0][0]).toContain("set_config('search_path', $11, true)")
+    expect(query).toHaveBeenNthCalledWith(2, 'SELECT 1', undefined)
+    expect(
+      query.mock.calls.filter(([statement]) => String(statement).includes('search_path'))
     ).toHaveLength(1)
   })
 
@@ -1550,41 +1650,6 @@ describe('PgTenantConnection', () => {
       })
     } finally {
       stringifySpy.mockRestore()
-    }
-  })
-
-  it('preserves setup errors when external-pool rollback fails', async () => {
-    const setupError = new Error('search_path setup failed')
-    const rollbackError = new Error('rollback failed')
-    const transaction = {
-      query: vi.fn(),
-      runSetupQuery: vi.fn().mockRejectedValue(setupError),
-      rollback: vi.fn().mockRejectedValue(rollbackError),
-    } as unknown as PgTransaction
-    const pool = {
-      acquire: vi.fn().mockReturnValue({
-        beginTransaction: vi.fn().mockResolvedValue(transaction),
-      }),
-    } as unknown as PgPoolStrategy
-    const connection = new PgTenantConnection(pool, createPoolStrategySettings())
-    const logSpy = vi.spyOn(logSchema, 'warning').mockImplementation(() => undefined)
-
-    try {
-      await expect(connection.transaction()).rejects.toBe(setupError)
-
-      expect(transaction.rollback).toHaveBeenCalledTimes(1)
-      expect(logSpy).toHaveBeenCalledWith(
-        logger,
-        '[PgTenantConnection] Failed to rollback transaction',
-        expect.objectContaining({
-          type: 'db',
-          tenantId: 'pg-pool-strategy-test',
-          project: 'pg-pool-strategy-test',
-          error: rollbackError,
-        })
-      )
-    } finally {
-      logSpy.mockRestore()
     }
   })
 })

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -42,6 +42,7 @@ const {
 pg.types.setTypeParser(20, 'text', parseInt)
 
 interface PgTransactionOptions {
+  searchPath?: string
   statementTimeoutMs?: number
 }
 
@@ -54,6 +55,11 @@ const defaultBeginTransactionOptions: PgBeginTransactionOptions | undefined =
   defaultStatementTimeoutMs !== undefined
     ? Object.freeze({ statementTimeoutMs: defaultStatementTimeoutMs })
     : undefined
+const externalPoolSearchPath = searchPath.join(',')
+const defaultExternalPoolBeginTransactionOptions: PgBeginTransactionOptions = Object.freeze({
+  ...defaultBeginTransactionOptions,
+  searchPath: externalPoolSearchPath,
+})
 
 const scopeConfigSetters = `set_config('role', $1, true),
           set_config('request.jwt.claim.role', $2, true),
@@ -75,6 +81,19 @@ const scopeConfigSqlWithStatementTimeout = `
         SELECT
           ${scopeConfigSetters},
           set_config('statement_timeout', $10, true);
+      `
+
+const scopeConfigSqlWithSearchPath = `
+        SELECT
+          ${scopeConfigSetters},
+          set_config('search_path', $10, true);
+      `
+
+const scopeConfigSqlWithStatementTimeoutAndSearchPath = `
+        SELECT
+          ${scopeConfigSetters},
+          set_config('statement_timeout', $10, true),
+          set_config('search_path', $11, true);
       `
 
 interface PgPoolErrorContext {
@@ -448,6 +467,7 @@ export class PgPoolExecutor implements DatabaseTransactionalExecutor {
 
     const clientErrorTracker = new PgClientErrorTracker(client)
     const transaction = new PgTransaction(client, clientErrorTracker, {
+      searchPath: options?.searchPath,
       statementTimeoutMs: options?.statementTimeoutMs ?? options?.timeout,
     })
 
@@ -470,14 +490,16 @@ export class PgPoolExecutor implements DatabaseTransactionalExecutor {
 
 export class PgTransaction implements DatabaseTransaction {
   private completed = false
-  private statementTimeoutMs?: number
+  private pendingSearchPath?: string
+  private pendingStatementTimeoutMs?: number
 
   constructor(
     private readonly client: PoolClient,
     private readonly clientErrorTracker?: PgClientErrorTracker,
     options: PgTransactionOptions = {}
   ) {
-    this.statementTimeoutMs = normalizeStatementTimeoutMs(options.statementTimeoutMs)
+    this.pendingSearchPath = options.searchPath || undefined
+    this.pendingStatementTimeoutMs = normalizeStatementTimeoutMs(options.statementTimeoutMs)
   }
 
   isCompleted(): boolean {
@@ -495,22 +517,28 @@ export class PgTransaction implements DatabaseTransaction {
     statement: string | DatabaseStatement,
     options?: DatabaseQueryArgument
   ): Promise<QueryResult<T>> {
-    // Setup statements must not consume a deferred timeout before scope can fold it in.
+    // Setup statements must not consume deferred settings before scope can fold them in.
     return this.runQuery(statement, options, false)
   }
 
-  // Hands the deferred timeout to the caller (setScope) so it can be folded
-  // into its next statement instead of costing a separate set_config round trip.
+  // Hands deferred settings to the caller (setScope) so they can be folded
+  // into its next statement instead of costing separate set_config round trips.
   takePendingStatementTimeoutMs(): number | undefined {
-    const timeoutMs = this.statementTimeoutMs
-    this.statementTimeoutMs = undefined
+    const timeoutMs = this.pendingStatementTimeoutMs
+    this.pendingStatementTimeoutMs = undefined
     return timeoutMs
+  }
+
+  takePendingSearchPath(): string | undefined {
+    const pendingSearchPath = this.pendingSearchPath
+    this.pendingSearchPath = undefined
+    return pendingSearchPath
   }
 
   private async runQuery<T extends QueryResultRow = QueryResultRow>(
     statement: string | DatabaseStatement,
     options: DatabaseQueryArgument | undefined,
-    applyPendingStatementTimeout: boolean
+    applyPendingSettings: boolean
   ): Promise<QueryResult<T>> {
     if (this.completed) {
       throw new Error('Cannot query a completed transaction')
@@ -521,8 +549,11 @@ export class PgTransaction implements DatabaseTransaction {
     try {
       assertValidSignal(signal)
 
-      if (applyPendingStatementTimeout) {
-        await this.applyPendingStatementTimeoutBeforeQuery(signal)
+      if (
+        applyPendingSettings &&
+        (this.pendingSearchPath !== undefined || this.pendingStatementTimeoutMs !== undefined)
+      ) {
+        await this.applyPendingSettingsBeforeQuery(signal)
       }
 
       const result = await runPgQuery<T>(this.client, statement, options)
@@ -590,19 +621,25 @@ export class PgTransaction implements DatabaseTransaction {
     }
   }
 
-  private async applyPendingStatementTimeoutBeforeQuery(signal?: AbortSignal): Promise<void> {
+  private async applyPendingSettingsBeforeQuery(signal?: AbortSignal): Promise<void> {
     const timeoutMs = this.takePendingStatementTimeoutMs()
-    if (!timeoutMs) {
-      return
+    const pendingSearchPath = this.takePendingSearchPath()
+
+    const values: string[] = []
+    if (timeoutMs) {
+      values.push(`${timeoutMs}ms`)
+    }
+    if (pendingSearchPath) {
+      values.push(pendingSearchPath)
     }
 
     await runPgQuery(
       this.client,
       {
-        text: `SELECT set_config('statement_timeout', $1, true)`,
-        values: [`${timeoutMs}ms`],
+        text: getPendingSettingsSql(timeoutMs, pendingSearchPath),
+        values,
       },
-      { signal }
+      signal ? { signal } : undefined
     )
   }
 }
@@ -691,22 +728,8 @@ export class PgTenantConnection implements TenantConnection {
     this.assertNotDisposed()
 
     try {
-      const beginOptions = withDefaultStatementTimeout(opts)
-      const transaction = await this.beginTransactionWithRetry(beginOptions)
-
-      if (this.options.isExternalPool) {
-        try {
-          await transaction.runSetupQuery({
-            text: `SELECT set_config('search_path', $1, true)`,
-            values: [searchPath.join(',')],
-          })
-        } catch (e) {
-          await this.rollbackTransactionSafely(transaction, e, 'search_path setup')
-          throw e
-        }
-      }
-
-      return transaction
+      const beginOptions = withDefaultTransactionSettings(opts, this.options.isExternalPool)
+      return await this.beginTransactionWithRetry(beginOptions)
     } catch (e) {
       if (isConnectionTimeoutError(e)) {
         throw ERRORS.DatabaseTimeout(e)
@@ -759,30 +782,13 @@ export class PgTenantConnection implements TenantConnection {
     }
   }
 
-  private async rollbackTransactionSafely(
-    transaction: PgTransaction,
-    originalError: unknown,
-    reason: string
-  ): Promise<void> {
-    try {
-      await transaction.rollback()
-    } catch (rollbackError) {
-      logSchema.warning(logger, '[PgTenantConnection] Failed to rollback transaction', {
-        type: 'db',
-        tenantId: this.options.tenantId,
-        project: this.options.tenantId,
-        error: rollbackError,
-        metadata: JSON.stringify({
-          reason,
-          originalError: String(originalError),
-        }),
-      })
-    }
-  }
-
   async setScope(tnx: DatabaseExecutor) {
-    const statementTimeoutMs =
-      tnx instanceof PgTransaction ? tnx.takePendingStatementTimeoutMs() : undefined
+    let statementTimeoutMs: number | undefined
+    let pendingSearchPath: string | undefined
+    if (tnx instanceof PgTransaction) {
+      statementTimeoutMs = tnx.takePendingStatementTimeoutMs()
+      pendingSearchPath = tnx.takePendingSearchPath()
+    }
 
     const values: unknown[] = [
       this.role,
@@ -799,9 +805,12 @@ export class PgTenantConnection implements TenantConnection {
     if (statementTimeoutMs) {
       values.push(`${statementTimeoutMs}ms`)
     }
+    if (pendingSearchPath) {
+      values.push(pendingSearchPath)
+    }
 
     await tnx.query({
-      text: statementTimeoutMs ? scopeConfigSqlWithStatementTimeout : scopeConfigSql,
+      text: getScopeConfigSql(statementTimeoutMs, pendingSearchPath),
       values,
     })
   }
@@ -809,6 +818,59 @@ export class PgTenantConnection implements TenantConnection {
   private getUserPayload(): string {
     this.userPayload ??= serializeJwtPayload(this.options.user.payload)
     return this.userPayload
+  }
+}
+
+function getPendingSettingsSql(
+  statementTimeoutMs: number | undefined,
+  pendingSearchPath: string | undefined
+): string {
+  if (statementTimeoutMs && pendingSearchPath) {
+    return "SELECT set_config('statement_timeout', $1, true), set_config('search_path', $2, true)"
+  }
+
+  if (statementTimeoutMs) {
+    return "SELECT set_config('statement_timeout', $1, true)"
+  }
+
+  return "SELECT set_config('search_path', $1, true)"
+}
+
+function getScopeConfigSql(
+  statementTimeoutMs: number | undefined,
+  pendingSearchPath: string | undefined
+): string {
+  if (statementTimeoutMs && pendingSearchPath) {
+    return scopeConfigSqlWithStatementTimeoutAndSearchPath
+  }
+
+  if (statementTimeoutMs) {
+    return scopeConfigSqlWithStatementTimeout
+  }
+
+  if (pendingSearchPath) {
+    return scopeConfigSqlWithSearchPath
+  }
+
+  return scopeConfigSql
+}
+
+function withDefaultTransactionSettings(
+  options: TransactionOptions | undefined,
+  isExternalPool: boolean | undefined
+): PgBeginTransactionOptions | undefined {
+  if (!isExternalPool) {
+    return withDefaultStatementTimeout(options)
+  }
+
+  if (!options) {
+    return defaultExternalPoolBeginTransactionOptions
+  }
+
+  return {
+    ...options,
+    statementTimeoutMs: options.timeout === undefined ? defaultStatementTimeoutMs : undefined,
+    searchPath: externalPoolSearchPath,
   }
 }
 
@@ -857,34 +919,40 @@ async function runPgQuery<T extends QueryResultRow = QueryResultRow>(
   options?: DatabaseQueryArgument
 ): Promise<QueryResult<T>> {
   const signal = Array.isArray(options) ? undefined : options?.signal
+  const query = normalizeStatement(statement, Array.isArray(options) ? options : undefined)
+
+  if (!signal) {
+    try {
+      return await client.query<T>(query.text, query.values)
+    } catch (e) {
+      if (isConnectionStateError(e)) {
+        markClientDisposable(e)
+      }
+      throw e
+    }
+  }
+
   assertValidSignal(signal)
 
-  const query = normalizeStatement(statement, Array.isArray(options) ? options : undefined)
   let aborted = false
   let cancelPromise: Promise<void> | undefined
   let rejectAbort: ((error: Error) => void) | undefined
-  const abortPromise = signal
-    ? new Promise<never>((_, reject) => {
-        rejectAbort = reject
-      })
-    : undefined
-
-  const rejectWithAbortError = () => {
-    rejectAbort?.(createAbortError())
-    rejectAbort = undefined
-  }
+  const abortPromise = new Promise<never>((_, reject) => {
+    rejectAbort = reject
+  })
 
   const onAbort = () => {
     aborted = true
     cancelPromise = cancelPgQuery(client).catch(() => undefined)
-    rejectWithAbortError()
+    rejectAbort?.(createAbortError())
+    rejectAbort = undefined
   }
 
-  signal?.addEventListener('abort', onAbort, { once: true })
+  signal.addEventListener('abort', onAbort, { once: true })
 
   try {
     const queryPromise = client.query<T>(query.text, query.values)
-    const result = await (abortPromise ? Promise.race([queryPromise, abortPromise]) : queryPromise)
+    const result = await Promise.race([queryPromise, abortPromise])
 
     if (aborted) {
       throw createAbortError()
@@ -902,7 +970,7 @@ async function runPgQuery<T extends QueryResultRow = QueryResultRow>(
     }
     throw e
   } finally {
-    signal?.removeEventListener('abort', onAbort)
+    signal.removeEventListener('abort', onAbort)
   }
 }
 

--- a/src/test/pg-connection.test.ts
+++ b/src/test/pg-connection.test.ts
@@ -4,7 +4,7 @@ import {
   PgPoolStrategy,
   PgTenantConnection,
 } from '@internal/database'
-import type { TenantConnectionOptions } from '@internal/database/pool'
+import { searchPath, type TenantConnectionOptions } from '@internal/database/pool'
 import { getConfig } from '../config'
 
 const { databaseURL, databasePoolURL, tenantId } = getConfig()
@@ -115,7 +115,7 @@ describe('Pg database foundation', () => {
     }
   })
 
-  it('sets transaction-local request scope and statement timeout', async () => {
+  it('sets transaction-local search path, request scope, and statement timeout', async () => {
     const { connection, pool, superUser } = await createConnection()
     const transaction = await connection.transaction({ timeout: 1234 })
 
@@ -128,6 +128,7 @@ describe('Pg database foundation', () => {
         request_path: string
         storage_operation: string
         allow_delete: string
+        search_path: string
         statement_timeout: string
       }>({
         text: `
@@ -137,6 +138,7 @@ describe('Pg database foundation', () => {
             current_setting('request.path', true) as request_path,
             current_setting('storage.operation', true) as storage_operation,
             current_setting('storage.allow_delete_query', true) as allow_delete,
+            current_setting('search_path') as search_path,
             current_setting('statement_timeout') as statement_timeout
         `,
       })
@@ -148,6 +150,7 @@ describe('Pg database foundation', () => {
           request_path: '/pg-foundation',
           storage_operation: 'pg-foundation-test',
           allow_delete: 'true',
+          search_path: searchPath.join(','),
           statement_timeout: '1234ms',
         })
       )


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor for performance

## What is the current behavior?

If pool is external, we do an extra round trip for search path.

## What is the new behavior?

Fold it into scope query similar to statement timeout (#1154).

## Additional context

Also added a fast path for no signal to reduce GC overhead. 
Related to #1154
