### PR TITLE
fix: purge CDN cache on bucket update or delete

### DIFF
--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -328,6 +328,22 @@ describe('CdnCacheManager', () => {
     })
   })
 
+  it('isConfigured returns true when CDN_PURGE_ENDPOINT_URL is set', async () => {
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+    })
+
+    expect(new CdnCacheManager().isConfigured()).toBe(true)
+  })
+
+  it('isConfigured returns false when CDN_PURGE_ENDPOINT_URL is not set', async () => {
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: undefined,
+    })
+
+    expect(new CdnCacheManager().isConfigured()).toBe(false)
+  })
+
   it('sends a purge request for tenant transformations', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
     vi.stubGlobal('fetch', fetchMock)

--- a/src/storage/cdn/cdn-cache-manager.ts
+++ b/src/storage/cdn/cdn-cache-manager.ts
@@ -125,4 +125,8 @@ export class CdnCacheManager {
       )
     }
   }
+
+  isConfigured() {
+    return Boolean(cdnPurgeUrl)
+  }
 }

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -141,7 +141,7 @@ export interface Database {
   updateBucket(
     bucketId: string,
     fields: Pick<Bucket, 'public' | 'file_size_limit' | 'allowed_mime_types'>
-  ): Promise<void>
+  ): Promise<{ previous: Pick<Bucket, 'public'> } | void>
 
   upsertObject(
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'version' | 'user_metadata'>

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -841,14 +841,19 @@ export class StoragePgDB implements Database {
       const setClause = entries
         .map(([column], index) => `${quoteIdentifier(column)} = $${index + 1}`)
         .join(', ')
+      const idParam = `$${entries.length + 1}`
 
-      return this.query(
+      return this.query<Pick<Bucket, 'public'>>(
         db,
         {
           text: `
+            WITH previous_bucket AS (
+              SELECT public FROM storage.buckets WHERE id = ${idParam}
+            )
             UPDATE storage.buckets
             SET ${setClause}
-            WHERE id = $${entries.length + 1}
+            WHERE id = ${idParam}
+            RETURNING (SELECT public FROM previous_bucket) AS public
           `,
           values: [...values, bucketId],
         },
@@ -859,6 +864,8 @@ export class StoragePgDB implements Database {
     if (result.rowCount === 0) {
       throw ERRORS.NoSuchBucket(bucketId)
     }
+
+    return { previous: { public: result.rows[0].public } }
   }
 
   async upsertObject(

--- a/src/storage/events/cdn/purge-cdn-cache.test.ts
+++ b/src/storage/events/cdn/purge-cdn-cache.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../base-event', () => ({
+  BaseEvent: class {},
+}))
+
+type CdnConfig = {
+  cdnPurgeEndpointURL?: string
+  cdnPurgeEndpointKey?: string
+}
+
+async function importPurgeCdnCache(config: CdnConfig = {}) {
+  vi.resetModules()
+
+  const configModule = await import('../../../config')
+  configModule.getConfig({ reload: true })
+  configModule.mergeConfig(config)
+
+  return import('./purge-cdn-cache')
+}
+
+function makeJob() {
+  return {
+    id: 'test-purge-cdn-cache',
+    name: 'cdn:purge-cache',
+    data: {
+      tenant: { ref: 'tenant-ref', host: 'tenant-host' },
+      sbReqId: 'sb-req-1',
+      purgeOptions: {
+        type: 'bucket',
+        bucket: 'bucket-id',
+        tenant: 'tenant-ref',
+      },
+    },
+  }
+}
+
+describe('PurgeCdnCache.handle', () => {
+  const cdnPurgeEndpointURL = 'https://cdn.example.com/stub/cache'
+  const cdnPurgeEndpointKey = 'test-key'
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('purges the CDN cache end-to-end when CDN_PURGE_ENDPOINT_URL is configured', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { PurgeCdnCache } = await importPurgeCdnCache({
+      cdnPurgeEndpointURL,
+      cdnPurgeEndpointKey,
+    })
+
+    await expect(PurgeCdnCache.handle(makeJob() as never)).resolves.toBeUndefined()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [input, init] = fetchMock.mock.calls[0]
+    const requestInit = init as RequestInit
+    expect(input.toString()).toBe(`${cdnPurgeEndpointURL}/purge`)
+    expect((requestInit.headers as Headers).get('authorization')).toBe(
+      `Bearer ${cdnPurgeEndpointKey}`
+    )
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      type: 'bucket',
+      tenant: { ref: 'tenant-ref' },
+      bucketId: 'bucket-id',
+    })
+  })
+
+  it('returns early without attempting a request when CDN_PURGE_ENDPOINT_URL is not set', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { PurgeCdnCache } = await importPurgeCdnCache({
+      cdnPurgeEndpointURL: undefined,
+    })
+
+    await expect(PurgeCdnCache.handle(makeJob() as never)).resolves.toBeUndefined()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('logs and rethrows when the CDN cache manager throws an unexpected error, so pg-boss retries the job', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error('socket hang up'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { PurgeCdnCache } = await importPurgeCdnCache({
+      cdnPurgeEndpointURL,
+      cdnPurgeEndpointKey,
+    })
+
+    await expect(PurgeCdnCache.handle(makeJob() as never)).rejects.toMatchObject({
+      code: 'InternalError',
+      message: 'Error purging cache',
+      originalError: expect.objectContaining({
+        message: 'socket hang up',
+      }),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/storage/events/cdn/purge-cdn-cache.ts
+++ b/src/storage/events/cdn/purge-cdn-cache.ts
@@ -1,0 +1,67 @@
+import { logger, logSchema } from '@internal/monitoring'
+import { BasePayload } from '@internal/queue'
+import { CdnCacheManager, PurgeCacheInput } from '@storage/cdn/cdn-cache-manager'
+import { Job, Queue, SendOptions, WorkOptions } from 'pg-boss'
+import { BaseEvent } from '../base-event'
+
+export interface PurgeCdnCachePayload extends BasePayload {
+  purgeOptions: PurgeCacheInput
+}
+
+const cdnCacheManager = new CdnCacheManager()
+
+export class PurgeCdnCache extends BaseEvent<PurgeCdnCachePayload> {
+  static queueName = 'cdn:purge-cache'
+
+  static getQueueOptions(): Queue {
+    return {
+      name: this.queueName,
+      policy: 'exactly_once',
+    }
+  }
+
+  static getWorkerOptions(): WorkOptions {
+    return {
+      includeMetadata: true,
+    }
+  }
+
+  static getSendOptions(payload: PurgeCdnCachePayload): SendOptions {
+    const { purgeOptions } = payload
+    const singletonKey = [
+      purgeOptions.type,
+      purgeOptions.tenant,
+      'bucket' in purgeOptions ? purgeOptions.bucket : undefined,
+      'objectName' in purgeOptions ? purgeOptions.objectName : undefined,
+    ]
+      .filter(Boolean)
+      .join('/')
+
+    return {
+      singletonKey,
+      retryLimit: 5,
+      retryDelay: 5,
+      priority: 10,
+    }
+  }
+
+  static async handle(job: Job<PurgeCdnCachePayload>) {
+    if (!cdnCacheManager.isConfigured()) {
+      // exit early if cdn cache manager is not configured (missing CDN_PURGE_ENDPOINT_URL)
+      return
+    }
+
+    try {
+      await cdnCacheManager.purge(job.data.purgeOptions)
+    } catch (e) {
+      logSchema.error(logger, '[CDN] Failed to purge cache', {
+        type: 'cdn',
+        error: e,
+        project: job.data.tenant.ref,
+        sbReqId: job.data.sbReqId,
+        metadata: JSON.stringify(job.data.purgeOptions),
+      })
+      throw e
+    }
+  }
+}

--- a/src/storage/events/index.ts
+++ b/src/storage/events/index.ts
@@ -1,4 +1,5 @@
 export * from './base-event'
+export * from './cdn/purge-cdn-cache'
 export * from './jwks/jwks-create-signing-secret'
 export * from './jwks/jwks-roll-url-signing-key'
 export * from './lifecycle/bucket-created'

--- a/src/storage/events/workers.ts
+++ b/src/storage/events/workers.ts
@@ -1,4 +1,5 @@
 import { Queue } from '@internal/queue'
+import { PurgeCdnCache } from './cdn/purge-cdn-cache'
 import { DeleteIcebergResources } from './iceberg/delete-iceberg-resources'
 import { ReconcileIcebergCatalog } from './iceberg/reconcile-catalog'
 import { JwksCreateSigningSecret } from './jwks/jwks-create-signing-secret'
@@ -14,6 +15,7 @@ import { SyncCatalogIds } from './upgrades/sync-catalog-ids'
 
 export function registerWorkers() {
   Queue.register(Webhook)
+  Queue.register(PurgeCdnCache)
   Queue.register(ObjectAdminDelete)
   Queue.register(ObjectAdminDeleteAllBefore)
   Queue.register(RunMigrationsOnTenants)

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,6 +1,7 @@
 import { tenantHasFeature } from '@internal/database'
 import { ERRORS, StorageBackendError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
+import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import { BucketCreatedEvent, BucketDeleted } from '@storage/events'
 import { StorageObjectLocator } from '@storage/locator'
 import { InfoRenderer } from '@storage/renderer/info'
@@ -30,6 +31,8 @@ function assertNever(value: never): never {
  * to provide a rich management API for any folders and files operations
  */
 export class Storage {
+  private readonly cdnCache = new CdnCacheManager()
+
   constructor(
     public readonly backend: StorageBackendAdapter,
     public readonly db: Database,
@@ -232,7 +235,12 @@ export class Storage {
     }
     bucketData.allowed_mime_types = data.allowedMimeTypes
 
-    return this.db.updateBucket(id, bucketData)
+    const result = await this.db.updateBucket(id, bucketData)
+
+    // purge cache if a bucket is changing from public to private
+    if (data.public === false && result?.previous.public === true) {
+      await this.purgeBucketCache(id)
+    }
   }
 
   /**
@@ -240,7 +248,7 @@ export class Storage {
    * @param id
    */
   async deleteBucket(id: string) {
-    return this.db.withTransaction(async (db) => {
+    const deleted = await this.db.withTransaction(async (db) => {
       await db.asSuperUser().findBucketById(id, 'id', {
         forUpdate: true,
       })
@@ -259,6 +267,32 @@ export class Storage {
 
       return deleted
     })
+
+    await this.purgeBucketCache(id)
+
+    return deleted
+  }
+
+  /**
+   * Purges the CDN cache for a bucket, tolerating failures since this is a
+   * best-effort side effect that must not block the underlying DB operation.
+   * @param bucketId
+   */
+  private async purgeBucketCache(bucketId: string) {
+    try {
+      await this.cdnCache.purge({
+        type: 'bucket',
+        bucket: bucketId,
+        tenant: this.db.tenantId,
+      })
+    } catch (error) {
+      logSchema.error(logger, 'Failed to purge bucket cache', {
+        type: 'cdn',
+        project: this.db.tenantId,
+        sbReqId: this.db.sbReqId,
+        error,
+      })
+    }
   }
 
   async deleteIcebergBucket(name: string) {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,8 +1,7 @@
 import { tenantHasFeature } from '@internal/database'
 import { ERRORS, StorageBackendError } from '@internal/errors'
 import { logger, logSchema } from '@internal/monitoring'
-import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
-import { BucketCreatedEvent, BucketDeleted } from '@storage/events'
+import { BucketCreatedEvent, BucketDeleted, PurgeCdnCache } from '@storage/events'
 import { StorageObjectLocator } from '@storage/locator'
 import { InfoRenderer } from '@storage/renderer/info'
 import { getConfig } from '../config'
@@ -31,8 +30,6 @@ function assertNever(value: never): never {
  * to provide a rich management API for any folders and files operations
  */
 export class Storage {
-  private readonly cdnCache = new CdnCacheManager()
-
   constructor(
     public readonly backend: StorageBackendAdapter,
     public readonly db: Database,
@@ -273,17 +270,19 @@ export class Storage {
     return deleted
   }
 
-  /**
-   * Purges the CDN cache for a bucket, tolerating failures since this is a
-   * best-effort side effect that must not block the underlying DB operation.
-   * @param bucketId
-   */
   private async purgeBucketCache(bucketId: string) {
     try {
-      await this.cdnCache.purge({
-        type: 'bucket',
-        bucket: bucketId,
-        tenant: this.db.tenantId,
+      await PurgeCdnCache.send({
+        tenant: {
+          ref: this.db.tenantId,
+          host: this.db.tenantHost,
+        },
+        sbReqId: this.db.sbReqId,
+        purgeOptions: {
+          type: 'bucket',
+          bucket: bucketId,
+          tenant: this.db.tenantId,
+        },
       })
     } catch (error) {
       logSchema.error(logger, 'Failed to purge bucket cache', {

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -1,7 +1,7 @@
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
 import { ErrorCode } from '@internal/errors'
-import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import { StoragePgDB } from '@storage/database'
+import { PurgeCdnCache } from '@storage/events'
 import { randomUUID } from 'crypto'
 import dotenv from 'dotenv'
 import { FastifyInstance } from 'fastify'
@@ -17,7 +17,6 @@ const { tenantId } = getConfig()
 
 let appInstance: FastifyInstance
 let adminDb: StoragePgDB
-let purgeCacheSpy: ReturnType<typeof vi.spyOn>
 
 beforeAll(async () => {
   vi.spyOn(S3Backend.prototype, 'deleteObjects').mockImplementation(() => {
@@ -39,8 +38,6 @@ beforeAll(async () => {
       body: Buffer.from(''),
     })
   })
-
-  purgeCacheSpy = vi.spyOn(CdnCacheManager.prototype, 'purge').mockResolvedValue(undefined)
 
   const serviceKeyUser = await getServiceKeyUser(tenantId)
   const pg = await getPostgresConnection({
@@ -429,6 +426,7 @@ describe('testing POST bucket', () => {
 describe('testing public bucket functionality', () => {
   test('user is able to make a bucket public and private', async () => {
     const bucketId = 'public-bucket'
+    const sendSpy = vi.spyOn(PurgeCdnCache, 'send').mockResolvedValue(undefined)
     const makePublicResponse = await appInstance.inject({
       method: 'PUT',
       url: `/bucket/${bucketId}`,
@@ -442,7 +440,7 @@ describe('testing public bucket functionality', () => {
     expect(makePublicResponse.statusCode).toBe(200)
     const makePublicJSON = JSON.parse(makePublicResponse.body)
     expect(makePublicJSON.message).toBe('Successfully updated')
-    expect(purgeCacheSpy).not.toHaveBeenCalled()
+    expect(sendSpy).not.toHaveBeenCalled()
 
     const publicResponse = await appInstance.inject({
       method: 'GET',
@@ -486,12 +484,17 @@ describe('testing public bucket functionality', () => {
     expect(makePrivateResponse.statusCode).toBe(200)
     const makePrivateJSON = JSON.parse(makePrivateResponse.body)
     expect(makePrivateJSON.message).toBe('Successfully updated')
-    expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
-    expect(purgeCacheSpy).toHaveBeenCalledWith({
-      type: 'bucket',
-      bucket: bucketId,
-      tenant: tenantId,
-    })
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purgeOptions: {
+          type: 'bucket',
+          bucket: bucketId,
+          tenant: tenantId,
+        },
+      })
+    )
+    sendSpy.mockRestore()
 
     const privateResponse = await appInstance.inject({
       method: 'GET',
@@ -502,6 +505,7 @@ describe('testing public bucket functionality', () => {
 
   test('does not purge the CDN cache when making a private bucket public', async () => {
     const bucketId = `no-purge-make-public-${randomUUID()}`
+    const sendSpy = vi.spyOn(PurgeCdnCache, 'send')
 
     try {
       await createBucket(bucketId)
@@ -517,14 +521,16 @@ describe('testing public bucket functionality', () => {
         },
       })
       expect(response.statusCode).toBe(200)
-      expect(purgeCacheSpy).not.toHaveBeenCalled()
+      expect(sendSpy).not.toHaveBeenCalled()
     } finally {
+      sendSpy.mockRestore()
       await cleanupBucket(bucketId)
     }
   })
 
   test('does not purge the CDN cache when updating a bucket without changing public', async () => {
     const bucketId = `no-purge-unrelated-update-${randomUUID()}`
+    const sendSpy = vi.spyOn(PurgeCdnCache, 'send')
 
     try {
       await createBucket(bucketId)
@@ -540,8 +546,50 @@ describe('testing public bucket functionality', () => {
         },
       })
       expect(response.statusCode).toBe(200)
-      expect(purgeCacheSpy).not.toHaveBeenCalled()
+      expect(sendSpy).not.toHaveBeenCalled()
     } finally {
+      sendSpy.mockRestore()
+      await cleanupBucket(bucketId)
+    }
+  })
+
+  test('bucket update succeeds even if purging the CDN cache fails', async () => {
+    const bucketId = `update-bucket-purge-fails-${randomUUID()}`
+    const sendSpy = vi
+      .spyOn(PurgeCdnCache, 'send')
+      .mockRejectedValueOnce(new Error('purge event failed'))
+
+    try {
+      await createBucket(bucketId)
+
+      const makePublicResponse = await appInstance.inject({
+        method: 'PUT',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${authenticatedKey}`,
+        },
+        payload: {
+          public: true,
+        },
+      })
+      expect(makePublicResponse.statusCode).toBe(200)
+
+      const makePrivateResponse = await appInstance.inject({
+        method: 'PUT',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${authenticatedKey}`,
+        },
+        payload: {
+          public: false,
+        },
+      })
+      expect(makePrivateResponse.statusCode).toBe(200)
+      const responseJSON = JSON.parse(makePrivateResponse.body)
+      expect(responseJSON.message).toBe('Successfully updated')
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      sendSpy.mockRestore()
       await cleanupBucket(bucketId)
     }
   })
@@ -673,6 +721,7 @@ describe('testing count objects in bucket', () => {
 describe('testing DELETE bucket', () => {
   test('user is able to delete a bucket', async () => {
     const bucketId = `delete-bucket-${randomUUID()}`
+    const sendSpy = vi.spyOn(PurgeCdnCache, 'send').mockResolvedValue(undefined)
     let deleted = false
 
     try {
@@ -688,14 +737,19 @@ describe('testing DELETE bucket', () => {
       expect(response.statusCode).toBe(200)
       const responseJSON = response.json()
       expect(responseJSON.message).toBe('Successfully deleted')
-      expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
-      expect(purgeCacheSpy).toHaveBeenCalledWith({
-        type: 'bucket',
-        bucket: bucketId,
-        tenant: tenantId,
-      })
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          purgeOptions: {
+            type: 'bucket',
+            bucket: bucketId,
+            tenant: tenantId,
+          },
+        })
+      )
       deleted = true
     } finally {
+      sendSpy.mockRestore()
       if (!deleted) {
         await cleanupBucket(bucketId)
       }
@@ -704,11 +758,13 @@ describe('testing DELETE bucket', () => {
 
   test('bucket deletion succeeds even if purging the CDN cache fails', async () => {
     const bucketId = `delete-bucket-purge-fails-${randomUUID()}`
+    const sendSpy = vi
+      .spyOn(PurgeCdnCache, 'send')
+      .mockRejectedValueOnce(new Error('purge event failed'))
     let deleted = false
 
     try {
       await createBucket(bucketId)
-      purgeCacheSpy.mockRejectedValueOnce(new Error('cdn purge failed'))
 
       const response = await appInstance.inject({
         method: 'DELETE',
@@ -720,9 +776,10 @@ describe('testing DELETE bucket', () => {
       expect(response.statusCode).toBe(200)
       const responseJSON = response.json()
       expect(responseJSON.message).toBe('Successfully deleted')
-      expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy).toHaveBeenCalledTimes(1)
       deleted = true
     } finally {
+      sendSpy.mockRestore()
       if (!deleted) {
         await cleanupBucket(bucketId)
       }

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -1,5 +1,6 @@
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
 import { ErrorCode } from '@internal/errors'
+import { CdnCacheManager } from '@storage/cdn/cdn-cache-manager'
 import { StoragePgDB } from '@storage/database'
 import { randomUUID } from 'crypto'
 import dotenv from 'dotenv'
@@ -16,6 +17,7 @@ const { tenantId } = getConfig()
 
 let appInstance: FastifyInstance
 let adminDb: StoragePgDB
+let purgeCacheSpy: ReturnType<typeof vi.spyOn>
 
 beforeAll(async () => {
   vi.spyOn(S3Backend.prototype, 'deleteObjects').mockImplementation(() => {
@@ -37,6 +39,8 @@ beforeAll(async () => {
       body: Buffer.from(''),
     })
   })
+
+  purgeCacheSpy = vi.spyOn(CdnCacheManager.prototype, 'purge').mockResolvedValue(undefined)
 
   const serviceKeyUser = await getServiceKeyUser(tenantId)
   const pg = await getPostgresConnection({
@@ -438,6 +442,7 @@ describe('testing public bucket functionality', () => {
     expect(makePublicResponse.statusCode).toBe(200)
     const makePublicJSON = JSON.parse(makePublicResponse.body)
     expect(makePublicJSON.message).toBe('Successfully updated')
+    expect(purgeCacheSpy).not.toHaveBeenCalled()
 
     const publicResponse = await appInstance.inject({
       method: 'GET',
@@ -481,12 +486,64 @@ describe('testing public bucket functionality', () => {
     expect(makePrivateResponse.statusCode).toBe(200)
     const makePrivateJSON = JSON.parse(makePrivateResponse.body)
     expect(makePrivateJSON.message).toBe('Successfully updated')
+    expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
+    expect(purgeCacheSpy).toHaveBeenCalledWith({
+      type: 'bucket',
+      bucket: bucketId,
+      tenant: tenantId,
+    })
 
     const privateResponse = await appInstance.inject({
       method: 'GET',
       url: `/object/public/public-bucket/favicon.ico`,
     })
     expect(privateResponse.statusCode).toBe(400)
+  })
+
+  test('does not purge the CDN cache when making a private bucket public', async () => {
+    const bucketId = `no-purge-make-public-${randomUUID()}`
+
+    try {
+      await createBucket(bucketId)
+
+      const response = await appInstance.inject({
+        method: 'PUT',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${authenticatedKey}`,
+        },
+        payload: {
+          public: true,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(purgeCacheSpy).not.toHaveBeenCalled()
+    } finally {
+      await cleanupBucket(bucketId)
+    }
+  })
+
+  test('does not purge the CDN cache when updating a bucket without changing public', async () => {
+    const bucketId = `no-purge-unrelated-update-${randomUUID()}`
+
+    try {
+      await createBucket(bucketId)
+
+      const response = await appInstance.inject({
+        method: 'PUT',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${authenticatedKey}`,
+        },
+        payload: {
+          file_size_limit: 1000,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(purgeCacheSpy).not.toHaveBeenCalled()
+    } finally {
+      await cleanupBucket(bucketId)
+    }
   })
 
   test('checking RLS: anon user is not able to update a bucket', async () => {
@@ -631,6 +688,39 @@ describe('testing DELETE bucket', () => {
       expect(response.statusCode).toBe(200)
       const responseJSON = response.json()
       expect(responseJSON.message).toBe('Successfully deleted')
+      expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
+      expect(purgeCacheSpy).toHaveBeenCalledWith({
+        type: 'bucket',
+        bucket: bucketId,
+        tenant: tenantId,
+      })
+      deleted = true
+    } finally {
+      if (!deleted) {
+        await cleanupBucket(bucketId)
+      }
+    }
+  })
+
+  test('bucket deletion succeeds even if purging the CDN cache fails', async () => {
+    const bucketId = `delete-bucket-purge-fails-${randomUUID()}`
+    let deleted = false
+
+    try {
+      await createBucket(bucketId)
+      purgeCacheSpy.mockRejectedValueOnce(new Error('cdn purge failed'))
+
+      const response = await appInstance.inject({
+        method: 'DELETE',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${authenticatedKey}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const responseJSON = response.json()
+      expect(responseJSON.message).toBe('Successfully deleted')
+      expect(purgeCacheSpy).toHaveBeenCalledTimes(1)
       deleted = true
     } finally {
       if (!deleted) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- If a public bucket becomes private the objects are still available via the public endpoint until the CDN cache expires
- If a bucket is deleted the objects are still available via CDN cache

## What is the new behavior?

Proactively purge CDN cache if a public bucket becomes private or a bucket is deleted.

If a private bucket becomes public the objects become public and there is no need to purge the CDN and we can just let it expire naturally.