### PR TITLE
fix(tus): fail closed on incomplete uploads without discarding safe retries

### DIFF
--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -11,7 +11,9 @@ import {
   FileStore,
   LockNotifier,
   PgLocker,
+  runWithTusRequest,
   S3Store,
+  setTusRequestCancellationSignal,
   UploadId,
 } from '@storage/protocols/tus'
 import { S3Locker } from '@storage/protocols/tus/s3-locker'
@@ -52,6 +54,18 @@ const {
   storageBackendType,
   storageFilePath,
 } = getConfig()
+
+class StorageTusServer extends Server {
+  override handle(request: http.IncomingMessage, response: http.ServerResponse) {
+    return runWithTusRequest(request, () => super.handle(request, response))
+  }
+
+  protected override createContext() {
+    const context = super.createContext()
+    setTusRequestCancellationSignal(context.signal)
+    return context
+  }
+}
 
 function createTusStore(agent: { httpsAgent: https.Agent; httpAgent: http.Agent }) {
   if (storageBackendType === 's3') {
@@ -171,7 +185,7 @@ function createTusServer(
       return fileSizeLimit
     },
   }
-  return new Server(serverOptions)
+  return new StorageTusServer(serverOptions)
 }
 
 export default async function routes(fastify: FastifyInstance) {

--- a/src/http/routes/tus/lifecycle.test.ts
+++ b/src/http/routes/tus/lifecycle.test.ts
@@ -100,6 +100,26 @@ describe('tus lifecycle logging', () => {
     expect(reqLog.warn).not.toHaveBeenCalled()
   })
 
+  it('silently ignores Upload-Checksum until checksum support is available', async () => {
+    const canUploadSpy = vi.spyOn(Uploader.prototype, 'canUpload').mockResolvedValue(undefined)
+    const getUpload = vi.fn(async () => ({ metadata: {}, size: 1 }))
+    const { dispose, rawReq, response } = createRawTusRequest({
+      method: 'PATCH',
+      headers: {
+        'upload-checksum': 'sha1 Kq5sNclPz7QV2+lfQIuc6R7oRu0=',
+      },
+    })
+
+    await expect(
+      onIncomingRequest(rawReq, uploadId, { getUpload } as unknown as DataStore)
+    ).resolves.toBeUndefined()
+
+    expect(getUpload).toHaveBeenCalledWith(uploadId)
+    expect(canUploadSpy).toHaveBeenCalledOnce()
+    response.emit('finish')
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
   it('logs user metadata parse failures with sbReqId through logSchema', async () => {
     const warningSpy = vi.spyOn(logSchema, 'warning').mockImplementation(() => undefined)
     const canUploadSpy = vi.spyOn(Uploader.prototype, 'canUpload').mockResolvedValue(undefined)

--- a/src/storage/protocols/tus/file-store.test.ts
+++ b/src/storage/protocols/tus/file-store.test.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs'
 import * as fsp from 'node:fs/promises'
+import type { IncomingMessage } from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
-import { Readable } from 'node:stream'
+import { Readable, Writable } from 'node:stream'
 import { pathExists, removePath } from '@internal/fs'
 import type { Configstore } from '@tus/file-store'
 import { Upload } from '@tus/server'
@@ -9,6 +11,9 @@ import { ERRORS as TUS_ERRORS } from '@tus/utils'
 import { vi } from 'vitest'
 import { getConfig } from '../../../config'
 import { FileStore, type FileStoreOptions } from './file-store'
+import { runWithTusRequest } from './request-context'
+
+const EXPIRED_CREATION_DATE = '2000-01-01T00:00:00.000Z'
 
 describe('TUS FileStore traversal protection', () => {
   let tmpDir: string
@@ -27,6 +32,8 @@ describe('TUS FileStore traversal protection', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
+
     if (originalStoragePath === undefined) {
       delete process.env.STORAGE_FILE_BACKEND_PATH
     } else {
@@ -77,6 +84,28 @@ describe('TUS FileStore traversal protection', () => {
     })
   }
 
+  function createRequest(contentLength: number): IncomingMessage {
+    return {
+      aborted: false,
+      complete: true,
+      headers: { 'content-length': String(contentLength) },
+    } as unknown as IncomingMessage
+  }
+
+  function mockWriteStreamFailure(afterOpen: boolean) {
+    const writable = new Writable({
+      write() {
+        queueMicrotask(() => {
+          if (afterOpen) {
+            writable.emit('open', 123)
+          }
+          writable.destroy(Object.assign(new Error('too many open files'), { code: 'EMFILE' }))
+        })
+      },
+    })
+    vi.spyOn(fs, 'createWriteStream').mockReturnValue(writable as fs.WriteStream)
+  }
+
   it('creates and reads safe nested upload ids under the configured directory', async () => {
     const store = createStore()
     const upload = createUpload('tenant-a/bucket-a/folder/file.txt/version-a')
@@ -98,6 +127,42 @@ describe('TUS FileStore traversal protection', () => {
     expect(storedUpload.offset).toBe(5)
     expect(storedUpload.size).toBe(5)
     expect(storedUpload.storage).toEqual(created.storage)
+  })
+
+  it('preserves prior progress when the write stream fails before opening', async () => {
+    const store = createStore()
+    const upload = createUpload('tenant-a/bucket-a/folder/file.txt/version-a', 10)
+    const created = await store.create(upload)
+    await store.write(Readable.from(Buffer.from('hello')), upload.id, 0)
+    const remove = vi.spyOn(store, 'remove')
+    mockWriteStreamFailure(false)
+
+    const result = runWithTusRequest(createRequest(5), () =>
+      store.write(Readable.from(Buffer.from('world')), upload.id, 5)
+    )
+
+    await expect(result).rejects.toBe(TUS_ERRORS.FILE_WRITE_ERROR)
+    expect(remove).not.toHaveBeenCalled()
+    expect(await fsp.readFile(created.storage!.path, 'utf8')).toBe('hello')
+    await expect(store.getUpload(upload.id)).resolves.toMatchObject({ offset: 5, size: 10 })
+  })
+
+  it('invalidates prior progress when the write stream fails after opening', async () => {
+    const store = createStore()
+    const upload = createUpload('tenant-a/bucket-a/folder/file.txt/version-a', 10)
+    const created = await store.create(upload)
+    await store.write(Readable.from(Buffer.from('hello')), upload.id, 0)
+    const remove = vi.spyOn(store, 'remove')
+    mockWriteStreamFailure(true)
+
+    const result = runWithTusRequest(createRequest(5), () =>
+      store.write(Readable.from(Buffer.from('world')), upload.id, 5)
+    )
+
+    await expect(result).rejects.toBe(TUS_ERRORS.FILE_WRITE_ERROR)
+    expect(remove).toHaveBeenCalledWith(upload.id)
+    expect(await pathExists(created.storage!.path)).toBe(false)
+    expect(await pathExists(`${created.storage!.path}.json`)).toBe(false)
   })
 
   it('rejects traversal upload ids before touching blob or configstore paths', async () => {
@@ -203,10 +268,9 @@ describe('TUS FileStore traversal protection', () => {
   it('deleteExpired skips invalid upload ids and still cleans up valid expired uploads', async () => {
     const validId = 'tenant-a/bucket-a/folder/file.txt/version-a'
     const invalidId = '../escaped/upload'
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
     const uploads = new Map<string, Upload>([
-      [validId, createUpload(validId, 5, { creationDate })],
-      [invalidId, createUpload(invalidId, 5, { creationDate })],
+      [validId, createUpload(validId, 5, { creationDate: EXPIRED_CREATION_DATE })],
+      [invalidId, createUpload(invalidId, 5, { creationDate: EXPIRED_CREATION_DATE })],
     ])
     const configstore = {
       get: vi.fn(async (key: string) => uploads.get(key)),
@@ -236,8 +300,9 @@ describe('TUS FileStore traversal protection', () => {
   it('deleteExpired skips invalid upload ids before configstore.get runs', async () => {
     const validId = 'tenant-a/bucket-a/folder/file.txt/version-a'
     const invalidId = '../escaped/upload'
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
-    const uploads = new Map<string, Upload>([[validId, createUpload(validId, 5, { creationDate })]])
+    const uploads = new Map<string, Upload>([
+      [validId, createUpload(validId, 5, { creationDate: EXPIRED_CREATION_DATE })],
+    ])
     const configstore = {
       get: vi.fn(async (key: string) => {
         if (key === invalidId) {
@@ -271,9 +336,8 @@ describe('TUS FileStore traversal protection', () => {
 
   it('deleteExpired keeps uploads whose on-disk bytes match the declared size', async () => {
     const uploadId = 'tenant-a/bucket-a/folder/file.txt/version-a'
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
     const uploads = new Map<string, Upload>([
-      [uploadId, createUpload(uploadId, 5, { creationDate })],
+      [uploadId, createUpload(uploadId, 5, { creationDate: EXPIRED_CREATION_DATE })],
     ])
     const configstore = {
       get: vi.fn(async (key: string) => uploads.get(key)),
@@ -302,9 +366,8 @@ describe('TUS FileStore traversal protection', () => {
 
   it('deleteExpired removes orphaned metadata when the blob is missing', async () => {
     const uploadId = 'tenant-a/bucket-a/folder/file.txt/version-a'
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
     const uploads = new Map<string, Upload>([
-      [uploadId, createUpload(uploadId, 5, { creationDate })],
+      [uploadId, createUpload(uploadId, 5, { creationDate: EXPIRED_CREATION_DATE })],
     ])
     const configstore = {
       get: vi.fn(async (key: string) => uploads.get(key)),
@@ -333,10 +396,9 @@ describe('TUS FileStore traversal protection', () => {
   it('deleteExpired ignores FILE_NOT_FOUND races from remove and keeps queued count', async () => {
     const racedUploadId = 'tenant-a/bucket-a/folder/raced-file.txt/version-a'
     const removedUploadId = 'tenant-a/bucket-a/folder/removed-file.txt/version-a'
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
     const uploads = new Map<string, Upload>([
-      [racedUploadId, createUpload(racedUploadId, 5, { creationDate })],
-      [removedUploadId, createUpload(removedUploadId, 5, { creationDate })],
+      [racedUploadId, createUpload(racedUploadId, 5, { creationDate: EXPIRED_CREATION_DATE })],
+      [removedUploadId, createUpload(removedUploadId, 5, { creationDate: EXPIRED_CREATION_DATE })],
     ])
     const configstore = {
       get: vi.fn(async (key: string) => uploads.get(key)),
@@ -377,13 +439,15 @@ describe('TUS FileStore traversal protection', () => {
   })
 
   it('deleteExpired limits concurrent removals for large expired batches', async () => {
-    const creationDate = new Date(Date.now() - 60_000).toISOString()
     const uploadIds = Array.from(
       { length: 96 },
       (_, index) => `tenant-a/bucket-a/folder/file-${index}.txt/version-a`
     )
     const uploads = new Map(
-      uploadIds.map((uploadId) => [uploadId, createUpload(uploadId, 5, { creationDate })])
+      uploadIds.map((uploadId) => [
+        uploadId,
+        createUpload(uploadId, 5, { creationDate: EXPIRED_CREATION_DATE }),
+      ])
     )
     const configstore = {
       get: vi.fn(async (key: string) => uploads.get(key)),
@@ -397,21 +461,32 @@ describe('TUS FileStore traversal protection', () => {
     })
     let activeRemovals = 0
     let maxConcurrentRemovals = 0
+    let startedRemovals = 0
+    const concurrentRemovalsStarted = Promise.withResolvers<void>()
+    const releaseRemovals = Promise.withResolvers<void>()
 
     await Promise.all(uploadIds.map((uploadId) => store.create(uploads.get(uploadId)!)))
 
     vi.spyOn(store, 'remove').mockImplementation(async () => {
       activeRemovals += 1
+      startedRemovals += 1
       maxConcurrentRemovals = Math.max(maxConcurrentRemovals, activeRemovals)
+      if (startedRemovals === 2) {
+        concurrentRemovalsStarted.resolve()
+      }
 
-      await new Promise((resolve) => setTimeout(resolve, 5))
+      await releaseRemovals.promise
 
       activeRemovals -= 1
     })
 
-    await expect(store.deleteExpired()).resolves.toBe(uploadIds.length)
+    const deletion = store.deleteExpired()
+    await concurrentRemovalsStarted.promise
 
-    expect(maxConcurrentRemovals).toBeGreaterThan(0)
+    expect(maxConcurrentRemovals).toBeGreaterThan(1)
     expect(maxConcurrentRemovals).toBeLessThan(uploadIds.length)
+
+    releaseRemovals.resolve()
+    await expect(deletion).resolves.toBe(uploadIds.length)
   })
 })

--- a/src/storage/protocols/tus/file-store.ts
+++ b/src/storage/protocols/tus/file-store.ts
@@ -8,6 +8,7 @@ import { FileBackend, resolveSecureFilesystemPath } from '@storage/backend'
 import { Configstore, FileStore as TusFileStore } from '@tus/file-store'
 import { Upload } from '@tus/server'
 import { ERRORS as TUS_ERRORS } from '@tus/utils'
+import { markTusWriteMutation, writeWithRequestCompletion } from './request-context'
 
 const DELETE_EXPIRED_CONCURRENCY = 32
 
@@ -66,27 +67,35 @@ export class FileStore extends TusFileStore {
     offset: number
   ): Promise<number> {
     const filePath = this.resolveUploadPath(fileId)
-    const writable = fs.createWriteStream(filePath, {
-      flags: 'r+',
-      start: offset,
-    })
 
-    let bytesReceived = 0
-    const transform = new stream.Transform({
-      transform(chunk, _, callback) {
-        bytesReceived += chunk.length
-        callback(null, chunk)
-      },
-    })
-
-    return new Promise((resolve, reject) => {
-      stream.pipeline(readable, transform, writable, (err) => {
-        if (err) {
-          return reject(TUS_ERRORS.FILE_WRITE_ERROR)
-        }
-
-        resolve(offset + bytesReceived)
+    const writeToUploadFile = () => {
+      const writable = fs.createWriteStream(filePath, {
+        flags: 'r+',
+        start: offset,
       })
+      writable.once('open', markTusWriteMutation)
+
+      let bytesReceived = 0
+      const transform = new stream.Transform({
+        transform(chunk, _, callback) {
+          bytesReceived += chunk.length
+          callback(null, chunk)
+        },
+      })
+
+      return new Promise<number>((resolve, reject) => {
+        stream.pipeline(readable, transform, writable, (err) => {
+          if (err) {
+            return reject(TUS_ERRORS.FILE_WRITE_ERROR)
+          }
+
+          resolve(offset + bytesReceived)
+        })
+      })
+    }
+
+    return writeWithRequestCompletion(this, 'file', fileId, offset, writeToUploadFile, {
+      trackedMutations: true,
     })
   }
 

--- a/src/storage/protocols/tus/index.ts
+++ b/src/storage/protocols/tus/index.ts
@@ -1,5 +1,6 @@
 export * from './als-memory-kv'
 export * from './file-store'
 export * from './postgres-locker'
+export * from './request-context'
 export * from './s3-store'
 export * from './upload-id'

--- a/src/storage/protocols/tus/request-context.test.ts
+++ b/src/storage/protocols/tus/request-context.test.ts
@@ -1,0 +1,171 @@
+import type { IncomingMessage } from 'node:http'
+import {
+  runWithTusRequest,
+  setTusRequestCancellationSignal,
+  writeWithRequestCompletion,
+} from './request-context'
+
+type RequestOptions = {
+  aborted?: boolean
+  complete?: boolean
+  contentLength?: string
+}
+
+function createRequest(options: RequestOptions = {}): IncomingMessage {
+  const contentLength = 'contentLength' in options ? options.contentLength : '5'
+
+  return {
+    aborted: options.aborted ?? false,
+    complete: options.complete ?? true,
+    headers: contentLength === undefined ? {} : { 'content-length': contentLength },
+    log: { warn: vi.fn() },
+    upload: {
+      tenantId: 'tenant-123',
+      reqId: 'req-123',
+      sbReqId: 'sb-req-123',
+    },
+  } as unknown as IncomingMessage
+}
+
+function createStore(remove = vi.fn(async () => undefined)) {
+  return { remove }
+}
+
+describe('TUS request write completion', () => {
+  it.each([
+    {
+      name: 'a complete fixed-length body',
+      request: createRequest(),
+    },
+    {
+      name: 'a fixed-length body whose bytes committed before a late abort',
+      request: createRequest({ aborted: true, complete: false }),
+    },
+    {
+      name: 'a complete chunked body',
+      request: createRequest({ contentLength: undefined }),
+    },
+  ])('keeps the upload after $name', async ({ request }) => {
+    const store = createStore()
+
+    const offset = await runWithTusRequest(request, () =>
+      writeWithRequestCompletion(store, 'file', 'upload-id', 7, async () => 12)
+    )
+
+    expect(offset).toBe(12)
+    expect(store.remove).not.toHaveBeenCalled()
+  })
+
+  it.each(
+    [
+      {
+        name: 'the fixed-length body is short',
+        request: createRequest({ contentLength: '6' }),
+        reason: 'length_mismatch',
+      },
+      {
+        name: 'Content-Length is unsafe',
+        request: createRequest({ contentLength: '9007199254740992' }),
+        reason: 'length_mismatch',
+        newOffset: 12,
+      },
+      {
+        name: 'the datastore returns a lower offset',
+        request: createRequest(),
+        reason: 'offset_mismatch',
+        newOffset: 6,
+      },
+      {
+        name: 'a chunked request is aborted',
+        request: createRequest({ aborted: true, complete: false, contentLength: undefined }),
+        reason: 'aborted',
+      },
+      {
+        name: 'a chunked HTTP message is incomplete',
+        request: createRequest({ complete: false, contentLength: undefined }),
+        reason: 'incomplete',
+      },
+    ].map((testCase) => ({ newOffset: 12, ...testCase }))
+  )('invalidates when $name', async ({ request, reason, newOffset }) => {
+    const store = createStore()
+
+    await expect(
+      runWithTusRequest(request, () =>
+        writeWithRequestCompletion(store, 'file', 'upload-id', 7, async () => newOffset)
+      )
+    ).rejects.toMatchObject({
+      status_code: 400,
+      body: 'Upload request body was incomplete\n',
+    })
+
+    expect(store.remove).toHaveBeenCalledWith('upload-id')
+    expect(
+      (request as IncomingMessage & { log: { warn: ReturnType<typeof vi.fn> } }).log.warn
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: JSON.stringify({ backend: 'file', reason, outcome: 'success' }),
+      }),
+      'TUS upload invalidated'
+    )
+  })
+
+  it('invalidates a chunked write cancelled internally by tus', async () => {
+    const request = createRequest({ contentLength: undefined })
+    const store = createStore()
+    const cancellation = new AbortController()
+
+    const result = runWithTusRequest(request, () => {
+      setTusRequestCancellationSignal(cancellation.signal)
+      cancellation.abort()
+      return writeWithRequestCompletion(store, 's3', 'upload-id', 7, async () => 12)
+    })
+
+    await expect(result).rejects.toMatchObject({ status_code: 400 })
+    expect(store.remove).toHaveBeenCalledWith('upload-id')
+  })
+
+  it('invalidates an ambiguous datastore write error', async () => {
+    const request = createRequest()
+    const store = createStore()
+    const writeError = new Error('backend write failed')
+
+    const result = runWithTusRequest(request, () =>
+      writeWithRequestCompletion(store, 's3', 'upload-id', 7, async () => {
+        throw writeError
+      })
+    )
+
+    await expect(result).rejects.toBe(writeError)
+    expect(store.remove).toHaveBeenCalledWith('upload-id')
+  })
+
+  it('surfaces both write and cleanup failures', async () => {
+    const writeError = new Error('backend write failed')
+    const cleanupError = new Error('cleanup failed')
+    const store = createStore(
+      vi.fn(async () => {
+        throw cleanupError
+      })
+    )
+
+    const result = runWithTusRequest(createRequest(), () =>
+      writeWithRequestCompletion(store, 's3', 'upload-id', 7, async () => {
+        throw writeError
+      })
+    )
+
+    await expect(result).rejects.toMatchObject({
+      message: 'Failed to invalidate incomplete TUS upload upload-id',
+      errors: [writeError, cleanupError],
+    })
+  })
+
+  it('leaves direct datastore writes unchanged outside a request', async () => {
+    const store = createStore()
+
+    await expect(
+      writeWithRequestCompletion(store, 'file', 'upload-id', 7, async () => 8)
+    ).resolves.toBe(8)
+    expect(store.remove).not.toHaveBeenCalled()
+  })
+})

--- a/src/storage/protocols/tus/request-context.ts
+++ b/src/storage/protocols/tus/request-context.ts
@@ -1,0 +1,188 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { IncomingMessage } from 'node:http'
+import { logSchema, type RequestLogContext } from '@internal/monitoring/logger'
+import type { FastifyBaseLogger } from 'fastify'
+
+type RemovableStore = {
+  remove(id: string): Promise<void>
+}
+
+type TusBackend = 'file' | 's3'
+type InvalidationReason =
+  | 'aborted'
+  | 'cancelled'
+  | 'incomplete'
+  | 'length_mismatch'
+  | 'offset_mismatch'
+  | 'write_error'
+
+type TusRequest = IncomingMessage & {
+  log?: FastifyBaseLogger
+  upload?: RequestLogContext
+}
+
+type TusRequestState = {
+  request: TusRequest
+  cancellationSignal?: AbortSignal
+  writeDidMutate?: boolean
+}
+
+type WriteCompletionOptions = {
+  trackedMutations?: boolean
+}
+
+// Upstream closes its datastore proxy with a clean EOF when a request is
+// cancelled. Keep the original Node request available to the datastore so a
+// truncated HTTP message cannot be mistaken for a successful partial write.
+const requestStorage = new AsyncLocalStorage<TusRequestState>()
+
+class IncompleteTusRequestError extends Error {
+  readonly status_code = 400
+  readonly body = 'Upload request body was incomplete\n'
+
+  constructor() {
+    super('TUS upload request body was incomplete')
+    this.name = 'IncompleteTusRequestError'
+  }
+}
+
+export function runWithTusRequest<T>(request: IncomingMessage, callback: () => T): T {
+  return requestStorage.run({ request }, callback)
+}
+
+// Makes upstream internal cancellation observable to datastore guards.
+export function setTusRequestCancellationSignal(signal: AbortSignal): void {
+  const state = requestStorage.getStore()
+  if (state) {
+    state.cancellationSignal = signal
+  }
+}
+
+// Marks the first backend operation that can change durable upload state.
+export function markTusWriteMutation(): void {
+  const state = requestStorage.getStore()
+  if (state) {
+    state.writeDidMutate = true
+  }
+}
+
+export async function writeWithRequestCompletion(
+  store: RemovableStore,
+  backend: TusBackend,
+  id: string,
+  offset: number,
+  write: () => Promise<number>,
+  options: WriteCompletionOptions = {}
+): Promise<number> {
+  const state = requestStorage.getStore()
+
+  if (!state) {
+    return write()
+  }
+
+  state.writeDidMutate = false
+
+  let newOffset: number
+  try {
+    newOffset = await write()
+  } catch (error) {
+    if (options.trackedMutations && !state.writeDidMutate) {
+      throw error
+    }
+
+    return invalidateUpload(state.request, store, backend, id, 'write_error', error)
+  }
+
+  const reason = getInvalidationReason(state, offset, newOffset)
+  if (!reason) {
+    return newOffset
+  }
+
+  return invalidateUpload(
+    state.request,
+    store,
+    backend,
+    id,
+    reason,
+    new IncompleteTusRequestError()
+  )
+}
+
+function getInvalidationReason(
+  state: TusRequestState,
+  offset: number,
+  newOffset: number
+): InvalidationReason | undefined {
+  const { request } = state
+
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(newOffset) ||
+    offset < 0 ||
+    newOffset < offset
+  ) {
+    return 'offset_mismatch'
+  }
+
+  const bytesWritten = newOffset - offset
+
+  const contentLength = request.headers['content-length']
+  if (contentLength !== undefined) {
+    if (typeof contentLength !== 'string' || !/^\d+$/.test(contentLength)) {
+      return 'length_mismatch'
+    }
+
+    const expectedBytes = Number(contentLength)
+    return Number.isSafeInteger(bytesWritten) &&
+      Number.isSafeInteger(expectedBytes) &&
+      bytesWritten === expectedBytes
+      ? undefined
+      : 'length_mismatch'
+  }
+
+  if (request.aborted) {
+    return 'aborted'
+  }
+
+  if (!request.complete) {
+    return 'incomplete'
+  }
+
+  return state.cancellationSignal?.aborted ? 'cancelled' : undefined
+}
+
+async function invalidateUpload(
+  request: TusRequest,
+  store: RemovableStore,
+  backend: TusBackend,
+  id: string,
+  reason: InvalidationReason,
+  cause: unknown
+): Promise<never> {
+  let error = cause
+  let outcome: 'success' | 'cleanup_error' = 'success'
+
+  try {
+    await store.remove(id)
+  } catch (cleanupError) {
+    error = new AggregateError(
+      [cause, cleanupError],
+      `Failed to invalidate incomplete TUS upload ${id}`
+    )
+    outcome = 'cleanup_error'
+  }
+
+  if (request.log) {
+    logSchema.warning(request.log, 'TUS upload invalidated', {
+      type: 'tus',
+      tenantId: request.upload?.tenantId,
+      project: request.upload?.tenantId,
+      reqId: request.upload?.reqId,
+      sbReqId: request.upload?.sbReqId,
+      error,
+      metadata: JSON.stringify({ backend, reason, outcome }),
+    })
+  }
+
+  throw error
+}

--- a/src/storage/protocols/tus/s3-store.test.ts
+++ b/src/storage/protocols/tus/s3-store.test.ts
@@ -1,9 +1,19 @@
+import type { IncomingMessage } from 'node:http'
+import { Readable } from 'node:stream'
+import { NoSuchUpload } from '@aws-sdk/client-s3'
 import { HttpResponse } from '@smithy/protocol-http'
+import { type MetadataValue, S3Store as TusS3Store } from '@tus/s3-store'
+import { Upload } from '@tus/server'
+import { runWithTusRequest } from './request-context'
 import { S3Store } from './s3-store'
 
 class TestS3Store extends S3Store {
   getClient() {
     return this.client
+  }
+
+  attemptWriteMutation() {
+    return this.deleteIncompletePart('upload-id')
   }
 }
 
@@ -26,7 +36,37 @@ function createStore(
   })
 }
 
+function createRequest(): IncomingMessage {
+  return {
+    aborted: false,
+    complete: true,
+    headers: { 'content-length': '1' },
+  } as unknown as IncomingMessage
+}
+
 describe('S3Store', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockMetadata(store: TestS3Store) {
+    vi.spyOn(
+      store as unknown as { getMetadata(id: string): Promise<MetadataValue> },
+      'getMetadata'
+    ).mockResolvedValue({
+      file: new Upload({ id: 'upload-id', offset: 0 }),
+      'upload-id': 'mpu-1',
+      'tus-version': '1.0.0',
+    })
+  }
+
+  function noSuchUpload() {
+    return new NoSuchUpload({
+      $metadata: { httpStatusCode: 404 },
+      message: 'The specified multipart upload does not exist',
+    })
+  }
+
   test('removes the no-op logger middleware from the internal TUS client', () => {
     const store = createStore(vi.fn())
 
@@ -66,5 +106,164 @@ describe('S3Store', () => {
     expect(expectedError).toMatchObject({
       $metadata: { attempts: 1, totalRetryDelay: 0 },
     })
+  })
+
+  test('settles multipart abort before deleting data and metadata', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    const abortStarted = Promise.withResolvers<void>()
+    const pendingAbort = Promise.withResolvers<void>()
+    mockMetadata(store)
+    const abort = vi.spyOn(client, 'abortMultipartUpload').mockImplementation(() => {
+      abortStarted.resolve()
+      return pendingAbort.promise as never
+    })
+    const deleteObjects = vi.spyOn(client, 'deleteObjects').mockResolvedValue({} as never)
+
+    const removal = store.remove('upload-id')
+
+    await abortStarted.promise
+    expect(abort).toHaveBeenCalledOnce()
+    expect(deleteObjects).not.toHaveBeenCalled()
+    pendingAbort.resolve()
+    await removal
+
+    expect(deleteObjects).toHaveBeenNthCalledWith(1, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: [{ Key: 'upload-id' }, { Key: 'upload-id.part' }] },
+    })
+    expect(deleteObjects).toHaveBeenNthCalledWith(2, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: [{ Key: 'upload-id.info' }] },
+    })
+  })
+
+  test('deletes completed-upload artifacts when abort returns NoSuchUpload', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    mockMetadata(store)
+    vi.spyOn(client, 'abortMultipartUpload').mockRejectedValue(noSuchUpload())
+    const deleteObjects = vi.spyOn(client, 'deleteObjects').mockResolvedValue({} as never)
+
+    await expect(store.remove('upload-id')).resolves.toBeUndefined()
+
+    expect(deleteObjects).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries reported DeleteObjects errors before deleting metadata', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    mockMetadata(store)
+    vi.spyOn(client, 'abortMultipartUpload').mockRejectedValue(noSuchUpload())
+    const deleteObjects = vi
+      .spyOn(client, 'deleteObjects')
+      .mockResolvedValueOnce({
+        $metadata: {},
+        Errors: [{ Key: 'upload-id', Code: 'InternalError', Message: 'retry later' }],
+      } as never)
+      .mockResolvedValue({ $metadata: {} } as never)
+
+    await expect(store.remove('upload-id')).resolves.toBeUndefined()
+
+    expect(deleteObjects).toHaveBeenCalledTimes(3)
+    expect(deleteObjects).toHaveBeenNthCalledWith(2, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: [{ Key: 'upload-id' }] },
+    })
+    expect(deleteObjects).toHaveBeenNthCalledWith(3, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: [{ Key: 'upload-id.info' }] },
+    })
+  })
+
+  test('keeps metadata when data cleanup still fails after retry', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    mockMetadata(store)
+    vi.spyOn(client, 'abortMultipartUpload').mockResolvedValue(undefined as never)
+    const deleteObjects = vi.spyOn(client, 'deleteObjects').mockResolvedValue({
+      $metadata: {},
+      Errors: [{ Key: 'upload-id', Code: 'AccessDenied', Message: 'denied' }],
+    } as never)
+
+    await expect(store.remove('upload-id')).rejects.toMatchObject({
+      message: 'Failed to delete TUS upload artifacts for upload-id',
+    })
+
+    expect(deleteObjects).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries the full deletion phase when S3 omits the failed key', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    mockMetadata(store)
+    vi.spyOn(client, 'abortMultipartUpload').mockRejectedValue(noSuchUpload())
+    const deleteObjects = vi
+      .spyOn(client, 'deleteObjects')
+      .mockResolvedValueOnce({
+        $metadata: {},
+        Errors: [{ Code: 'InternalError', Message: 'retry later' }],
+      } as never)
+      .mockResolvedValue({ $metadata: {} } as never)
+
+    await expect(store.remove('upload-id')).resolves.toBeUndefined()
+
+    expect(deleteObjects).toHaveBeenNthCalledWith(2, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: [{ Key: 'upload-id' }, { Key: 'upload-id.part' }] },
+    })
+  })
+
+  test('aggregates abort, data, and cache cleanup failures', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    const abortError = new Error('abort failed')
+    const dataError = new Error('data cleanup failed')
+    const cacheError = new Error('cache cleanup failed')
+    mockMetadata(store)
+    vi.spyOn(client, 'abortMultipartUpload').mockRejectedValue(abortError)
+    vi.spyOn(client, 'deleteObjects').mockRejectedValue(dataError)
+    vi.spyOn(
+      store as unknown as { clearCache(id: string): Promise<void> },
+      'clearCache'
+    ).mockRejectedValue(cacheError)
+
+    await expect(store.remove('upload-id')).rejects.toMatchObject({
+      message: 'Failed to remove TUS upload upload-id',
+      errors: [abortError, dataError, cacheError],
+    })
+  })
+
+  test('preserves the upload when S3 rejects before a write mutation', async () => {
+    const store = createStore(vi.fn())
+    const writeError = new Error('metadata lookup failed')
+    vi.spyOn(TusS3Store.prototype, 'write').mockRejectedValue(writeError)
+    const remove = vi.spyOn(store, 'remove').mockResolvedValue(undefined)
+
+    const result = runWithTusRequest(createRequest(), () =>
+      store.write(Readable.from('x'), 'upload-id', 0)
+    )
+
+    await expect(result).rejects.toBe(writeError)
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  test('invalidates the upload when S3 rejects after a write mutation', async () => {
+    const store = createStore(vi.fn())
+    const client = store.getClient()
+    const writeError = new Error('upload part failed')
+    vi.spyOn(client, 'deleteObject').mockResolvedValue(undefined as never)
+    vi.spyOn(TusS3Store.prototype, 'write').mockImplementation(async function (this: TusS3Store) {
+      await (this as TestS3Store).attemptWriteMutation()
+      throw writeError
+    })
+    const remove = vi.spyOn(store, 'remove').mockResolvedValue(undefined)
+
+    const result = runWithTusRequest(createRequest(), () =>
+      store.write(Readable.from('x'), 'upload-id', 0)
+    )
+
+    await expect(result).rejects.toBe(writeError)
+    expect(remove).toHaveBeenCalledWith('upload-id')
   })
 })

--- a/src/storage/protocols/tus/s3-store.ts
+++ b/src/storage/protocols/tus/s3-store.ts
@@ -1,8 +1,190 @@
-import { type Options, S3Store as TusS3Store } from '@tus/s3-store'
+import type fs from 'node:fs'
+import type stream from 'node:stream'
+import type { Part } from '@aws-sdk/client-s3'
+import { type MetadataValue, type Options, S3Store as TusS3Store } from '@tus/s3-store'
+import { ERRORS as TUS_ERRORS } from '@tus/utils'
+import { markTusWriteMutation, writeWithRequestCompletion } from './request-context'
+
+const MISSING_RESOURCE_CODES = new Set(['NotFound', 'NoSuchKey', 'NoSuchUpload'])
+
+function isMissingResourceError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  if (error === TUS_ERRORS.FILE_NOT_FOUND) {
+    return true
+  }
+
+  const candidate = error as Record<string, unknown>
+  const name = candidate.name // canonical
+  if (typeof name === 'string' && MISSING_RESOURCE_CODES.has(name)) {
+    return true
+  }
+
+  const upperCode = candidate.Code // compat, upstream s3-store checks this as well
+  if (typeof upperCode === 'string' && MISSING_RESOURCE_CODES.has(upperCode)) {
+    return true
+  }
+
+  const lowerCode = candidate.code // defensive check
+  return typeof lowerCode === 'string' && MISSING_RESOURCE_CODES.has(lowerCode)
+}
 
 export class S3Store extends TusS3Store {
   constructor(options: Options) {
     super(options)
     this.client.middlewareStack.remove('loggerMiddleware')
+  }
+
+  write(readable: stream.Readable, id: string, offset: number): Promise<number> {
+    return writeWithRequestCompletion(
+      this,
+      's3',
+      id,
+      offset,
+      () => super.write(readable, id, offset),
+      { trackedMutations: true }
+    )
+  }
+
+  protected uploadPart(
+    metadata: MetadataValue,
+    readStream: fs.ReadStream | stream.Readable | Buffer,
+    partNumber: number
+  ): Promise<string> {
+    markTusWriteMutation()
+    return super.uploadPart(metadata, readStream, partNumber)
+  }
+
+  protected uploadIncompletePart(
+    id: string,
+    readStream: fs.ReadStream | stream.Readable
+  ): Promise<string> {
+    markTusWriteMutation()
+    return super.uploadIncompletePart(id, readStream)
+  }
+
+  protected deleteIncompletePart(id: string): Promise<void> {
+    markTusWriteMutation()
+    return super.deleteIncompletePart(id)
+  }
+
+  protected finishMultipartUpload(
+    metadata: MetadataValue,
+    parts: Part[]
+  ): Promise<string | undefined> {
+    markTusWriteMutation()
+    return super.finishMultipartUpload(metadata, parts)
+  }
+
+  // Owns a checked removal sequence because upstream does not clean completed
+  // multipart uploads or .part and ignores per-key DeleteObjects errors. Abort
+  // settles before data deletion so a concurrent multipart completion cannot
+  // recreate the object after deletion. Its failure does not short-circuit the
+  // remaining cleanup, and .info remains unless every phase succeeds.
+  async remove(id: string): Promise<void> {
+    let multipartUploadId: string | undefined
+    try {
+      const metadata = await this.getMetadata(id)
+      multipartUploadId = metadata['upload-id']
+    } catch (error) {
+      if (isMissingResourceError(error)) {
+        throw TUS_ERRORS.FILE_NOT_FOUND
+      }
+      throw error
+    }
+
+    await this.deleteUploadArtifacts(id, multipartUploadId)
+  }
+
+  private async deleteUploadArtifacts(
+    id: string,
+    multipartUploadId: string | undefined
+  ): Promise<void> {
+    const [abortResult] = await Promise.allSettled([
+      this.abortMultipartUpload(id, multipartUploadId),
+    ])
+    const cleanupResults = await Promise.allSettled([
+      this.deleteObjectsWithRetry(id, [id, this.partKey(id, true)]),
+      this.clearCache(id),
+    ])
+    const results = [abortResult, ...cleanupResults]
+    const errors = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+
+    if (errors.length === 1) {
+      throw errors[0]
+    }
+
+    if (errors.length > 1) {
+      throw new AggregateError(errors, `Failed to remove TUS upload ${id}`)
+    }
+
+    // .info is the durable discovery record for direct cleanup. Delete it only
+    // after every data-bearing object and live cache entry is gone.
+    await this.deleteObjectsWithRetry(id, [this.infoKey(id)])
+  }
+
+  private async abortMultipartUpload(
+    id: string,
+    multipartUploadId: string | undefined
+  ): Promise<void> {
+    if (!multipartUploadId) {
+      return
+    }
+
+    try {
+      await this.client.abortMultipartUpload({
+        Bucket: this.bucket,
+        Key: id,
+        UploadId: multipartUploadId,
+      })
+    } catch (error) {
+      // A completed multipart upload reports a missing upload id on abort;
+      // its object, .info, .part, and cache entries still need deletion.
+      if (!isMissingResourceError(error)) {
+        throw error
+      }
+    }
+  }
+
+  private async deleteObjectsWithRetry(id: string, keys: string[]): Promise<void> {
+    const allObjects = keys.map((Key) => ({ Key }))
+    let objects = allObjects
+    let errors: Error[] = []
+
+    // Retry only the reported failures without repeating confirmed deletions.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const output = await this.client.deleteObjects({
+        Bucket: this.bucket,
+        Delete: { Objects: objects },
+      })
+      const outputErrors = output?.Errors ?? []
+      errors = outputErrors.map((error) => {
+        const code = error.Code ?? 'UnknownError'
+        const key = error.Key ?? 'unknown key'
+        const message = error.Message ? `: ${error.Message}` : ''
+        return Object.assign(new Error(`${code} deleting ${key}${message}`), {
+          code,
+          key,
+        })
+      })
+
+      if (errors.length === 0) {
+        return
+      }
+
+      const failedKeys = outputErrors.flatMap((error) =>
+        error.Key === undefined ? [] : [error.Key]
+      )
+      objects =
+        failedKeys.length === outputErrors.length
+          ? Array.from(new Set(failedKeys), (Key) => ({ Key }))
+          : allObjects
+    }
+
+    throw new AggregateError(errors, `Failed to delete TUS upload artifacts for ${id}`)
   }
 }

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -1,10 +1,17 @@
+import { once } from 'node:events'
 import { mkdtemp } from 'node:fs/promises'
+import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 import {
   CreateBucketCommand,
   HeadObjectCommand,
   ListMultipartUploadsCommand,
+  ListObjectsV2Command,
+  NoSuchUpload,
+  PutObjectCommand,
+  type S3,
   S3Client,
 } from '@aws-sdk/client-s3'
 import { getPostgresConnection, getServiceKeyUser } from '@internal/database'
@@ -18,6 +25,8 @@ import { DetailedError } from 'tus-js-client'
 import type { StorageBackendAdapter } from '../storage/backend'
 import type { StoragePgDB as StoragePgDBType } from '../storage/database/pg'
 import type { TenantLocation as TenantLocationType } from '../storage/locator'
+import type { FileStore as StorageTusFileStore } from '../storage/protocols/tus/file-store'
+import type { S3Store as StorageTusS3Store } from '../storage/protocols/tus/s3-store'
 import type { Storage as StorageType } from '../storage/storage'
 import { checkBucketExists } from './common'
 
@@ -38,6 +47,8 @@ type TusTestContext = {
   Storage: typeof StorageType
   StoragePgDB: typeof StoragePgDBType
   TenantLocation: typeof TenantLocationType
+  TusFileStore: typeof StorageTusFileStore
+  TusS3Store: typeof StorageTusS3Store
   backend: StorageBackendAdapter
   baseUrl: string
   config: TusTestConfig
@@ -56,6 +67,21 @@ function encodeTusMetadata(metadata: Record<string, string>): string {
   return Object.entries(metadata)
     .map(([key, value]) => `${key} ${Buffer.from(value).toString('base64')}`)
     .join(',')
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+  })
+
+  try {
+    return await Promise.race([promise, timeoutPromise])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
 }
 
 function decodeTusUploadId(location: string): string {
@@ -136,6 +162,224 @@ async function deleteTusUpload(location: string, authorization: string) {
   })
 }
 
+function patchTusUpload(
+  location: string,
+  authorization: string,
+  offset: number,
+  body: Uint8Array<ArrayBuffer>
+) {
+  return fetch(location, {
+    method: 'PATCH',
+    headers: {
+      authorization,
+      'tus-resumable': '1.0.0',
+      'upload-offset': String(offset),
+      'content-type': 'application/offset+octet-stream',
+    },
+    body,
+  })
+}
+
+type RawTusRequest = {
+  socket: ReturnType<typeof connect>
+  closed: Promise<void>
+}
+
+async function openRawTusRequest(
+  endpoint: string,
+  method: 'PATCH' | 'POST',
+  headers: string[],
+  body: Buffer
+): Promise<RawTusRequest> {
+  const url = new URL(endpoint)
+  const socket = connect({ host: url.hostname, port: Number(url.port) })
+  const closed = new Promise<void>((resolve) => socket.once('close', () => resolve()))
+
+  await once(socket, 'connect')
+  socket.on('error', () => {
+    // The request is intentionally truncated.
+  })
+
+  const requestHeaders = [
+    `${method} ${url.pathname}${url.search} HTTP/1.1`,
+    `Host: ${url.host}`,
+    ...headers,
+    'Connection: close',
+    '',
+    '',
+  ].join('\r\n')
+
+  await new Promise<void>((resolve, reject) => {
+    socket.write(Buffer.concat([Buffer.from(requestHeaders), body]), (error) =>
+      error ? reject(error) : resolve()
+    )
+  })
+
+  return { socket, closed }
+}
+
+function openTusPatch(
+  location: string,
+  authorization: string,
+  declaredLength: number,
+  body: Buffer
+): Promise<RawTusRequest> {
+  return openRawTusRequest(
+    location,
+    'PATCH',
+    [
+      `Authorization: ${authorization}`,
+      'Tus-Resumable: 1.0.0',
+      'Upload-Offset: 0',
+      'Content-Type: application/offset+octet-stream',
+      `Content-Length: ${declaredLength}`,
+    ],
+    body
+  )
+}
+
+async function abortTusCreation<T>(
+  endpoint: string,
+  authorization: string,
+  metadata: Record<string, string>,
+  uploadLength: number,
+  declaredLength: number,
+  body: Buffer,
+  waitForCreationStarted: () => Promise<T>
+): Promise<T> {
+  const { socket, closed } = await openRawTusRequest(
+    endpoint,
+    'POST',
+    [
+      `Authorization: ${authorization}`,
+      'Tus-Resumable: 1.0.0',
+      `Upload-Length: ${uploadLength}`,
+      `Upload-Metadata: ${encodeTusMetadata(metadata)}`,
+      'Content-Type: application/offset+octet-stream',
+      `Content-Length: ${declaredLength}`,
+      'X-Upsert: true',
+    ],
+    body
+  )
+
+  try {
+    return await waitForCreationStarted()
+  } finally {
+    socket.destroy()
+    await closed
+  }
+}
+
+async function waitForTusUploadRemoval(location: string, authorization: string) {
+  // It can wait up to 5 seconds for the lock.
+  const deadline = Date.now() + 10_000
+  let lastStatus: number | undefined
+
+  do {
+    const response = await fetch(location, {
+      method: 'HEAD',
+      headers: { authorization, 'tus-resumable': '1.0.0' },
+    })
+    lastStatus = response.status
+
+    if (response.status === 404 || response.status === 410) {
+      return response
+    }
+
+    await delay(25)
+  } while (Date.now() < deadline)
+
+  throw new Error(`TUS upload remained accessible after invalidation (status ${lastStatus})`)
+}
+
+type S3TusPrefixArtifacts = { objects: string[]; uploads: string[] }
+
+async function listS3TusPrefixArtifacts(
+  client: S3Client,
+  bucket: string,
+  prefix: string
+): Promise<S3TusPrefixArtifacts> {
+  const [objects, uploads] = await Promise.all([
+    client.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix })),
+    client.send(new ListMultipartUploadsCommand({ Bucket: bucket, Prefix: prefix })),
+  ])
+
+  return {
+    objects: objects.Contents?.flatMap((object) => (object.Key ? [object.Key] : [])) ?? [],
+    uploads: uploads.Uploads?.flatMap((upload) => (upload.Key ? [upload.Key] : [])) ?? [],
+  }
+}
+
+async function waitForS3TusPrefixCreation(
+  client: S3Client,
+  bucket: string,
+  prefix: string
+): Promise<S3TusPrefixArtifacts> {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const artifacts = await listS3TusPrefixArtifacts(client, bucket, prefix)
+    if (artifacts.objects.length > 0 || artifacts.uploads.length > 0) {
+      return artifacts
+    }
+
+    await delay(25)
+  }
+
+  throw new Error(`TUS creation did not start for S3 prefix ${prefix}`)
+}
+
+async function waitForS3TusPrefixRemoval(
+  client: S3Client,
+  bucket: string,
+  prefix: string
+): Promise<S3TusPrefixArtifacts> {
+  let remaining = { objects: [] as string[], uploads: [] as string[] }
+  const deadline = Date.now() + 5000
+
+  do {
+    remaining = await listS3TusPrefixArtifacts(client, bucket, prefix)
+    if (remaining.objects.length === 0 && remaining.uploads.length === 0) {
+      return remaining
+    }
+
+    await delay(25)
+  } while (Date.now() < deadline)
+
+  return remaining
+}
+
+function mockAwsCompletedMultipartAbort(store: StorageTusS3Store) {
+  const client = (store as unknown as { client: S3 }).client
+
+  return vi.spyOn(client, 'abortMultipartUpload').mockRejectedValue(
+    new NoSuchUpload({
+      $metadata: { httpStatusCode: 404 },
+      message: 'The specified multipart upload does not exist',
+    })
+  )
+}
+
+type TusWriteStore = {
+  write(...args: Parameters<StorageTusFileStore['write']>): Promise<number>
+}
+
+function observeNextTusWrite(storeClass: { prototype: unknown }) {
+  const prototype = storeClass.prototype as TusWriteStore
+  const originalWrite = prototype.write
+  let signalWriteStarted: (() => void) | undefined
+  const writeStarted = new Promise<void>((resolve) => {
+    signalWriteStarted = resolve
+  })
+  const write = vi.spyOn(prototype, 'write').mockImplementation(function (
+    this: TusWriteStore,
+    ...args
+  ) {
+    signalWriteStarted?.()
+    return originalWrite.apply(this, args)
+  })
+
+  return { write, writeStarted }
+}
+
 function expectTusErrorResponse(error: unknown) {
   expect(error).toBeInstanceOf(DetailedError)
 
@@ -167,14 +411,23 @@ async function createTusTestContext(
   }
   configModule.mergeConfig(overrides)
 
-  const [appModule, backendModule, storageModule, databaseModule, locatorModule] =
-    await Promise.all([
-      import('../app'),
-      import('../storage/backend'),
-      import('../storage/storage'),
-      import('../storage/database'),
-      import('../storage/locator'),
-    ])
+  const [
+    appModule,
+    backendModule,
+    storageModule,
+    databaseModule,
+    locatorModule,
+    tusFileStoreModule,
+    tusS3StoreModule,
+  ] = await Promise.all([
+    import('../app'),
+    import('../storage/backend'),
+    import('../storage/storage'),
+    import('../storage/database'),
+    import('../storage/locator'),
+    import('../storage/protocols/tus/file-store'),
+    import('../storage/protocols/tus/s3-store'),
+  ])
 
   const server = appModule.default({ loggerInstance: logger })
   const listener = await server.listen()
@@ -192,6 +445,8 @@ async function createTusTestContext(
     Storage: storageModule.Storage,
     StoragePgDB: databaseModule.StoragePgDB,
     TenantLocation: locatorModule.TenantLocation,
+    TusFileStore: tusFileStoreModule.FileStore,
+    TusS3Store: tusS3StoreModule.S3Store,
     backend,
     baseUrl: listener.replace('[::1]', '127.0.0.1'),
     config,
@@ -594,6 +849,387 @@ describe.each([
       const storedObjectPath = getStoredObjectPath(context, bucket.id, objectName, dbAsset.version)
       expect(await pathExists(storedObjectPath)).toBe(true)
     }
+  })
+
+  it('invalidates an upload after the incident-sized PATCH is truncated', async () => {
+    const uploadLength = 12_445_929
+    const declaredPatchLength = 6 * 1024 * 1024
+    const objectName = `${randomUUID()}-aborted.txt`
+
+    await storage.createBucket({
+      id: bucketName,
+      name: bucketName,
+      public: true,
+    })
+
+    const authorization = `Bearer ${await context.config.serviceKeyAsync}`
+    const createResponse = await createTusUpload(
+      context,
+      authorization,
+      {
+        bucketName,
+        objectName,
+        contentType: 'text/plain',
+        cacheControl: '3600',
+      },
+      uploadLength
+    )
+    const location = createResponse.headers.get('location')
+
+    expect(createResponse.status).toBe(201)
+    expect(location).toBeTruthy()
+
+    const storeClass = backendType === 's3' ? context.TusS3Store : context.TusFileStore
+    const { write, writeStarted } = observeNextTusWrite(storeClass)
+    let patchRequest: RawTusRequest | undefined
+
+    try {
+      patchRequest = await openTusPatch(
+        location!,
+        authorization,
+        declaredPatchLength,
+        Buffer.alloc(6_193_399, 0x61)
+      )
+      await withTimeout(writeStarted, 5000, 'truncated TUS PATCH did not enter the datastore write')
+      patchRequest.socket.destroy()
+      await patchRequest.closed
+    } finally {
+      write.mockRestore()
+      patchRequest?.socket.destroy()
+      await patchRequest?.closed
+    }
+
+    const headResponse = await waitForTusUploadRemoval(location!, authorization)
+    expect([404, 410]).toContain(headResponse.status)
+    expect(headResponse.headers.get('upload-offset')).toBeNull()
+  })
+
+  it.runIf(backendType === 's3')(
+    'preserves a complete fixed-length PATCH when lock contention cancels its context',
+    async () => {
+      const uploadLength = 2 * 1024 * 1024
+      const patchLength = 1024 * 1024
+      const objectName = `${randomUUID()}-contended-complete.txt`
+
+      await storage.createBucket({
+        id: bucketName,
+        name: bucketName,
+        public: true,
+      })
+
+      const authorization = `Bearer ${await context.config.serviceKeyAsync}`
+      const createResponse = await createTusUpload(
+        context,
+        authorization,
+        {
+          bucketName,
+          objectName,
+          contentType: 'text/plain',
+          cacheControl: '3600',
+        },
+        uploadLength
+      )
+
+      expect(createResponse.status).toBe(201)
+      const location = createResponse.headers.get('location')
+      expect(location).toBeTruthy()
+
+      const originalWrite = context.TusS3Store.prototype.write
+      let isFirstWrite = true
+      let signalFirstWriteCompleted: (() => void) | undefined
+      const firstWriteCompleted = new Promise<void>((resolve) => {
+        signalFirstWriteCompleted = resolve
+      })
+      let releaseFirstWrite: (() => void) | undefined
+      const firstWriteRelease = new Promise<void>((resolve) => {
+        releaseFirstWrite = resolve
+      })
+      const write = vi
+        .spyOn(context.TusS3Store.prototype, 'write')
+        .mockImplementation(async function (this: StorageTusS3Store, readable, id, offset) {
+          const newOffset = await originalWrite.call(this, readable, id, offset)
+          if (isFirstWrite) {
+            isFirstWrite = false
+            signalFirstWriteCompleted?.()
+            await firstWriteRelease
+          }
+          return newOffset
+        })
+
+      let firstResponsePromise: Promise<Response> | undefined
+      try {
+        firstResponsePromise = patchTusUpload(
+          location!,
+          authorization,
+          0,
+          Buffer.alloc(patchLength, 0x61)
+        )
+
+        await withTimeout(
+          firstWriteCompleted,
+          5000,
+          'first TUS PATCH did not complete its datastore write'
+        )
+
+        const competingResponse = await patchTusUpload(
+          location!,
+          authorization,
+          0,
+          Buffer.from('b')
+        )
+
+        expect(competingResponse.status).toBe(503)
+
+        releaseFirstWrite?.()
+        const firstResponse = await firstResponsePromise
+        expect(firstResponse.status).toBe(204)
+        expect(firstResponse.headers.get('upload-offset')).toBe(String(patchLength))
+      } finally {
+        releaseFirstWrite?.()
+        await firstResponsePromise?.catch(() => undefined)
+        write.mockRestore()
+      }
+
+      const resumeResponse = await patchTusUpload(
+        location!,
+        authorization,
+        patchLength,
+        Buffer.from('b')
+      )
+
+      expect(resumeResponse.status).toBe(204)
+      expect(resumeResponse.headers.get('upload-offset')).toBe(String(patchLength + 1))
+    },
+    20_000
+  )
+
+  it.runIf(backendType === 's3')(
+    'invalidates an upload when a part write fails after attempting an S3 mutation',
+    async () => {
+      const uploadLength = 2 * 1024 * 1024
+      const patchLength = 1024 * 1024
+      const objectName = `${randomUUID()}-failed-part.txt`
+
+      await storage.createBucket({
+        id: bucketName,
+        name: bucketName,
+        public: true,
+      })
+
+      const authorization = `Bearer ${await context.config.serviceKeyAsync}`
+      const createResponse = await createTusUpload(
+        context,
+        authorization,
+        {
+          bucketName,
+          objectName,
+          contentType: 'text/plain',
+          cacheControl: '3600',
+        },
+        uploadLength
+      )
+
+      expect(createResponse.status).toBe(201)
+      const location = createResponse.headers.get('location')
+      expect(location).toBeTruthy()
+
+      const injectedFailure = new Error('injected part upload failure')
+      const prototype = Object.getPrototypeOf(context.TusS3Store.prototype) as {
+        uploadPart(...args: unknown[]): Promise<string>
+        uploadIncompletePart(...args: unknown[]): Promise<string>
+      }
+      const uploadPart = vi.spyOn(prototype, 'uploadPart').mockRejectedValue(injectedFailure)
+      const uploadIncompletePart = vi
+        .spyOn(prototype, 'uploadIncompletePart')
+        .mockRejectedValue(injectedFailure)
+
+      try {
+        const patchResponse = await patchTusUpload(
+          location!,
+          authorization,
+          0,
+          Buffer.alloc(patchLength, 0x61)
+        )
+
+        expect(patchResponse.status).toBe(500)
+      } finally {
+        uploadPart.mockRestore()
+        uploadIncompletePart.mockRestore()
+      }
+
+      const headResponse = await waitForTusUploadRemoval(location!, authorization)
+      expect([404, 410]).toContain(headResponse.status)
+    }
+  )
+
+  it.runIf(backendType === 's3')(
+    'invalidates a completed multipart upload through the AWS NoSuchUpload path',
+    async () => {
+      const uploadLength = 512 * 1024
+      const objectName = `${randomUUID()}-completed-invalidation.txt`
+
+      await storage.createBucket({
+        id: bucketName,
+        name: bucketName,
+        public: true,
+      })
+
+      const authorization = `Bearer ${await context.config.serviceKeyAsync}`
+      const createResponse = await createTusUpload(
+        context,
+        authorization,
+        {
+          bucketName,
+          objectName,
+          contentType: 'text/plain',
+          cacheControl: '3600',
+        },
+        uploadLength
+      )
+
+      expect(createResponse.status).toBe(201)
+      const location = createResponse.headers.get('location')
+      expect(location).toBeTruthy()
+
+      const client = context.backend.client
+      if (!(client instanceof S3Client)) {
+        throw new Error('Expected S3 client for s3 backend')
+      }
+
+      const uploadId = getTusDatastoreUploadId(context.config, location!)
+      const injectedFailure = new Error('injected post-completion cache failure')
+      const upstreamPrototype = context.TusS3Store.prototype as unknown as {
+        clearCache(id: string): Promise<void>
+      }
+      const originalClearCache = upstreamPrototype.clearCache
+      const originalRemove = context.TusS3Store.prototype.remove
+      let completedObjectObserved = false
+      let abortMultipartUpload: ReturnType<typeof mockAwsCompletedMultipartAbort> | undefined
+
+      const clearCache = vi
+        .spyOn(upstreamPrototype, 'clearCache')
+        .mockImplementationOnce(async (id) => {
+          await client.send(
+            new HeadObjectCommand({
+              Bucket: context.config.storageS3Bucket,
+              Key: id,
+            })
+          )
+          completedObjectObserved = true
+          await client.send(
+            new PutObjectCommand({
+              Bucket: context.config.storageS3Bucket,
+              Key: `${id}.part`,
+              Body: Buffer.from('staged incomplete tail'),
+            })
+          )
+          throw injectedFailure
+        })
+        .mockImplementation(function (this: typeof upstreamPrototype, id) {
+          return originalClearCache.call(this, id)
+        })
+
+      const remove = vi
+        .spyOn(context.TusS3Store.prototype, 'remove')
+        .mockImplementation(async function (this: StorageTusS3Store, id) {
+          abortMultipartUpload = mockAwsCompletedMultipartAbort(this)
+          return originalRemove.call(this, id)
+        })
+
+      try {
+        const patchResponse = await patchTusUpload(
+          location!,
+          authorization,
+          0,
+          Buffer.alloc(uploadLength, 0x61)
+        )
+
+        expect(patchResponse.status).toBe(500)
+        expect(completedObjectObserved).toBe(true)
+        expect(remove).toHaveBeenCalledOnce()
+        expect(remove).toHaveBeenCalledWith(uploadId)
+        expect(abortMultipartUpload).toHaveBeenCalledOnce()
+        expect(abortMultipartUpload).toHaveBeenCalledWith({
+          Bucket: context.config.storageS3Bucket,
+          Key: uploadId,
+          UploadId: expect.any(String),
+        })
+      } finally {
+        remove.mockRestore()
+        abortMultipartUpload?.mockRestore()
+        clearCache.mockRestore()
+      }
+
+      const headResponse = await waitForTusUploadRemoval(location!, authorization)
+      expect([404, 410]).toContain(headResponse.status)
+
+      const remaining = await waitForS3TusPrefixRemoval(
+        client,
+        context.config.storageS3Bucket,
+        uploadId
+      )
+      expect(remaining).toEqual({ objects: [], uploads: [] })
+    }
+  )
+
+  it.runIf(backendType === 's3')('invalidates a truncated creation-with-upload POST', async () => {
+    const objectName = `${randomUUID()}-truncated-creation.txt`
+    const uploadLength = 2 * 1024 * 1024
+
+    await storage.createBucket({
+      id: bucketName,
+      name: bucketName,
+      public: true,
+    })
+
+    const authorization = `Bearer ${await context.config.serviceKeyAsync}`
+    const client = context.backend.client
+    if (!(client instanceof S3Client)) {
+      throw new Error('Expected S3 client for s3 backend')
+    }
+
+    const uploadPrefix = `${context.config.tenantId}/${bucketName}/${objectName}/`
+    const { write, writeStarted } = observeNextTusWrite(context.TusS3Store)
+    let startedArtifacts: S3TusPrefixArtifacts = { objects: [], uploads: [] }
+
+    try {
+      startedArtifacts = await abortTusCreation(
+        `${context.baseUrl}${context.config.tusPath}`,
+        authorization,
+        {
+          bucketName,
+          objectName,
+          contentType: 'text/plain',
+          cacheControl: '3600',
+        },
+        uploadLength,
+        1024 * 1024,
+        Buffer.alloc(512 * 1024, 0x61),
+        async () => {
+          const artifacts = await waitForS3TusPrefixCreation(
+            client,
+            context.config.storageS3Bucket,
+            uploadPrefix
+          )
+          await withTimeout(
+            writeStarted,
+            5000,
+            'truncated creation POST did not enter the datastore write'
+          )
+          return artifacts
+        }
+      )
+    } finally {
+      write.mockRestore()
+    }
+    expect(startedArtifacts.objects.length + startedArtifacts.uploads.length).toBeGreaterThan(0)
+
+    const remaining = await waitForS3TusPrefixRemoval(
+      client,
+      context.config.storageS3Bucket,
+      uploadPrefix
+    )
+    expect(remaining).toEqual({ objects: [], uploads: [] })
   })
 
   it('can delete an incomplete upload via TUS', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Upstream gracefully ends the proxy stream on request abort so the datastore sees a clean EOF and a truncated PATCH resolves a successful partial write with a phantom offset.

## What is the new behavior?

Incoming message and internal cancellation signal are carried into the datastore through async local storage. After write resolves, bytes written are compared to content length, or abort/complete/cancel for chunked bodies, and accordingly upload is destroyed than resumed to prevent silent corruption.

Mutation is tracked to stay resumable if errors came before durable store changes.
Also, harden remove for genuine upstream gaps to delete part, clear cache, handle per key delete errors.

## Additional context

* Upload-Checksum is silently ignored as before.
* Ultimate solution is in upstream, which I will follow up, and checksum extension will provide the missing guarantee even if byte arithmetric holds. 