### PR TITLE
fix: replace xmljs with fxp and hoist builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,8 @@
         "fast-decode-uri-component": "^1.0.1",
         "fast-json-stringify": "^6.3.0",
         "fast-querystring": "^1.1.2",
+        "fast-xml-builder": "^1.1.8",
+        "fast-xml-parser": "^5.7.2",
         "fastify": "^5.8.5",
         "fastify-plugin": "^5.1.0",
         "fs-xattr": "0.3.1",
@@ -67,8 +69,7 @@
         "pprof-format": "^2.2.1",
         "safe-stable-stringify": "^2.3.1",
         "undici": "^7.24.0",
-        "wattpm": "^3.62.2",
-        "xml2js": "^0.6.2"
+        "wattpm": "^3.62.2"
       },
       "bin": {
         "supa-storage": "dist/server.js"
@@ -80,7 +81,6 @@
         "@types/json-bigint": "^1.0.4",
         "@types/node": "^24.12.0",
         "@types/pg": "^8.6.4",
-        "@types/xml2js": "^0.4.14",
         "@vitest/coverage-v8": "^4.1.5",
         "esbuild": "^0.25.8",
         "form-data": "^4.0.0",
@@ -11912,15 +11912,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/xml2js": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
-      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
@@ -16087,11 +16078,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -17646,26 +17632,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {
@@ -25854,15 +25820,6 @@
         "@types/node": "*"
       }
     },
-    "@types/xml2js": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
-      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@vitest/coverage-v8": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
@@ -28547,11 +28504,6 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
       "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
-    "sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
-    },
     "scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -29409,20 +29361,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "requires": {}
-    },
-    "xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "fast-decode-uri-component": "^1.0.1",
     "fast-json-stringify": "^6.3.0",
     "fast-querystring": "^1.1.2",
+    "fast-xml-builder": "^1.1.8",
+    "fast-xml-parser": "^5.7.2",
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fs-xattr": "0.3.1",
@@ -109,8 +111,7 @@
     "pprof-format": "^2.2.1",
     "safe-stable-stringify": "^2.3.1",
     "undici": "^7.24.0",
