### PR TITLE
fix: make sync possible hooks to be sync

### DIFF
--- a/src/http/plugins/apikey.ts
+++ b/src/http/plugins/apikey.ts
@@ -6,10 +6,13 @@ const apiKeyPlugin = fastifyPlugin(
   async (fastify) => {
     const { adminApiKeys } = getConfig()
     const apiKeys = new Set(adminApiKeys.split(','))
-    fastify.addHook('onRequest', async (request, reply) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       if (typeof request.headers.apikey !== 'string' || !apiKeys.has(request.headers.apikey)) {
-        return reply.status(401).send()
+        reply.status(401).send()
+        return
       }
+
+      done()
     })
   },
   { name: 'auth-admin-api-key' }

--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -83,16 +83,20 @@ interface EnforceJWTRoleOptions {
 
 export const enforceJwtRole = fastifyPlugin<EnforceJWTRoleOptions>(
   async (fastify, opts) => {
-    fastify.addHook('preHandler', async (request) => {
+    fastify.addHook('preHandler', (request, _reply, done) => {
       if (!request.isAuthenticated) {
-        throw ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403)
+        done(ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403))
+        return
       }
 
       const hasRoles = request.jwtPayload?.role && opts.roles.includes(request.jwtPayload.role)
 
       if (!hasRoles) {
-        throw ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403)
+        done(ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403))
+        return
       }
+
+      done()
     })
   },
   { name: 'allow-invalid-jwt' }

