### PR TITLE
fix: mark storage.filename as IMMUTABLE

### DIFF
--- a/migrations/tenant/0061-mark-filename-immutable.sql
+++ b/migrations/tenant/0061-mark-filename-immutable.sql
@@ -1,0 +1,18 @@
+-- storage.filename is pure path parsing (same as foldername / extension) but was
+-- left VOLATILE because PL/pgSQL defaults to that when unmarked. That breaks
+-- plpgsql_check / `supabase db lint` for STABLE callers:
+--   routine is marked as STABLE, but expression is VOLATILE
+-- Align with foldername / extension (0036 / 0060).
+
+CREATE OR REPLACE FUNCTION storage.filename(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    IMMUTABLE
+AS $function$
+DECLARE
+    _parts text[];
+BEGIN
+    SELECT string_to_array(name, '/') INTO _parts;
+    RETURN _parts[array_length(_parts, 1)];
+END
+$function$;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -60,4 +60,5 @@ export const DBMigration = {
   'operation-ergonomics': 58,
   'drop-unused-functions': 59,
   'optimize-existing-functions-again': 60,
+  'mark-filename-immutable': 61,
 } as const


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`storage.filename(text)` is pure path parsing but was never marked `IMMUTABLE`, so PL/pgSQL leaves it `VOLATILE`. `plpgsql_check` / `supabase db lint` then warn when STABLE functions call it:

> routine is marked as STABLE, but expression is VOLATILE

`storage.foldername` and `storage.extension` were already marked `IMMUTABLE` in `0036` / `0060`; `filename` was left behind.

## What is the new behavior?

Tenant migration `0061` recreates `storage.filename` as `IMMUTABLE`, matching the sibling helpers.

## Additional context

Same body as today — only the volatility label changes.