### PR TITLE
refactor: make normalizeColumns table dependent

### DIFF
--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -9,9 +9,25 @@ import { dbQueryPerformance } from '@internal/monitoring/metrics'
 import { EventEmitter } from 'events'
 import { DatabaseError, type Pool, type PoolClient } from 'pg'
 import { vi } from 'vitest'
-import { escapeLike, StoragePgDB } from './pg'
+import { type ColumnRuleTable, escapeLike, StoragePgDB } from './pg'
 
 class TestStoragePgDB extends StoragePgDB {
+  normalizeColumnsProbe(table: ColumnRuleTable, columns: string): string
+  normalizeColumnsProbe(
+    table: ColumnRuleTable,
+    columns: Record<string, unknown>
+  ): Record<string, unknown>
+  normalizeColumnsProbe(
+    table: ColumnRuleTable,
+    columns: string | Record<string, unknown>
+  ): string | Record<string, unknown> {
+    if (typeof columns === 'string') {
+      return this.normalizeColumns(table, columns)
+    }
+
+    return this.normalizeColumns(table, columns)
+  }
+
   runMetricProbe(): Promise<string> {
     return this.runUnscopedQuery('MetricWithoutTenantAttribute', async () => 'ok')
   }
@@ -59,6 +75,93 @@ describe('StoragePgDB migration context', () => {
 
     await expect(storage.hasMigration('custom-metadata')).resolves.toBe(true)
     await expect(storage.hasMigration('add-search-v2-sort-support')).resolves.toBe(false)
+  })
+})
+
+describe('StoragePgDB normalizeColumns', () => {
+  const connection = {} as PgTenantConnection
+
+  function createStorage(
+    latestMigration?: ConstructorParameters<typeof StoragePgDB>[1]['latestMigration']
+  ) {
+    return new TestStoragePgDB(connection, {
+      tenantId: 'normalize-columns-tenant',
+      host: 'localhost',
+      latestMigration,
+    })
+  }
+
+  test('excludes a not-yet-migrated column from a comma-separated string, table-scoped', () => {
+    const storage = createStorage('initialmigration')
+
+    const result = storage.normalizeColumnsProbe('objects', 'id, name, user_metadata')
+
+    expect(result).not.toBeUndefined()
+    expect(typeof result).toBe('string')
+    expect(result).toBe('id,name')
+  })
+
+  test('excludes a not-yet-migrated key from a record, table-scoped', () => {
+    const storage = createStorage('initialmigration')
+
+    const result = storage.normalizeColumnsProbe('objects', {
+      id: '1',
+      name: 'file.txt',
+      user_metadata: { foo: 'bar' },
+    })
+
+    expect(result).not.toBeUndefined()
+    expect(typeof result).toBe('object')
+    expect(result).toEqual({ id: '1', name: 'file.txt' })
+  })
+
+  test('leaves columns untouched once the owning migration has run', () => {
+    const storage = createStorage('custom-metadata')
+
+    expect(storage.normalizeColumnsProbe('objects', 'id, user_metadata')).toBe('id,user_metadata')
+    expect(
+      storage.normalizeColumnsProbe('objects', { id: '1', user_metadata: { foo: 'bar' } })
+    ).toEqual({ id: '1', user_metadata: { foo: 'bar' } })
+  })
+
+  test('returns columns unchanged when no migration version is known', () => {
+    const storage = createStorage(undefined)
+    const columns = 'id, user_metadata'
+
+    expect(storage.normalizeColumnsProbe('objects', columns)).toBe(columns)
+  })
+
+  test('applies every pending rule for a table with more than one', () => {
+    // custom-metadata (25) and s3-multipart-uploads-metadata (57) both gate
+    // columns on s3_multipart_uploads; initialmigration predates both.
+    const beforeEither = createStorage('initialmigration')
+
+    expect(
+      beforeEither.normalizeColumnsProbe('s3_multipart_uploads', 'id, user_metadata, metadata')
+    ).toBe('id')
+
+    // custom-metadata has run, but s3-multipart-uploads-metadata hasn't yet -
+    // only 'metadata' should still be excluded.
+    const betweenTheTwo = createStorage('custom-metadata')
+
+    expect(
+      betweenTheTwo.normalizeColumnsProbe('s3_multipart_uploads', 'id, user_metadata, metadata')
+    ).toBe('id,user_metadata')
+  })
+
+  test('excludes the type column on buckets until iceberg-catalog-flag-on-buckets has run', () => {
+    // Mirrors createBucket: bucketData always defaults type to 'STANDARD' and
+    // relies on normalizeColumns to strip it out pre-migration.
+    const bucketData = { id: 'bucket-1', name: 'bucket-1', type: 'STANDARD' }
+
+    const beforeMigration = createStorage('initialmigration')
+    expect(beforeMigration.normalizeColumnsProbe('buckets', bucketData)).toEqual({
+      id: 'bucket-1',
+      name: 'bucket-1',
+    })
+
+    const afterMigration = createStorage('iceberg-catalog-flag-on-buckets')
+    expect(afterMigration.normalizeColumnsProbe('buckets', bucketData)).toEqual(bucketData)
   })
 })
 

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -57,6 +57,20 @@ interface UnscopedQueryOptions {
   readonly timeoutMs?: number
 }
 
