### PR TITLE
fix: hardening for non-json object reply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "fast-querystring": "^1.1.2",
         "fast-xml-builder": "^1.1.8",
         "fast-xml-parser": "^5.7.2",
-        "fastify": "^5.8.5",
+        "fastify": "^5.11.2",
         "fastify-plugin": "^5.1.0",
         "fs-xattr": "0.4.0",
         "ioredis": "^5.2.4",
@@ -13176,9 +13176,9 @@
       }
     },
     "node_modules/fastify": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.2.tgz",
+      "integrity": "sha512-i/eJG7nXR9OkbFgoX4jFiPOHoRq0rXqDACVAXELh5Fdg6BFBErIVZ8MyibGCwup9Go1pYrxZJ0ogIub8vVdEcQ==",
       "funding": [
         {
           "type": "github",
@@ -13197,8 +13197,8 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
@@ -13223,6 +13223,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-uri": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -26003,9 +26043,9 @@
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
     },
     "fastify": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.2.tgz",
+      "integrity": "sha512-i/eJG7nXR9OkbFgoX4jFiPOHoRq0rXqDACVAXELh5Fdg6BFBErIVZ8MyibGCwup9Go1pYrxZJ0ogIub8vVdEcQ==",
       "requires": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -26013,8 +26053,8 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
@@ -26022,6 +26062,26 @@
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
+      },
+      "dependencies": {
+        "fast-json-stringify": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+          "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+          "requires": {
+            "@fastify/merge-json-schemas": "^0.2.0",
+            "ajv": "^8.12.0",
+            "ajv-formats": "^3.0.1",
+            "fast-uri": "^4.0.0",
+            "json-schema-ref-resolver": "^3.0.0",
+            "rfdc": "^1.2.0"
+          }
+        },
+        "fast-uri": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+          "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="
+        }
       }
     },
     "fastify-plugin": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fast-querystring": "^1.1.2",
     "fast-xml-builder": "^1.1.8",
     "fast-xml-parser": "^5.7.2",
-    "fastify": "^5.8.5",
+    "fastify": "^5.11.2",
     "fastify-plugin": "^5.1.0",
     "fs-xattr": "0.4.0",
     "ioredis": "^5.2.4",

--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -54,6 +54,16 @@ describe('admin app', () => {
     }
   })
 
+  it('registers shared Blob response handling', async () => {
+    const app = await buildAdminApp()
+
+    try {
+      expect(app.hasPlugin('blob-response')).toBe(true)
+    } finally {
+      await app.close()
+    }
+  })
+
   it('registers protected pprof endpoints', async () => {
     const app = await buildAdminApp()
 

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -55,6 +55,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
     })
   }
 
