### PR TITLE
fix: add a test to catch migrations:types run

### DIFF
--- a/src/internal/database/migrations/types.test.ts
+++ b/src/internal/database/migrations/types.test.ts
@@ -1,0 +1,10 @@
+import { loadMigrationFiles } from 'postgres-migrations'
+import { DBMigration } from './types'
+
+describe('DBMigration', () => {
+  it('matches the tenant migration files exactly', async () => {
+    const migrations = await loadMigrationFiles('./migrations/tenant')
+
+    expect(Object.entries(DBMigration)).toEqual(migrations.map(({ id, name }) => [name, id]))
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

While adding a tenant migration, there are two steps:
1. migration file itself
2. npm run migrations:types

Second step isn't obvious and can be forgotten as in #1297

## What is the new behavior?

Add a test that it's exercised and caught, instead of depending humans.