+const COLUMN_MIGRATION_RULES = {
+  objects: [{ migration: 'custom-metadata', newColumns: ['user_metadata'] }],
+  s3_multipart_uploads: [
+    { migration: 'custom-metadata', newColumns: ['user_metadata'] },
+    { migration: 's3-multipart-uploads-metadata', newColumns: ['metadata'] },
+  ],
+  buckets: [{ migration: 'iceberg-catalog-flag-on-buckets', newColumns: ['type'] }],
+} as const satisfies Record<
+  string,
+  ReadonlyArray<{ migration: keyof typeof DBMigration; newColumns: readonly string[] }>
+>
+
+export type ColumnRuleTable = keyof typeof COLUMN_MIGRATION_RULES
+
 const HEALTHCHECK_SQL = 'SELECT id from storage.buckets limit 1'
 const HEALTHCHECK_QUERY_OPTIONS: UnscopedQueryOptions = Object.freeze({
   timeoutMs: databaseStatementTimeout,
@@ -379,15 +393,14 @@ export class StoragePgDB implements Database {
       public: data.public,
       allowed_mime_types: data.allowed_mime_types,
       file_size_limit: data.file_size_limit,
+      type: 'STANDARD',
     }
 
-    if (await this.hasMigration('iceberg-catalog-flag-on-buckets')) {
-      bucketData.type = 'STANDARD'
-    }
+    const normalizedBucketData = this.normalizeColumns('buckets', bucketData)
 
     try {
       const result = await this.runQuery('CreateBucket', async (db, signal) => {
-        const insert = buildInsert(bucketData as Record<string, unknown>)
+        const insert = buildInsert(normalizedBucketData)
 
         return this.query(
           db,
@@ -406,7 +419,7 @@ export class StoragePgDB implements Database {
         throw ERRORS.NoSuchBucket(data.id)
       }
 
-      return bucketData
+      return normalizedBucketData
     } catch (e) {
       if (isStorageError(ErrorCode.ResourceAlreadyExists, e)) {
         throw ERRORS.BucketAlreadyExists(data.id, e)
@@ -416,15 +429,7 @@ export class StoragePgDB implements Database {
   }
 
   async findBucketById(bucketId: string, columns = 'id', filters?: FindBucketFilters) {
-    const hasBucketType = await this.hasMigration('iceberg-catalog-flag-on-buckets')
-
     const result = await this.runQuery('FindBucketById', async (db, signal) => {
-      let columnNames = columns.split(',').map((column) => column.trim())
-
-      if (!hasBucketType) {
-        columnNames = columnNames.filter((name) => name !== 'type')
-      }
-
       const conditions = ['id = $1']
       const values: unknown[] = [bucketId]
 
@@ -437,7 +442,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(columnNames)}
+            SELECT ${selectColumns(this.normalizeColumns('buckets', columns))}
             FROM storage.buckets
             WHERE ${conditions.join(' AND ')}
             LIMIT 1
@@ -871,7 +876,7 @@ export class StoragePgDB implements Database {
   async upsertObject(
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'user_metadata' | 'version'>
   ) {
-    const objectData = this.normalizeColumns({
+    const objectData = this.normalizeColumns('objects', {
       name: data.name,
       owner: isUuid(data.owner || '') ? data.owner : undefined,
       owner_id: data.owner,
@@ -880,7 +885,7 @@ export class StoragePgDB implements Database {
       user_metadata: data.user_metadata,
       version: data.version,
     })
-    const updateData = this.normalizeColumns({
+    const updateData = this.normalizeColumns('objects', {
       metadata: data.metadata,
       user_metadata: data.user_metadata,
       version: data.version,
@@ -931,7 +936,7 @@ export class StoragePgDB implements Database {
     name: string,
     data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>
   ) {
-    const objectData = this.normalizeColumns({
+    const objectData = this.normalizeColumns('objects', {
       name: data.name,
       bucket_id: data.bucket_id,
       owner: isUuid(data.owner || '') ? data.owner : undefined,
@@ -971,7 +976,7 @@ export class StoragePgDB implements Database {
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'version' | 'user_metadata'>
   ) {
     try {
-      const object = this.normalizeColumns({
+      const object = this.normalizeColumns('objects', {
         name: data.name,
         owner: isUuid(data.owner || '') ? data.owner : undefined,
         owner_id: data.owner,
@@ -1143,7 +1148,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(this.normalizeColumns(columns))}
+            SELECT ${selectColumns(this.normalizeColumns('objects', columns))}
             FROM storage.objects
             WHERE name = $1
               AND bucket_id = $2
@@ -1174,7 +1179,7 @@ export class StoragePgDB implements Database {
         db,
         {
           text: `
-            SELECT ${selectColumns(this.normalizeColumns(columns))}
+            SELECT ${selectColumns(this.normalizeColumns('objects', columns))}
             FROM storage.objects
             WHERE bucket_id = $1
               AND name = ANY($2::text[])
@@ -1433,13 +1438,10 @@ export class StoragePgDB implements Database {
         upload_signature: signature,
         owner_id: owner,
         user_metadata: userMetadata,
+        metadata,
       }
 
-      if (this.hasMultipartMetadataColumn()) {
-        data.metadata = metadata
-      }
-
-      const insert = buildInsert(this.normalizeColumns(data))
+      const insert = buildInsert(this.normalizeColumns('s3_multipart_uploads', data))
       const result = await this.query<S3MultipartUpload>(
         db,
         {
@@ -1459,13 +1461,11 @@ export class StoragePgDB implements Database {
 
   async findMultipartUpload(uploadId: string, columns = 'id', options?: { forUpdate?: boolean }) {
     const result = await this.runQuery('FindMultipartUpload', async (db, signal) => {
-      const normalizedColumns = this.normalizeMultipartUploadColumns(columns)
-
       return this.query<S3MultipartUpload>(
         db,
         {
           text: `
-            SELECT ${selectColumns(normalizedColumns)}
+            SELECT ${selectColumns(this.normalizeColumns('s3_multipart_uploads', columns))}
             FROM storage.s3_multipart_uploads
             WHERE id = $1
             LIMIT 1
@@ -1736,76 +1736,48 @@ export class StoragePgDB implements Database {
   /**
    * Excludes columns selection if a specific migration wasn't run.
    */
-  protected normalizeColumns<T extends string | Record<string, unknown>>(columns: T): T {
+  protected normalizeColumns(table: ColumnRuleTable, columns: string): string
+  protected normalizeColumns<T extends Record<string, unknown>>(
+    table: ColumnRuleTable,
+    columns: T
+  ): T
+  protected normalizeColumns(
+    table: ColumnRuleTable,
+    columns: string | Record<string, unknown>
+  ): string | Record<string, unknown> {
     const latestMigration = this.latestMigration
 
     if (!latestMigration) {
       return columns
     }
 
-    const rules = [{ migration: 'custom-metadata', newColumns: ['user_metadata'] }]
+    const excludedColumns: readonly string[] = COLUMN_MIGRATION_RULES[table]
+      .filter((rule) => DBMigration[latestMigration] < DBMigration[rule.migration])
+      .flatMap((rule) => rule.newColumns)
 
-    for (const rule of rules) {
-      if (DBMigration[latestMigration] >= DBMigration[rule.migration as keyof typeof DBMigration]) {
-        continue
-      }
-
-      if (typeof columns === 'string') {
-        const normalizedColumns: string[] = []
-        for (const column of columns.split(',')) {
-          const trimmed = column.trim()
-          if (rule.newColumns.includes(trimmed)) {
-            continue
-          }
-
-          normalizedColumns.push(trimmed)
-        }
-
-        return normalizedColumns.join(',') as T
-      }
-
-      const normalizedColumns: Record<string, unknown> = {}
-      const sourceColumns = columns as Record<string, unknown>
-
-      for (const column in sourceColumns) {
-        if (!Object.prototype.hasOwnProperty.call(sourceColumns, column)) {
-          continue
-        }
-
-        if (rule.newColumns.includes(column)) {
-          continue
-        }
-
-        normalizedColumns[column] = sourceColumns[column]
-      }
-
-      return normalizedColumns as T
+    if (typeof columns === 'string') {
+      return columns
+        .split(',')
+        .map((column) => column.trim())
+        .filter((column) => !excludedColumns.includes(column))
+        .join(',')
     }
 
-    return columns
-  }
+    const normalizedColumns: Record<string, unknown> = {}
 
-  protected normalizeMultipartUploadColumns(columns: string): string[] {
-    const normalizedColumns: string[] = []
-    const hasMetadataColumn = this.hasMultipartMetadataColumn()
-
-    for (const column of this.normalizeColumns(columns).split(',')) {
-      const trimmed = column.trim()
-      if (!trimmed || (!hasMetadataColumn && trimmed === 'metadata')) {
+    for (const column in columns) {
+      if (!Object.prototype.hasOwnProperty.call(columns, column)) {
         continue
       }
 
-      normalizedColumns.push(trimmed)
+      if (excludedColumns.includes(column)) {
+        continue
+      }
+
+      normalizedColumns[column] = columns[column]
     }
 
     return normalizedColumns
-  }
-
-  protected hasMultipartMetadataColumn(): boolean {
-    return (
-      !this.latestMigration ||
-      DBMigration[this.latestMigration] >= DBMigration['s3-multipart-uploads-metadata']
-    )
   }
 
   protected async runQuery<T>(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor to make `normalizeColumns()` table dependent and consolidate all new column checking to use this function so we can have all rules defined in one spot. 

## What is the current behavior?

Currently all rules apply to all callers of `normalizeColumns` even though the new columns added are tied to certain tables. This has caused other normalize column like behavior elsewhere for specific functions.

## What is the new behavior?

- Made a `COLUMN_MIGRATION_RULES` object that defines all rules per table. Callers of `normalizeColumns()` now must pass in one of the keys of this object which corresponds to the table name.
- Old loop returned as soon as it hit the first rule whose migration hadn't run, so only
  one rule ever actually got applied. New version collects every pending rule for the table
  and excludes all their columns. This matters now since `s3_multipart_uploads` has two rules
  (`custom-metadata` -> `user_metadata`, `s3-multipart-uploads-metadata` -> `metadata`).
- Folded buckets' type filtering and s3_multipart_uploads' metadata filtering into the same
  rules table too, since they were doing the exact same thing by hand elsewhere. Deleted
  `hasMultipartMetadataColumn()` and `normalizeMultipartUploadColumns()` since they're not needed
  anymore.
- Made `normalizeColumns()` overloaded instead of generic so we could drop the as T casts.


