### PR TITLE
fix: use common cache for pgvector metrics

### DIFF
--- a/src/internal/cache/names.ts
+++ b/src/internal/cache/names.ts
@@ -1,4 +1,5 @@
 export const JWT_CACHE_NAME = 'jwt' as const
+export const PGVECTOR_METRIC_CACHE_NAME = 'pgvector_metric' as const
 export const TENANT_CONFIG_CACHE_NAME = 'tenant_config' as const
 export const TENANT_JWKS_CACHE_NAME = 'tenant_jwks' as const
 export const TENANT_POOL_CACHE_NAME = 'tenant_pool' as const
@@ -6,6 +7,7 @@ export const TENANT_S3_CREDENTIALS_CACHE_NAME = 'tenant_s3_credentials' as const
 
 export type CacheName =
   | typeof JWT_CACHE_NAME
+  | typeof PGVECTOR_METRIC_CACHE_NAME
   | typeof TENANT_CONFIG_CACHE_NAME
   | typeof TENANT_JWKS_CACHE_NAME
   | typeof TENANT_POOL_CACHE_NAME

--- a/src/internal/database/pg-connection.test.ts
+++ b/src/internal/database/pg-connection.test.ts
@@ -331,6 +331,34 @@ describe('getPgCancelConnectionTarget', () => {
 })
 
 describe('PgPoolExecutor', () => {
+  it('uses the physical pool as cache scope across executor wrappers', () => {
+    const pool = {} as Pool
+    const otherPool = {} as Pool
+    const first = new PgPoolExecutor(pool)
+    const second = new PgPoolExecutor(pool)
+    const other = new PgPoolExecutor(otherPool)
+
+    expect(first.getCacheScope()).toBe(pool)
+    expect(second.getCacheScope()).toBe(pool)
+    expect(other.getCacheScope()).toBe(otherPool)
+  })
+
+  it('propagates the physical pool cache scope into transactions', async () => {
+    const client = Object.assign(new EventEmitter(), {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    }) as unknown as PoolClient
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    } as unknown as Pool
+    const executor = new PgPoolExecutor(pool)
+
+    const transaction = await executor.beginTransaction()
+
+    expect(transaction.getCacheScope()).toBe(pool)
+    await transaction.rollback()
+  })
+
   it('tracks checked-out client errors during direct queries', async () => {
     const socketError = new Error('socket reset')
     const client = Object.assign(new EventEmitter(), {

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -44,6 +44,7 @@ pg.types.setTypeParser(20, 'text', parseInt)
 interface PgTransactionOptions {
   searchPath?: string
   statementTimeoutMs?: number
+  cacheScope?: object
 }
 
 type PgBeginTransactionOptions = TransactionOptions & PgTransactionOptions
@@ -421,6 +422,10 @@ class PgClientErrorTracker {
 export class PgPoolExecutor implements DatabaseTransactionalExecutor {
   constructor(private readonly pool: Pool) {}
 
+  getCacheScope(): object {
+    return this.pool
+  }
+
   async query<T extends QueryResultRow = QueryResultRow>(
     statement: string | DatabaseStatement,
     options?: DatabaseQueryArgument
@@ -476,6 +481,7 @@ export class PgPoolExecutor implements DatabaseTransactionalExecutor {
     const transaction = new PgTransaction(client, clientErrorTracker, {
       searchPath: options?.searchPath,
       statementTimeoutMs: options?.statementTimeoutMs ?? options?.timeout,
+      cacheScope: this.getCacheScope(),
     })
 
     try {
@@ -499,6 +505,7 @@ export class PgTransaction implements DatabaseTransaction {
   private completed = false
   private pendingSearchPath?: string
   private pendingStatementTimeoutMs?: number
+  private readonly cacheScope: object
 
   constructor(
     private readonly client: PoolClient,
@@ -507,6 +514,11 @@ export class PgTransaction implements DatabaseTransaction {
   ) {
     this.pendingSearchPath = options.searchPath || undefined
     this.pendingStatementTimeoutMs = normalizeStatementTimeoutMs(options.statementTimeoutMs)
+    this.cacheScope = options.cacheScope ?? client
+  }
+
+  getCacheScope(): object {
+    return this.cacheScope
   }
 
   isCompleted(): boolean {
@@ -698,6 +710,15 @@ export class PgTenantConnection implements TenantConnection {
 
   getAbortSignal(): AbortSignal | undefined {
     return this.abortSignal
+  }
+
+  acquireExecutor(): PgPoolExecutor {
+    this.assertNotDisposed()
+    return this.pool.acquire()
+  }
+
+  getCacheScope(): object {
+    return this.acquireExecutor().getCacheScope()
   }
 
   async query<T extends QueryResultRow = QueryResultRow>(

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -148,12 +148,15 @@ describe('metrics registry', () => {
       { name: 'cache_evictions_total', enabled: false },
     ])
     metricsModule.recordCacheRequest('jwt', 'hit')
+    metricsModule.recordCacheRequest('pgvector_metric', 'hit')
+    metricsModule.recordCacheRequest('pgvector_metric', 'miss')
     metricsModule.recordCacheRequest('tenant_config', 'hit')
     metricsModule.recordCacheRequest('tenant_config', 'hit')
     metricsModule.recordCacheRequest('tenant_config', 'miss')
     metricsModule.recordCacheRequest('tenant_jwks', 'miss')
     metricsModule.recordCacheRequest('tenant_pool', 'miss')
     metricsModule.recordCacheRequest('tenant_s3_credentials', 'hit')
+    metricsModule.recordCacheEviction('pgvector_metric')
     metricsModule.recordCacheEviction('tenant_config')
 
     const firstRequestCollection = mockMeter.invoke('cache_requests_total')
@@ -163,6 +166,14 @@ describe('metrics registry', () => {
       {
         value: 1,
         attributes: { cache: 'jwt', outcome: 'hit' },
+      },
+      {
+        value: 1,
+        attributes: { cache: 'pgvector_metric', outcome: 'hit' },
+      },
+      {
+        value: 1,
+        attributes: { cache: 'pgvector_metric', outcome: 'miss' },
       },
       {
         value: 2,
@@ -189,6 +200,10 @@ describe('metrics registry', () => {
     expect(secondRequestCollection[0].attributes).toBe(firstRequestCollection[0].attributes)
 
     expect(mockMeter.invoke('cache_evictions_total')).toEqual([
+      {
+        value: 1,
+        attributes: { cache: 'pgvector_metric' },
+      },
       {
         value: 1,
         attributes: { cache: 'tenant_config' },

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -350,6 +350,7 @@ function createCacheMetricsState(cache: CacheName): CacheMetricsState {
 
 const cacheMetrics = {
   jwt: createCacheMetricsState('jwt'),
+  pgvector_metric: createCacheMetricsState('pgvector_metric'),
   tenant_config: createCacheMetricsState('tenant_config'),
   tenant_jwks: createCacheMetricsState('tenant_jwks'),
   tenant_pool: createCacheMetricsState('tenant_pool'),

--- a/src/storage/protocols/vector/adapter/pgvector/index.ts
+++ b/src/storage/protocols/vector/adapter/pgvector/index.ts
@@ -25,7 +25,6 @@ import {
   quoteIdentifier,
 } from '@internal/database'
 import { ERRORS } from '@internal/errors'
-import BaseTtlCache from '@isaacs/ttlcache'
 import type { DocumentType } from '@smithy/types'
 import {
   MAX_DELETE_VECTOR_KEYS,
@@ -40,23 +39,8 @@ import { paginateNPlusOne } from '../../pagination'
 import { VectorStore } from '../s3-vector'
 import { handlePgVectorError } from './errors'
 import { S3VectorFilter, translateFilter } from './filter'
+import { metricCache } from './metric-cache'
 
-// Cache the resolved distance metric for ~5 min per (bucket, index). Avoids
-// hammering pg_index on every queryVectors call; stale entries (e.g., an
-// index dropped out-of-band) self-heal on miss via the lookupMetric fallback.
-//
-// Module-scoped on purpose: in multi-tenant mode the Fastify plugin builds a
-// new PgVectorStore per request, so an instance-scoped cache would be cold
-// every call. Bucket/index identifiers are already tenant-scoped at the HTTP
-// layer (each tenant's `storage_vectors` schema lives in its own DB pool), so
-// sharing across requests within a process is safe.
-const METRIC_CACHE_TTL_MS = 5 * 60 * 1000
-const METRIC_CACHE_MAX = 1_000
-const metricCache = new BaseTtlCache<string, DistanceMetric>({
-  ttl: METRIC_CACHE_TTL_MS,
-  max: METRIC_CACHE_MAX,
-  updateAgeOnGet: true,
-})
 type PgVectorTableCapabilityKind = 'bridged-hnsw' | 'standard' | 'unknown'
 interface PgVectorTableCapability {
   kind: PgVectorTableCapabilityKind
@@ -79,8 +63,33 @@ const UNKNOWN_TABLE_CAPABILITY: PgVectorTableCapability = {
   requiresExactQueryScan: true,
 }
 const tableCapabilityCaches = new WeakMap<object, Map<string, Promise<PgVectorTableCapability>>>()
+const metricLookupCaches = new WeakMap<object, Map<string, Promise<DistanceMetric>>>()
+const metricCacheScopeIds = new WeakMap<object, number>()
+let nextMetricCacheScopeId = 1
 
-function metricCacheKey(bucket: string, index: string): string {
+function metricLookupCache(db: object): Map<string, Promise<DistanceMetric>> {
+  let cache = metricLookupCaches.get(db)
+  if (!cache) {
+    cache = new Map()
+    metricLookupCaches.set(db, cache)
+  }
+  return cache
+}
+
+function metricCacheScopeId(db: object): number {
+  let id = metricCacheScopeIds.get(db)
+  if (id === undefined) {
+    id = nextMetricCacheScopeId++
+    metricCacheScopeIds.set(db, id)
+  }
+  return id
+}
+
+function metricCacheKey(db: object, bucket: string, index: string): string {
+  return `${metricCacheScopeId(db)}\x00${bucket}\x00${index}`
+}
+
+function metricLookupKey(bucket: string, index: string): string {
   return `${bucket}\x00${index}`
 }
 
@@ -154,11 +163,11 @@ function tableCapabilityCache(db: object): Map<string, Promise<PgVectorTableCapa
 }
 
 function tableCapabilityCacheKey(db: DatabaseExecutor): object {
-  if (db instanceof PgTenantConnection) {
-    return db.pool
-  }
+  return databaseCacheScope(db)
+}
 
-  return db
+function databaseCacheScope(db: DatabaseExecutor): object {
+  return (db as DatabaseExecutor & { getCacheScope?: () => object }).getCacheScope?.() ?? db
 }
 
 function capabilityForAccessMethod(accessMethod: unknown): PgVectorTableCapability {
@@ -383,11 +392,34 @@ export class PgVectorStore implements VectorStore {
   }
 
   private db(): DatabaseTransactionalExecutor | DatabaseTransaction {
-    return resolvePgExecutor(this.executor)
+    const db = resolvePgExecutor(this.executor)
+    return db instanceof PgTenantConnection ? db.acquireExecutor() : db
+  }
+
+  private withTenantTransaction<T>(
+    fn: (
+      db: DatabaseTransactionalExecutor | DatabaseTransaction,
+      ownsTransaction: boolean
+    ) => Promise<T>
+  ): Promise<T> {
+    const db = resolvePgExecutor(this.executor)
+    return db instanceof PgTenantConnection
+      ? withPgTransaction(db, (trx) => fn(trx, true))
+      : fn(db, false)
   }
 
   private rootDb(): DatabaseTransactionalExecutor | DatabaseTransaction {
     return resolveRootPgExecutor(this.executor)
+  }
+
+  private clearMetricLookup(
+    db: DatabaseTransactionalExecutor | DatabaseTransaction,
+    bucket: string,
+    index: string
+  ): string {
+    const scope = databaseCacheScope(db)
+    metricLookupCache(scope).delete(metricLookupKey(bucket, index))
+    return metricCacheKey(scope, bucket, index)
   }
 
   async createVectorIndex(command: CreateIndexCommandInput): Promise<CreateIndexCommandOutput> {
@@ -417,11 +449,11 @@ export class PgVectorStore implements VectorStore {
 
     return handlePgVectorError(
       async () => {
-        const db = this.db()
+        const db = resolvePgExecutor(this.executor)
         // Wrap DDL in a transaction so a failed CREATE INDEX (missing
         // opclass, permissions, transient error) rolls back the CREATE TABLE.
         // Otherwise the orphan table would block retries with "already exists".
-        await withPgTransaction(db, async (trx) => {
+        const transactionDb = await withPgTransaction(db, async (trx) => {
           // Postgres doesn't allow parameter binding inside type modifiers
           // like `halfvec(N)` — N must be a literal at parse time. We've
           // validated `dimension` is an integer in [1, 4_000] above, so
@@ -441,16 +473,20 @@ export class PgVectorStore implements VectorStore {
             ON ${qualifiedTableName(table)}
             USING hnsw (embedding ${choice.opClass})
           `)
+          return trx
         })
-        forgetTableCapability(tableCapabilityCacheKey(db), table)
-        forgetTableCapability(tableCapabilityCacheKey(this.rootDb()), table)
+        forgetTableCapability(tableCapabilityCacheKey(transactionDb), table)
+        const rootDb = this.rootDb()
+        if (rootDb !== db) {
+          forgetTableCapability(tableCapabilityCacheKey(rootDb), table)
+        }
         // Prime the metric cache so subsequent queryVectors don't need a
         // round-trip lookup to pick the right distance operator. The two
         // names are validated non-empty at the top of this method.
-        metricCache.set(
-          metricCacheKey(command.vectorBucketName as string, command.indexName as string),
-          choice.metric
-        )
+        const bucket = command.vectorBucketName as string
+        const index = command.indexName as string
+        const cacheKey = this.clearMetricLookup(transactionDb, bucket, index)
+        metricCache.set(cacheKey, choice.metric)
         return { $metadata: {} } as CreateIndexCommandOutput
       },
       { type: 'vector-index', name: command.indexName }
@@ -465,9 +501,14 @@ export class PgVectorStore implements VectorStore {
       async () => {
         const db = this.db()
         await db.query(`DROP TABLE IF EXISTS ${qualifiedTableName(table)}`)
-        forgetTableCapability(tableCapabilityCacheKey(db), table)
-        forgetTableCapability(tableCapabilityCacheKey(this.rootDb()), table)
-        metricCache.delete(metricCacheKey(bucket, index))
+        const capabilityScope = tableCapabilityCacheKey(db)
+        const rootCapabilityScope = tableCapabilityCacheKey(this.rootDb())
+        forgetTableCapability(capabilityScope, table)
+        if (rootCapabilityScope !== capabilityScope) {
+          forgetTableCapability(rootCapabilityScope, table)
+        }
+        const cacheKey = this.clearMetricLookup(db, bucket, index)
+        metricCache.delete(cacheKey)
         return { $metadata: {} } as DeleteIndexCommandOutput
       },
       { type: 'vector-index', name: index }
@@ -503,7 +544,9 @@ export class PgVectorStore implements VectorStore {
         const capability = await resolveTableCapability(db, table, capabilityCacheKey)
 
         if (capability.requiresManualUpsert) {
-          await this.putVectorsManually(db, qualified, serializedRows)
+          await this.withTenantTransaction((transactionDb) =>
+            this.putVectorsManually(transactionDb, qualified, serializedRows)
+          )
           return {} as PutVectorsOutput
         }
 
@@ -531,7 +574,9 @@ export class PgVectorStore implements VectorStore {
             throw e
           }
 
-          await this.putVectorsManually(db, qualified, serializedRows)
+          await this.withTenantTransaction((transactionDb) =>
+            this.putVectorsManually(transactionDb, qualified, serializedRows)
+          )
         }
 
         return {} as PutVectorsOutput
@@ -613,29 +658,33 @@ export class PgVectorStore implements VectorStore {
     table: string,
     sql: string,
     params: unknown[],
-    topK: number
+    topK: number,
+    ownsTransaction = false
   ): Promise<{ rows: unknown[] }> {
     const capability = await resolveTableCapability(db, table, tableCapabilityCacheKey(db))
-    if (!capability.requiresExactQueryScan) {
-      return withPgTransaction(db, async (trx): Promise<{ rows: unknown[] }> => {
+
+    const runQuery = async (trx: DatabaseTransaction): Promise<{ rows: unknown[] }> => {
+      if (!capability.requiresExactQueryScan) {
         await trx.query({
           text: `SELECT set_config('hnsw.ef_search', $1, true)`,
           values: [String(Math.max(topK, DEFAULT_HNSW_EF_SEARCH))],
         })
         return trx.query({ text: sql, values: params })
-      })
-    }
+      }
 
-    // The same OrioleDB bridged HNSW path that rejects ON CONFLICT DO UPDATE
-    // can also miss rows inserted after the index was created. Use exact scan
-    // semantics for pools where we have observed that path.
-    return withPgTransaction(db, async (trx): Promise<{ rows: unknown[] }> => {
+      // The same OrioleDB bridged HNSW path that rejects ON CONFLICT DO UPDATE
+      // can also miss rows inserted after the index was created. Use exact scan
+      // semantics for pools where we have observed that path.
       await trx.query(`
         SELECT set_config('enable_indexscan', 'off', true),
                set_config('enable_bitmapscan', 'off', true)
       `)
       return trx.query({ text: sql, values: params })
-    })
+    }
+
+    return ownsTransaction && isDatabaseTransaction(db)
+      ? runQuery(db)
+      : withPgTransaction(db, runQuery)
   }
 
   async getVectors(input: GetVectorsCommandInput): Promise<GetVectorsCommandOutput> {
@@ -701,65 +750,90 @@ export class PgVectorStore implements VectorStore {
     const topK = validatePositiveInt('topK', input.topK ?? 10, MAX_QUERY_TOP_K)
 
     return handlePgVectorError(
-      async () => {
-        // The operator chosen for the distance expression AND for ORDER BY must
-        // match the HNSW index's operator class — otherwise the index isn't
-        // used and the returned distance is in the wrong metric. Resolve the
-        // metric (cached after createVectorIndex) before assembling the query.
-        const metric = await this.getOrLookupMetric(bucket, index)
-        const distanceOp: '<=>' | '<->' = metric === 'euclidean' ? '<->' : '<=>'
+      () =>
+        this.withTenantTransaction(async (db, ownsTransaction) => {
+          // The operator chosen for the distance expression AND for ORDER BY must
+          // match the HNSW index's operator class — otherwise the index isn't
+          // used and the returned distance is in the wrong metric. Resolve the
+          // metric (cached after createVectorIndex) before assembling the query.
+          const metric = await this.getOrLookupMetric(db, bucket, index)
+          const distanceOp: '<=>' | '<->' = metric === 'euclidean' ? '<->' : '<=>'
 
-        const cols: string[] = ['key']
-        if (wantDistance) cols.push(`embedding ${distanceOp} $1::halfvec AS distance`)
-        if (wantMeta) cols.push('metadata')
+          const cols: string[] = ['key']
+          if (wantDistance) cols.push(`embedding ${distanceOp} $1::halfvec AS distance`)
+          if (wantMeta) cols.push('metadata')
 
-        const params: unknown[] = []
-        if (wantDistance) params.push(toVectorLiteral(queryVector.float32 as number[]))
+          const params: unknown[] = []
+          if (wantDistance) params.push(toVectorLiteral(queryVector.float32 as number[]))
 
-        let whereClause = ''
-        if (input.filter) {
-          const translated = translateFilter(input.filter as unknown as S3VectorFilter)
-          whereClause = ' WHERE ' + offsetPlaceholders(translated.sql, params.length)
-          params.push(...translated.params)
-        }
+          let whereClause = ''
+          if (input.filter) {
+            const translated = translateFilter(input.filter as unknown as S3VectorFilter)
+            whereClause = ' WHERE ' + offsetPlaceholders(translated.sql, params.length)
+            params.push(...translated.params)
+          }
 
-        params.push(toVectorLiteral(queryVector.float32 as number[]))
-        params.push(topK)
+          params.push(toVectorLiteral(queryVector.float32 as number[]))
+          params.push(topK)
 
-        const table = tableName(bucket, index)
-        const orderVectorParam = params.length - 1
-        const limitParam = params.length
-        const sql = `SELECT ${cols.join(', ')}
+          const table = tableName(bucket, index)
+          const orderVectorParam = params.length - 1
+          const limitParam = params.length
+          const sql = `SELECT ${cols.join(', ')}
                      FROM ${qualifiedTableName(table)}${whereClause}
                      ORDER BY embedding ${distanceOp} $${orderVectorParam}::halfvec ASC
                      LIMIT $${limitParam}`
-        const result = await this.queryVectorsRaw(this.db(), table, sql, params, topK)
-        const rows = result.rows as Array<{
-          key: string
-          distance?: number
-          metadata?: DocumentType
-        }>
+          const result = await this.queryVectorsRaw(db, table, sql, params, topK, ownsTransaction)
+          const rows = result.rows as Array<{
+            key: string
+            distance?: number
+            metadata?: DocumentType
+          }>
 
-        return {
-          vectors: rows.map((r) => ({
-            key: r.key,
-            distance: wantDistance ? r.distance : undefined,
-            metadata: wantMeta ? (r.metadata ?? {}) : undefined,
-          })),
-          distanceMetric: metric,
-        } as QueryVectorsOutput
-      },
+          return {
+            vectors: rows.map((r) => ({
+              key: r.key,
+              distance: wantDistance ? r.distance : undefined,
+              metadata: wantMeta ? (r.metadata ?? {}) : undefined,
+            })),
+            distanceMetric: metric,
+          } as QueryVectorsOutput
+        }),
       { type: 'vector-index', name: index }
     )
   }
 
-  private async getOrLookupMetric(bucket: string, index: string): Promise<DistanceMetric> {
-    const key = metricCacheKey(bucket, index)
-    const cached = metricCache.get(key)
+  private async getOrLookupMetric(
+    db: DatabaseTransactionalExecutor | DatabaseTransaction,
+    bucket: string,
+    index: string
+  ): Promise<DistanceMetric> {
+    const scope = databaseCacheScope(db)
+    const cacheKey = metricCacheKey(scope, bucket, index)
+    const cached = metricCache.get(cacheKey)
     if (cached) return cached
-    const metric = await this.lookupMetric(bucket, index)
-    metricCache.set(key, metric)
-    return metric
+
+    const lookupKey = metricLookupKey(bucket, index)
+    const lookups = metricLookupCache(scope)
+    let lookup = lookups.get(lookupKey)
+    if (!lookup) {
+      lookup = this.lookupMetric(db, bucket, index)
+      lookups.set(lookupKey, lookup)
+    }
+
+    try {
+      const metric = await lookup
+      if (lookups.get(lookupKey) === lookup) {
+        lookups.delete(lookupKey)
+        metricCache.set(cacheKey, metric)
+      }
+      return metric
+    } catch {
+      if (lookups.get(lookupKey) === lookup) {
+        lookups.delete(lookupKey)
+      }
+      return 'cosine'
+    }
   }
 
   async listVectors(input: ListVectorsInput): Promise<ListVectorsOutput> {
@@ -817,11 +891,14 @@ export class PgVectorStore implements VectorStore {
     )
   }
 
-  private async lookupMetric(bucket: string, index: string): Promise<DistanceMetric> {
+  private async lookupMetric(
+    db: DatabaseTransactionalExecutor | DatabaseTransaction,
+    bucket: string,
+    index: string
+  ): Promise<DistanceMetric> {
     const table = tableName(bucket, index)
-    try {
-      const result = await this.db().query({
-        text: `
+    const result = await db.query({
+      text: `
           SELECT am.amname, opc.opcname
           FROM pg_index i
           JOIN pg_class ic ON ic.oid = i.indexrelid
@@ -834,14 +911,11 @@ export class PgVectorStore implements VectorStore {
             AND am.amname = 'hnsw'
           LIMIT 1
         `,
-        values: [SCHEMA, table],
-      })
-      const op = result.rows?.[0]?.opcname as string | undefined
-      if (op === 'halfvec_l2_ops') return 'euclidean'
-      return 'cosine'
-    } catch {
-      return 'cosine'
-    }
+      values: [SCHEMA, table],
+    })
+    const op = result.rows?.[0]?.opcname as string | undefined
+    if (op === 'halfvec_l2_ops') return 'euclidean'
+    return 'cosine'
   }
 }
 

--- a/src/storage/protocols/vector/adapter/pgvector/metric-cache.test.ts
+++ b/src/storage/protocols/vector/adapter/pgvector/metric-cache.test.ts
@@ -1,0 +1,23 @@
+import { createMetricCache } from './metric-cache'
+
+describe('pgvector metric cache', () => {
+  it('renews the TTL on hot reads', () => {
+    let now = 1
+    const cache = createMetricCache({
+      ttl: 10,
+      ttlResolution: 0,
+      perf: { now: () => now },
+    })
+
+    cache.set('index', 'euclidean')
+    now = 10
+    expect(cache.get('index')).toBe('euclidean')
+
+    now = 12
+    expect(cache.get('index')).toBe('euclidean')
+
+    now = 23
+    expect(cache.get('index')).toBeUndefined()
+    cache.dispose()
+  })
+})

--- a/src/storage/protocols/vector/adapter/pgvector/metric-cache.ts
+++ b/src/storage/protocols/vector/adapter/pgvector/metric-cache.ts
@@ -1,0 +1,30 @@
+import type { DistanceMetric } from '@aws-sdk/client-s3vectors'
+import {
+  createLruCache,
+  DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
+  PGVECTOR_METRIC_CACHE_NAME,
+} from '@internal/cache'
+import type { Perf } from 'lru-cache'
+
+const METRIC_CACHE_TTL_MS = 5 * 60 * 1000
+const METRIC_CACHE_MAX = 1_000
+
+interface MetricCacheOptions {
+  ttl?: number
+  ttlResolution?: number
+  perf?: Perf
+}
+
+export function createMetricCache(options: MetricCacheOptions = {}) {
+  return createLruCache<string, DistanceMetric>(PGVECTOR_METRIC_CACHE_NAME, {
+    ttl: options.ttl ?? METRIC_CACHE_TTL_MS,
+    ttlResolution: options.ttlResolution,
+    max: METRIC_CACHE_MAX,
+    updateAgeOnGet: true,
+    purgeStaleIntervalMs: DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
+    perf: options.perf,
+  })
+}
+
+// Module-scoped because the Fastify plugin builds a new PgVectorStore per request.
+export const metricCache = createMetricCache()

--- a/src/test/pgvector-adapter.test.ts
+++ b/src/test/pgvector-adapter.test.ts
@@ -1,6 +1,8 @@
+import { PGVECTOR_METRIC_CACHE_NAME } from '@internal/cache'
 import { PgPoolExecutor, PgTenantConnection, PgTransaction } from '@internal/database'
+import * as metrics from '@internal/monitoring/metrics'
 import { PgVectorStore } from '@storage/protocols/vector'
-import { Pool as PgPool, type PoolClient, type QueryResult } from 'pg'
+import { DatabaseError, Pool as PgPool, type PoolClient, type QueryResult } from 'pg'
 import { afterAll, beforeAll, describe, expect, it, type Mock, vi } from 'vitest'
 
 const TEST_DATABASE_URL =
@@ -48,42 +50,56 @@ function executeRawQuery(
   ) as Promise<QueryResult> | QueryResult
 }
 
-function createMockPgTransaction(raw: RawQueryMock): PgTransaction {
+function createMockPgTransaction(raw: RawQueryMock, cacheScope?: object): PgTransaction {
   const client = {
     query: (statement: string | { text: string; values?: unknown[] }, values?: unknown[]) =>
       executeRawQuery(raw, statement, values),
     release: vi.fn(),
   } as unknown as PoolClient
 
-  return new PgTransaction(client)
+  return new PgTransaction(client, undefined, { cacheScope })
 }
 
-function createMockExecutor(raw: RawQueryMock, transaction?: Mock) {
+function createMockExecutor(raw: RawQueryMock, transaction?: Mock, cacheScope?: object) {
+  const scope = cacheScope ?? {}
   return {
+    getCacheScope: () => scope,
     query: (statement: string | { text: string; values?: unknown[] }, options?: unknown[]) =>
       executeRawQuery(raw, statement, options),
     beginTransaction: async () => {
       if (!transaction) {
-        return createMockPgTransaction(raw)
+        return createMockPgTransaction(raw, scope)
       }
 
       let transactionRaw = raw
       await transaction(async (trx: { raw: RawQueryMock }) => {
         transactionRaw = trx.raw
       })
-      return createMockPgTransaction(transactionRaw)
+      return createMockPgTransaction(transactionRaw, scope)
     },
   } as never
 }
 
+const mockTenantPoolExecutor = Symbol('mockTenantPoolExecutor')
+
 function createMockTenantConnection(raw: RawQueryMock, sharedPool: object): PgTenantConnection {
-  return new PgTenantConnection(
-    Object.assign(sharedPool, {
-      acquire: () => createMockExecutor(raw),
+  const pool = sharedPool as {
+    [mockTenantPoolExecutor]?: ReturnType<typeof createMockExecutor>
+  }
+
+  if (!pool[mockTenantPoolExecutor]) {
+    const executor = createMockExecutor(raw)
+    Object.assign(pool, {
+      [mockTenantPoolExecutor]: executor,
+      acquire: () => executor,
       destroy: vi.fn(),
       getPoolStats: vi.fn(),
       rebalance: vi.fn(),
-    }) as never,
+    })
+  }
+
+  return new PgTenantConnection(
+    pool as never,
     {
       tenantId: 'tenant-a',
       dbUrl: 'postgres://tenant-a',
@@ -92,6 +108,40 @@ function createMockTenantConnection(raw: RawQueryMock, sharedPool: object): PgTe
       superUser: { jwt: 'service', payload: { role: 'service_role' } },
     } as never
   )
+}
+
+function createRetryingMockTenantConnection(raw: RawQueryMock) {
+  const scope = {}
+  const transaction = createMockPgTransaction(raw, scope)
+  const connectionError = new DatabaseError('connection failure', 18, 'error')
+  connectionError.code = '08006'
+  const beginTransaction = vi
+    .fn()
+    .mockRejectedValueOnce(connectionError)
+    .mockResolvedValue(transaction)
+  const executor = {
+    getCacheScope: () => scope,
+    query: (statement: string | { text: string; values?: unknown[] }, options?: unknown[]) =>
+      executeRawQuery(raw, statement, options),
+    beginTransaction,
+  }
+  const connection = new PgTenantConnection(
+    {
+      acquire: vi.fn().mockReturnValue(executor),
+      destroy: vi.fn(),
+      getPoolStats: vi.fn(),
+      rebalance: vi.fn(),
+    } as never,
+    {
+      tenantId: 'tenant-a',
+      dbUrl: 'postgres://tenant-a',
+      maxConnections: 2,
+      user: { jwt: 'jwt', payload: { role: 'authenticated' } },
+      superUser: { jwt: 'service', payload: { role: 'service_role' } },
+    } as never
+  )
+
+  return { beginTransaction, connection }
 }
 
 function createManualUpsertDb(
@@ -668,6 +718,7 @@ describe('PgVectorStore (real pgvector)', () => {
   })
 
   it('reuses the cached distance metric for repeated queries on the same index', async () => {
+    const recordCacheRequest = vi.spyOn(metrics, 'recordCacheRequest')
     const localBucket = `bucket-cache-${Date.now()}-${Math.random()}`
     const localIndex = `index-cache-${Date.now()}-${Math.random()}`
     const raw = vi.fn(async (sql: string) => {
@@ -691,16 +742,440 @@ describe('PgVectorStore (real pgvector)', () => {
       topK: 1,
     }
 
-    await localStore.queryVectors(command)
-    await localStore.queryVectors(command)
+    try {
+      await localStore.queryVectors(command)
+      await localStore.queryVectors(command)
 
-    const metricLookups = raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+      const metricLookups = raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+      const vectorQueries = raw.mock.calls.filter(([sql]) =>
+        String(sql).includes('ORDER BY embedding')
+      )
+      expect(metricLookups).toHaveLength(1)
+      expect(vectorQueries).toHaveLength(2)
+      expect(vectorQueries.every(([sql]) => String(sql).includes('<->'))).toBe(true)
+      expect(
+        recordCacheRequest.mock.calls.filter(([cache]) => cache === PGVECTOR_METRIC_CACHE_NAME)
+      ).toEqual([
+        [PGVECTOR_METRIC_CACHE_NAME, 'miss'],
+        [PGVECTOR_METRIC_CACHE_NAME, 'hit'],
+      ])
+    } finally {
+      recordCacheRequest.mockRestore()
+    }
+  })
+
+  it('isolates in-flight and cached metrics across database executors', async () => {
+    const localBucket = `bucket-cache-scope-${Date.now()}-${Math.random()}`
+    const localIndex = `index-cache-scope-${Date.now()}-${Math.random()}`
+    const cosineLookup = Promise.withResolvers<{ rows: Array<{ opcname: string }> }>()
+    const createRaw = (
+      lookup: Promise<{ rows: Array<{ opcname: string }> }> | { rows: Array<{ opcname: string }> }
+    ) =>
+      vi.fn(async (sql: string) => {
+        const text = String(sql)
+        if (text.includes('FROM pg_index')) return lookup
+        if (isTableAccessMethodLookup(text)) return { rows: [{ amname: 'heap' }] }
+        return { rows: [] }
+      })
+    const cosineRaw = createRaw(cosineLookup.promise)
+    const euclideanRaw = createRaw({ rows: [{ opcname: 'halfvec_l2_ops' }] })
+    const cosineStore = new PgVectorStore(createMockExecutor(cosineRaw))
+    const euclideanStore = new PgVectorStore(createMockExecutor(euclideanRaw))
+    const command = {
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    }
+
+    const cosineQuery = cosineStore.queryVectors(command)
+    await vi.waitFor(() => {
+      expect(
+        cosineRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+      ).toHaveLength(1)
+    })
+    const euclideanQuery = euclideanStore.queryVectors(command)
+    await vi.waitFor(() => {
+      expect(
+        euclideanRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+      ).toHaveLength(1)
+    })
+
+    cosineLookup.resolve({ rows: [{ opcname: 'halfvec_cosine_ops' }] })
+    await expect(cosineQuery).resolves.toMatchObject({ distanceMetric: 'cosine' })
+    await expect(euclideanQuery).resolves.toMatchObject({ distanceMetric: 'euclidean' })
+
+    await expect(cosineStore.queryVectors(command)).resolves.toMatchObject({
+      distanceMetric: 'cosine',
+    })
+    await expect(euclideanStore.queryVectors(command)).resolves.toMatchObject({
+      distanceMetric: 'euclidean',
+    })
+    expect(
+      cosineRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+    ).toHaveLength(1)
+    expect(
+      euclideanRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+    ).toHaveLength(1)
+  })
+
+  it('keeps an old transaction metric out of a reconciled endpoint scope', async () => {
+    const localBucket = `bucket-cache-rollover-${Date.now()}-${Math.random()}`
+    const localIndex = `index-cache-rollover-${Date.now()}-${Math.random()}`
+    const createRaw = (opcname: string) =>
+      vi.fn(async (sql: string) => {
+        const text = String(sql)
+        if (text.includes('FROM pg_index')) return { rows: [{ opcname }] }
+        if (isTableAccessMethodLookup(text)) return { rows: [{ amname: 'heap' }] }
+        return { rows: [] }
+      })
+    const oldRaw = createRaw('halfvec_l2_ops')
+    const currentRaw = createRaw('halfvec_cosine_ops')
+    const oldScope = {}
+    const currentScope = {}
+    const oldTransaction = createMockPgTransaction(oldRaw, oldScope)
+    const currentRoot = createMockExecutor(currentRaw, undefined, currentScope)
+    const oldTransactionStore = new PgVectorStore({
+      resolve: () => oldTransaction,
+      root: () => currentRoot,
+    })
+    const currentStore = new PgVectorStore(currentRoot)
+    const command = {
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    }
+
+    await oldTransactionStore.queryVectors(command)
+    await currentStore.queryVectors(command)
+
+    expect(oldRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(
+      1
+    )
+    expect(
+      currentRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+    ).toHaveLength(1)
+    expect(
+      oldRaw.mock.calls.find(([sql]) => String(sql).includes('ORDER BY embedding'))?.[0]
+    ).toContain('<->')
+    expect(
+      currentRaw.mock.calls.find(([sql]) => String(sql).includes('ORDER BY embedding'))?.[0]
+    ).toContain('<=>')
+  })
+
+  it('uses one endpoint-bound executor for metric lookup and vector query', async () => {
+    const localBucket = `bucket-cache-bound-${Date.now()}-${Math.random()}`
+    const localIndex = `index-cache-bound-${Date.now()}-${Math.random()}`
+    const createRaw = (opcname: string) =>
+      vi.fn(async (sql: string) => {
+        const text = String(sql)
+        if (text.includes('FROM pg_index')) return { rows: [{ opcname }] }
+        if (isTableAccessMethodLookup(text)) return { rows: [{ amname: 'heap' }] }
+        return { rows: [] }
+      })
+    const oldRaw = createRaw('halfvec_l2_ops')
+    const currentRaw = createRaw('halfvec_cosine_ops')
+    const oldExecutor = createMockExecutor(oldRaw)
+    const currentExecutor = createMockExecutor(currentRaw)
+    const acquire = vi.fn().mockReturnValueOnce(oldExecutor).mockReturnValue(currentExecutor)
+    const connection = new PgTenantConnection(
+      {
+        acquire,
+        destroy: vi.fn(),
+        getPoolStats: vi.fn(),
+        rebalance: vi.fn(),
+      } as never,
+      {
+        tenantId: 'tenant-a',
+        dbUrl: 'postgres://tenant-a',
+        maxConnections: 2,
+        user: { jwt: 'jwt', payload: { role: 'authenticated' } },
+        superUser: { jwt: 'service', payload: { role: 'service_role' } },
+      } as never
+    )
+    const localStore = new PgVectorStore(connection)
+
+    await localStore.queryVectors({
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    })
+
+    expect(acquire).toHaveBeenCalledTimes(1)
+    expect(oldRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(
+      1
+    )
+    expect(
+      oldRaw.mock.calls.find(([sql]) => String(sql).includes('ORDER BY embedding'))?.[0]
+    ).toContain('<->')
+    expect(currentRaw).not.toHaveBeenCalled()
+
+    connection.dispose()
+  })
+
+  it('retries tenant transaction setup before pinning a vector query', async () => {
+    vi.useFakeTimers()
+    const localBucket = `bucket-cache-retry-${Date.now()}-${Math.random()}`
+    const localIndex = `index-cache-retry-${Date.now()}-${Math.random()}`
+    const raw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM pg_index')) {
+        return { rows: [{ opcname: 'halfvec_l2_ops' }] }
+      }
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const { beginTransaction, connection } = createRetryingMockTenantConnection(raw)
+    const localStore = new PgVectorStore(connection)
+
+    try {
+      const query = localStore.queryVectors({
+        vectorBucketName: localBucket,
+        indexName: localIndex,
+        queryVector: { float32: [1, 0] },
+        topK: 1,
+      })
+      const result = query.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(result).resolves.toMatchObject({
+        status: 'resolved',
+        value: { distanceMetric: 'euclidean' },
+      })
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+      expect(raw.mock.calls.some(([sql]) => String(sql).startsWith('SAVEPOINT '))).toBe(false)
+      expect(raw.mock.calls.some(([sql]) => String(sql).startsWith('RELEASE SAVEPOINT '))).toBe(
+        false
+      )
+    } finally {
+      connection.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries tenant transaction setup for a manual vector upsert', async () => {
+    vi.useFakeTimers()
+    const localBucket = `bucket-upsert-retry-${Date.now()}-${Math.random()}`
+    const localIndex = `index-upsert-retry-${Date.now()}-${Math.random()}`
+    const raw = vi.fn(async (sql: string) => {
+      if (isTableAccessMethodLookup(sql)) {
+        return { rows: [{ amname: 'orioledb' }] }
+      }
+      return { rows: [] }
+    })
+    const { beginTransaction, connection } = createRetryingMockTenantConnection(raw)
+    const localStore = new PgVectorStore(connection)
+
+    try {
+      const put = localStore.putVectors({
+        vectorBucketName: localBucket,
+        indexName: localIndex,
+        vectors: [{ key: 'a', data: { float32: [1, 0] } }],
+      })
+      const result = put.then(
+        () => ({ status: 'resolved' as const }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(result).resolves.toEqual({ status: 'resolved' })
+      expect(beginTransaction).toHaveBeenCalledTimes(2)
+    } finally {
+      connection.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries tenant index creation and primes the successful transaction scope', async () => {
+    vi.useFakeTimers()
+    const localBucket = `bucket-create-retry-${Date.now()}-${Math.random()}`
+    const localIndex = `index-create-retry-${Date.now()}-${Math.random()}`
+    const successfulRaw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM pg_index')) {
+        return { rows: [{ opcname: 'halfvec_l2_ops' }] }
+      }
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const successfulScope = {}
+    const successfulExecutor = createMockExecutor(successfulRaw, undefined, successfulScope)
+    const connectionError = new DatabaseError('connection failure', 18, 'error')
+    connectionError.code = '08006'
+    const failingExecutor = {
+      beginTransaction: vi.fn().mockRejectedValue(connectionError),
+    }
+    const currentExecutor = createMockExecutor(vi.fn().mockResolvedValue({ rows: [] }))
+    const acquire = vi
+      .fn()
+      .mockReturnValueOnce(failingExecutor)
+      .mockReturnValueOnce(successfulExecutor)
+      .mockReturnValue(currentExecutor)
+    const connection = new PgTenantConnection(
+      {
+        acquire,
+        destroy: vi.fn(),
+        getPoolStats: vi.fn(),
+        rebalance: vi.fn(),
+      } as never,
+      {
+        tenantId: 'tenant-a',
+        dbUrl: 'postgres://tenant-a',
+        maxConnections: 2,
+        user: { jwt: 'jwt', payload: { role: 'authenticated' } },
+        superUser: { jwt: 'service', payload: { role: 'service_role' } },
+      } as never
+    )
+    const localStore = new PgVectorStore(connection)
+
+    try {
+      const create = localStore.createVectorIndex({
+        vectorBucketName: localBucket,
+        indexName: localIndex,
+        dataType: 'float32',
+        dimension: 2,
+        distanceMetric: 'euclidean',
+      })
+      const result = create.then(
+        () => ({ status: 'resolved' as const }),
+        (error) => ({ status: 'rejected' as const, error })
+      )
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      await expect(result).resolves.toEqual({ status: 'resolved' })
+      expect(acquire).toHaveBeenCalledTimes(2)
+
+      const successfulStore = new PgVectorStore(successfulExecutor)
+      await expect(
+        successfulStore.queryVectors({
+          vectorBucketName: localBucket,
+          indexName: localIndex,
+          queryVector: { float32: [1, 0] },
+          topK: 1,
+        })
+      ).resolves.toMatchObject({ distanceMetric: 'euclidean' })
+      expect(
+        successfulRaw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))
+      ).toHaveLength(0)
+    } finally {
+      connection.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not let an older metric lookup overwrite a freshly primed metric', async () => {
+    const localBucket = `bucket-cache-race-${Date.now()}-${Math.random()}`
+    const localIndex = `index-cache-race-${Date.now()}-${Math.random()}`
+    const firstLookup = Promise.withResolvers<{ rows: Array<{ opcname: string }> }>()
+    const raw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM pg_index')) {
+        return firstLookup.promise
+      }
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const localStore = new PgVectorStore(createMockExecutor(raw))
+    const command = {
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    }
+
+    const staleQuery = localStore.queryVectors(command)
+    await vi.waitFor(() => {
+      expect(raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(
+        1
+      )
+    })
+
+    await localStore.createVectorIndex({
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      dataType: 'float32',
+      dimension: 2,
+      distanceMetric: 'euclidean',
+    })
+
+    firstLookup.resolve({ rows: [{ opcname: 'halfvec_cosine_ops' }] })
+    await staleQuery
+    await expect(localStore.queryVectors(command)).resolves.toMatchObject({
+      distanceMetric: 'euclidean',
+    })
+
     const vectorQueries = raw.mock.calls.filter(([sql]) =>
       String(sql).includes('ORDER BY embedding')
     )
-    expect(metricLookups).toHaveLength(1)
     expect(vectorQueries).toHaveLength(2)
-    expect(vectorQueries.every(([sql]) => String(sql).includes('<->'))).toBe(true)
+    expect(String(vectorQueries[0][0])).toContain('<=>')
+    expect(String(vectorQueries[1][0])).toContain('<->')
+    expect(raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(1)
+  })
+
+  it('primes the distance metric on create and invalidates it on delete', async () => {
+    const localBucket = `bucket-metric-lifecycle-${Date.now()}-${Math.random()}`
+    const localIndex = `index-metric-lifecycle-${Date.now()}-${Math.random()}`
+    const raw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM pg_index')) {
+        return { rows: [{ opcname: 'halfvec_cosine_ops' }] }
+      }
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const localStore = new PgVectorStore(createMockExecutor(raw))
+    const query = {
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    }
+
+    await localStore.createVectorIndex({
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      dataType: 'float32',
+      dimension: 2,
+      distanceMetric: 'euclidean',
+    })
+    await localStore.queryVectors(query)
+
+    expect(raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(0)
+    const primedVectorQueries = raw.mock.calls.filter(([sql]) =>
+      String(sql).includes('ORDER BY embedding')
+    )
+    expect(primedVectorQueries).toHaveLength(1)
+    expect(String(primedVectorQueries[0][0])).toContain('<->')
+
+    await localStore.deleteVectorIndex({
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+    })
+    await localStore.queryVectors(query)
+
+    expect(raw.mock.calls.filter(([sql]) => String(sql).includes('FROM pg_index'))).toHaveLength(1)
+    const vectorQueries = raw.mock.calls.filter(([sql]) =>
+      String(sql).includes('ORDER BY embedding')
+    )
+    expect(vectorQueries).toHaveLength(2)
+    expect(String(vectorQueries[1][0])).toContain('<=>')
   })
 
   it('uses exact scan semantics and retries the OrioleDB probe after a transient probe failure', async () => {
@@ -853,8 +1328,15 @@ describe('PgVectorStore (real pgvector)', () => {
     })
     const sharedPool = {}
 
-    const firstStore = new PgVectorStore(createMockTenantConnection(raw, sharedPool))
-    const secondStore = new PgVectorStore(createMockTenantConnection(raw, sharedPool))
+    const firstConnection = createMockTenantConnection(raw, sharedPool)
+    const acquire = (sharedPool as { acquire: () => unknown }).acquire
+    const secondConnection = createMockTenantConnection(raw, sharedPool)
+
+    expect((sharedPool as { acquire: () => unknown }).acquire).toBe(acquire)
+    expect(firstConnection.acquireExecutor()).toBe(secondConnection.acquireExecutor())
+
+    const firstStore = new PgVectorStore(firstConnection)
+    const secondStore = new PgVectorStore(secondConnection)
 
     await firstStore.putVectors({
       vectorBucketName: bucket,
@@ -1235,6 +1717,35 @@ describe('PgVectorStore (real pgvector)', () => {
     expect(String(raw.mock.calls[1][0])).toContain('CREATE TABLE')
     expect(String(raw.mock.calls[2][0])).toContain('CREATE INDEX')
     expect(String(raw.mock.calls[3][0])).toContain('RELEASE SAVEPOINT')
+  })
+
+  it('keeps query savepoint isolation for an active transaction resolver', async () => {
+    const localBucket = `bucket-query-savepoint-${Date.now()}-${Math.random()}`
+    const localIndex = `index-query-savepoint-${Date.now()}-${Math.random()}`
+    const raw = vi.fn(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM pg_index')) {
+        return { rows: [{ opcname: 'halfvec_l2_ops' }] }
+      }
+      if (isTableAccessMethodLookup(text)) {
+        return { rows: [{ amname: 'heap' }] }
+      }
+      return { rows: [] }
+    })
+    const transaction = createMockPgTransaction(raw)
+    const localStore = new PgVectorStore({
+      resolve: () => transaction,
+    })
+
+    await localStore.queryVectors({
+      vectorBucketName: localBucket,
+      indexName: localIndex,
+      queryVector: { float32: [1, 0] },
+      topK: 1,
+    })
+
+    expect(raw.mock.calls.some(([sql]) => String(sql).startsWith('SAVEPOINT '))).toBe(true)
+    expect(raw.mock.calls.some(([sql]) => String(sql).startsWith('RELEASE SAVEPOINT '))).toBe(true)
   })
 
   it('invalidates a root capability cache after transaction-scoped index creation', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

pgvector metric cache is using a TTL cache but we're trying to drop it. 
It caches lookup failures at the moment.

## What is the new behavior?

Use common LRU cache wrapper with the same TTL, we can drop age update separately for all caches.
Don't cache metric lookup failure but still fallback to `cosine`.
Fix cross tenant contamination by scoping db identity.

## Additional context

This enables to drop TTL dependency after pool cache is refactored. 
