### PR TITLE
fix(docs): normalize nullable JSON Schema idioms for OpenAPI 3.0 docs

### DIFF
--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -6,7 +6,8 @@ import { getGlobal } from '@platformatic/globals'
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import { getConfig } from './config'
 import { plugins, routes, setErrorHandler } from './http'
-import { finiteSwaggerTransform, withFiniteAjv } from './http/finite'
+import { withFiniteAjv } from './http/finite'
+import { docsSwaggerTransform } from './http/openapi-nullable'
 
 interface buildOpts extends FastifyServerOptions {
   exposeDocs?: boolean
@@ -21,7 +22,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   if (opts.exposeDocs) {
     app.register(fastifySwagger, {
       exposeHeadRoutes: true,
-      transform: finiteSwaggerTransform,
+      transform: docsSwaggerTransform,
       openapi: {
         info: {
           title: 'Supabase Storage Admin API',

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,8 @@ import fastifySwaggerUi from '@fastify/swagger-ui'
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import { getConfig } from './config'
 import { plugins, routes, schemas, setErrorHandler } from './http'
-import { finiteSwaggerTransform, withFiniteAjv } from './http/finite'
+import { withFiniteAjv } from './http/finite'
+import { docsSwaggerTransform } from './http/openapi-nullable'
 
 interface buildOpts extends FastifyServerOptions {
   exposeDocs?: boolean
@@ -27,7 +28,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   if (opts.exposeDocs) {
     app.register(fastifySwagger, {
       exposeHeadRoutes: true,
-      transform: finiteSwaggerTransform,
+      transform: docsSwaggerTransform,
       openapi: {
         info: {
           title: 'Supabase Storage API',

--- a/src/http/openapi-nullable.test.ts
+++ b/src/http/openapi-nullable.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeNullableSchema } from './openapi-nullable'
+
+describe('normalizeNullableSchema', () => {
+  it('rewrites a two-element type array with null into type + nullable', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        file_size_limit: { type: ['integer', 'null'] },
+        allowed_mime_types: { type: ['array', 'null'], items: { type: 'string' } },
+      },
+    }
+
+    expect(normalizeNullableSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        file_size_limit: { type: 'integer', nullable: true },
+        allowed_mime_types: { type: 'array', nullable: true, items: { type: 'string' } },
+      },
+    })
+  })
+
+  it('rewrites a two-branch anyOf with a null-only branch into the other branch + nullable', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        id: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        metadata: {
+          anyOf: [{ $ref: 'someSchema#' }, { type: 'null' }],
+        },
+      },
+    }
+
+    expect(normalizeNullableSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string', nullable: true },
+        metadata: { $ref: 'someSchema#', nullable: true },
+      },
+    })
+  })
+
+  it('handles the null-only branch appearing first', () => {
+    const schema = { anyOf: [{ type: 'null' }, { type: 'string' }] }
+
+    expect(normalizeNullableSchema(schema)).toEqual({ type: 'string', nullable: true })
+  })
+
+  it('leaves a genuine multi-type union untouched', () => {
+    const schema = {
+      anyOf: [
+        { type: 'integer', minimum: 0 },
+        { type: 'string', pattern: '^[0-9]+$' },
+      ],
+    }
+
+    expect(normalizeNullableSchema(schema)).toEqual(schema)
+  })
+
+  it('leaves anyOf with more than two branches untouched', () => {
+    const schema = {
+      anyOf: [{ required: ['a'] }, { required: ['b'] }, { required: ['c'] }],
+    }
+
+    expect(normalizeNullableSchema(schema)).toEqual(schema)
+  })
+
+  it('recurses through arrays and nested items', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        anyOf: [{ type: 'integer' }, { type: 'null' }],
+      },
+    }
+
+    expect(normalizeNullableSchema(schema)).toEqual({
+      type: 'array',
+      items: { type: 'integer', nullable: true },
+    })
+  })
+
+  it('does not mutate the source schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { type: ['integer', 'null'] },
+      },
+    }
+
+    const normalized = normalizeNullableSchema(schema)
+
+    expect(normalized).not.toBe(schema)
+    expect(schema.properties.value).toEqual({ type: ['integer', 'null'] })
+  })
+})

