### PR TITLE
fix: s3 canonical uri normalization and make it cheaper

### DIFF
--- a/src/http/plugins/signature-v4.test.ts
+++ b/src/http/plugins/signature-v4.test.ts
@@ -1,0 +1,172 @@
+import { request as httpRequest } from 'node:http'
+import { type AddressInfo } from 'node:net'
+import Fastify from 'fastify'
+import { vi } from 'vitest'
+import { createRawSignatureV4Signer } from '../../test/utils/signature-v4'
+
+const { configState, getJwtSecretMock, verifyJwtMock } = vi.hoisted(() => ({
+  configState: {
+    requestAllowXForwardedPrefix: true,
+  },
+  getJwtSecretMock: vi.fn(),
+  verifyJwtMock: vi.fn(),
+}))
+
+vi.mock('../../config', () => ({
+  getConfig: () => ({
+    anonKeyAsync: Promise.resolve('anon-key'),
+    isMultitenant: false,
+    jwtCachingEnabled: false,
+    requestAllowXForwardedPrefix: configState.requestAllowXForwardedPrefix,
+    s3ProtocolAccessKeyId: 'access-key',
+    s3ProtocolAccessKeySecret: 'secret-key',
+    s3ProtocolAllowForwardedHeader: false,
+    s3ProtocolEnforceRegion: false,
+    s3ProtocolNonCanonicalHostHeader: undefined,
+    s3ProtocolPrefix: '',
+    serviceKeyAsync: Promise.resolve('service-key'),
+    storagePublicUrl: undefined,
+    storageS3Region: 'us-east-1',
+  }),
+}))
+
+vi.mock('@internal/auth', () => ({
+  isJwtToken: () => false,
+  signJWT: vi.fn(),
+  verifyJWT: verifyJwtMock,
+  verifyJWTWithCache: verifyJwtMock,
+}))
+
+vi.mock('@internal/database', () => ({
+  getJwtSecret: getJwtSecretMock,
+  getTenantConfig: vi.fn(),
+  s3CredentialsManager: {
+    getS3CredentialsByAccessKey: vi.fn(),
+  },
+}))
+
+const credentials = {
+  accessKeyId: 'access-key',
+  secretAccessKey: 'secret-key',
+  region: 'us-east-1',
+  service: 's3',
+}
+
+const forwardedPrefix = '/storage/v1'
+const signRawPath = createRawSignatureV4Signer(credentials, {
+  method: 'GET',
+})
+
+async function buildApp(requestAllowXForwardedPrefix: boolean) {
+  configState.requestAllowXForwardedPrefix = requestAllowXForwardedPrefix
+  vi.resetModules()
+  getJwtSecretMock.mockResolvedValue({
+    secret: 'jwt-secret',
+    jwks: null,
+  })
+  verifyJwtMock.mockResolvedValue({
+    role: 'service_role',
+    sub: 'service-user',
+  })
+
+  const { signatureV4 } = await import('./signature-v4')
+  const app = Fastify()
+  let handled = false
+
+  app.decorateRequest('tenantId', 'tenant-id')
+  app.setErrorHandler((error, _request, reply) => {
+    const storageError = error as Error & {
+      code?: string
+      httpStatusCode?: number
+    }
+    void reply.status(storageError.httpStatusCode ?? 500).send({
+      code: storageError.code,
+    })
+  })
+  app.register(signatureV4, {
+    allowBodyHash: false,
+  })
+  app.get('/:Bucket/*', async (_request, reply) => {
+    handled = true
+    return reply.status(204).send()
+  })
+  await app.listen({
+    host: '127.0.0.1',
+    port: 0,
+  })
+
+  return {
+    app,
+    wasHandled: () => handled,
+  }
+}
+
+async function sendRequest(
+  app: ReturnType<typeof Fastify>,
+  signedRequest: Awaited<ReturnType<typeof signRawPath>>,
+  path: string
+) {
+  const address = app.server.address() as AddressInfo
+
+  return await new Promise<{ body: string; statusCode: number | undefined }>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        host: '127.0.0.1',
+        port: address.port,
+        method: signedRequest.method,
+        path,
+        headers: {
+          ...signedRequest.headers,
+          'x-forwarded-prefix': forwardedPrefix,
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = []
+        response.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+        response.on('end', () => {
+          resolve({
+            body: Buffer.concat(chunks).toString('utf8'),
+            statusCode: response.statusCode,
+          })
+        })
+      }
+    )
+    request.on('error', reject)
+    request.end()
+  })
+}
+
+describe('SignatureV4 plugin forwarded prefix', () => {
+  it('verifies a raw external path using a trusted x-forwarded-prefix', async () => {
+    const internalPath = '/bucket/folder/%2E%2E/object'
+    const signedRequest = await signRawPath(`${forwardedPrefix}${internalPath}`)
+    const { app, wasHandled } = await buildApp(true)
+
+    try {
+      const response = await sendRequest(app, signedRequest, internalPath)
+
+      expect(response.statusCode).toBe(204)
+      expect(wasHandled()).toBe(true)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ignores x-forwarded-prefix when forwarded paths are not trusted', async () => {
+    const internalPath = '/bucket/folder/%2E%2E/object'
+    const signedRequest = await signRawPath(`${forwardedPrefix}${internalPath}`)
+    const { app, wasHandled } = await buildApp(false)
+
+    try {
+      const response = await sendRequest(app, signedRequest, internalPath)
+
+      expect(response.statusCode).toBe(403)
+      expect(JSON.parse(response.body)).toEqual({
+        code: 'SignatureDoesNotMatch',
+      })
+      expect(wasHandled()).toBe(false)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/storage/protocols/s3/signature-v4.test.ts
+++ b/src/storage/protocols/s3/signature-v4.test.ts
@@ -1,0 +1,280 @@
+import { createServer, request as httpRequest, type IncomingHttpHeaders } from 'node:http'
+import { type AddressInfo } from 'node:net'
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { SignatureV4, SignatureV4Service } from '@storage/protocols/s3/signature-v4'
+import { createRawSignatureV4Signer } from '../../../test/utils/signature-v4'
+
+const credentials = {
+  accessKeyId: 'access-key',
+  secretAccessKey: 'secret-key',
+  region: 'us-east-1',
+  service: SignatureV4Service.S3,
+}
+
+const verifier = new SignatureV4({
+  enforceRegion: false,
+  credentials: {
+    accessKey: credentials.accessKeyId,
+    secretKey: credentials.secretAccessKey,
+    region: credentials.region,
+    service: credentials.service,
+  },
+})
+
+type SignedRequest = {
+  method: string
+  path: string
+  query: Record<string, string>
+  headers: Record<string, string>
+}
+
+type AwsRequest = Omit<SignedRequest, 'query'> & {
+  query?: Record<string, string | string[] | null>
+}
+
+const forwardedPrefix = '/storage/v1'
+
+async function signWithAwsClient(key: string, versionId?: string) {
+  let signedRequest: SignedRequest | undefined
+  const client = new S3Client({
+    endpoint: `http://storage.test${forwardedPrefix}`,
+    forcePathStyle: true,
+    region: credentials.region,
+    credentials,
+    requestHandler: {
+      handle: async (request: AwsRequest) => {
+        signedRequest = {
+          method: request.method,
+          path: request.path,
+          query: Object.fromEntries(
+            Object.entries(request.query ?? {}).map(([key, value]) => [
+              key,
+              Array.isArray(value) ? value.join(',') : (value ?? ''),
+            ])
+          ),
+          headers: request.headers,
+        }
+
+        return {
+          response: {
+            statusCode: 200,
+            headers: {},
+          },
+        }
+      },
+    },
+  })
+
+  try {
+    await client.send(
+      new HeadObjectCommand({
+        Bucket: 'bucket',
+        Key: key,
+        VersionId: versionId,
+      })
+    )
+  } finally {
+    client.destroy()
+  }
+
+  if (!signedRequest) {
+    throw new Error('AWS client did not produce a signed request')
+  }
+
+  return signedRequest
+}
+
+function requestTarget(request: SignedRequest) {
+  const path = request.path.slice(forwardedPrefix.length)
+  const query = Object.entries(request.query)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&')
+
+  return query ? `${path}?${query}` : path
+}
+
+const signRawPath = createRawSignatureV4Signer(credentials)
+
+function definedHeaders(headers: IncomingHttpHeaders) {
+  const result: Record<string, string | string[]> = {}
+  for (const [name, value] of Object.entries(headers)) {
+    if (value !== undefined) {
+      result[name] = value
+    }
+  }
+  return result
+}
+
+describe('SignatureV4 verification', () => {
+  it.each([
+    {
+      name: 'parent segment without a query string',
+      key: 'folder/../object',
+      prefix: forwardedPrefix,
+      versionId: undefined,
+    },
+    {
+      name: 'parent segment with a query string and trailing-slash prefix',
+      key: 'folder/../object',
+      prefix: `${forwardedPrefix}/`,
+      versionId: 'version-1',
+    },
+    {
+      name: 'current segment without a query string',
+      key: 'folder/./object',
+      prefix: forwardedPrefix,
+      versionId: undefined,
+    },
+  ])('verifies an AWS-signed dot-segment path with a $name', async ({ key, prefix, versionId }) => {
+    const signedRequest = await signWithAwsClient(key, versionId)
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+
+    await expect(
+      verifier.verify(clientSignature, {
+        url: requestTarget(signedRequest),
+        prefix,
+        headers: signedRequest.headers,
+        method: signedRequest.method,
+        query: signedRequest.query,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it.each([
+    {
+      name: 'literal parent segment',
+      parentSegment: '..',
+    },
+    {
+      name: 'uppercase encoded parent segment',
+      parentSegment: '%2E%2E',
+    },
+    {
+      name: 'lowercase encoded parent segment',
+      parentSegment: '%2e%2e',
+    },
+    {
+      name: 'literal dot followed by an encoded dot',
+      parentSegment: '.%2E',
+    },
+    {
+      name: 'encoded dot followed by a literal dot',
+      parentSegment: '%2E.',
+    },
+  ])('binds signatures to the raw path for a $name', async ({ parentSegment }) => {
+    const requestPath = `/bucket/folder/${parentSegment}/object`
+    const exactRequest = await signRawPath(`${forwardedPrefix}${requestPath}`)
+    const exactSignature = SignatureV4.parseAuthorizationHeader(exactRequest.headers)
+
+    await expect(
+      verifier.verify(exactSignature, {
+        url: requestPath,
+        prefix: forwardedPrefix,
+        headers: exactRequest.headers,
+        method: exactRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(true)
+
+    const normalizedRequest = await signRawPath(`${forwardedPrefix}/bucket/object`)
+    const normalizedSignature = SignatureV4.parseAuthorizationHeader(normalizedRequest.headers)
+
+    await expect(
+      verifier.verify(normalizedSignature, {
+        url: requestPath,
+        prefix: forwardedPrefix,
+        headers: normalizedRequest.headers,
+        method: normalizedRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('verifies a raw percent-encoded parent segment over HTTP', async () => {
+    const rawPath = `${forwardedPrefix}/bucket/folder/%2E%2E/object`
+    const signedRequest = await signRawPath(rawPath)
+    let receivedTarget: string | undefined
+    let verificationResult = false
+    let verificationError: unknown
+
+    const server = createServer((request, response) => {
+      void (async () => {
+        receivedTarget = request.url
+        const headers = definedHeaders(request.headers)
+        const clientSignature = SignatureV4.parseAuthorizationHeader(headers)
+        const storageRequestTarget = (request.url ?? '').slice(forwardedPrefix.length)
+
+        verificationResult = await verifier.verify(clientSignature, {
+          url: storageRequestTarget,
+          prefix: forwardedPrefix,
+          headers,
+          method: request.method ?? 'HEAD',
+          query: {},
+        })
+
+        response.writeHead(verificationResult ? 204 : 403)
+        response.end()
+      })().catch((error: unknown) => {
+        verificationError = error
+        response.writeHead(500)
+        response.end()
+      })
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address() as AddressInfo
+      const statusCode = await new Promise<number | undefined>((resolve, reject) => {
+        const request = httpRequest(
+          {
+            host: '127.0.0.1',
+            port: address.port,
+            method: signedRequest.method,
+            path: signedRequest.path,
+            headers: signedRequest.headers,
+          },
+          (response) => {
+            response.resume()
+            response.on('end', () => resolve(response.statusCode))
+          }
+        )
+        request.on('error', reject)
+        request.end()
+      })
+
+      if (verificationError) {
+        throw verificationError
+      }
+      expect(receivedTarget).toBe(rawPath)
+      expect(verificationResult).toBe(true)
+      expect(statusCode).toBe(204)
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
+      })
+    }
+  })
+
+  it('verifies a root-path signature for an empty request target', async () => {
+    const signedRequest = await signRawPath('/')
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+
+    await expect(
+      verifier.verify(clientSignature, {
+        url: '',
+        headers: signedRequest.headers,
+        method: signedRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(true)
+  })
+})

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -81,6 +81,14 @@ export const ALWAYS_UNSIGNABLE_QUERY_PARAMS = {
 
 export const EMPTY_SHA256_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
+function canonicalUri(requestTarget: string, prefix?: string) {
+  const queryIndex = requestTarget.indexOf('?')
+  const path = queryIndex === -1 ? requestTarget : requestTarget.slice(0, queryIndex)
+  const pathPrefix = prefix ? prefix.replace(/\/+$/, '') : ''
+
+  return pathPrefix + path || '/'
+}
+
 export class SignatureV4 {
   public readonly serverCredentials: SignatureV4Options['credentials']
   enforceRegion: boolean
@@ -443,14 +451,13 @@ export class SignatureV4 {
     signedHeaders: string[]
   ) {
     const method = request.method
-    const prefix = request.prefix ? request.prefix.replace(/\/+$/, '') : ''
-    const canonicalUri = new URL(`http://localhost:8080${prefix}${request.url}`).pathname
+    const uri = canonicalUri(request.url, request.prefix)
     const canonicalQueryString = this.constructCanonicalQueryString(request.query || {})
     const canonicalHeaders = this.constructCanonicalHeaders(request, signedHeaders)
     const signedHeadersString = signedHeaders.sort().join(';')
     const payloadHash = await this.getPayloadHash(clientSignature, request)
 
-    return `${method}\n${canonicalUri}\n${canonicalQueryString}\n${canonicalHeaders}\n${signedHeadersString}\n${payloadHash}`
+    return `${method}\n${uri}\n${canonicalQueryString}\n${canonicalHeaders}\n${signedHeadersString}\n${payloadHash}`
   }
 
   /**

--- a/src/test/utils/signature-v4.ts
+++ b/src/test/utils/signature-v4.ts
@@ -1,0 +1,42 @@
+import { Hash } from '@smithy/hash-node'
+import { HttpRequest } from '@smithy/protocol-http'
+import { SignatureV4 } from '@smithy/signature-v4'
+
+interface RawSignatureV4Credentials {
+  accessKeyId: string
+  secretAccessKey: string
+  region: string
+  service: string
+}
+
+export function createRawSignatureV4Signer(
+  credentials: RawSignatureV4Credentials,
+  options: {
+    hostname?: string
+    method?: string
+  } = {}
+) {
+  const hostname = options.hostname ?? 'storage.test'
+  const method = options.method ?? 'HEAD'
+  const signer = new SignatureV4({
+    credentials,
+    region: credentials.region,
+    service: credentials.service,
+    sha256: Hash.bind(null, 'sha256'),
+    uriEscapePath: false,
+  })
+
+  return (path: string) =>
+    signer.sign(
+      new HttpRequest({
+        protocol: 'http:',
+        hostname,
+        method,
+        path,
+        query: {},
+        headers: {
+          host: hostname,
+        },
+      })
+    )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 canonical uri is parsed by WHATWG URL parser, which does normalization and costly (query parsing is separate and unneeded here). Normalization is wrong in certain edge cases and create security risk because a signature verified for key A can refer to another key.

## What is the new behavior?

Use indexOf to separate query and accept raw path as S3 expects. It handles edge cases correctly while improving performance posture (10x faster, 5x less garbage).

## Additional context

We could cache prefix to reduce its allocation as well but it didn't seem worthy at this stage.