+  app.register(plugins.blobResponse)
   app.register(plugins.requestContext)
   app.register(plugins.signals)
   app.register(plugins.adminTenantId)

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -3,6 +3,18 @@ import buildApp from './app'
 import { stripFiniteKeyword } from './http/finite'
 
 describe('public app', () => {
+  it('registers shared Blob response handling', async () => {
+    const app = buildApp()
+
+    try {
+      await app.ready()
+
+      expect(app.hasPlugin('blob-response')).toBe(true)
+    } finally {
+      await app.close()
+    }
+  })
+
   it('installs finite validation on the production Fastify instance', async () => {
     const app = buildApp()
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,6 +75,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.addSchema(schemas.authSchema)
   app.addSchema(schemas.errorSchema)
 
+  app.register(plugins.blobResponse)
   app.register(plugins.requestContext)
   app.register(plugins.signals)
   app.register(plugins.tenantId)

--- a/src/http/plugins/blob-response.test.ts
+++ b/src/http/plugins/blob-response.test.ts
@@ -1,0 +1,120 @@
+import { Readable, Writable } from 'node:stream'
+import Fastify, { LogController } from 'fastify'
+import pino from 'pino'
+import { blobResponse } from './blob-response'
+
+function createApp(lines: string[]) {
+  return Fastify({
+    loggerInstance: pino(
+      { level: 'error' },
+      new Writable({
+        write(chunk, _encoding, callback) {
+          lines.push(chunk.toString())
+          callback()
+        },
+      })
+    ),
+    logController: new LogController({ disableRequestLogging: true }),
+  })
+}
+
+describe('blobResponse', () => {
+  it('converts Blob payloads to Fastify-compatible web streams', async () => {
+    const app = Fastify()
+    await app.register(blobResponse)
+    app.get('/blob', (_request, reply) =>
+      reply.type('application/octet-stream').send(new Blob(['body']))
+    )
+
+    try {
+      const response = await app.inject('/blob')
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toBe('application/octet-stream')
+      expect(response.body).toBe('body')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('preserves already supported payloads', async () => {
+    const lines: string[] = []
+    const app = createApp(lines)
+    await app.register(blobResponse)
+    app.get('/json', async () => ({ ok: true }))
+    app.get('/buffer', (_request, reply) =>
+      reply.type('application/octet-stream').send(Buffer.from('buffer'))
+    )
+    app.get('/node-stream', (_request, reply) =>
+      reply.type('application/octet-stream').send(Readable.from(['node-stream']))
+    )
+    app.get('/web-stream', (_request, reply) =>
+      reply.type('application/octet-stream').send(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('web-stream'))
+            controller.close()
+          },
+        })
+      )
+    )
+    app.get('/response', () => new Response('response'))
+
+    try {
+      const responses = await Promise.all(
+        ['/json', '/buffer', '/node-stream', '/web-stream', '/response'].map((url) =>
+          app.inject(url)
+        )
+      )
+
+      expect(responses.map((response) => response.statusCode)).toEqual([200, 200, 200, 200, 200])
+      expect(responses[0].json()).toEqual({ ok: true })
+      expect(responses.slice(1).map((response) => response.body)).toEqual([
+        'buffer',
+        'node-stream',
+        'web-stream',
+        'response',
+      ])
+      expect(lines).toEqual([])
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('logs unsupported payload metadata without the query string or payload', async () => {
+    const lines: string[] = []
+    const app = createApp(lines)
+    await app.register(blobResponse)
+    app.get('/unsupported/:name', (_request, reply) =>
+      reply.type('application/octet-stream').send({ secret: 'do-not-log' })
+    )
+
+    try {
+      const response = await app.inject('/unsupported/file.txt?token=do-not-log')
+
+      expect(response.statusCode).toBe(500)
+      const logs = lines.map((line) => JSON.parse(line) as Record<string, unknown>)
+      const log = logs.find((entry) => entry.msg === 'Unsupported Fastify reply payload')
+
+      expect(log).toEqual(
+        expect.objectContaining({
+          type: 'fastify',
+          msg: 'Unsupported Fastify reply payload',
+        })
+      )
+      expect(JSON.parse(String(log?.metadata))).toEqual({
+        method: 'GET',
+        route: '/unsupported/:name',
+        url: '/unsupported/file.txt',
+        statusCode: 200,
+        contentType: 'application/octet-stream',
+        payloadType: 'object',
+        payloadConstructor: 'Object',
+        payloadTag: '[object Object]',
+      })
+      expect(lines.join('')).not.toContain('do-not-log')
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/src/http/plugins/blob-response.ts
+++ b/src/http/plugins/blob-response.ts
@@ -1,0 +1,66 @@
+import { logSchema } from '@internal/monitoring/logger'
+import type { FastifyInstance } from 'fastify'
+import fastifyPlugin from 'fastify-plugin'
+
+export const blobResponse = fastifyPlugin(
+  async function blobResponse(fastify: FastifyInstance) {
+    fastify.addHook('onSend', (request, reply, payload, done) => {
+      if (typeof Blob !== 'undefined' && payload instanceof Blob) {
+        done(null, payload.stream())
+        return
+      }
+
+      if (!isSupportedFastifyPayload(payload)) {
+        logSchema.error(request.log, 'Unsupported Fastify reply payload', {
+          type: 'fastify',
+          metadata: JSON.stringify({
+            method: request.method,
+            route: request.routeOptions.url,
+            url: request.url.split('?', 1)[0],
+            statusCode: reply.statusCode,
+            contentType: reply.getHeader('content-type'),
+            payloadType: typeof payload,
+            ...describePayload(payload),
+          }),
+        })
+      }
+
+      done(null, payload)
+    })
+  },
+  { name: 'blob-response' }
+)
+
+function isSupportedFastifyPayload(payload: unknown) {
+  if (
+    payload === null ||
+    payload === undefined ||
+    typeof payload === 'string' ||
+    Buffer.isBuffer(payload)
+  ) {
+    return true
+  }
+
+  try {
+    const stream = payload as { getReader?: unknown; pipe?: unknown }
+    return (
+      typeof stream.pipe === 'function' ||
+      typeof stream.getReader === 'function' ||
+      Object.prototype.toString.call(payload) === '[object Response]'
+    )
+  } catch {
+    return false
+  }
+}
+
+function describePayload(payload: unknown) {
+  try {
+    return {
+      payloadConstructor:
+        typeof payload === 'object' && payload !== null ? payload.constructor?.name : undefined,
+      payloadTag: Object.prototype.toString.call(payload),
+    }
+  } catch {
+    return { payloadTag: '[uninspectable]' }
+  }
+}

--- a/src/http/plugins/db.ts
+++ b/src/http/plugins/db.ts
@@ -15,6 +15,7 @@ import {
   updateTenantMigrationsState,
 } from '@internal/database/migrations'
 import { ERRORS } from '@internal/errors'
+import type { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import { getConfig, MultitenantMigrationStrategy } from '../../config'
 
@@ -78,18 +79,7 @@ export const db = fastifyPlugin(
       }
     })
 
-    fastify.addHook('onSend', async (request, reply, payload) => {
-      request.db?.dispose()
-      return payload
-    })
-
-    fastify.addHook('onTimeout', async (request) => {
-      request.db?.dispose()
-    })
-
-    fastify.addHook('onRequestAbort', async (request) => {
-      request.db?.dispose()
-    })
+    registerConnectionCleanupHooks(fastify)
   },
   { name: 'db-init' }
 )
@@ -124,21 +114,27 @@ export const dbSuperUser = fastifyPlugin<DbSuperUserPluginOptions>(
       }
     })
 
-    fastify.addHook('onSend', async (request, reply, payload) => {
-      request.db?.dispose()
-      return payload
-    })
-
-    fastify.addHook('onTimeout', async (request) => {
-      request.db?.dispose()
-    })
-
-    fastify.addHook('onRequestAbort', async (request) => {
-      request.db?.dispose()
-    })
+    registerConnectionCleanupHooks(fastify)
   },
   { name: 'db-superuser-init' }
 )
+
+function registerConnectionCleanupHooks(fastify: FastifyInstance) {
+  fastify.addHook('onSend', (request, _reply, payload, done) => {
+    request.db?.dispose()
+    done(null, payload)
+  })
+
+  fastify.addHook('onTimeout', (request, _reply, done) => {
+    request.db?.dispose()
+    done()
+  })
+
+  fastify.addHook('onRequestAbort', (request, done) => {
+    request.db?.dispose()
+    done()
+  })
+}
 
 /**
  * Handle database migration for multitenant applications when a request is made

--- a/src/http/plugins/index.ts
+++ b/src/http/plugins/index.ts
@@ -1,4 +1,5 @@
 export * from './apikey'
+export * from './blob-response'
 export * from './db'
 export * from './empty-json-body'
 export * from './header-validator'

--- a/src/http/plugins/log-request.test.ts
+++ b/src/http/plugins/log-request.test.ts
@@ -1,12 +1,12 @@
 import { Writable } from 'node:stream'
-import Fastify from 'fastify'
+import Fastify, { LogController } from 'fastify'
 import pino from 'pino'
 import { logRequest } from './log-request'
 import { requestContext } from './request-context'
 
 function createApp(lines: string[]) {
   return Fastify({
-    disableRequestLogging: true,
+    logController: new LogController({ disableRequestLogging: true }),
     loggerInstance: pino(
       {
         level: 'info',

--- a/src/http/plugins/sync-hooks.test.ts
+++ b/src/http/plugins/sync-hooks.test.ts
@@ -1,5 +1,8 @@
 import type { FastifyInstance } from 'fastify'
 import Fastify from 'fastify'
+import pprofRoutes from '../routes/admin/pprof'
+import { blobResponse } from './blob-response'
+import { db, dbSuperUser } from './db'
 import { headerValidator } from './header-validator'
 import { logRequest } from './log-request'
 import { httpMetrics } from './metrics'
@@ -14,6 +17,16 @@ type CapturedHook = {
 }
 
 type HookFunction = (...args: unknown[]) => unknown
+
+const expectedHookArity: Record<string, number> = {
+  onRequest: 3,
+  onRequestAbort: 2,
+  onResponse: 3,
+  onSend: 4,
+  onTimeout: 3,
+  preHandler: 3,
+  preSerialization: 4,
+}
 
 function captureHooks(app: FastifyInstance): CapturedHook[] {
   const hooks: CapturedHook[] = []
@@ -43,8 +56,31 @@ async function collectHooks(register: (app: FastifyInstance) => Promise<unknown>
   }
 }
 
+function expectHooksToUseCallbackFastPath(capturedHooks: CapturedHook[], hookNames: string[]) {
+  for (const hookName of hookNames) {
+    const matches = capturedHooks.filter((candidate) => candidate.name === hookName)
+    const expectedArity = expectedHookArity[hookName]
+
+    expect(matches.length, `${hookName} hook should be registered`).toBeGreaterThan(0)
+    expect(expectedArity, `${hookName} should have an expected callback arity`).toBeDefined()
+
+    for (const { hook } of matches) {
+      expect(hook.constructor.name).not.toBe('AsyncFunction')
+      expect(
+        hook.length,
+        `${hookName} hook should use Fastify callback arity`
+      ).toBeGreaterThanOrEqual(expectedArity)
+    }
+  }
+}
+
 describe('sync request lifecycle hooks', () => {
   it.each([
+    {
+      name: 'blobResponse',
+      register: (app: FastifyInstance) => app.register(blobResponse),
+      hooks: ['onSend'],
+    },
     {
       name: 'requestContext',
       register: (app: FastifyInstance) => app.register(requestContext),
@@ -81,6 +117,24 @@ describe('sync request lifecycle hooks', () => {
       hooks: ['onSend'],
     },
     {
+      name: 'db cleanup',
+      register: (app: FastifyInstance) => app.register(db),
+      hooks: ['onSend', 'onTimeout', 'onRequestAbort'],
+    },
+    {
+      name: 'dbSuperUser cleanup',
+      register: (app: FastifyInstance) => app.register(dbSuperUser),
+      hooks: ['onSend', 'onTimeout', 'onRequestAbort'],
+    },
+    {
+      name: 'pprof response headers',
+      register: (app: FastifyInstance) => {
+        app.setValidatorCompiler(() => () => true)
+        return app.register(pprofRoutes)
+      },
+      hooks: ['onSend'],
+    },
+    {
       name: 'xmlParser',
       register: (app: FastifyInstance) => app.register(xmlParser),
       hooks: ['preSerialization'],
@@ -88,11 +142,17 @@ describe('sync request lifecycle hooks', () => {
   ])('registers $name hot hooks without async functions', async ({ register, hooks }) => {
     const capturedHooks = await collectHooks(register)
 
-    for (const hookName of hooks) {
-      const hook = capturedHooks.find((candidate) => candidate.name === hookName)?.hook
+    expectHooksToUseCallbackFastPath(capturedHooks, hooks)
+  })
 
-      expect(hook, `${hookName} hook should be registered`).toBeDefined()
-      expect(hook?.constructor.name).not.toBe('AsyncFunction')
-    }
+  it('rejects promise-returning hooks without callback arity', () => {
+    const promiseReturningHook = () => Promise.resolve()
+
+    expect(() =>
+      expectHooksToUseCallbackFastPath(
+        [{ name: 'onRequest', hook: promiseReturningHook }],
+        ['onRequest']
+      )
+    ).toThrow(/callback arity/)
   })
 })

--- a/src/http/routes/admin/pprof.test.ts
+++ b/src/http/routes/admin/pprof.test.ts
@@ -30,12 +30,14 @@ vi.mock('@internal/monitoring/pprof/trigger', () => ({
 vi.mock('../../../config', () => ({
   getConfig: () => ({
     adminApiKeys: 'secret',
+    logLevel: 'info',
     profilingS3Bucket: mocks.profilingS3Bucket,
   }),
 }))
 
 import { ProfilingBusyError } from '@internal/monitoring/pprof/controller'
 import { InvalidProfileDateError, ProfileNotFoundError } from '@internal/monitoring/pprof/store'
+import { blobResponse } from '../../plugins/blob-response'
 import { signals } from '../../plugins/signals'
 import routes from './pprof'
 
@@ -44,6 +46,7 @@ const profileKey =
 
 async function app() {
   const fastify = Fastify(withFiniteAjv({}))
+  await fastify.register(blobResponse)
   await fastify.register(signals)
   await fastify.register(routes, { prefix: '/debug/pprof' })
   return fastify
@@ -258,6 +261,32 @@ describe('admin pprof routes', () => {
     expect(download.headers['cache-control']).toBe('no-store')
     expect(mocks.get).toHaveBeenCalledWith(profileKey)
     await fastify.close()
+  })
+
+  it('streams Blob profile bodies instead of sending object payloads to Fastify', async () => {
+    mocks.get.mockResolvedValue({
+      object: { ContentType: 'application/gzip', Body: new Blob(['stored']) },
+      profile: {
+        class: 'auto',
+        kind: 'cpu',
+        startedAt: new Date('2026-07-13T12:00:00.000Z'),
+      },
+    })
+    const fastify = await app()
+
+    try {
+      const download = await fastify.inject({
+        method: 'GET',
+        url: `/debug/pprof/profiles/download?key=${encodeURIComponent(profileKey)}`,
+        headers: { apikey: 'secret' },
+      })
+
+      expect(download.statusCode).toBe(200)
+      expect(download.headers['content-type']).toBe('application/gzip')
+      expect(download.body).toBe('stored')
+    } finally {
+      await fastify.close()
+    }
   })
 
   it('returns 404 only when the stored profile is missing', async () => {

--- a/src/http/routes/admin/pprof.ts
+++ b/src/http/routes/admin/pprof.ts
@@ -42,9 +42,9 @@ function filenameTimestamp(date = new Date()) {
 
 export default async function routes(fastify: FastifyInstance) {
   registerApiKeyAuth(fastify)
-  fastify.addHook('onSend', async (_request, reply, payload) => {
+  fastify.addHook('onSend', (_request, reply, payload, done) => {
     reply.header('cache-control', 'no-store')
-    return payload
+    done(null, payload)
   })
   const shutdown = new AbortController()
   fastify.addHook('preClose', async () => shutdown.abort())

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -4,6 +4,7 @@ import type { JSONSchema } from 'json-schema-to-ts'
 import { vi } from 'vitest'
 import { S3ProtocolHandler } from '../../../storage/protocols/s3/s3-handler'
 import { Uploader } from '../../../storage/uploader'
+import { blobResponse } from '../../plugins/blob-response'
 import CompleteMultipartUpload from './commands/complete-multipart-upload'
 import ListMultipartUploads from './commands/list-multipart-uploads'
 import ListObjects from './commands/list-objects'
@@ -389,6 +390,7 @@ describe('S3 route handler matching', () => {
     const app = fastify()
 
     try {
+      await app.register(blobResponse)
       await app.register(routes)
       await app.ready()
       await callback(app)
@@ -495,6 +497,59 @@ describe('S3 route handler matching', () => {
         },
       }
     )
+  })
+
+  it('streams Blob object bodies instead of sending object payloads to Fastify', async () => {
+    const getObject = vi.fn().mockResolvedValue({
+      body: new Blob(['stored']),
+      httpStatusCode: 200,
+      metadata: {
+        cacheControl: 'no-cache',
+        contentLength: 6,
+        eTag: '"etag"',
+        mimetype: 'text/plain',
+      },
+    })
+
+    await withMockedS3App(
+      async (app) => {
+        const response = await app.inject({
+          method: 'GET',
+          url: '/bucket/object.txt',
+        })
+
+        expect(response.statusCode).toBe(200)
+        expect(response.headers['content-type']).toBe('text/plain')
+        expect(response.body).toBe('stored')
+      },
+      {
+        configureRequest: (request) => {
+          Object.assign(request, {
+            owner: 'owner-id',
+            signals: {
+              body: new AbortController(),
+              response: new AbortController(),
+            },
+            storage: {
+              backend: { getObject },
+              from: vi.fn(() => ({
+                findObject: vi.fn().mockResolvedValue({
+                  user_metadata: null,
+                  version: 'version',
+                }),
+              })),
+              location: {
+                getKeyLocation: vi.fn().mockReturnValue('tenant-id/bucket/object.txt'),
+                getRootLocation: vi.fn().mockReturnValue('root'),
+              },
+            },
+            tenantId: 'tenant-id',
+          })
+        },
+      }
+    )
+
+    expect(getObject).toHaveBeenCalled()
   })
 })
 

--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -21,7 +21,7 @@ import { PgShardStoreFactory, ShardCatalog } from '@internal/sharding'
 import { getGlobal } from '@platformatic/globals'
 import { registerWorkers } from '@storage/events'
 import { SyncCatalogIds } from '@storage/events/upgrades/sync-catalog-ids'
-import { FastifyInstance } from 'fastify'
+import { FastifyInstance, LogController } from 'fastify'
 import buildAdmin from '../admin-app'
 import build from '../app'
 import { getConfig } from '../config'
@@ -185,7 +185,7 @@ async function httpServer(signal: AbortSignal) {
 
   const app: FastifyInstance<Server, IncomingMessage, ServerResponse> = build({
     loggerInstance: logger,
-    disableRequestLogging: true,
+    logController: new LogController({ disableRequestLogging: true }),
     childLoggerFactory(logger) {
       return logger
     },
@@ -237,7 +237,7 @@ async function httpAdminServer(
 
   const adminApp = buildAdmin({
     loggerInstance: logger,
-    disableRequestLogging: true,
+    logController: new LogController({ disableRequestLogging: true }),
     childLoggerFactory(logger) {
       return logger
     },

--- a/src/start/worker.ts
+++ b/src/start/worker.ts
@@ -3,6 +3,7 @@ import { listenForTenantUpdate, PubSub } from '@internal/database'
 import { logger, logSchema, setLogger } from '@internal/monitoring'
 import { Queue } from '@internal/queue'
 import { registerWorkers } from '@storage/events'
+import { LogController } from 'fastify'
 import adminApp from '../admin-app'
 import { getConfig } from '../config'
 import { bindShutdownSignals, createServerClosedPromise, shutdown } from './shutdown'
@@ -63,7 +64,7 @@ export async function main() {
 
   const server = adminApp({
     loggerInstance: logger,
-    disableRequestLogging: true,
+    logController: new LogController({ disableRequestLogging: true }),
     childLoggerFactory(logger) {
       return logger
     },

--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { ErrorCode } from '@internal/errors'
 import Fastify, { type FastifyRequest } from 'fastify'
 import { Readable } from 'stream'
+import { blobResponse } from '../../http/plugins/blob-response'
 import { errorSchema } from '../../http/schemas/error'
 import { spyOnAbortSignalTimeout } from '../../test/utils/abort-signal'
 import type { StorageBackendAdapter } from '../backend'
@@ -417,6 +418,39 @@ describe('ImageRenderer fetch client', () => {
 
       expect(response.statusCode).toBe(499)
       expect(response.json()).toEqual(REQUEST_ABORTED_RESPONSE)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('streams Blob asset bodies instead of sending object payloads to Fastify', async () => {
+    await loadRendererModule()
+    const { Renderer } = await import('./renderer')
+
+    class BlobRenderer extends Renderer {
+      async getAsset() {
+        return {
+          body: new Blob(['blob-body']),
+          metadata: {
+            contentLength: 9,
+            mimetype: 'text/plain',
+          },
+        }
+      }
+    }
+
+    const app = Fastify()
+    await app.register(blobResponse)
+    app.get('/blob', async (request, reply) =>
+      new BlobRenderer().render(request, reply, createRenderOptions())
+    )
+
+    try {
+      const response = await app.inject('/blob')
+
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toBe('text/plain')
+      expect(response.body).toBe('blob-body')
     } finally {
       await app.close()
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Non-JSON content-type payload isn't serialized and causes uncaught exception. 

## What is the new behavior?

Convert blob payload to web streams where applicable.
Make db connection cleanup hooks sync, any escape will be caught by fastify and it's faster as well by not allocating one promise and doing one less microtask execution.

## Additional context

Bump fastify due to https://github.com/fastify/fastify/pull/6889