### PR TITLE
fix(storage): pin distinct operationIds for iceberg's analytics-bucket routes

### DIFF
--- a/src/http/routes/iceberg/bucket.ts
+++ b/src/http/routes/iceberg/bucket.ts
@@ -59,6 +59,7 @@ export default async function routes(fastify: FastifyInstance) {
         },
         config: {
           operation: ROUTE_OPERATIONS.DELETE_BUCKET,
+          operationId: 'deleteIcebergBucket',
         },
       },
       async (request, response) => {
@@ -80,6 +81,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       config: {
         operation: ROUTE_OPERATIONS.CREATE_BUCKET,
+        operationId: 'createIcebergBucket',
       },
     },
     async (request, response) => {
@@ -107,6 +109,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
       config: {
         operation: ROUTE_OPERATIONS.LIST_BUCKET,
+        operationId: 'listIcebergBuckets',
       },
     },
     async (request, response) => {


### PR DESCRIPTION
## Context
Follow-up from [#1270 review discussion](https://github.com/supabase/storage/pull/1270#discussion_r3665796480) - stacked on top of it since it depends on the `config.operationId` mechanism added there. Rebase onto master once #1270 merges.

## Summary
`src/http/routes/iceberg/bucket.ts` reuses `ROUTE_OPERATIONS.CREATE_BUCKET`/`DELETE_BUCKET`/`LIST_BUCKET` verbatim - the exact same constants `src/http/routes/bucket/*.ts` uses for the unrelated S3 storage-bucket endpoints. Two entirely different resources (S3 storage buckets vs Iceberg analytics buckets) were deriving the same OpenAPI `operationId`.

Pins `createIcebergBucket`/`deleteIcebergBucket`/`listIcebergBuckets` explicitly via `config.operationId`, so the generated SDK gets distinct, correctly-named methods for each instead of the collision being silently papered over (or, with #1270's original stricter design, crashing doc generation - see #1270's own fix for that).

## Test plan
- [x] `tsc -noEmit` — no errors
- [x] `biome check` on touched file — clean
- [x] Full unit suite: 116 files / 1466 tests passing