--- a/src/http/plugins/storage.ts
+++ b/src/http/plugins/storage.ts
@@ -23,7 +23,7 @@ const tenantLocation = new TenantLocation(storageS3Bucket)
 export const storage = fastifyPlugin(
   async function storagePlugin(fastify) {
     fastify.decorateRequest('storage')
-    fastify.addHook('preHandler', async (request) => {
+    fastify.addHook('preHandler', (request, _reply, done) => {
       const databaseOptions = {
         tenantId: request.tenantId,
         host: request.headers['x-forwarded-host'] as string,
@@ -40,10 +40,12 @@ export const storage = fastifyPlugin(
 
       request.backend = storageBackend
       request.storage = new Storage(storageBackend, database, location)
+      done()
     })
 
-    fastify.addHook('onClose', async () => {
+    fastify.addHook('onClose', (_instance, done) => {
       storageBackend.close()
+      done()
     })
   },
   { name: 'storage-init' }

--- a/src/http/plugins/sync-hooks.test.ts
+++ b/src/http/plugins/sync-hooks.test.ts
@@ -1,13 +1,18 @@
+import type { Server } from '@tus/server'
 import type { FastifyInstance } from 'fastify'
 import Fastify from 'fastify'
 import pprofRoutes from '../routes/admin/pprof'
+import { publicRoutes } from '../routes/tus'
+import { registerApiKeyAuth } from './apikey'
 import { blobResponse } from './blob-response'
 import { db, dbSuperUser } from './db'
 import { headerValidator } from './header-validator'
+import { enforceJwtRole } from './jwt'
 import { logRequest } from './log-request'
 import { httpMetrics } from './metrics'
 import { requestContext } from './request-context'
 import { signals as signalsPlugin } from './signals'
+import { storage } from './storage'
 import { adminTenantId, tenantId } from './tenant-id'
 import { xmlParser } from './xml'
 
@@ -19,11 +24,13 @@ type CapturedHook = {
 type HookFunction = (...args: unknown[]) => unknown
 
 const expectedHookArity: Record<string, number> = {
+  onClose: 2,
   onRequest: 3,
   onRequestAbort: 2,
   onResponse: 3,
   onSend: 4,
   onTimeout: 3,
+  preClose: 1,
   preHandler: 3,
   preSerialization: 4,
 }
@@ -117,6 +124,11 @@ describe('sync request lifecycle hooks', () => {
       hooks: ['onSend'],
     },
     {
+      name: 'storage',
+      register: (app: FastifyInstance) => app.register(storage),
+      hooks: ['preHandler', 'onClose'],
+    },
+    {
       name: 'db cleanup',
       register: (app: FastifyInstance) => app.register(db),
       hooks: ['onSend', 'onTimeout', 'onRequestAbort'],
@@ -127,12 +139,31 @@ describe('sync request lifecycle hooks', () => {
       hooks: ['onSend', 'onTimeout', 'onRequestAbort'],
     },
     {
+      name: 'admin API key auth',
+      register: (app: FastifyInstance) => registerApiKeyAuth(app),
+      hooks: ['onRequest'],
+    },
+    {
+      name: 'JWT role enforcement',
+      register: (app: FastifyInstance) =>
+        app.register(enforceJwtRole, { roles: ['authenticated'] }),
+      hooks: ['preHandler'],
+    },
+    {
       name: 'pprof response headers',
       register: (app: FastifyInstance) => {
         app.setValidatorCompiler(() => () => true)
         return app.register(pprofRoutes)
       },
-      hooks: ['onSend'],
+      hooks: ['onSend', 'preClose', 'onClose'],
+    },
+    {
+      name: 'public TUS request context',
+      register: (app: FastifyInstance) =>
+        app.register(publicRoutes, {
+          tusServer: { handle: vi.fn() } as unknown as Server,
+        }),
+      hooks: ['preHandler'],
     },
     {
       name: 'xmlParser',

--- a/src/http/routes/admin/pprof.ts
+++ b/src/http/routes/admin/pprof.ts
@@ -47,8 +47,14 @@ export default async function routes(fastify: FastifyInstance) {
     done(null, payload)
   })
   const shutdown = new AbortController()
-  fastify.addHook('preClose', async () => shutdown.abort())
-  fastify.addHook('onClose', async () => closeProfileStore())
+  fastify.addHook('preClose', (done) => {
+    shutdown.abort()
+    done()
+  })
+  fastify.addHook('onClose', (_instance, done) => {
+    closeProfileStore()
+    done()
+  })
 
   for (const [path, type] of [
     ['profile', 'cpu'],

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -16,7 +16,12 @@ import {
 } from '@storage/protocols/tus'
 import { S3Locker } from '@storage/protocols/tus/s3-locker'
 import { DataStore, Server, ServerOptions } from '@tus/server'
-import { FastifyInstance } from 'fastify'
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  HookHandlerDoneFunction,
+} from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 import * as http from 'http'
 import type { ServerRequest as Request } from 'srvx'
@@ -243,6 +248,24 @@ export default async function routes(fastify: FastifyInstance) {
   )
 }
 
+function setTusRequestContext(
+  req: FastifyRequest,
+  _reply: FastifyReply,
+  done: HookHandlerDoneFunction
+) {
+  ;(req.raw as MultiPartRequest).log = req.log
+  ;(req.raw as MultiPartRequest).upload = {
+    tenantId: req.tenantId,
+    storage: req.storage,
+    owner: req.owner,
+    db: req.db,
+    isUpsert: req.headers['x-upsert'] === 'true',
+    reqId: req.id,
+    sbReqId: req.sbReqId,
+  }
+  done()
+}
+
 const authenticatedRoutes = fastifyPlugin(
   async (fastify: FastifyInstance, options: { tusServer: Server; operation?: string }) => {
     fastify.register(async function authorizationContext(fastify) {
@@ -256,18 +279,7 @@ const authenticatedRoutes = fastifyPlugin(
         })
       })
 
-      fastify.addHook('preHandler', async (req) => {
-        ;(req.raw as MultiPartRequest).log = req.log
-        ;(req.raw as MultiPartRequest).upload = {
-          tenantId: req.tenantId,
-          storage: req.storage,
-          owner: req.owner,
-          db: req.db,
-          isUpsert: req.headers['x-upsert'] === 'true',
-          reqId: req.id,
-          sbReqId: req.sbReqId,
-        }
-      })
+      fastify.addHook('preHandler', setTusRequestContext)
 
       fastify.post(
         '/',
@@ -360,18 +372,7 @@ export const publicRoutes = fastifyPlugin(
         done(null)
       )
 
-      fastify.addHook('preHandler', async (req) => {
-        ;(req.raw as MultiPartRequest).log = req.log
-        ;(req.raw as MultiPartRequest).upload = {
-          tenantId: req.tenantId,
-          storage: req.storage,
-          owner: req.owner,
-          db: req.db,
-          isUpsert: req.headers['x-upsert'] === 'true',
-          reqId: req.id,
-          sbReqId: req.sbReqId,
-        }
-      })
+      fastify.addHook('preHandler', setTusRequestContext)
 
       fastify.options(
         '/',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some hooks are just doing property assignment but they are still async, which allocates promises and schedules microtask. They should be sync instead. 

## What is the new behavior?

Make last leftover hooks sync. 

