### PR TITLE
fix: prefix match for root check to empty folders in file driver

### DIFF
--- a/src/storage/backend/file.test.ts
+++ b/src/storage/backend/file.test.ts
@@ -315,6 +315,7 @@ describe('FileBackend empty directory cleanup', () => {
   let tmpDir: string
   let originalStoragePath: string | undefined
   let originalFilePath: string | undefined
+  let siblingDirectory: string | undefined
 
   class TestFileBackend extends FileBackend {
     async cleanup(dirPath: string) {
@@ -343,6 +344,9 @@ describe('FileBackend empty directory cleanup', () => {
       process.env.FILE_STORAGE_BACKEND_PATH = originalFilePath
     }
     await removePath(tmpDir)
+    if (siblingDirectory) {
+      await removePath(siblingDirectory)
+    }
   })
 
   it('preserves a directory repopulated by an upload', async () => {
@@ -381,6 +385,16 @@ describe('FileBackend empty directory cleanup', () => {
 
     await expect(fsp.access(bucketDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(fsp.access(tmpDir)).resolves.toBeUndefined()
+  })
+
+  it('does not clean a sibling directory that shares the storage-root prefix', async () => {
+    const backend = new TestFileBackend()
+    siblingDirectory = `${tmpDir}-sibling`
+    await fsp.mkdir(siblingDirectory)
+
+    await backend.cleanup(siblingDirectory)
+
+    await expect(fsp.access(siblingDirectory)).resolves.toBeUndefined()
   })
 })
 

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -647,8 +647,14 @@ export class FileBackend implements StorageBackendAdapter {
    */
   protected async cleanupEmptyDirectories(dirPath: string): Promise<void> {
     try {
-      // Don't cleanup beyond the storage root path
-      if (!dirPath.startsWith(this.filePath) || dirPath === this.filePath) {
+      const relativePath = path.relative(this.filePath, dirPath)
+      const isOutsideStorageRoot =
+        relativePath === '..' ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativePath)
+
+      // Do not remove the storage root or directories outside it.
+      if (relativePath === '' || isOutsideStorageRoot) {
         return
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Empty check does prefix matching and it can match sibling directory. 
It is guarded by resolve secure path so not exploitable as it is but error-prone if subclassed.

## What is the new behavior?

Do cross platform relative check from the root.
This is just defense in depth.

