### PR TITLE
fix: cleanup empty folder failure from concurrent upload in file driver

### DIFF
--- a/src/storage/backend/file.test.ts
+++ b/src/storage/backend/file.test.ts
@@ -311,6 +311,79 @@ describe('FileBackend traversal protection', () => {
   })
 })
 
+describe('FileBackend empty directory cleanup', () => {
+  let tmpDir: string
+  let originalStoragePath: string | undefined
+  let originalFilePath: string | undefined
+
+  class TestFileBackend extends FileBackend {
+    async cleanup(dirPath: string) {
+      await this.cleanupEmptyDirectories(dirPath)
+    }
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'storage-file-backend-'))
+    originalStoragePath = process.env.STORAGE_FILE_BACKEND_PATH
+    originalFilePath = process.env.FILE_STORAGE_BACKEND_PATH
+    process.env.STORAGE_FILE_BACKEND_PATH = tmpDir
+    process.env.FILE_STORAGE_BACKEND_PATH = tmpDir
+    getConfig({ reload: true })
+  })
+
+  afterEach(async () => {
+    if (originalStoragePath === undefined) {
+      delete process.env.STORAGE_FILE_BACKEND_PATH
+    } else {
+      process.env.STORAGE_FILE_BACKEND_PATH = originalStoragePath
+    }
+    if (originalFilePath === undefined) {
+      delete process.env.FILE_STORAGE_BACKEND_PATH
+    } else {
+      process.env.FILE_STORAGE_BACKEND_PATH = originalFilePath
+    }
+    await removePath(tmpDir)
+  })
+
+  it('preserves a directory repopulated by an upload', async () => {
+    const backend = new TestFileBackend()
+    const objectDirectory = path.join(tmpDir, 'bucket', 'object.jpg')
+    const version = 'new-version'
+    await fsp.mkdir(objectDirectory, { recursive: true })
+    await fsp.writeFile(path.join(objectDirectory, version), 'new upload')
+
+    await backend.cleanup(objectDirectory)
+
+    await expect(fsp.readFile(path.join(objectDirectory, version), 'utf8')).resolves.toBe(
+      'new upload'
+    )
+  })
+
+  it('removes empty directories recursively up to the storage root', async () => {
+    const backend = new TestFileBackend()
+    const bucketDirectory = path.join(tmpDir, 'bucket')
+    const objectDirectory = path.join(bucketDirectory, 'nested', 'object.jpg')
+    await fsp.mkdir(objectDirectory, { recursive: true })
+
+    await backend.cleanup(objectDirectory)
+
+    await expect(fsp.access(bucketDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.access(tmpDir)).resolves.toBeUndefined()
+  })
+
+  it('continues cleaning parents when the target directory is already absent', async () => {
+    const backend = new TestFileBackend()
+    const bucketDirectory = path.join(tmpDir, 'bucket')
+    const objectDirectory = path.join(bucketDirectory, 'nested', 'object.jpg')
+    await fsp.mkdir(path.dirname(objectDirectory), { recursive: true })
+
+    await backend.cleanup(objectDirectory)
+
+    await expect(fsp.access(bucketDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.access(tmpDir)).resolves.toBeUndefined()
+  })
+})
+
 describe('FileBackend copy metadata options', () => {
   let tmpDir: string
   let backend: FileBackend

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -642,23 +642,6 @@ export class FileBackend implements StorageBackendAdapter {
   }
 
   /**
-   * Efficiently checks if a directory is empty by reading only the first entry
-   * @param dirPath The directory path to check
-   * @returns Promise<boolean> true if directory is empty, false otherwise
-   */
-  protected async isEmptyDirectory(dirPath: string): Promise<boolean> {
-    try {
-      const directory = await fsp.opendir(dirPath)
-      const entry = await directory.read()
-      await directory.close()
-
-      return entry === null
-    } catch {
-      return false
-    }
-  }
-
-  /**
    * Recursively removes empty directories up to the storage root
    * @param dirPath The directory path to start cleanup from
    */
@@ -669,22 +652,19 @@ export class FileBackend implements StorageBackendAdapter {
         return
       }
 
-      // Check if directory exists
-      const exists = await pathExists(dirPath)
-      if (!exists) {
-        return
+      try {
+        // Atomically removes an empty directory and fails if a concurrent upload repopulated it.
+        await fsp.rmdir(dirPath)
+      } catch (error) {
+        // If another cleanup removed this directory, its parents may still need cleanup.
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return
+        }
       }
 
-      // Check if directory is empty - using opendir for better performance with large directories
-      const isEmpty = await this.isEmptyDirectory(dirPath)
-      if (isEmpty) {
-        // Remove empty directory - using fs.remove for better cross-platform compatibility
-        await removePath(dirPath)
-
-        // Recursively check parent directory
-        const parentDir = path.dirname(dirPath)
-        await this.cleanupEmptyDirectories(parentDir)
-      }
+      // Recursively check the parent after this directory was removed or was already absent.
+      const parentDir = path.dirname(dirPath)
+      await this.cleanupEmptyDirectories(parentDir)
     } catch {
       // Ignore errors during cleanup to not affect main operations
       // Could be permission issues, concurrent access, directory not empty due to race conditions, etc.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There is a TOCTOU race while cleaning up empty directories in file driver.
Between check and deletion, a concurrent write can write a new version in the folder and error.

## What is the new behavior?

Use an atomic delete which does nothing if folder isn't empty.
