### PR TITLE
fix: increase pause for signed urls in acceptance tests

### DIFF
--- a/acceptance/specs/cdn.test.ts
+++ b/acceptance/specs/cdn.test.ts
@@ -67,7 +67,7 @@ const TEST_CONFIGS: TestConfig[] = [
  */
 async function pauseForWebhookIfNeeded(accessMethod: AccessMethod) {
   if (accessMethod === 'signed') {
-    await delay(3000)
+    await delay(5000)
   }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

For tests against signed URLs we get stuck in a "REVALIDATED" state for 60s due to KV if the first MISS request happens before the webhook. This just increases that timing a little more to reduce the likelihood of this happening.

This delay will be removed in the future as we refactor the CDN logic.