### PR TITLE
fix: add retries to acceptance test cdn cache hit checks

### DIFF
--- a/acceptance/specs/cdn.test.ts
+++ b/acceptance/specs/cdn.test.ts
@@ -218,6 +218,7 @@ describeAcceptance(
           await client.request('GET', controlRoute, {
             expectedCacheStatus: 'HIT',
             expectedStatus: 200,
+            retries: CACHE_RETRIES,
           })
         }
       } finally {
@@ -312,6 +313,7 @@ describeAcceptance(
           await client.request('GET', controlRoute, {
             expectedCacheStatus: 'HIT',
             expectedStatus: 200,
+            retries: CACHE_RETRIES,
           })
         }
       } finally {
@@ -368,6 +370,7 @@ describeAcceptance(
           await client.request('GET', objectRoute, {
             expectedCacheStatus: 'HIT',
             expectedStatus: 200,
+            retries: CACHE_RETRIES,
           })
         }
       } finally {
@@ -494,10 +497,12 @@ describeAcceptance(
           await client.request('GET', objectRoute, {
             expectedCacheStatus: 'HIT',
             expectedStatus: 200,
+            retries: CACHE_RETRIES,
           })
           await client.request('GET', secondObjectRoute, {
             expectedCacheStatus: 'HIT',
             expectedStatus: 200,
+            retries: CACHE_RETRIES,
           })
         }
       } finally {
@@ -853,6 +858,7 @@ TEST_CONFIGS.forEach(({ bucketType, accessMethods }) => {
               expectedCacheStatus: 'HIT',
               expectedStatus: 200,
               token: sourceToken,
+              retries: CACHE_RETRIES,
             })
           } finally {
             await cleanupRestObjects(bucketName, [sourceKey, destKey], client)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Acceptance tests do not currently retry on the cache HIT checks. This can result in intermittent test failures if we outpace the CDN cache propagation. 