-    "wattpm": "^3.62.2",
-    "xml2js": "^0.6.2"
+    "wattpm": "^3.62.2"
   },
   "devDependencies": {
     "@aws-sdk/s3-presigned-post": "^3.1023.0",
@@ -119,7 +120,6 @@
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^24.12.0",
     "@types/pg": "^8.6.4",
-    "@types/xml2js": "^0.4.14",
     "@vitest/coverage-v8": "^4.1.5",
     "esbuild": "^0.25.8",
     "form-data": "^4.0.0",

--- a/src/http/plugins/sync-hooks.test.ts
+++ b/src/http/plugins/sync-hooks.test.ts
@@ -6,6 +6,7 @@ import { httpMetrics } from './metrics'
 import { requestContext } from './request-context'
 import { signals as signalsPlugin } from './signals'
 import { adminTenantId, tenantId } from './tenant-id'
+import { xmlParser } from './xml'
 
 type CapturedHook = {
   name: string
@@ -78,6 +79,11 @@ describe('sync request lifecycle hooks', () => {
       name: 'headerValidator',
       register: (app: FastifyInstance) => app.register(headerValidator()),
       hooks: ['onSend'],
+    },
+    {
+      name: 'xmlParser',
+      register: (app: FastifyInstance) => app.register(xmlParser),
+      hooks: ['preSerialization'],
     },
   ])('registers $name hot hooks without async functions', async ({ register, hooks }) => {
     const capturedHooks = await collectHooks(register)

--- a/src/http/plugins/xml.test.ts
+++ b/src/http/plugins/xml.test.ts
@@ -1,10 +1,28 @@
 import fastify, { FastifyInstance } from 'fastify'
-import { xmlParser } from './xml'
+import { s3ErrorHandler } from '../routes/s3/error-handler'
+import { escapeXmlAttribute, insertRootNamespace, xmlParser } from './xml'
 
-async function buildXmlApp(parseAsArray: string[] = []): Promise<FastifyInstance> {
+const multipartArrayPaths = ['CompleteMultipartUpload.Part']
+
+async function buildXmlApp(
+  parseAsArray: string[] = [],
+  responseNamespace?: string,
+  onAcceptsCall?: () => void
+): Promise<FastifyInstance> {
   const app = fastify()
 
-  await app.register(xmlParser, { parseAsArray })
+  await app.register(xmlParser, { parseAsArray, responseNamespace })
+
+  if (onAcceptsCall) {
+    app.addHook('onRequest', (request, _reply, done) => {
+      const originalAccepts = request.accepts.bind(request)
+      request.accepts = () => {
+        onAcceptsCall()
+        return originalAccepts()
+      }
+      done()
+    })
+  }
 
   app.post('/xml', async (req) => {
     return { body: req.body }
@@ -14,23 +32,64 @@ async function buildXmlApp(parseAsArray: string[] = []): Promise<FastifyInstance
     return {
       ListBucketResult: {
         Name: 'test-bucket',
+        Empty: '',
+        IsTruncated: false,
+        Size: 0,
+        Skipped: [],
+        Optional: undefined,
+        Timestamp: new Date('2026-07-16T00:00:00.000Z'),
+        Value: { _: 'text', $: { kind: 'true' } },
+        Text: `'"&<>\r\0`,
+        Attribute: { _: 'text', $: { special: `'"&<>\r\n\t\0` } },
+        Contents: [{ Key: 'first' }, { Key: 'second' }],
       },
     }
+  })
+
+  app.get('/xml/multi-root', async () => {
+    return { ETag: 'etag', LastModified: 'now' }
+  })
+
+  app.get('/xml/empty', async () => {
+    return {}
+  })
+
+  app.get('/xml/undefined-root', async () => {
+    return { Root: undefined }
+  })
+
+  app.get('/xml/empty-array-root', async () => {
+    return { Root: [] }
+  })
+
+  app.get('/xml/repeated-root', async () => {
+    return { Root: [1, 2] }
+  })
+
+  app.get('/xml/null-root', async () => {
+    return { Root: null }
+  })
+
+  app.get('/xml/invalid-root', async () => {
+    return { 'bad root': 'value' }
   })
 
   return app
 }
 
 describe('xmlParser plugin', () => {
-  it('parses XML bodies and enforces configured array paths', async () => {
-    const app = await buildXmlApp(['CompleteMultipartUpload.Part'])
+  it.each([
+    'application/xml',
+    'text/xml',
+  ])('parses %s bodies and enforces configured array paths', async (contentType) => {
+    const app = await buildXmlApp(multipartArrayPaths)
 
     try {
       const response = await app.inject({
         method: 'POST',
         url: '/xml',
         headers: {
-          'content-type': 'application/xml',
+          'content-type': contentType,
           accept: 'application/json',
         },
         payload:
@@ -41,7 +100,7 @@ describe('xmlParser plugin', () => {
       expect(response.json()).toEqual({
         body: {
           CompleteMultipartUpload: {
-            Part: [{ PartNumber: 1, ETag: 'etag-1' }],
+            Part: [{ PartNumber: '1', ETag: 'etag-1' }],
           },
         },
       })
@@ -50,7 +109,7 @@ describe('xmlParser plugin', () => {
     }
   })
 
-  it('returns 400 for malformed XML payloads', async () => {
+  it('parses an empty XML body as null', async () => {
     const app = await buildXmlApp()
 
     try {
@@ -61,11 +120,299 @@ describe('xmlParser plugin', () => {
           'content-type': 'application/xml',
           accept: 'application/json',
         },
-        payload: '<CompleteMultipartUpload><Part></CompleteMultipartUpload>',
+        payload: '',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ body: null })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ignores the XML declaration while preserving the root namespace', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload:
+          '<?xml version="1.0" encoding="UTF-8"?><Root xmlns="urn:test"><Value>1</Value></Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        body: {
+          Root: {
+            Value: '1',
+            $: { xmlns: 'urn:test' },
+          },
+        },
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it.each([
+    ['without an XML declaration', '\uFEFF<Root><Value>ok</Value></Root>'],
+    [
+      'with an XML declaration',
+      '\uFEFF<?xml version="1.0" encoding="UTF-8"?><Root><Value>ok</Value></Root>',
+    ],
+  ])('parses BOM-prefixed XML bodies %s', async (_description, payload) => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ body: { Root: { Value: 'ok' } } })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('preserves XML attributes, text nodes, repeated elements, and scalar text', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload:
+          '<Root><Value kind="example">text</Value><EscapedAttribute named="&amp;" numeric="&#x26;"/><Item>1</Item><Item>2</Item><Exponent>1e3</Exponent><Hex>0x1F</Hex><LeadingZeros>007</LeadingZeros><Huge>12345678901234567890</Huge><UnsafeInteger>9007199254740992</UnsafeInteger><Float> 1.5 </Float><Enabled>FALSE</Enabled><Astral>😀</Astral><Entities>&amp;&lt;&gt;&quot;&apos;</Entities><Numeric>&#48;&#x31;</Numeric><EscapedNumeric>&amp;#48;</EscapedNumeric><Pi>p<?pi?>iab</Pi><Empty/></Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        body: {
+          Root: {
+            Value: { _: 'text', $: { kind: 'example' } },
+            EscapedAttribute: { $: { named: '&', numeric: '&' } },
+            Item: ['1', '2'],
+            Exponent: '1e3',
+            Hex: '0x1F',
+            LeadingZeros: '007',
+            Huge: '12345678901234567890',
+            UnsafeInteger: '9007199254740992',
+            Float: ' 1.5 ',
+            Enabled: 'FALSE',
+            Astral: '😀',
+            Entities: `&<>"'`,
+            Numeric: '01',
+            EscapedNumeric: '&#48;',
+            Pi: 'piab',
+            Empty: '',
+          },
+        },
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ignores PI-like text inside comments and preserves it inside CDATA', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload: '<Root><!-- <?pi x="&bogus;"?> --><![CDATA[<?pi x="&bogus;"?>]]></Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ body: { Root: '<?pi x="&bogus;"?>' } })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('preserves leaf whitespace while dropping non-leaf formatting whitespace', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload:
+          '<Root>\n  <!-- <!DOCTYPE Root> -->\n  <Blank>   </Blank>\n  <MultilineBlank>\n    \n  </MultilineBlank>\n  <Cdata><![CDATA[   ]]></Cdata>\n  <CommentLikeCdata><![CDATA[<!DOCTYPE Root><!-- bad -- comment -->]]></CommentLikeCdata>\n  <Padded>  a b  </Padded>\n  <Attributed kind="  example  ">   </Attributed>\n  <Container>\n    <Child>value</Child>\n  </Container>\n</Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        body: {
+          Root: {
+            Blank: '   ',
+            MultilineBlank: '\n    \n  ',
+            Cdata: '   ',
+            CommentLikeCdata: '<!DOCTYPE Root><!-- bad -- comment -->',
+            Padded: '  a b  ',
+            Attributed: { _: '   ', $: { kind: '  example  ' } },
+            Container: { Child: 'value' },
+          },
+        },
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('drops space and tab formatting whitespace from parent elements', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload: '<Root> <A>1</A>\t<B>2</B> </Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        body: {
+          Root: { A: '1', B: '2' },
+        },
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('preserves non-whitespace mixed content', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload: '<Root>text <A>1</A></Root>',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        body: {
+          Root: { A: '1', _: 'text ' },
+        },
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it.each([
+    ['mismatched tags', '<CompleteMultipartUpload><Part></CompleteMultipartUpload>'],
+    ['multiple roots', '<First/><Root/>'],
+    ['repeated roots', '<Root/><Root/>'],
+    ['DOCTYPE declarations', '<!DOCTYPE Root><Root/>'],
+    ['custom entities', '<!DOCTYPE Root [<!ENTITY value "expanded">]><Root>&value;</Root>'],
+    [
+      'external entities',
+      '<!DOCTYPE Root [<!ENTITY value SYSTEM "file:///etc/passwd">]><Root>&value;</Root>',
+    ],
+    ['undeclared entities', '<Root>&bogus;</Root>'],
+    ['unescaped ampersands in attributes', '<Delete xmlns="urn:a&b"/>'],
+    ['unterminated comments', '<Root><!-- data</Root>'],
+    ['unterminated CDATA', '<Root><![CDATA[data</Root>'],
+    ['unterminated processing instructions', '<Root><?pi data</Root>'],
+    ['null references', '<Root>&#0;</Root>'],
+    ['surrogate references', '<Root>&#xD800;</Root>'],
+    ['noncharacter references', '<Root>&#xFFFF;</Root>'],
+    ['out-of-range references', '<Root>&#x110000;</Root>'],
+    ['malformed numeric references', '<Root>&#x;</Root>'],
+    ['raw invalid characters', '<Root>\0</Root>'],
+  ])('returns 400 for unsupported or malformed XML payloads with %s', async (_case, payload) => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload,
       })
 
       expect(response.statusCode).toBe(400)
       expect(response.json().message).toContain('Invalid XML payload')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('does not scan entity references across unescaped ampersands', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: {
+          'content-type': 'application/xml',
+          accept: 'application/json',
+        },
+        payload: '<Root value="&bare&amp;"/>',
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json().message).toBe('Invalid XML payload: Unescaped ampersand')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('bounds XML nesting depth', async () => {
+    const app = await buildXmlApp()
+    const parse = (payload: string) =>
+      app.inject({
+        method: 'POST',
+        url: '/xml',
+        headers: { 'content-type': 'application/xml', accept: 'application/json' },
+        payload,
+      })
+
+    try {
+      const nestedDocument = (depth: number) =>
+        `${'<Node>'.repeat(depth)}value${'</Node>'.repeat(depth)}`
+      expect((await parse(nestedDocument(100))).statusCode).toBe(200)
+      expect((await parse(nestedDocument(101))).statusCode).toBe(200)
+      expect((await parse(nestedDocument(102))).statusCode).toBe(400)
     } finally {
       await app.close()
     }
@@ -85,11 +432,188 @@ describe('xmlParser plugin', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.headers['content-type']).toContain('application/xml')
-      expect(response.payload).toContain(
-        '<ListBucketResult><Name>test-bucket</Name></ListBucketResult>'
+      expect(response.payload).toBe(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><ListBucketResult><Name>test-bucket</Name><Empty/><IsTruncated>false</IsTruncated><Size>0</Size><Timestamp>2026-07-16T00:00:00.000Z</Timestamp><Value kind="true">text</Value><Text>\'"&amp;&lt;&gt;&#xD;�</Text><Attribute special="&apos;&quot;&amp;&lt;&gt;&#xD;&#xA;&#x9;�">text</Attribute><Contents><Key>first</Key></Contents><Contents><Key>second</Key></Contents></ListBucketResult>'
       )
     } finally {
       await app.close()
     }
+  })
+
+  it('rejects payloads that cannot form a single-rooted XML document', async () => {
+    const app = await buildXmlApp()
+
+    try {
+      for (const url of [
+        '/xml/multi-root',
+        '/xml/empty',
+        '/xml/undefined-root',
+        '/xml/empty-array-root',
+        '/xml/repeated-root',
+        '/xml/invalid-root',
+      ]) {
+        const response = await app.inject({
+          method: 'GET',
+          url,
+          headers: {
+            accept: 'application/xml',
+          },
+        })
+
+        expect(response.statusCode).toBe(500)
+      }
+
+      const nullRootResponse = await app.inject({
+        method: 'GET',
+        url: '/xml/null-root',
+        headers: {
+          accept: 'application/xml',
+        },
+      })
+
+      expect(nullRootResponse.statusCode).toBe(200)
+      expect(nullRootResponse.payload).toBe(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Root/>'
+      )
+    } finally {
+      await app.close()
+    }
+  })
+
+  it.each([
+    ['a missing Accept header', undefined, 'application/xml', 0],
+    ['a wildcard Accept header', '*/*', 'application/xml', 0],
+    ['an explicit XML Accept header', 'application/xml', 'application/xml', 0],
+    ['an explicit text XML Accept header', 'text/xml', 'application/xml', 0],
+    ['an explicit HTML Accept header', 'text/html', 'application/xml', 0],
+    ['a case-variant XML Accept header', 'Application/XML', 'application/xml', 0],
+    ['a padded XML Accept header', '  Application/XML  ', 'application/xml', 0],
+    [
+      'a multi-value Accept header',
+      'application/json, application/xml;q=0.9',
+      'application/xml',
+      1,
+    ],
+    ['an explicit JSON Accept header', 'application/json', 'application/json', 1],
+    ['an excluded XML media type', 'application/xml;q=0', 'application/json', 1],
+  ])('negotiates %s', async (_case, accept, expectedContentType, expectedAcceptsCalls) => {
+    let acceptsCalls = 0
+    const app = await buildXmlApp([], undefined, () => acceptsCalls++)
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/xml',
+        headers: accept === undefined ? undefined : { accept },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain(expectedContentType)
+      expect(acceptsCalls).toBe(expectedAcceptsCalls)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('serializes response guard failures through the S3 XML error handler', async () => {
+    const app = fastify()
+
+    await app.register(xmlParser)
+    app.setErrorHandler(s3ErrorHandler)
+    app.get('/xml', async () => ({ First: 'one', Second: 'two' }))
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/xml',
+        headers: {
+          accept: 'application/xml',
+        },
+      })
+
+      expect(response.statusCode).toBe(500)
+      expect(response.headers['content-type']).toContain('application/xml')
+      expect(response.payload).toContain('<Error>')
+      expect(response.payload).toContain('<Code>InternalError</Code>')
+      expect(response.payload).toContain(
+        '<Message>XML response payload must be an object with a single root element</Message>'
+      )
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('adds the configured namespace to the response root', async () => {
+    const app = await buildXmlApp([], 'http://s3.amazonaws.com/doc/2006-03-01/')
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/xml',
+        headers: {
+          accept: 'application/xml',
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.payload).toContain(
+        '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+          '<Name>test-bucket</Name><Empty/>'
+      )
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+describe('insertRootNamespace', () => {
+  const nsAttr = ' xmlns="http://s3.amazonaws.com/doc/2006-03-01/"'
+  const decl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+
+  it('inserts into a plain root tag', () => {
+    expect(
+      insertRootNamespace(`${decl}<ListBucketResult><Name>b</Name></ListBucketResult>`, nsAttr)
+    ).toBe(`${decl}<ListBucketResult${nsAttr}><Name>b</Name></ListBucketResult>`)
+  })
+
+  it('inserts into a scalar-valued root tag', () => {
+    expect(
+      insertRootNamespace(`${decl}<LocationConstraint>us-east-1</LocationConstraint>`, nsAttr)
+    ).toBe(`${decl}<LocationConstraint${nsAttr}>us-east-1</LocationConstraint>`)
+  })
+
+  it('inserts before the slash of a self-closing root tag', () => {
+    expect(insertRootNamespace(`${decl}<LocationConstraint/>`, nsAttr)).toBe(
+      `${decl}<LocationConstraint${nsAttr}/>`
+    )
+  })
+
+  it('does not duplicate an existing xmlns attribute', () => {
+    const xml = `${decl}<DeleteResult xmlns="urn:other"><Deleted/></DeleteResult>`
+    expect(insertRootNamespace(xml, nsAttr)).toBe(xml)
+  })
+
+  it('ignores > inside quoted attribute values', () => {
+    expect(insertRootNamespace(`${decl}<Root note="x > y"><A/></Root>`, nsAttr)).toBe(
+      `${decl}<Root note="x > y"${nsAttr}><A/></Root>`
+    )
+  })
+
+  it('ignores xmlns= inside quoted attribute values', () => {
+    expect(insertRootNamespace(`${decl}<Root note=" xmlns=not-an-attr"><A/></Root>`, nsAttr)).toBe(
+      `${decl}<Root note=" xmlns=not-an-attr"${nsAttr}><A/></Root>`
+    )
+  })
+
+  it('does not match prefixed namespace declarations', () => {
+    expect(insertRootNamespace(`${decl}<Root xmlns:x="urn:x"><A/></Root>`, nsAttr)).toBe(
+      `${decl}<Root xmlns:x="urn:x"${nsAttr}><A/></Root>`
+    )
+  })
+})
+
+describe('escapeXmlAttribute', () => {
+  it('escapes attribute-special characters', () => {
+    expect(escapeXmlAttribute('a&b"c<d>e')).toBe('a&amp;b&quot;c&lt;d&gt;e')
   })
 })

--- a/src/http/plugins/xml.ts
+++ b/src/http/plugins/xml.ts
@@ -1,42 +1,191 @@
 import accepts from '@fastify/accepts'
 import { ERRORS } from '@internal/errors'
-import { FastifyInstance } from 'fastify'
+import Builder from 'fast-xml-builder'
+import { XMLParser } from 'fast-xml-parser'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
-import xml from 'xml2js'
 
-type XmlParserOptions = { disableContentParser?: boolean; parseAsArray?: string[] }
-type RequestError = Error & { statusCode?: number }
+type XmlParserOptions = {
+  disableContentParser?: boolean
+  parseAsArray?: string[]
+  responseNamespace?: string
+}
 
-function forcePathAsArray(node: unknown, pathSegments: string[]): void {
-  if (pathSegments.length === 0 || node === null || node === undefined) {
-    return
-  }
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+const XML_NAME = /^[A-Za-z_][A-Za-z0-9_.:-]*$/
+const XML_ENTITY_REFERENCE = /&([^;&]*);|&/g
+const XML_NUMERIC_ENTITY = /^#(?:x([\dA-F]+)|(\d+))$/i
+const XML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  quot: '"',
+}
+const XML_CHARACTER_RANGE = String.raw`\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}`
+// biome-ignore lint/suspicious/noControlCharactersInRegex: XML 1.0 excludes these ranges.
+const INVALID_XML_CHARACTER = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/
+const XML_ESCAPED_CHARACTER = new RegExp(`[&<>\\t\\n\\r]|[^${XML_CHARACTER_RANGE}]`, 'gu')
+const HAS_XML_ESCAPED_CHARACTER = new RegExp(XML_ESCAPED_CHARACTER.source, 'u')
+const XML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '\t': '&#x9;',
+  '\n': '&#xA;',
+  '\r': '&#xD;',
+}
 
-  if (Array.isArray(node)) {
-    node.forEach((item) => forcePathAsArray(item, pathSegments))
-    return
-  }
+const escapeXmlValue = (value: unknown, attribute: boolean) => {
+  const string = typeof value === 'string' ? value : String(value)
+  if (!HAS_XML_ESCAPED_CHARACTER.test(string)) return string
 
-  if (typeof node !== 'object') {
-    return
-  }
+  return string.replace(XML_ESCAPED_CHARACTER, (character) =>
+    !attribute && (character === '\t' || character === '\n')
+      ? character
+      : (XML_ESCAPES[character] ?? '\uFFFD')
+  )
+}
+const serializeXmlText = (_tagName: string, value: unknown) =>
+  escapeXmlValue(value instanceof Date ? value.toISOString() : value, false)
+const serializeXmlAttribute = (_name: string, value: unknown) => escapeXmlValue(value, true)
 
-  const [current, ...rest] = pathSegments
-  const currentRecord = node as Record<string, unknown>
+// Escapes a string for use inside a double-quoted XML attribute value.
+export function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
 
-  if (!(current in currentRecord)) {
-    return
-  }
+/**
+ * Inserts a precomputed ` xmlns="..."` attribute into the root tag of an
+ * already-built XML document. The scan is quote-aware and stops at the end of
+ * the opening root tag, so its cost is independent from the response body size.
+ */
+export function insertRootNamespace(xmlPayload: string, namespaceAttribute: string): string {
+  const declarationEnd = xmlPayload.indexOf('?>')
+  const rootStart = declarationEnd === -1 ? 0 : declarationEnd + 2
 
-  if (rest.length === 0) {
-    const value = currentRecord[current]
-    if (value !== undefined && !Array.isArray(value)) {
-      currentRecord[current] = [value]
+  let quote = 0
+  for (let index = rootStart; index < xmlPayload.length; index++) {
+    const character = xmlPayload.charCodeAt(index)
+    if (quote !== 0) {
+      if (character === quote) {
+        quote = 0
+      }
+      continue
     }
-    return
+
+    if (character === 34 || character === 39) {
+      quote = character
+      continue
+    }
+
+    if (character === 32 && xmlPayload.startsWith('xmlns=', index + 1)) {
+      return xmlPayload
+    }
+
+    if (character === 62) {
+      const tagEnd = xmlPayload.charCodeAt(index - 1) === 47 ? index - 1 : index
+      return xmlPayload.slice(0, tagEnd) + namespaceAttribute + xmlPayload.slice(tagEnd)
+    }
   }
 
-  forcePathAsArray(currentRecord[current], rest)
+  return xmlPayload
+}
+
+function isValidXmlCodePoint(codePoint: number) {
+  return (
+    codePoint === 0x9 ||
+    codePoint === 0xa ||
+    codePoint === 0xd ||
+    (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0x10ffff)
+  )
+}
+
+const xmlEntityDecoder = {
+  setExternalEntities() {},
+  addInputEntities() {
+    throw new Error('DOCTYPE is not supported')
+  },
+  reset() {},
+  setXmlVersion() {},
+  decode(text: string) {
+    if (text.indexOf('&') === -1) return text
+
+    return text.replace(XML_ENTITY_REFERENCE, (_reference, entity: string | undefined) => {
+      if (entity === undefined) throw new Error('Unescaped ampersand')
+
+      if (Object.hasOwn(XML_ENTITIES, entity)) {
+        return XML_ENTITIES[entity]
+      }
+
+      const match = XML_NUMERIC_ENTITY.exec(entity)
+      const codePoint = match
+        ? Number.parseInt(match[1] ?? match[2], match[1] === undefined ? 10 : 16)
+        : Number.NaN
+
+      if (!isValidXmlCodePoint(codePoint)) {
+        const message = entity.startsWith('#')
+          ? 'Invalid numeric character reference'
+          : 'Undeclared XML entity'
+        throw new Error(message)
+      }
+
+      return String.fromCodePoint(codePoint)
+    })
+  },
+}
+
+const xmlBuilder = new Builder({
+  format: false,
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  attributesGroupName: '$',
+  textNodeName: '_',
+  suppressEmptyNode: true,
+  suppressBooleanAttributes: false,
+  processEntities: false,
+  tagValueProcessor: serializeXmlText,
+  attributeValueProcessor: serializeXmlAttribute,
+})
+
+const acceptedTypes = ['application/xml', 'text/xml', 'text/html']
+const buildXml = (payload: unknown) => XML_DECLARATION + xmlBuilder.build(payload)
+
+function acceptsXmlResponse(req: FastifyRequest): boolean {
+  const accept = req.headers.accept
+  if (accept === undefined || accept === '*/*' || acceptedTypes.includes(accept)) {
+    return true
+  }
+
+  const normalizedAccept = accept.trim().toLowerCase()
+  if (
+    normalizedAccept !== accept &&
+    (normalizedAccept === '*/*' || acceptedTypes.includes(normalizedAccept))
+  ) {
+    return true
+  }
+
+  return req.accepts().types(acceptedTypes) !== false
+}
+
+function isXmlDocumentPayload(payload: unknown): payload is Record<string, unknown> {
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false
+  }
+
+  const rootKeys = Object.keys(payload)
+  if (rootKeys.length !== 1 || !XML_NAME.test(rootKeys[0])) {
+    return false
+  }
+
+  const rootValue = (payload as Record<string, unknown>)[rootKeys[0]]
+  return rootValue !== undefined && !Array.isArray(rootValue)
 }
 
 export const xmlParser = fastifyPlugin(
@@ -44,6 +193,26 @@ export const xmlParser = fastifyPlugin(
     fastify.register(accepts)
 
     if (!opts.disableContentParser) {
+      const arrayPaths = new Set(opts.parseAsArray?.filter(Boolean))
+      const arrayTags = new Set(
+        [...arrayPaths].map((path) => path.slice(path.lastIndexOf('.') + 1))
+      )
+      const parser = new XMLParser({
+        ignoreDeclaration: true,
+        ignoreAttributes: false,
+        attributeNamePrefix: '',
+        attributesGroupName: '$',
+        textNodeName: '_',
+        parseTagValue: false,
+        trimValues: false,
+        ignorePiTags: true,
+        jPath: false,
+        entityDecoder: xmlEntityDecoder,
+        tagValueProcessor: (_tagName, value, _jPath, _hasAttributes, isLeafNode) =>
+          !isLeafNode && value.trim() === '' ? '' : undefined,
+        isArray: (tagName, path) => arrayTags.has(tagName) && arrayPaths.has(String(path)),
+      })
+
       fastify.addContentTypeParser(
         ['text/xml', 'application/xml'],
         { parseAs: 'string' },
@@ -53,59 +222,53 @@ export const xmlParser = fastifyPlugin(
             return
           }
 
-          xml.parseString(
-            body,
-            {
-              explicitArray: false,
-              trim: true,
-              valueProcessors: [xml.processors.parseNumbers, xml.processors.parseBooleans],
-            },
-            (err: Error | null, parsed: unknown) => {
-              if (err) {
-                const parseError: RequestError = ERRORS.InvalidRequest(
-                  `Invalid XML payload: ${err.message}`
-                )
-                parseError.statusCode = 400
-                done(parseError)
-                return
-              }
-
-              if (parsed && opts.parseAsArray?.length) {
-                opts.parseAsArray.forEach((path) => {
-                  if (!path) {
-                    return
-                  }
-                  forcePathAsArray(parsed, path.split('.'))
-                })
-              }
-
-              done(null, parsed)
+          try {
+            const raw = body.toString()
+            const xml = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
+            if (INVALID_XML_CHARACTER.test(xml) || !xml.isWellFormed()) {
+              throw new Error('Invalid XML character')
             }
-          )
+            const payload = parser.parse(xml, true)
+            if (!isXmlDocumentPayload(payload)) {
+              throw new Error('XML payload must contain a single root element')
+            }
+            done(null, payload)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            done(
+              Object.assign(ERRORS.InvalidRequest(`Invalid XML payload: ${message}`), {
+                statusCode: 400,
+              })
+            )
+          }
         }
       )
     }
 
-    fastify.addHook('preSerialization', async (req, res, payload) => {
-      const accept = req.accepts()
+    const namespaceAttribute = opts.responseNamespace
+      ? ` xmlns="${escapeXmlAttribute(opts.responseNamespace)}"`
+      : undefined
+    const serializeXml = namespaceAttribute
+      ? (payload: unknown) => insertRootNamespace(buildXml(payload), namespaceAttribute)
+      : buildXml
 
-      const acceptedTypes = ['application/xml', 'text/html']
+    fastify.addHook('preSerialization', (req, res, payload, done) => {
+      if (acceptsXmlResponse(req)) {
+        if (!isXmlDocumentPayload(payload)) {
+          done(
+            ERRORS.InternalError(
+              undefined,
+              'XML response payload must be an object with a single root element'
+            )
+          )
+          return
+        }
 
-      if (acceptedTypes.some((allowed) => accept.types(acceptedTypes) === allowed)) {
-        res.serializer((payload) => payload)
-
-        const xmlBuilder = new xml.Builder({
-          renderOpts: {
-            pretty: false,
-          },
-        })
-        const xmlPayload = xmlBuilder.buildObject(payload)
-        res.type('application/xml')
         res.header('content-type', 'application/xml; charset=utf-8')
-        return xmlPayload
+        res.serializer(serializeXml)
       }
 
-      return payload
+      done(null, payload)
     })
   },
   { name: 'xml-parser' }

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -13,9 +13,10 @@ import {
   xmlParser,
 } from '../../plugins'
 import { s3ErrorHandler } from './error-handler'
-import { findArrayPathsInSchemas, getRouter, RequestInput, RouteQuery } from './router'
+import { findArraySchemaPaths, getRouter, RequestInput, RouteQuery } from './router'
 
 const { s3ProtocolEnabled } = getConfig()
+const S3_XML_NAMESPACE = 'http://s3.amazonaws.com/doc/2006-03-01/'
 
 export default async function routes(fastify: FastifyInstance) {
   if (!s3ProtocolEnabled) {
@@ -38,6 +39,9 @@ export default async function routes(fastify: FastifyInstance) {
         const routesByMethod = routes.filter((e) => e.method === method)
         const icebergRoutes = routesByMethod.filter((e) => e.type === 'iceberg')
         const standardRoutes = routesByMethod.filter((e) => e.type === undefined)
+        const bodySchemas = routesByMethod.flatMap((route) =>
+          route.schema.Body ? [route.schema.Body as JSONSchema] : []
+        )
 
         const routeHandler: RouteHandlerMethod = async (req, reply) => {
           const matchType = req.isIcebergBucket ? 'iceberg' : undefined
@@ -182,9 +186,8 @@ export default async function routes(fastify: FastifyInstance) {
           localFastify.register(signatureV4)
           localFastify.register(xmlParser, {
             disableContentParser,
-            parseAsArray: findArrayPathsInSchemas(
-              routesByMethod.filter((r) => r.schema.Body).map((r) => r.schema.Body as JSONSchema)
-            ),
+            parseAsArray: findArraySchemaPaths(bodySchemas),
+            responseNamespace: S3_XML_NAMESPACE,
           })
 
           localFastify.register(db)

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -1,5 +1,6 @@
 import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
+import type { JSONSchema } from 'json-schema-to-ts'
 import { vi } from 'vitest'
 import { S3ProtocolHandler } from '../../../storage/protocols/s3/s3-handler'
 import { Uploader } from '../../../storage/uploader'
@@ -10,13 +11,34 @@ import ListParts from './commands/list-parts'
 import PutObject from './commands/put-object'
 import UploadPart from './commands/upload-part'
 import UploadPartCopy from './commands/upload-part-copy'
-import { getRouter, type RouteQuery, Router, type S3Router } from './router'
+import { findArraySchemaPaths, getRouter, type RouteQuery, Router, type S3Router } from './router'
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
 type S3HandlerStorage = ConstructorParameters<typeof S3ProtocolHandler>[0]
+
+describe('S3 schema path discovery', () => {
+  it('finds nested array paths through array items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        Items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              Parts: { type: 'array', items: { type: 'string' } },
+            },
+          },
+        },
+      },
+    } satisfies JSONSchema
+
+    expect(findArraySchemaPaths([schema])).toEqual(['Items', 'Items.Parts'])
+  })
+})
 
 function createHandler() {
   return new S3ProtocolHandler({} as unknown as S3HandlerStorage, 'tenant-id')
@@ -675,9 +697,17 @@ describe('CompleteMultipartUpload route mapping', () => {
     ['', false],
     [0, false],
     [1, true],
+    ['1', true],
+    ['  +1  ', true],
+    ['007', true],
     ['Infinity', false],
     ['-Infinity', false],
     ['1e999', false],
+    [Infinity, false],
+    [-Infinity, false],
+    [Number.NaN, false],
+    ['9'.repeat(400), false],
+    ['   ', false],
     [10_000, true],
     [10_001, false],
   ])('validates body PartNumber %s against the S3 range', (partNumber, expected) => {
@@ -690,18 +720,21 @@ describe('CompleteMultipartUpload route mapping', () => {
       ?.find((candidate) => candidate.method === 'post' && candidate.type === undefined)
 
     expect(route).toBeDefined()
-    expect(
-      route!.validate({
-        Params: { Bucket: 'bucket', '*': 'object' },
-        Querystring: { uploadId: 'upload-id' },
-        Headers: { authorization: 'authorization' },
-        Body: {
-          CompleteMultipartUpload: {
-            Part: [{ PartNumber: partNumber, ETag: 'etag' }],
-          },
+    const input = {
+      Params: { Bucket: 'bucket', '*': 'object' },
+      Querystring: { uploadId: 'upload-id' },
+      Headers: { authorization: 'authorization' },
+      Body: {
+        CompleteMultipartUpload: {
+          Part: [{ PartNumber: partNumber, ETag: 'etag' }],
         },
-      })
-    ).toBe(expected)
+      },
+    }
+
+    expect(route!.validate(input)).toBe(expected)
+    if (expected) {
+      expect(input.Body.CompleteMultipartUpload.Part[0].PartNumber).toBe(Number(partNumber))
+    }
   })
 
   it('maps ChecksumCRC32C from the backend response on iceberg routes', async () => {

--- a/src/http/routes/s3/router.ts
+++ b/src/http/routes/s3/router.ts
@@ -402,11 +402,13 @@ function erase<R extends Schema, Context>(
 }
 
 /**
- * Given a JSONSchema Definition, it returns dotted paths of all array properties
+ * Returns dotted paths for all array nodes in the provided JSON schemas.
+ * Traversing an array's item schemas retains the current path because `items`
+ * does not add a property segment to the parsed document.
  * @param schemas
  */
-export function findArrayPathsInSchemas(schemas: JSONSchema[]): string[] {
-  const arrayPaths: string[] = []
+export function findArraySchemaPaths(schemas: JSONSchema[]): string[] {
+  const paths: string[] = []
 
   function traverse(schema: JSONSchema, currentPath = ''): void {
     if (typeof schema === 'boolean') {
@@ -414,7 +416,7 @@ export function findArrayPathsInSchemas(schemas: JSONSchema[]): string[] {
     }
 
     if (schema.type === 'array') {
-      arrayPaths.push(currentPath)
+      paths.push(currentPath)
     }
 
     if (schema.properties) {
@@ -423,9 +425,14 @@ export function findArrayPathsInSchemas(schemas: JSONSchema[]): string[] {
         traverse(nextSchema, currentPath ? `${currentPath}.${key}` : key)
       }
     }
+
+    if (schema.items) {
+      const itemSchemas = Array.isArray(schema.items) ? schema.items : [schema.items]
+      itemSchemas.forEach((itemSchema) => traverse(itemSchema, currentPath))
+    }
   }
 
   schemas.forEach((schema) => traverse(schema))
 
-  return arrayPaths
+  return paths
 }

--- a/src/storage/protocols/s3/s3-handler.test.ts
+++ b/src/storage/protocols/s3/s3-handler.test.ts
@@ -1,5 +1,29 @@
 import { MAX_HEADER_NAME_LENGTH } from '@internal/http/header'
 import { S3ProtocolHandler } from '@storage/protocols/s3/s3-handler'
+import * as config from '../../../config'
+
+describe('S3ProtocolHandler.getBucketLocation', () => {
+  it('returns an empty location constraint when the storage region is not configured', async () => {
+    const configured = config.getConfig()
+    vi.resetModules()
+    vi.doMock('../../../config', () => ({
+      ...config,
+      getConfig: () => ({ ...configured, storageS3Region: undefined }),
+    }))
+
+    try {
+      const { S3ProtocolHandler: UnconfiguredRegionHandler } = await import('./s3-handler')
+      const handler = new UnconfiguredRegionHandler({} as never, 'tenant-id')
+
+      await expect(handler.getBucketLocation()).resolves.toEqual({
+        responseBody: { LocationConstraint: '' },
+      })
+    } finally {
+      vi.doUnmock('../../../config')
+      vi.resetModules()
+    }
+  })
+})
 
 describe('S3ProtocolHandler.dbHeadObject', () => {
   it('emits empty user metadata values as valid S3 metadata headers', async () => {

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -67,9 +67,7 @@ export class S3ProtocolHandler {
   async getBucketLocation() {
     return {
       responseBody: {
-        LocationConstraint: {
-          LocationConstraint: storageS3Region,
-        },
+        LocationConstraint: storageS3Region ?? '',
       },
     }
   }

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -37,7 +37,7 @@ import { StoragePgDB } from '@storage/database'
 import { Uploader } from '@storage/uploader'
 import { createHash, createHmac, randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
-import { vi } from 'vitest'
+import { onTestFinished, vi } from 'vitest'
 import app from '../app'
 import { getConfig, mergeConfig } from '../config'
 import type { ObjectMetadata } from '../storage/backend'
@@ -461,12 +461,24 @@ describe('S3 Protocol', () => {
 
       it('can get bucket location', async () => {
         const bucket = await createBucket(client)
-        const bucketVersioningCommand = new GetBucketLocationCommand({
+        const getBucketLocationCommand = new GetBucketLocationCommand({
           Bucket: bucket,
         })
 
-        const resp = await client.send(bucketVersioningCommand)
+        const resp = await client.send(getBucketLocationCommand)
         expect(resp.LocationConstraint).toEqual(storageS3Region)
+
+        const signedUrl = await getSignedUrl(client, getBucketLocationCommand, { expiresIn: 100 })
+        const rawResponse = await fetch(signedUrl, {
+          headers: { accept: 'application/xml' },
+        })
+        const rawBody = (await rawResponse.text()).replace(/^<\?xml[^>]*\?>/, '')
+
+        expect(rawResponse.status).toBe(200)
+        expect(rawBody).toBe(
+          '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            `${storageS3Region}</LocationConstraint>`
+        )
       })
     })
 
@@ -1273,7 +1285,9 @@ describe('S3 Protocol', () => {
         })
 
         expect(emptyJsonPostResp.status).toBe(400)
-        expect(emptyJsonPostResp.data).toContain('<Error>')
+        expect(emptyJsonPostResp.data).toContain(
+          '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        )
         expect(emptyJsonPostResp.data).toContain('<Code>InvalidRequest</Code>')
         expect(emptyJsonPostResp.data).toContain(
           "<Message>Body cannot be empty when content-type is set to 'application/json'</Message>"
@@ -1410,7 +1424,9 @@ describe('S3 Protocol', () => {
         })
 
         expect(malformedCompleteResp.status).toBe(400)
-        expect(malformedCompleteResp.data).toContain('<Error>')
+        expect(malformedCompleteResp.data).toContain(
+          '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        )
         expect(malformedCompleteResp.data).toContain('<Code>InvalidRequest</Code>')
         expect(malformedCompleteResp.data).toContain('<Message>Invalid XML payload:')
 
@@ -1449,6 +1465,73 @@ describe('S3 Protocol', () => {
         const data = await getResp.Body?.transformToByteArray()
         expect(Buffer.from(data || [])).toEqual(part1Body)
         expect(part1.ETag).toBeTruthy()
+      })
+
+      it('rejects invalid multipart part numbers through route validation', async () => {
+        const bucketName = await createBucket(client)
+        const key = 'test-non-decimal-part-number.bin'
+        const createResp = await client.send(
+          new CreateMultipartUploadCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentType: 'application/octet-stream',
+          })
+        )
+        expect(createResp.UploadId).toBeTruthy()
+        onTestFinished(async () => {
+          await client.send(
+            new AbortMultipartUploadCommand({
+              Bucket: bucketName,
+              Key: key,
+              UploadId: createResp.UploadId,
+            })
+          )
+        })
+
+        const partBody = Buffer.alloc(1024 * 5, 'p')
+        const part = await client.send(
+          new UploadPartCommand({
+            Bucket: bucketName,
+            Key: key,
+            ContentLength: partBody.length,
+            UploadId: createResp.UploadId,
+            Body: partBody,
+            PartNumber: 1,
+          })
+        )
+
+        const malformedPartNumbers = [
+          '<PartNumber>   </PartNumber>',
+          '<PartNumber/>',
+          '<PartNumber>Infinity</PartNumber>',
+          `<PartNumber>${'9'.repeat(400)}</PartNumber>`,
+        ]
+
+        for (const partNumber of malformedPartNumbers) {
+          const completeResp = await sendSignedS3Request({
+            baseUrl,
+            method: 'POST',
+            path: `/s3/${bucketName}/${key}`,
+            query: {
+              uploadId: createResp.UploadId!,
+            },
+            headers: {
+              'Content-Type': 'application/xml',
+            },
+            body: `<CompleteMultipartUpload><Part>${partNumber}<ETag>${part.ETag}</ETag></Part></CompleteMultipartUpload>`,
+          })
+
+          expect(completeResp.status).toBe(400)
+          expect(completeResp.data).toContain('<Code>InvalidRequest</Code>')
+          expect(completeResp.data).toContain('PartNumber')
+        }
+
+        await expectMultipartUploadToRemainPending(client, {
+          bucket: bucketName,
+          key,
+          uploadId: createResp.UploadId!,
+          partETag: part.ETag!,
+        })
       })
 
       it('does not complete multipart upload on malformed json body', async () => {
@@ -1490,7 +1573,9 @@ describe('S3 Protocol', () => {
         })
 
         expect(malformedCompleteResp.status).toBe(400)
-        expect(malformedCompleteResp.data).toContain('<Error>')
+        expect(malformedCompleteResp.data).toContain(
+          '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        )
         expect(malformedCompleteResp.data).toContain('<Code>InvalidRequest</Code>')
         expect(malformedCompleteResp.data).toContain(
           "<Message>Body is not valid JSON but content-type is set to 'application/json'</Message>"
@@ -1571,7 +1656,9 @@ describe('S3 Protocol', () => {
         })
 
         expect(emptyJsonCompleteResp.status).toBe(400)
-        expect(emptyJsonCompleteResp.data).toContain('<Error>')
+        expect(emptyJsonCompleteResp.data).toContain(
+          '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        )
         expect(emptyJsonCompleteResp.data).toContain('<Code>InvalidRequest</Code>')
         expect(emptyJsonCompleteResp.data).toContain(
           "<Message>Body cannot be empty when content-type is set to 'application/json'</Message>"
@@ -2219,6 +2306,76 @@ describe('S3 Protocol', () => {
           })
           expect(webhookCall.metadata).toBeDefined()
           expect(webhookCall.metadata).toHaveProperty('size')
+        } finally {
+          webhookSpy.mockRestore()
+        }
+      })
+
+      it('preserves whitespace-only, numeric-looking, and boolean-looking keys in bulk deletes', async () => {
+        const webhookSpy = vi.spyOn(ObjectRemoved, 'sendWebhook').mockResolvedValue(undefined)
+        const numericReferenceKeys = ['0', '1']
+        const keys = [
+          '   ',
+          ' file ',
+          '007',
+          '1e3',
+          '0x10',
+          '12345678901234567890',
+          'true',
+          'FALSE',
+          ...numericReferenceKeys,
+        ]
+
+        try {
+          const bucketName = await createBucket(client)
+          await Promise.all(
+            keys.map((Key) =>
+              client.send(
+                new PutObjectCommand({
+                  Bucket: bucketName,
+                  Key,
+                  Body: 'x',
+                })
+              )
+            )
+          )
+
+          const entityDeleteResp = await sendSignedS3Request({
+            baseUrl,
+            method: 'POST',
+            path: `/s3/${bucketName}`,
+            query: { delete: '' },
+            headers: { 'Content-Type': 'application/xml' },
+            body: '<Delete><Object><Key>&#48;</Key></Object><Object><Key>&#x31;</Key></Object></Delete>',
+          })
+
+          expect(entityDeleteResp.status).toBe(200)
+          expect(entityDeleteResp.data).toContain('<Key>0</Key>')
+          expect(entityDeleteResp.data).toContain('<Key>1</Key>')
+
+          const remainingKeys = keys.filter((key) => !numericReferenceKeys.includes(key))
+          const remainingResp = await client.send(new ListObjectsV2Command({ Bucket: bucketName }))
+          expect(remainingResp.Contents?.map(({ Key }) => Key).sort()).toEqual(
+            remainingKeys.toSorted()
+          )
+
+          const deleteResp = await client.send(
+            new DeleteObjectsCommand({
+              Bucket: bucketName,
+              Delete: {
+                Objects: remainingKeys.map((Key) => ({ Key })),
+              },
+            })
+          )
+
+          expect(deleteResp.Deleted).toEqual(remainingKeys.map((Key) => ({ Key })))
+
+          const listResp = await client.send(
+            new ListObjectsV2Command({
+              Bucket: bucketName,
+            })
+          )
+          expect(listResp.Contents).toBeUndefined()
         } finally {
           webhookSpy.mockRestore()
         }
@@ -2924,6 +3081,62 @@ describe('S3 Protocol', () => {
     })
 
     describe('UploadPartCopyCommand', () => {
+      it('returns CopyPartResult as the raw XML root', async () => {
+        const bucket = await createBucket(client)
+        const sourceKey = `source-${randomUUID()}.txt`
+        const targetKey = `copy-${randomUUID()}.txt`
+
+        await client.send(
+          new PutObjectCommand({
+            Bucket: bucket,
+            Key: sourceKey,
+            Body: 'source',
+            ContentType: 'text/plain',
+          })
+        )
+
+        const multipart = await client.send(
+          new CreateMultipartUploadCommand({
+            Bucket: bucket,
+            Key: targetKey,
+            ContentType: 'text/plain',
+          })
+        )
+        onTestFinished(async () => {
+          await client.send(
+            new AbortMultipartUploadCommand({
+              Bucket: bucket,
+              Key: targetKey,
+              UploadId: multipart.UploadId,
+            })
+          )
+        })
+
+        const signedRequest = await createSignedS3Request({
+          baseUrl,
+          path: `/s3/${bucket}/${targetKey}`,
+          method: 'PUT',
+          query: {
+            partNumber: '1',
+            uploadId: multipart.UploadId!,
+          },
+          headers: {
+            'x-amz-copy-source': `${bucket}/${sourceKey}`,
+          },
+        })
+
+        const response = await fetch(signedRequest.requestUrl, {
+          method: 'PUT',
+          headers: signedRequest.headers,
+        })
+        const body = await response.text()
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain('application/xml')
+        expect(body).toContain('?><CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">')
+        expect(body).not.toContain('<responseBody>')
+      })
+
       it('copies inclusive source ranges without dropping boundary bytes', async () => {
         const bucket = await createBucket(client)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor for performance while improving spec compliance

## What is the current behavior?

xmljs is used for xml parsing/building

## What is the new behavior?

fast-xml-parser and fast-xml-builder are used instead.

## Additional context

Build 3-7x faster, parse is up to 30% faster while being more GC friendly (up to 120x in build). 
Added `text/xml` into accepted xml types.
Fixed double nesting [get bucket location](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html). 
Added S3 namespace.
Hoist the builder.
Disabling coercing for delete, otherwise it can delete wrong keys. 