### PR TITLE
fix: add code into errors

### DIFF
--- a/src/http/error-handler.test.ts
+++ b/src/http/error-handler.test.ts
@@ -1,10 +1,77 @@
-import { ErrorCode } from '@internal/errors'
+import { ERRORS, ErrorCode } from '@internal/errors'
 import { DBError } from '@storage/database/errors'
 import Fastify from 'fastify'
 import { DatabaseError } from 'pg'
 import { setErrorHandler } from './error-handler'
+import { errorSchema, sharedErrorResponseSchemas } from './schemas/error'
 
 describe('setErrorHandler', () => {
+  it('preserves service codes through the shared 4xx response schema', async () => {
+    const app = Fastify()
+    app.addSchema(errorSchema)
+    setErrorHandler(app)
+
+    app.get(
+      '/missing',
+      {
+        schema: {
+          response: {
+            '4xx': { $ref: 'errorSchema#' },
+          },
+        },
+      },
+      async () => {
+        throw ERRORS.NoSuchKey('missing.txt')
+      }
+    )
+
+    try {
+      const response = await app.inject('/missing')
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({
+        statusCode: '404',
+        error: 'not_found',
+        code: ErrorCode.NoSuchKey,
+        message: 'Object not found',
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('preserves service codes through the shared 5xx response schema', async () => {
+    const app = Fastify()
+    app.addSchema(errorSchema)
+    setErrorHandler(app)
+
+    app.get(
+      '/internal-error',
+      {
+        schema: {
+          response: sharedErrorResponseSchemas,
+        },
+      },
+      async () => {
+        throw ERRORS.InternalError()
+      }
+    )
+
+    try {
+      const response = await app.inject('/internal-error')
+
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        statusCode: '500',
+        error: ErrorCode.InternalError,
+        code: ErrorCode.InternalError,
+        message: 'Internal server error',
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
   it('maps Fastify schema validation failures to InvalidRequest', async () => {
     const app = Fastify()
     setErrorHandler(app)

--- a/src/http/not-found-handler.ts
+++ b/src/http/not-found-handler.ts
@@ -1,0 +1,20 @@
+import { ErrorCode } from '@internal/errors'
+import { FastifyInstance } from 'fastify'
+import { errorSchema } from './schemas'
+
+export function setRestNotFoundHandler(fastify: FastifyInstance) {
+  fastify.setNotFoundHandler((request, reply) => {
+    const serialize = reply.compileSerializationSchema(errorSchema, '404', 'application/json')
+
+    return reply
+      .status(404)
+      .type('application/json')
+      .serializer(serialize)
+      .send({
+        statusCode: '404',
+        error: 'Not Found',
+        message: `Route ${request.method}:${request.raw.url} not found`,
+        code: ErrorCode.InvalidRequest,
+      })
+  })
+}

--- a/src/http/plugins/tenant-feature.ts
+++ b/src/http/plugins/tenant-feature.ts
@@ -1,4 +1,5 @@
 import { Features, tenantHasFeature } from '@internal/database'
+import { ErrorCode } from '@internal/errors'
 import fastifyPlugin from 'fastify-plugin'
 
 import { getConfig } from '../../config'
@@ -24,6 +25,7 @@ export const requireTenantFeature = (feature: keyof Features) =>
             error: 'FeatureNotEnabled',
             statusCode: '403',
             message: 'feature not enabled for this tenant',
+            code: ErrorCode.FeatureNotEnabled,
           })
         }
       })

--- a/src/http/routes-helper.test.ts
+++ b/src/http/routes-helper.test.ts
@@ -51,6 +51,7 @@ describe('testing Generic Routes Utils', () => {
         response: {
           200: successResponseSchema,
           '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+          '5xx': { $ref: 'errorSchema#', description: 'Error response' },
         },
       }
 
@@ -67,6 +68,7 @@ describe('testing Generic Routes Utils', () => {
         response: {
           200: successResponseSchema,
           '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+          '5xx': { $ref: 'errorSchema#', description: 'Error response' },
         },
         ...additionalProperties,
       }

--- a/src/http/routes-helper.ts
+++ b/src/http/routes-helper.ts
@@ -1,3 +1,5 @@
+import { sharedErrorResponseSchemas } from './schemas/error'
+
 type BucketResponseType = { message: string; statusCode?: string; error?: string }
 type SchemaObject = Record<string, unknown>
 
@@ -32,7 +34,7 @@ function createDefaultSchema(
     headers: { $ref: 'authSchema#' },
     response: {
       200: { description: 'Successful response', ...successResponseSchema },
-      '4xx': { description: 'Error response', $ref: 'errorSchema#' },
+      ...sharedErrorResponseSchemas,
     },
     ...properties,
   }

--- a/src/http/routes/bucket/index.ts
+++ b/src/http/routes/bucket/index.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify'
+import { setRestNotFoundHandler } from '../../not-found-handler'
 import { db, registerJwtAuth, storage } from '../../plugins'
 import createBucket from './createBucket'
 import deleteBucket from './deleteBucket'
@@ -8,14 +9,18 @@ import getBucket from './getBucket'
 import updateBucket from './updateBucket'
 
 export default async function routes(fastify: FastifyInstance) {
-  registerJwtAuth(fastify)
-  fastify.register(db)
-  fastify.register(storage)
+  setRestNotFoundHandler(fastify)
 
-  fastify.register(createBucket)
-  fastify.register(emptyBucket)
-  fastify.register(getAllBuckets)
-  fastify.register(getBucket)
-  fastify.register(updateBucket)
-  fastify.register(deleteBucket)
+  fastify.register(async function authenticated(fastify) {
+    registerJwtAuth(fastify)
+    fastify.register(db)
+    fastify.register(storage)
+
+    fastify.register(createBucket)
+    fastify.register(emptyBucket)
+    fastify.register(getAllBuckets)
+    fastify.register(getBucket)
+    fastify.register(updateBucket)
+    fastify.register(deleteBucket)
+  })
 }

--- a/src/http/routes/cdn/index.ts
+++ b/src/http/routes/cdn/index.ts
@@ -1,11 +1,14 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
+import { setRestNotFoundHandler } from '../../not-found-handler'
 import { registerJwtAuth, requireTenantFeature } from '../../plugins'
 import purgeCache from './purgeCache'
 
 const { dbServiceRole } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
+  setRestNotFoundHandler(fastify)
+
   fastify.register(async function authenticated(fastify) {
     registerJwtAuth(fastify, {
       enforceJwtRoles: [dbServiceRole],

--- a/src/http/routes/iceberg/index.test.ts
+++ b/src/http/routes/iceberg/index.test.ts
@@ -1,5 +1,7 @@
+import { ErrorCode } from '@internal/errors'
 import type { FastifyInstance } from 'fastify'
 import { vi } from 'vitest'
+import { errorSchema } from '../../schemas/error'
 
 const icebergRouteModules = ['./bucket', './catalog', './namespace', './table']
 const icebergProbeRouteModule = './bucket'
@@ -73,6 +75,7 @@ describe('iceberg routes', () => {
         error: 'FeatureNotEnabled',
         statusCode: '403',
         message: 'feature not enabled for this tenant',
+        code: ErrorCode.FeatureNotEnabled,
       },
       expectedStatusCode: 403,
       hasFeature: false,
@@ -180,6 +183,7 @@ async function loadRoutes({
   const { default: fastify } = await import('fastify')
   const { default: routes } = await import('./index')
   const app = fastify()
+  app.addSchema(errorSchema)
   app.addHook('onRequest', (request, _reply, done) => {
     request.tenantId = 'tenant-a'
     done()
@@ -191,5 +195,15 @@ async function loadRoutes({
 }
 
 async function probeRoute(fastify: FastifyInstance) {
-  fastify.get('/probe', async () => ({ ok: true }))
+  fastify.get(
+    '/probe',
+    {
+      schema: {
+        response: {
+          '4xx': { $ref: 'errorSchema#' },
+        },
+      },
+    },
+    async () => ({ ok: true })
+  )
 }

--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -3,6 +3,7 @@ import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
@@ -94,7 +95,7 @@ export default async function routes(fastify: FastifyInstance) {
         querystring: getObjectQuerySchema,
         headers: { $ref: 'authSchema#' },
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['object'],
       },
       config: {
@@ -116,7 +117,7 @@ export default async function routes(fastify: FastifyInstance) {
         summary: 'Get object',
         description: 'Serve objects',
         tags: ['object'],
-        response: { '4xx': { $ref: 'errorSchema#' } },
+        response: sharedErrorResponseSchemas,
       },
       config: {
         operation: ROUTE_OPERATIONS.GET_AUTH_OBJECT,

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -3,6 +3,7 @@ import { Obj } from '@storage/schemas'
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { transformationOptionsSchema } from '../../schemas/transformations'
 import { AuthenticatedRangeRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
@@ -98,7 +99,7 @@ export async function publicRoutes(fastify: FastifyInstance) {
         summary: 'Get object info',
         description: 'returns object info',
         tags: ['object'],
-        response: { '4xx': { $ref: 'errorSchema#' } },
+        response: sharedErrorResponseSchemas,
       },
       config: {
         operation: ROUTE_OPERATIONS.INFO_PUBLIC_OBJECT,
@@ -119,7 +120,7 @@ export async function publicRoutes(fastify: FastifyInstance) {
         summary: 'Get object info',
         description: 'returns object info',
         tags: ['object'],
-        response: { '4xx': { $ref: 'errorSchema#' } },
+        response: sharedErrorResponseSchemas,
       },
       config: {
         operation: ROUTE_OPERATIONS.INFO_PUBLIC_OBJECT,
@@ -141,7 +142,7 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
         querystring: getObjectInfoQuerySchema,
         headers: { $ref: 'authSchema#' },
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['object'],
       },
       config: {
@@ -161,7 +162,7 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
         querystring: getObjectInfoQuerySchema,
         headers: { $ref: 'authSchema#' },
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['object'],
       },
       config: {
@@ -182,7 +183,7 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
         summary,
         description: 'Object Info',
         tags: ['object'],
-        response: { '4xx': { $ref: 'errorSchema#' } },
+        response: sharedErrorResponseSchemas,
       },
       config: {
         operation: ROUTE_OPERATIONS.GET_AUTH_OBJECT_INFO,
@@ -203,7 +204,7 @@ export async function authenticatedRoutes(fastify: FastifyInstance) {
         summary,
         description: 'Head object info',
         tags: ['object'],
-        response: { '4xx': { $ref: 'errorSchema#' } },
+        response: sharedErrorResponseSchemas,
       },
       config: {
         operation: ROUTE_OPERATIONS.HEAD_AUTH_OBJECT_INFO,

--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
@@ -40,7 +41,7 @@ export default async function routes(fastify: FastifyInstance) {
         params: getPublicObjectParamsSchema,
         querystring: getObjectQuerySchema,
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['object'],
       },
       config: {

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
 import { SIGNED_URL_SCOPE_DOWNLOAD } from '../../../internal/auth'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket } = getConfig()
@@ -47,7 +48,7 @@ export default async function routes(fastify: FastifyInstance) {
         params: getSignedObjectParamsSchema,
         querystring: getSignedObjectQSSchema,
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['object'],
       },
       config: {

--- a/src/http/routes/object/index.ts
+++ b/src/http/routes/object/index.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify'
+import { setRestNotFoundHandler } from '../../not-found-handler'
 import { db, dbSuperUser, registerJwtAuth, storage } from '../../plugins'
 import copyObject from './copyObject'
 import createObject from './createObject'
@@ -21,6 +22,8 @@ import updateObject from './updateObject'
 import uploadSignedObject from './uploadSignedObject'
 
 export default async function routes(fastify: FastifyInstance) {
+  setRestNotFoundHandler(fastify)
+
   fastify.register(async function authenticated(fastify) {
     registerJwtAuth(fastify)
     fastify.register(db)

--- a/src/http/routes/object/listObjectsV2.test.ts
+++ b/src/http/routes/object/listObjectsV2.test.ts
@@ -1,7 +1,9 @@
 import { DBMigration } from '@internal/database/migrations'
+import { ErrorCode } from '@internal/errors'
 import fastify from 'fastify'
 import { vi } from 'vitest'
 import { withFiniteAjv } from '../../finite'
+import { errorSchema } from '../../schemas/error'
 
 async function createApp(
   latestMigration: keyof typeof DBMigration,
@@ -16,6 +18,7 @@ async function createApp(
   const list = vi.fn().mockResolvedValue([])
   const app = fastify(withFiniteAjv({}))
 
+  app.addSchema(errorSchema)
   app.decorateRequest('latestMigration')
   app.decorateRequest('storage')
   app.addHook('preHandler', async (request) => {
@@ -31,7 +34,7 @@ async function createApp(
 }
 
 describe('listObjectsV2 migration gate', () => {
-  test('rejects an old migration version from multitenant request context', async () => {
+  test('returns the shared error contract for an old multitenant migration', async () => {
     const { app, list } = await createApp('initialmigration')
 
     try {
@@ -42,6 +45,12 @@ describe('listObjectsV2 migration gate', () => {
       })
 
       expect(response.statusCode).toBe(400)
+      expect(response.json()).toEqual({
+        statusCode: '400',
+        error: 'FeatureNotEnabled',
+        message: 'This feature is not available for your tenant',
+        code: ErrorCode.FeatureNotEnabled,
+      })
       expect(list).not.toHaveBeenCalled()
     } finally {
       await app.close()

--- a/src/http/routes/object/listObjectsV2.ts
+++ b/src/http/routes/object/listObjectsV2.ts
@@ -1,8 +1,10 @@
 import { DBMigration } from '@internal/database/migrations'
+import { ErrorCode } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FastifyRequest } from 'fastify/types/request'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 
@@ -46,6 +48,7 @@ export default async function routes(fastify: FastifyInstance) {
       schema: {
         body: searchRequestBodySchema,
         params: searchRequestParamsSchema,
+        response: sharedErrorResponseSchemas,
         summary,
         tags: ['object'],
       },
@@ -68,7 +71,10 @@ export default async function routes(fastify: FastifyInstance) {
         DBMigration[latestMigration] < DBMigration['search-v2']
       ) {
         return response.status(400).send({
+          statusCode: '400',
+          error: 'FeatureNotEnabled',
           message: 'This feature is not available for your tenant',
+          code: ErrorCode.FeatureNotEnabled,
         })
       }
 

--- a/src/http/routes/object/uploadSignedObject.ts
+++ b/src/http/routes/object/uploadSignedObject.ts
@@ -2,6 +2,7 @@ import fastifyMultipart from '@fastify/multipart'
 import { SIGNED_URL_SCOPE_UPLOAD } from '@internal/auth'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const uploadSignedObjectParamsSchema = {
@@ -70,7 +71,7 @@ export default async function routes(fastify: FastifyInstance) {
         summary,
         response: {
           200: { description: 'Successful response', ...successResponseSchema },
-          '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+          ...sharedErrorResponseSchemas,
         },
         tags: ['object'],
       },

--- a/src/http/routes/render/index.ts
+++ b/src/http/routes/render/index.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
+import { setRestNotFoundHandler } from '../../not-found-handler'
 import { db, dbSuperUser, registerJwtAuth, requireTenantFeature, storage } from '../../plugins'
 import { rateLimiter } from './rate-limiter'
 import renderAuthenticatedImage from './renderAuthenticatedImage'
@@ -9,6 +10,8 @@ import renderSignedImage from './renderSignedImage'
 const { imageTransformationEnabled, rateLimiterEnabled } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
+  setRestNotFoundHandler(fastify)
+
   if (!imageTransformationEnabled) {
     return
   }

--- a/src/http/routes/render/rate-limiter.test.ts
+++ b/src/http/routes/render/rate-limiter.test.ts
@@ -1,0 +1,60 @@
+import { ErrorCode } from '@internal/errors'
+import Fastify from 'fastify'
+import { setErrorHandler } from '../../error-handler'
+import { errorSchema } from '../../schemas/error'
+
+describe('render rate limiter', () => {
+  afterEach(() => {
+    vi.doUnmock('../../../config')
+    vi.resetModules()
+  })
+
+  it('returns SlowDown after the request limit is exceeded', async () => {
+    vi.doMock('../../../config', () => ({
+      getConfig: () => ({
+        rateLimiterDriver: 'memory',
+        rateLimiterRedisUrl: '',
+        rateLimiterSkipOnError: false,
+        rateLimiterRedisConnectTimeout: 1,
+        rateLimiterRedisCommandTimeout: 1,
+        rateLimiterRenderPathMaxReqSec: 1,
+      }),
+    }))
+
+    const { rateLimiter } = await import('./rate-limiter')
+    const app = Fastify()
+    app.addSchema(errorSchema)
+    setErrorHandler(app)
+    await app.register(rateLimiter)
+    app.get(
+      '/render',
+      {
+        schema: {
+          response: {
+            '4xx': { $ref: 'errorSchema#' },
+          },
+        },
+      },
+      async () => ({ ok: true })
+    )
+
+    try {
+      for (let request = 0; request < 4; request++) {
+        const response = await app.inject('/render')
+        expect(response.statusCode).toBe(200)
+      }
+
+      const response = await app.inject('/render')
+
+      expect(response.statusCode).toBe(429)
+      expect(response.json()).toMatchObject({
+        statusCode: '429',
+        error: 'Too Many Requests',
+        code: ErrorCode.SlowDown,
+        message: expect.stringContaining('Rate limit exceeded'),
+      })
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/http/routes/render/rate-limiter.ts
+++ b/src/http/routes/render/rate-limiter.ts
@@ -1,4 +1,5 @@
 import fastifyRateLimit from '@fastify/rate-limit'
+import { ErrorCode } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 import Redis from 'ioredis'
@@ -21,6 +22,13 @@ export const rateLimiter = fp((fastify: FastifyInstance, _ops: unknown, done: ()
     continueExceeding: true,
     nameSpace: 'image-transformation-ratelimit-',
     skipOnError: rateLimiterSkipOnError,
+    errorResponseBuilder(_request, context) {
+      return Object.assign(new Error(`Rate limit exceeded, retry in ${context.after}`), {
+        name: 'Too Many Requests',
+        code: ErrorCode.SlowDown,
+        statusCode: context.statusCode,
+      })
+    },
     redis:
       rateLimiterDriver === 'redis'
         ? new Redis(rateLimiterRedisUrl || '', {

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -3,6 +3,7 @@ import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
@@ -39,7 +40,7 @@ export default async function routes(fastify: FastifyInstance) {
         params: renderAuthenticatedImageParamsSchema,
         querystring: renderImageQuerySchema,
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['transformation'],
       },
       config: {

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -3,6 +3,7 @@ import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { transformationOptionsSchema } from '../../schemas/transformations'
 import { ROUTE_OPERATIONS } from '../operations'
 
@@ -39,7 +40,7 @@ export default async function routes(fastify: FastifyInstance) {
         params: renderPublicImageParamsSchema,
         querystring: renderImageQuerySchema,
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['transformation'],
       },
       config: {

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -4,6 +4,7 @@ import { ImageRenderer } from '@storage/renderer'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { getConfig } from '../../../config'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { ROUTE_OPERATIONS } from '../operations'
 
 const { storageS3Bucket, isMultitenant } = getConfig()
@@ -45,7 +46,7 @@ export default async function routes(fastify: FastifyInstance) {
         params: renderAuthenticatedImageParamsSchema,
         querystring: renderImageQuerySchema,
         summary,
-        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        response: sharedErrorResponseSchemas,
         tags: ['transformation'],
       },
       config: {

--- a/src/http/routes/vector/create-bucket.ts
+++ b/src/http/routes/vector/create-bucket.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -33,6 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...createVectorBucket,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/create-index.ts
+++ b/src/http/routes/vector/create-index.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -63,6 +64,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...createVectorIndex,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/delete-bucket.ts
+++ b/src/http/routes/vector/delete-bucket.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -33,6 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...deleteVectorBucket,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/delete-index.ts
+++ b/src/http/routes/vector/delete-index.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -41,6 +42,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...deleteVectorIndex,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/delete-vectors.ts
+++ b/src/http/routes/vector/delete-vectors.ts
@@ -2,6 +2,7 @@ import { ERRORS } from '@internal/errors'
 import { MAX_DELETE_VECTOR_KEYS, MAX_VECTOR_KEY_LENGTH } from '@storage/protocols/vector/limits'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -40,6 +41,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...deleteVector,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/get-bucket.ts
+++ b/src/http/routes/vector/get-bucket.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -33,6 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...getVectorBucket,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/get-index.ts
+++ b/src/http/routes/vector/get-index.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -41,6 +42,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...getVectorIndex,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/get-vectors.ts
+++ b/src/http/routes/vector/get-vectors.ts
@@ -2,6 +2,7 @@ import { ERRORS } from '@internal/errors'
 import { MAX_GET_VECTOR_KEYS, MAX_VECTOR_KEY_LENGTH } from '@storage/protocols/vector/limits'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -43,6 +44,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...getVectors,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/index.test.ts
+++ b/src/http/routes/vector/index.test.ts
@@ -1,5 +1,7 @@
+import { ErrorCode } from '@internal/errors'
 import type { FastifyInstance } from 'fastify'
 import { vi } from 'vitest'
+import { errorSchema } from '../../schemas/error'
 
 const vectorCommandModules = [
   './create-bucket',
@@ -87,6 +89,7 @@ describe('vector routes', () => {
         error: 'FeatureNotEnabled',
         statusCode: '403',
         message: 'feature not enabled for this tenant',
+        code: ErrorCode.FeatureNotEnabled,
       },
       expectedStatusCode: 403,
       hasFeature: false,
@@ -196,6 +199,7 @@ async function loadRoutes({
   const { default: fastify } = await import('fastify')
   const { default: routes } = await import('./index')
   const app = fastify()
+  app.addSchema(errorSchema)
   app.addHook('onRequest', (request, _reply, done) => {
     request.tenantId = 'tenant-a'
     done()
@@ -207,5 +211,15 @@ async function loadRoutes({
 }
 
 async function probeRoute(fastify: FastifyInstance) {
-  fastify.get('/probe', async () => ({ ok: true }))
+  fastify.get(
+    '/probe',
+    {
+      schema: {
+        response: {
+          '4xx': { $ref: 'errorSchema#' },
+        },
+      },
+    },
+    async () => ({ ok: true })
+  )
 }

--- a/src/http/routes/vector/index.ts
+++ b/src/http/routes/vector/index.ts
@@ -2,6 +2,7 @@ import { SignatureV4Service } from '@storage/protocols/s3'
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
 import { setErrorHandler } from '../../error-handler'
+import { setRestNotFoundHandler } from '../../not-found-handler'
 import {
   dbSuperUser,
   enforceJwtRole,
@@ -26,6 +27,8 @@ import queryVectors from './query-vectors'
 
 export default async function routes(fastify: FastifyInstance) {
   const { dbServiceRole, vectorEnabled, isMultitenant } = getConfig()
+
+  setRestNotFoundHandler(fastify)
 
   if (!vectorEnabled && !isMultitenant) {
     return

--- a/src/http/routes/vector/list-buckets.ts
+++ b/src/http/routes/vector/list-buckets.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -34,6 +35,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...listBucket,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/list-indexes.ts
+++ b/src/http/routes/vector/list-indexes.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -36,6 +37,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...listIndex,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/list-vectors.ts
+++ b/src/http/routes/vector/list-vectors.ts
@@ -2,6 +2,7 @@ import { ERRORS } from '@internal/errors'
 import { MAX_LIST_RESULTS, MAX_SEGMENT_COUNT } from '@storage/protocols/vector/limits'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -49,6 +50,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...listVectors,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/put-vectors.ts
+++ b/src/http/routes/vector/put-vectors.ts
@@ -6,6 +6,7 @@ import {
 } from '@storage/protocols/vector/limits'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -85,6 +86,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         ...putVector,
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
       },
     },

--- a/src/http/routes/vector/query-vectors.ts
+++ b/src/http/routes/vector/query-vectors.ts
@@ -2,6 +2,7 @@ import { ERRORS } from '@internal/errors'
 import { MAX_QUERY_TOP_K, MIN_VECTOR_DIMENSIONS } from '@storage/protocols/vector/limits'
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
+import { sharedErrorResponseSchemas } from '../../schemas/error'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
 import { compileNoCoercionValidator } from './validation'
@@ -199,6 +200,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       schema: {
         body: { $ref: 'queryVectorBodyDoc#' },
+        response: sharedErrorResponseSchemas,
         tags: ['vector'],
         summary: 'Query vectors',
       },

--- a/src/http/schemas/error.ts
+++ b/src/http/schemas/error.ts
@@ -5,6 +5,12 @@ export const errorSchema = {
     statusCode: { type: 'string' },
     error: { type: 'string' },
     message: { type: 'string' },
+    code: { type: 'string' },
   },
-  required: ['statusCode', 'error', 'message'],
+  required: ['statusCode', 'error', 'message', 'code'],
+} as const
+
+export const sharedErrorResponseSchemas = {
+  '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+  '5xx': { $ref: 'errorSchema#', description: 'Error response' },
 } as const

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -1,11 +1,19 @@
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import type { FastifyRequest } from 'fastify'
+import { ErrorCode } from '@internal/errors'
+import Fastify, { type FastifyRequest } from 'fastify'
 import { Readable } from 'stream'
+import { errorSchema } from '../../http/schemas/error'
 import { spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 import type { StorageBackendAdapter } from '../backend'
 
 const EXHAUSTED_RETRY_BACKOFF_MS = 50 + 100 + 200 + 400 + 800
+const REQUEST_ABORTED_RESPONSE = {
+  error: 'Request aborted',
+  message: 'Request aborted',
+  statusCode: '499',
+  code: ErrorCode.Aborted,
+} as const
 
 async function readStream(stream: unknown) {
   const chunks: Buffer[] = []
@@ -328,6 +336,90 @@ describe('ImageRenderer fetch client', () => {
     )
 
     expect(infoReply.header).not.toHaveBeenCalledWith('Cache-Control', expect.anything())
+  })
+
+  it('serializes backend 404s through the shared error schema', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class MissingAssetRenderer extends Renderer {
+      async getAsset(): Promise<never> {
+        throw Object.assign(new Error('missing asset'), {
+          $metadata: { httpStatusCode: 404 },
+        })
+      }
+    }
+
+    const app = Fastify()
+    app.addSchema(errorSchema)
+    app.get(
+      '/missing',
+      {
+        schema: {
+          response: {
+            '4xx': { $ref: 'errorSchema#' },
+          },
+        },
+      },
+      async (request, reply) =>
+        new MissingAssetRenderer().render(request, reply, createRenderOptions())
+    )
+
+    try {
+      const response = await app.inject('/missing')
+
+      expect(response.statusCode).toBe(400)
+      expect(response.headers['cache-control']).toBe('no-store')
+      expect(response.json()).toEqual({
+        error: 'Not found',
+        message: 'The resource was not found',
+        statusCode: '404',
+        code: ErrorCode.NoSuchKey,
+      })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('serializes caller aborts through the shared error schema', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class TestRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: Buffer.from('body'),
+          metadata: {},
+        }
+      }
+    }
+
+    const controller = new AbortController()
+    controller.abort()
+
+    const app = Fastify()
+    app.addSchema(errorSchema)
+    app.get(
+      '/aborted',
+      {
+        schema: {
+          response: {
+            '4xx': { $ref: 'errorSchema#' },
+          },
+        },
+      },
+      async (request, reply) =>
+        new TestRenderer().render(request, reply, createRenderOptions(controller.signal))
+    )
+
+    try {
+      const response = await app.inject('/aborted')
+
+      expect(response.statusCode).toBe(499)
+      expect(response.json()).toEqual(REQUEST_ABORTED_RESPONSE)
+    } finally {
+      await app.close()
+    }
   })
 
   it('omits nullish Cache-Control parts when only shared cache max-age applies', async () => {
@@ -1365,7 +1457,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
@@ -1408,7 +1500,7 @@ describe('ImageRenderer fetch client', () => {
       expect(unhandledRejection).not.toHaveBeenCalled()
       expect(reply.status).toHaveBeenCalledWith(499)
       expect(reply.status).not.toHaveBeenCalledWith(200)
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+      expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
       expect(fetchMock).toHaveBeenCalledTimes(1)
     } finally {
       process.off('unhandledRejection', unhandledRejection)
@@ -1698,7 +1790,7 @@ describe('ImageRenderer fetch client', () => {
 
     expect(cancelSpy).toHaveBeenCalledTimes(1)
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
@@ -1731,7 +1823,7 @@ describe('ImageRenderer fetch client', () => {
     expect(body.destroyed).toBe(true)
     expect(reply.status).toHaveBeenCalledWith(499)
     expect(reply.status).not.toHaveBeenCalledWith(200)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('destroys an asset body when header setup fails before send', async () => {
@@ -1911,7 +2003,7 @@ describe('ImageRenderer fetch client', () => {
     await renderPromise
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
@@ -1974,7 +2066,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('maps nested caller abort causes during render to the request-aborted response', async () => {
@@ -2003,7 +2095,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('maps storage errors wrapping caller aborts to the request-aborted response', async () => {
@@ -2029,7 +2121,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('maps nested storage original errors wrapping caller aborts to the request-aborted response', async () => {
@@ -2056,7 +2148,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('maps fresh SDK AbortError instances after caller aborts to the request-aborted response', async () => {
@@ -2082,7 +2174,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('maps deep caller abort cause chains without recursive stack growth', async () => {
@@ -2109,7 +2201,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
   })
 
   it('does not let throwing error cause getters poison caller abort checks', async () => {
@@ -2300,7 +2392,7 @@ describe('ImageRenderer fetch client', () => {
     await renderer.render(createRequest(), reply as never, createRenderOptions(controller.signal))
 
     expect(reply.status).toHaveBeenCalledWith(499)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'Request aborted', statusCode: '499' })
+    expect(reply.send).toHaveBeenCalledWith(REQUEST_ABORTED_RESPONSE)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '@internal/errors'
 import { validateXRobotsTag } from '@storage/validators/x-robots-tag'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { Readable } from 'stream'
@@ -90,6 +91,7 @@ export abstract class Renderer {
           error: 'Not found',
           message: 'The resource was not found',
           statusCode: '404',
+          code: ErrorCode.NoSuchKey,
         })
       }
 
@@ -203,7 +205,12 @@ export abstract class Renderer {
   }
 
   protected sendRequestAborted(response: FastifyReply) {
-    return response.status(499).send({ error: 'Request aborted', statusCode: '499' })
+    return response.status(499).send({
+      error: 'Request aborted',
+      message: 'Request aborted',
+      statusCode: '499',
+      code: ErrorCode.Aborted,
+    })
   }
 
   protected findEtagHeader(request: FastifyRequest) {

--- a/src/test/app.test.ts
+++ b/src/test/app.test.ts
@@ -1,4 +1,5 @@
 import net, { AddressInfo } from 'node:net'
+import { ErrorCode } from '@internal/errors'
 import { FastifyInstance } from 'fastify'
 import app from '../app'
 import { getConfig } from '../config'
@@ -80,6 +81,57 @@ describe('app request parsing', () => {
       statusCode: '415',
       error: 'invalid_mime_type',
       message: 'Invalid Content-Type header',
+      code: ErrorCode.InvalidMimeType,
     })
+  })
+
+  test('returns schema-bound error codes for unmatched REST routes', async () => {
+    const urls = [
+      '/bucket/not-a-route/extra',
+      '/object/not-a-route',
+      '/render/image/not-a-route',
+      '/cdn/not-a-route',
+      '/vector/not-a-route',
+    ]
+
+    for (const url of urls) {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(JSON.parse(response.body)).toEqual({
+        statusCode: '404',
+        error: 'Not Found',
+        message: `Route GET:${url} not found`,
+        code: ErrorCode.InvalidRequest,
+      })
+    }
+  })
+
+  test('leaves unmatched non-REST routes on their protocol-specific handlers', async () => {
+    const s3Response = await appInstance.inject({
+      method: 'GET',
+      url: '/s3/not-a-route',
+    })
+
+    expect(s3Response.statusCode).toBe(403)
+    expect(s3Response.headers['content-type']).toBe('application/xml; charset=utf-8')
+    expect(s3Response.body).toContain('<Code>AccessDenied</Code>')
+
+    for (const url of ['/iceberg/not-a-route', '/upload/resumable/not-a-route']) {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url,
+      })
+
+      expect(response.statusCode).toBe(404)
+      expect(JSON.parse(response.body)).toEqual({
+        message: `Route GET:${url} not found`,
+        error: 'Not Found',
+        statusCode: 404,
+      })
+    }
   })
 })

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -1,4 +1,5 @@
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
+import { ErrorCode } from '@internal/errors'
 import { StoragePgDB } from '@storage/database'
 import { randomUUID } from 'crypto'
 import dotenv from 'dotenv'
@@ -342,6 +343,7 @@ describe('testing POST bucket', () => {
       error: 'Invalid Input',
       message: 'Bucket name invalid',
       statusCode: '400',
+      code: ErrorCode.InvalidBucketName,
     })
   })
 
@@ -709,6 +711,7 @@ describe('testing DELETE bucket', () => {
       statusCode: '404',
       error: 'Bucket not found',
       message: 'Bucket not found',
+      code: ErrorCode.NoSuchBucket,
     })
   })
 
@@ -783,6 +786,7 @@ describe('testing EMPTY bucket', () => {
       statusCode: '404',
       error: 'Bucket not found',
       message: 'Bucket not found',
+      code: ErrorCode.NoSuchBucket,
     })
   })
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -265,6 +265,7 @@ describe('testing GET object', () => {
       statusCode: '404',
       error: 'not_found',
       message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
     })
     expect(S3Backend.prototype.headObject).not.toHaveBeenCalled()
   })
@@ -456,6 +457,7 @@ describe('testing POST object via multipart upload', () => {
         statusCode: '403',
         error: 'Unauthorized',
         message: 'new row violates row-level security policy',
+        code: ErrorCode.AccessDenied,
       })
     )
   })
@@ -545,6 +547,7 @@ describe('testing POST object via multipart upload', () => {
       error: 'Payload too large',
       message: 'The object exceeded the maximum allowed size',
       statusCode: '413',
+      code: ErrorCode.EntityTooLarge,
     })
     expect(S3Backend.prototype.uploadObject).toHaveBeenCalled()
   })
@@ -735,6 +738,7 @@ describe('testing POST object via multipart upload', () => {
       error: 'invalid_mime_type',
       message: `mime type image/png is not supported`,
       statusCode: '415',
+      code: ErrorCode.InvalidMimeType,
     })
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
@@ -759,6 +763,7 @@ describe('testing POST object via multipart upload', () => {
       error: 'invalid_mime_type',
       message: `mime type image/png is not supported`,
       statusCode: '415',
+      code: ErrorCode.InvalidMimeType,
     })
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
@@ -808,6 +813,7 @@ describe('testing POST object via multipart upload', () => {
         error: 'invalid_mime_type',
         message: `mime type image/png is not supported`,
         statusCode: '415',
+        code: ErrorCode.InvalidMimeType,
       })
       expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
     } finally {
@@ -845,6 +851,7 @@ describe('testing POST object via multipart upload', () => {
       error: 'invalid_mime_type',
       message: 'Invalid Content-Type header',
       statusCode: '415',
+      code: ErrorCode.InvalidMimeType,
     })
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
@@ -869,6 +876,7 @@ describe('testing POST object via multipart upload', () => {
       error: 'invalid_mime_type',
       message: 'Invalid Content-Type header',
       statusCode: '415',
+      code: ErrorCode.InvalidMimeType,
     })
     expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
@@ -914,6 +922,7 @@ describe('testing POST object via multipart upload', () => {
         statusCode: '413',
         error: 'Payload too large',
         message: 'The object exceeded the maximum allowed size',
+        code: ErrorCode.EntityTooLarge,
       })
     )
   })
@@ -1035,6 +1044,7 @@ describe('testing POST object via binary upload', () => {
         statusCode: '403',
         error: 'Unauthorized',
         message: 'new row violates row-level security policy',
+        code: ErrorCode.AccessDenied,
       })
     )
   })
@@ -1144,6 +1154,7 @@ describe('testing POST object via binary upload', () => {
         statusCode: '413',
         error: 'Payload too large',
         message: 'The object exceeded the maximum allowed size',
+        code: ErrorCode.EntityTooLarge,
       })
     )
   })
@@ -1195,6 +1206,7 @@ describe('testing POST object via binary upload', () => {
         statusCode: '413',
         error: 'Payload too large',
         message: 'The object exceeded the maximum allowed size',
+        code: ErrorCode.EntityTooLarge,
       })
     )
     // Early size check in fileUploadFromRequest rejects before reaching the backend
@@ -2316,6 +2328,7 @@ describe('testing generating signed URL for upload', () => {
         statusCode: '403',
         error: 'Unauthorized',
         message: 'new row violates row-level security policy',
+        code: ErrorCode.AccessDenied,
       })
     )
     // Ensure that row does not exist in database.

--- a/src/test/vectors.test.ts
+++ b/src/test/vectors.test.ts
@@ -7,7 +7,7 @@ import {
   QueryVectorsOutput,
 } from '@aws-sdk/client-s3vectors'
 import { signJWT } from '@internal/auth'
-import { ERRORS } from '@internal/errors'
+import { ERRORS, ErrorCode } from '@internal/errors'
 import { SingleShard } from '@internal/sharding'
 import { PgVectorMetadataDB, VectorStore, VectorStoreManager } from '@storage/protocols/vector'
 import { FastifyInstance } from 'fastify'
@@ -434,8 +434,12 @@ describe('Vectors API', () => {
         })
 
         expect(response.statusCode).toBe(404)
-        const body = JSON.parse(response.body)
-        expect(body.error).toBe('Not Found')
+        expect(JSON.parse(response.body)).toEqual({
+          statusCode: '404',
+          error: 'Not Found',
+          message: 'Route POST:/vector/CreateIndex not found',
+          code: ErrorCode.InvalidRequest,
+        })
       } finally {
         await appWithoutVector.close()
       }
@@ -482,6 +486,12 @@ describe('Vectors API', () => {
       })
 
       expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        statusCode: '500',
+        error: 'Internal',
+        message: 'Internal Server Error',
+        code: ErrorCode.InternalError,
+      })
       expect(mockVectorStore.createVectorIndex).toHaveBeenCalledTimes(1)
     })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Code is missing from shared error schema so it's removed in serialization.

## What is the new behavior?

Extend error schema to include code, handling a few missing cases and cover with tests. 

## Additional context

Related to https://supabase.com/docs/guides/storage/debugging/error-codes
Related to https://github.com/supabase/supabase-js/pull/2537
