### PR TITLE
fix: refresh on-request migration context

### DIFF
--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -4,10 +4,12 @@ import { MultitenantMigrationStrategy } from '../../config'
 
 async function loadDbPlugins({
   databaseEnableQueryCancellation = false,
+  dbMigration = {},
   dbMigrationStrategy = MultitenantMigrationStrategy.PROGRESSIVE,
   isMultitenant = false,
 }: {
   databaseEnableQueryCancellation?: boolean
+  dbMigration?: Record<string, number>
   dbMigrationStrategy?: MultitenantMigrationStrategy
   isMultitenant?: boolean
 } = {}) {
@@ -45,7 +47,7 @@ async function loadDbPlugins({
   vi.doMock('@internal/database/migrations', () => {
     return {
       areMigrationsUpToDate,
-      DBMigration: {},
+      DBMigration: dbMigration,
       lastLocalMigrationName,
       progressiveMigrations,
       runMigrationsOnTenant,
@@ -172,6 +174,36 @@ describe('migrations plugin', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.json()).toEqual({ latestMigration: 'search-v2' })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('keeps an applied migration version ahead of the local freeze target', async () => {
+    const plugins = await loadDbPlugins({
+      dbMigration: {
+        initialmigration: 1,
+        'search-v2': 27,
+        'search-v2-optimised': 50,
+      },
+      dbMigrationStrategy: MultitenantMigrationStrategy.ON_REQUEST,
+      isMultitenant: true,
+    })
+
+    plugins.getTenantConfig.mockResolvedValue({
+      databaseUrl: 'postgres://tenant-db',
+      migrationVersion: 'search-v2-optimised',
+      syncMigrationsDone: true,
+    })
+    plugins.lastLocalMigrationName.mockResolvedValue('search-v2')
+
+    const { app, injectTenant } = await buildMigrationApp(plugins)
+
+    try {
+      const response = await injectTenant()
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ latestMigration: 'search-v2-optimised' })
     } finally {
       await app.close()
     }

--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -41,6 +41,9 @@ async function loadDbPlugins({
       getServiceKeyUser,
       getTenantConfig,
       PgTenantConnection: class {},
+      TenantMigrationStatus: {
+        COMPLETED: 'COMPLETED',
+      },
     }
   })
 
@@ -204,6 +207,102 @@ describe('migrations plugin', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.json()).toEqual({ latestMigration: 'search-v2-optimised' })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('persists an applied migration version ahead of the freeze after retrying migrations', async () => {
+    const plugins = await loadDbPlugins({
+      dbMigration: {
+        initialmigration: 1,
+        'search-v2': 27,
+        'search-v2-optimised': 50,
+      },
+      dbMigrationStrategy: MultitenantMigrationStrategy.ON_REQUEST,
+      isMultitenant: true,
+    })
+    const tenant = {
+      databaseUrl: 'postgres://tenant-db',
+      migrationVersion: 'search-v2-optimised',
+      migrationStatus: 'FAILED',
+      syncMigrationsDone: false,
+    }
+
+    plugins.getTenantConfig.mockResolvedValue(tenant)
+    plugins.areMigrationsUpToDate.mockResolvedValue(false)
+    plugins.lastLocalMigrationName.mockResolvedValue('search-v2')
+    plugins.runMigrationsOnTenant.mockResolvedValue(undefined)
+    plugins.updateTenantMigrationsState.mockResolvedValue(undefined)
+
+    const { app, injectTenant } = await buildMigrationApp(plugins)
+
+    try {
+      const response = await injectTenant()
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ latestMigration: 'search-v2-optimised' })
+      expect(plugins.updateTenantMigrationsState).toHaveBeenCalledWith('tenant-id', {
+        migration: 'search-v2-optimised',
+        state: 'COMPLETED',
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('shares migration state refreshed during the flight with every waiting request', async () => {
+    const plugins = await loadDbPlugins({
+      dbMigration: {
+        initialmigration: 1,
+        'search-v2': 27,
+        'search-v2-optimised': 50,
+      },
+      dbMigrationStrategy: MultitenantMigrationStrategy.ON_REQUEST,
+      isMultitenant: true,
+    })
+    const initialTenant = {
+      databaseUrl: 'postgres://tenant-db',
+      migrationVersion: 'initialmigration',
+      syncMigrationsDone: false,
+    }
+    const refreshedTenant = {
+      ...initialTenant,
+      migrationVersion: 'search-v2-optimised',
+    }
+    const migration = Promise.withResolvers<void>()
+    let migrationFinished = false
+
+    plugins.getTenantConfig.mockImplementation(async () =>
+      migrationFinished ? refreshedTenant : initialTenant
+    )
+    plugins.areMigrationsUpToDate.mockResolvedValue(false)
+    plugins.lastLocalMigrationName.mockResolvedValue('search-v2')
+    plugins.runMigrationsOnTenant.mockImplementation(async () => {
+      await migration.promise
+      migrationFinished = true
+    })
+    plugins.updateTenantMigrationsState.mockResolvedValue(undefined)
+
+    const { app, injectTenant } = await buildMigrationApp(plugins)
+
+    try {
+      const first = injectTenant()
+      const second = injectTenant()
+
+      await waitForImmediate()
+      migration.resolve()
+
+      const responses = await Promise.all([first, second])
+
+      expect(responses.map((response) => response.json())).toEqual([
+        { latestMigration: 'search-v2-optimised' },
+        { latestMigration: 'search-v2-optimised' },
+      ])
+      expect(plugins.updateTenantMigrationsState).toHaveBeenCalledWith('tenant-id', {
+        migration: 'search-v2-optimised',
+        state: 'COMPLETED',
+      })
     } finally {
       await app.close()
     }

--- a/src/http/plugins/db.test.ts
+++ b/src/http/plugins/db.test.ts
@@ -26,6 +26,7 @@ async function loadDbPlugins({
   })
   const getTenantConfig = vi.fn()
   const areMigrationsUpToDate = vi.fn()
+  const lastLocalMigrationName = vi.fn().mockResolvedValue('initialmigration')
   const runMigrationsOnTenant = vi.fn()
   const updateTenantMigrationsState = vi.fn()
   const progressiveMigrations = {
@@ -45,7 +46,7 @@ async function loadDbPlugins({
     return {
       areMigrationsUpToDate,
       DBMigration: {},
-      lastLocalMigrationName: vi.fn().mockResolvedValue('initialmigration'),
+      lastLocalMigrationName,
       progressiveMigrations,
       runMigrationsOnTenant,
       updateTenantMigrationsState,
@@ -68,6 +69,7 @@ async function loadDbPlugins({
     areMigrationsUpToDate,
     getPostgresConnection,
     getTenantConfig,
+    lastLocalMigrationName,
     progressiveMigrations,
     requestDb,
     runMigrationsOnTenant,
@@ -127,7 +129,7 @@ describe('migrations plugin', () => {
       request.tenantId = getTenantId(request)
     })
     await app.register(plugins.dbSuperUser)
-    app.get('/test', async () => ({ ok: true }))
+    app.get('/test', async (request) => ({ latestMigration: request.latestMigration }))
 
     const injectTenant = (headers: Record<string, string> = {}) =>
       app.inject({ method: 'GET', url: '/test', headers })
@@ -144,6 +146,35 @@ describe('migrations plugin', () => {
     vi.doUnmock('@internal/database/migrations')
     vi.restoreAllMocks()
     vi.resetModules()
+  })
+
+  it('refreshes the migration version for the request that completes migrations', async () => {
+    const plugins = await loadDbPlugins({
+      dbMigrationStrategy: MultitenantMigrationStrategy.ON_REQUEST,
+      isMultitenant: true,
+    })
+    const tenant = {
+      databaseUrl: 'postgres://tenant-db',
+      migrationVersion: 'initialmigration',
+      syncMigrationsDone: false,
+    }
+
+    plugins.getTenantConfig.mockResolvedValue(tenant)
+    plugins.areMigrationsUpToDate.mockResolvedValue(false)
+    plugins.lastLocalMigrationName.mockResolvedValue('search-v2')
+    plugins.runMigrationsOnTenant.mockResolvedValue(undefined)
+    plugins.updateTenantMigrationsState.mockResolvedValue(undefined)
+
+    const { app, injectTenant } = await buildMigrationApp(plugins)
+
+    try {
+      const response = await injectTenant()
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ latestMigration: 'search-v2' })
+    } finally {
+      await app.close()
+    }
   })
 
   it('shares the same on-request migration check across concurrent same-tenant requests', async () => {
@@ -295,6 +326,7 @@ describe('migrations plugin', () => {
       migrationVersion: 'initialmigration',
       syncMigrationsDone: true,
     })
+    plugins.lastLocalMigrationName.mockResolvedValue('search-v2')
 
     const { app, injectTenant } = await buildMigrationApp(plugins)
 
@@ -302,6 +334,7 @@ describe('migrations plugin', () => {
       const response = await injectTenant()
 
       expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ latestMigration: 'search-v2' })
       expect(plugins.areMigrationsUpToDate).not.toHaveBeenCalled()
       expect(plugins.runMigrationsOnTenant).not.toHaveBeenCalled()
     } finally {

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -29,6 +29,20 @@ const { databaseEnableQueryCancellation, dbMigrationStrategy, isMultitenant, dbM
 
 const migrationSingleFlight = createSingleFlightByKey<void>()
 
+function resolveLatestMigration(
+  localLatest: keyof typeof DBMigration,
+  applied: keyof typeof DBMigration | undefined
+): keyof typeof DBMigration {
+  if (
+    applied &&
+    DBMigration[applied] !== undefined &&
+    DBMigration[applied] > DBMigration[localLatest]
+  ) {
+    return applied
+  }
+  return localLatest
+}
+
 export const db = fastifyPlugin(
   async function db(fastify) {
     fastify.register(migrations)
@@ -149,7 +163,10 @@ export const migrations = fastifyPlugin(
 
         const tenant = await getTenantConfig(request.tenantId)
         if (tenant.syncMigrationsDone) {
-          request.latestMigration = await lastLocalMigrationName()
+          request.latestMigration = resolveLatestMigration(
+            await lastLocalMigrationName(),
+            tenant.migrationVersion
+          )
           return
         }
 
@@ -168,7 +185,10 @@ export const migrations = fastifyPlugin(
           tenant.syncMigrationsDone = true
         })
 
-        request.latestMigration = await lastLocalMigrationName()
+        request.latestMigration = resolveLatestMigration(
+          await lastLocalMigrationName(),
+          tenant.migrationVersion
+        )
       })
     }
 

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -4,6 +4,7 @@ import {
   getServiceKeyUser,
   getTenantConfig,
   type TenantConnection,
+  TenantMigrationStatus,
 } from '@internal/database'
 import {
   areMigrationsUpToDate,
@@ -27,7 +28,7 @@ declare module 'fastify' {
 const { databaseEnableQueryCancellation, dbMigrationStrategy, isMultitenant, dbMigrationFreezeAt } =
   getConfig()
 
-const migrationSingleFlight = createSingleFlightByKey<void>()
+const migrationSingleFlight = createSingleFlightByKey<keyof typeof DBMigration>()
 
 function resolveLatestMigration(
   localLatest: keyof typeof DBMigration,
@@ -170,25 +171,42 @@ export const migrations = fastifyPlugin(
           return
         }
 
-        await migrationSingleFlight(request.tenantId, async () => {
-          if (await areMigrationsUpToDate(request.tenantId)) {
-            tenant.syncMigrationsDone = true
-            return
+        const latestMigration = await migrationSingleFlight(request.tenantId, async () => {
+          const localLatest = await lastLocalMigrationName()
+          const migrationsUpToDate = await areMigrationsUpToDate(request.tenantId)
+
+          if (!migrationsUpToDate) {
+            await runMigrationsOnTenant({
+              databaseUrl: tenant.databaseUrl,
+              tenantId: request.tenantId,
+              upToMigration: dbMigrationFreezeAt,
+            })
           }
 
-          await runMigrationsOnTenant({
-            databaseUrl: tenant.databaseUrl,
-            tenantId: request.tenantId,
-            upToMigration: dbMigrationFreezeAt,
-          })
-          await updateTenantMigrationsState(request.tenantId)
-          tenant.syncMigrationsDone = true
+          const refreshedTenant = await getTenantConfig(request.tenantId)
+          const resolvedMigration = resolveLatestMigration(
+            resolveLatestMigration(localLatest, tenant.migrationVersion),
+            refreshedTenant.migrationVersion
+          )
+
+          if (!migrationsUpToDate) {
+            await updateTenantMigrationsState(request.tenantId, {
+              migration: resolvedMigration,
+              state: TenantMigrationStatus.COMPLETED,
+            })
+          }
+
+          refreshedTenant.migrationVersion = resolvedMigration
+          refreshedTenant.migrationStatus = TenantMigrationStatus.COMPLETED
+          refreshedTenant.syncMigrationsDone = true
+
+          return resolvedMigration
         })
 
-        request.latestMigration = resolveLatestMigration(
-          await lastLocalMigrationName(),
-          tenant.migrationVersion
-        )
+        tenant.migrationVersion = latestMigration
+        tenant.migrationStatus = TenantMigrationStatus.COMPLETED
+        tenant.syncMigrationsDone = true
+        request.latestMigration = latestMigration
       })
     }
 

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -149,6 +149,7 @@ export const migrations = fastifyPlugin(
 
         const tenant = await getTenantConfig(request.tenantId)
         if (tenant.syncMigrationsDone) {
+          request.latestMigration = await lastLocalMigrationName()
           return
         }
 
@@ -166,6 +167,8 @@ export const migrations = fastifyPlugin(
           await updateTenantMigrationsState(request.tenantId)
           tenant.syncMigrationsDone = true
         })
+
+        request.latestMigration = await lastLocalMigrationName()
       })
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Latest migration is set on request so that it can be used in the life cycle of the request.
On request migration runner can run migrations but it doesn't refresh the property on request.
Downstream can see old migration value.

## What is the new behavior?

Migration version is refreshed correctly.

## Additional context

This makes latest migration property more useful (skips LRU cache lookups).