--- a/src/http/openapi-nullable.ts
+++ b/src/http/openapi-nullable.ts
@@ -1,0 +1,76 @@
+import type { SwaggerTransform } from '@fastify/swagger'
+import { finiteSwaggerTransform } from './finite'
+
+// Route schemas are authored as plain JSON Schema, e.g. `type: ['integer', 'null']`
+// or `{ anyOf: [<schema>, { type: 'null' }] }` for `$ref`-based unions — both of
+// which AJV validates natively. OpenAPI 3.0's Schema Object can't represent
+// either idiom: it only allows a single `type` string plus a separate
+// `nullable: true` boolean. Rewrite both into that OpenAPI 3.0 shape for the
+// generated docs; the schemas used for runtime validation are untouched (same
+// clone-before-mutate approach as `stripFiniteKeyword`).
+function isNullOnlySchema(value: unknown): value is { type: 'null' } {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    Object.keys(value).length === 1 &&
+    (value as { type?: unknown }).type === 'null'
+  )
+}
+
+export function normalizeNullableSchema<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(normalizeNullableSchema) as T
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value
+  }
+
+  const object = value as Record<string, unknown>
+
+  const anyOf = object.anyOf
+  if (Array.isArray(anyOf) && anyOf.length === 2) {
+    const nullIndex = anyOf.findIndex(isNullOnlySchema)
+    const other = nullIndex === -1 ? undefined : anyOf[1 - nullIndex]
+    if (other && typeof other === 'object') {
+      const merged: Record<string, unknown> = {
+        ...(normalizeNullableSchema(other) as Record<string, unknown>),
+        nullable: true,
+      }
+      for (const [key, nestedValue] of Object.entries(object)) {
+        if (key !== 'anyOf' && !(key in merged)) {
+          merged[key] = normalizeNullableSchema(nestedValue)
+        }
+      }
+      return merged as T
+    }
+  }
+
+  const result: Record<string, unknown> = {}
+  for (const [key, nestedValue] of Object.entries(object)) {
+    if (key === 'type' && Array.isArray(nestedValue) && nestedValue.length === 2) {
+      const nullIndex = nestedValue.indexOf('null')
+      if (nullIndex !== -1) {
+        result.type = nestedValue[1 - nullIndex]
+        result.nullable = true
+        continue
+      }
+    }
+    result[key] = normalizeNullableSchema(nestedValue)
+  }
+
+  return result as T
+}
+
+// Composes with `finiteSwaggerTransform`: strip the internal `finite` keyword
+// first, then normalize nullable idioms, so the generated docs schema is both
+// free of internal-only keywords and OpenAPI 3.0-valid.
+export const docsSwaggerTransform: SwaggerTransform = (params) => {
+  const { schema } = finiteSwaggerTransform(params)
+  return { schema: normalizeNullableSchema(schema), url: params.url }
+}


### PR DESCRIPTION
## Summary
- The generated OpenAPI docs declare `"openapi": "3.0.3"`, but route schemas are authored as plain JSON Schema (`type: [X, 'null']`, or `{ anyOf: [<schema>, { type: 'null' }] }` for `$ref`-based unions). Both idioms are valid JSON Schema — AJV validates them natively — but OpenAPI 3.0's Schema Object can't represent either: it only allows a single `type` string plus a separate `nullable: true` boolean.
- This mismatch breaks strict OpenAPI 3.0 consumers (e.g. Swift's `OpenAPIKit30`-based codegen used by supabase-swift), which fail to decode the document entirely.
- Adds `src/http/openapi-nullable.ts`, a docs-only swagger `transform` (composed with the existing `finiteSwaggerTransform`) that rewrites both idioms into their OpenAPI 3.0 equivalent before the doc is emitted. Runtime request/response validation schemas are completely untouched — same clone-before-mutate approach as the existing `stripFiniteKeyword`.
- Considered instead rewriting the schema files directly to `nullable: true`, but `nullable` isn't a real JSON Schema keyword — AJV would ignore it and reject legitimate `null` values at runtime. The transform-only approach has no runtime risk and touches no schema files.

## Test plan
- [x] `npx vitest run src/http/openapi-nullable.test.ts src/http/finite.test.ts` — new + existing tests pass
- [x] `npx tsc -noEmit` — clean
- [x] `npx @biomejs/biome check` on changed files — clean