### PR TITLE
fix: remove redundant tenant config check for migrations

### DIFF
--- a/src/http/routes/object/listObjectsV2.test.ts
+++ b/src/http/routes/object/listObjectsV2.test.ts
@@ -1,0 +1,84 @@
+import { DBMigration } from '@internal/database/migrations'
+import fastify from 'fastify'
+import { vi } from 'vitest'
+import { withFiniteAjv } from '../../finite'
+
+async function createApp(
+  latestMigration: keyof typeof DBMigration,
+  { isMultitenant = true }: { isMultitenant?: boolean } = {}
+) {
+  vi.resetModules()
+  const configModule = await import('../../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig({ isMultitenant })
+  const { default: listObjectsV2 } = await import('./listObjectsV2')
+
+  const list = vi.fn().mockResolvedValue([])
+  const app = fastify(withFiniteAjv({}))
+
+  app.decorateRequest('latestMigration')
+  app.decorateRequest('storage')
+  app.addHook('preHandler', async (request) => {
+    request.latestMigration = latestMigration
+    request.storage = {
+      from: () => ({ listObjectsV2: list }),
+    } as never
+  })
+  app.register(listObjectsV2)
+
+  await app.ready()
+  return { app, list }
+}
+
+describe('listObjectsV2 migration gate', () => {
+  test('rejects an old migration version from multitenant request context', async () => {
+    const { app, list } = await createApp('initialmigration')
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/list-v2/bucket',
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(list).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  test('allows a supported migration version from multitenant request context', async () => {
+    const { app, list } = await createApp('search-v2')
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/list-v2/bucket',
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(list).toHaveBeenCalledOnce()
+    } finally {
+      await app.close()
+    }
+  })
+
+  test('allows an old migration version in single-tenant mode', async () => {
+    const { app, list } = await createApp('initialmigration', { isMultitenant: false })
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/list-v2/bucket',
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(list).toHaveBeenCalledOnce()
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/http/routes/object/listObjectsV2.ts
+++ b/src/http/routes/object/listObjectsV2.ts
@@ -1,4 +1,3 @@
-import { getTenantConfig } from '@internal/database'
 import { DBMigration } from '@internal/database/migrations'
 import { FastifyInstance } from 'fastify'
 import { FastifyRequest } from 'fastify/types/request'
@@ -62,13 +61,15 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      if (isMultitenant) {
-        const { migrationVersion } = await getTenantConfig(request.tenantId)
-        if (migrationVersion && DBMigration[migrationVersion] < DBMigration['search-v2']) {
-          return response.status(400).send({
-            message: 'This feature is not available for your tenant',
-          })
-        }
+      const latestMigration = request.latestMigration
+      if (
+        isMultitenant &&
+        latestMigration &&
+        DBMigration[latestMigration] < DBMigration['search-v2']
+      ) {
+        return response.status(400).send({
+          message: 'This feature is not available for your tenant',
+        })
       }
 
       const { bucketName } = request.params

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -58,9 +58,12 @@ export interface Database {
   reqId?: string
   sbReqId?: string
   role?: string
+  latestMigration?: keyof typeof DBMigration
   connection: TenantConnection
 
   tenant(): { ref: string; host: string }
+
+  hasMigration(migration: keyof typeof DBMigration): Promise<boolean>
 
   asSuperUser(): Database
 

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -47,6 +47,21 @@ describe('escapeLike', () => {
   })
 })
 
+describe('StoragePgDB migration context', () => {
+  const connection = {} as PgTenantConnection
+
+  test('uses the supplied request migration version', async () => {
+    const storage = new StoragePgDB(connection, {
+      tenantId: 'tenant-with-request-context',
+      host: 'localhost',
+      latestMigration: 'search-v2',
+    })
+
+    await expect(storage.hasMigration('custom-metadata')).resolves.toBe(true)
+    await expect(storage.hasMigration('add-search-v2-sort-support')).resolves.toBe(false)
+  })
+})
+
 function createTestPermissionFixture() {
   const transaction = {
     commit: vi.fn().mockResolvedValue(undefined),

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -195,6 +195,14 @@ export class StoragePgDB implements Database {
     }
   }
 
+  async hasMigration(migration: keyof typeof DBMigration): Promise<boolean> {
+    if (this.latestMigration !== undefined) {
+      return DBMigration[this.latestMigration] >= DBMigration[migration]
+    }
+
+    return tenantHasMigrations(this.tenantId, migration)
+  }
+
   asSuperUser() {
     return new StoragePgDB(this.connection.asSuperUser(), {
       ...this.options,
@@ -373,7 +381,7 @@ export class StoragePgDB implements Database {
       file_size_limit: data.file_size_limit,
     }
 
-    if (await tenantHasMigrations(this.tenantId, 'iceberg-catalog-flag-on-buckets')) {
+    if (await this.hasMigration('iceberg-catalog-flag-on-buckets')) {
       bucketData.type = 'STANDARD'
     }
 
@@ -408,10 +416,12 @@ export class StoragePgDB implements Database {
   }
 
   async findBucketById(bucketId: string, columns = 'id', filters?: FindBucketFilters) {
+    const hasBucketType = await this.hasMigration('iceberg-catalog-flag-on-buckets')
+
     const result = await this.runQuery('FindBucketById', async (db, signal) => {
       let columnNames = columns.split(',').map((column) => column.trim())
 
-      if (!(await tenantHasMigrations(this.tenantId, 'iceberg-catalog-flag-on-buckets'))) {
+      if (!hasBucketType) {
         columnNames = columnNames.filter((name) => name !== 'type')
       }
 
@@ -544,6 +554,21 @@ export class StoragePgDB implements Database {
       }
     }
   ) {
+    let useNewSearchVersion2 = true
+    let hasSortSupport = false
+
+    if (options?.delimiter) {
+      if (isMultitenant) {
+        useNewSearchVersion2 = await this.hasMigration('search-v2')
+      }
+
+      if (useNewSearchVersion2 && options.delimiter === '/') {
+        hasSortSupport =
+          (await this.hasMigration('add-search-v2-sort-support')) ||
+          (await this.hasMigration('search-v2-optimised'))
+      }
+    }
+
     return this.runQuery('ListObjectsV2', async (db, signal) => {
       if (!options?.delimiter) {
         const values: unknown[] = [bucketId, options?.maxKeys || 100]
@@ -606,18 +631,9 @@ export class StoragePgDB implements Database {
         return result.rows
       }
 
-      let useNewSearchVersion2 = true
-
-      if (isMultitenant) {
-        useNewSearchVersion2 = await tenantHasMigrations(this.tenantId, 'search-v2')
-      }
-
       if (useNewSearchVersion2 && options?.delimiter === '/') {
         let paramPlaceholders = '$1,$2,$3,$4,$5'
         const sortParams: (string | null)[] = []
-        const hasSortSupport =
-          (await tenantHasMigrations(this.tenantId, 'add-search-v2-sort-support')) ||
-          (await tenantHasMigrations(this.tenantId, 'search-v2-optimised'))
 
         if (hasSortSupport) {
           paramPlaceholders += ',$6,$7,$8'

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,4 @@
 import { tenantHasFeature } from '@internal/database'
-import { tenantHasMigrations } from '@internal/database/migrations'
 import { ERRORS, StorageBackendError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
 import { BucketCreatedEvent, BucketDeleted } from '@storage/events'
@@ -121,7 +120,7 @@ export class Storage {
 
     if (data.type === 'ANALYTICS') {
       if (
-        !(await tenantHasMigrations(this.db.tenantId, 'iceberg-catalog-flag-on-buckets')) ||
+        !(await this.db.hasMigration('iceberg-catalog-flag-on-buckets')) ||
         !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog'))
       ) {
         throw ERRORS.FeatureNotEnabled(
@@ -264,7 +263,7 @@ export class Storage {
 
   async deleteIcebergBucket(name: string) {
     if (
-      !(await tenantHasMigrations(this.db.tenantId, 'iceberg-catalog-flag-on-buckets')) ||
+      !(await this.db.hasMigration('iceberg-catalog-flag-on-buckets')) ||
       !(await tenantHasFeature(this.db.tenantId, 'icebergCatalog'))
     ) {
       throw ERRORS.FeatureNotEnabled(

--- a/src/test/on-request-migrations.test.ts
+++ b/src/test/on-request-migrations.test.ts
@@ -1,0 +1,108 @@
+const previousEnv = vi.hoisted(() => {
+  const values = {
+    isMultitenant: process.env.IS_MULTITENANT,
+    multiTenant: process.env.MULTI_TENANT,
+    requestXForwardedHostRegExp: process.env.REQUEST_X_FORWARDED_HOST_REGEXP,
+  }
+
+  process.env.IS_MULTITENANT = 'true'
+  process.env.MULTI_TENANT = 'true'
+  process.env.REQUEST_X_FORWARDED_HOST_REGEXP = '^([a-z]{20})\\.local\\.test$'
+
+  return values
+})
+
+import { signJWT } from '@internal/auth'
+import { closeMultitenantPg, deleteTenantConfig, TenantMigrationStatus } from '@internal/database'
+import {
+  runMultitenantMigrations,
+  updateTenantMigrationsState,
+} from '@internal/database/migrations'
+import type { FastifyInstance } from 'fastify'
+import { getConfig, MultitenantMigrationStrategy, mergeConfig } from '../config'
+import { adminApp } from './common'
+
+const tenantId = 'migrationsnapshotfix'
+const forwardedHost = `${tenantId}.local.test`
+const adminHeaders = { apikey: process.env.ADMIN_API_KEYS }
+
+let appInstance: FastifyInstance
+let serviceKey: string
+
+beforeAll(async () => {
+  const config = getConfig({ reload: true })
+  mergeConfig({
+    isMultitenant: true,
+    dbMigrationStrategy: MultitenantMigrationStrategy.ON_REQUEST,
+    requestXForwardedHostRegExp: '^([a-z]{20})\\.local\\.test$',
+  })
+
+  await runMultitenantMigrations()
+  await adminApp.inject({
+    method: 'DELETE',
+    url: `/tenants/${tenantId}`,
+    headers: adminHeaders,
+  })
+
+  const jwtSecret = 'on-request-migration-secret'
+  serviceKey = await signJWT({ role: 'service_role' }, jwtSecret, 100)
+  const anonKey = await signJWT({ role: 'anon' }, jwtSecret, 100)
+
+  const createResponse = await adminApp.inject({
+    method: 'POST',
+    url: `/tenants/${tenantId}`,
+    headers: adminHeaders,
+    payload: {
+      anonKey,
+      databaseUrl: config.databaseURL,
+      jwtSecret,
+      serviceKey,
+    },
+  })
+  expect(createResponse.statusCode).toBe(201)
+
+  await updateTenantMigrationsState(tenantId, {
+    migration: 'initialmigration',
+    state: TenantMigrationStatus.COMPLETED,
+  })
+  deleteTenantConfig(tenantId)
+
+  appInstance = (await import('../app')).default()
+})
+
+afterAll(async () => {
+  await appInstance?.close()
+  await adminApp.inject({
+    method: 'DELETE',
+    url: `/tenants/${tenantId}`,
+    headers: adminHeaders,
+  })
+  await adminApp.close()
+  await closeMultitenantPg()
+
+  restoreEnv('IS_MULTITENANT', previousEnv.isMultitenant)
+  restoreEnv('MULTI_TENANT', previousEnv.multiTenant)
+  restoreEnv('REQUEST_X_FORWARDED_HOST_REGEXP', previousEnv.requestXForwardedHostRegExp)
+})
+
+test('list-v2 sees migrations completed by the current request', async () => {
+  const response = await appInstance.inject({
+    method: 'POST',
+    url: '/object/list-v2/bucket2',
+    headers: {
+      authorization: `Bearer ${serviceKey}`,
+      'x-forwarded-host': forwardedHost,
+    },
+    payload: { limit: 1 },
+  })
+
+  expect(response.statusCode).toBe(200)
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring for simplification and kinda performance

## What is the current behavior?

Latest migration is evaluated through tenant config multiple times.

## What is the new behavior?

It's actually set on request, instead use it directly.

## Additional context

Related to #1254 
