### PR TITLE
fix: cache crypto key

### DIFF
--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -1,4 +1,4 @@
-import { JWT_CACHE_NAME } from '@internal/cache'
+import { JWT_CACHE_NAME, JWT_VERIFICATION_KEY_CACHE_NAME } from '@internal/cache'
 import { ErrorCode } from '@internal/errors'
 import * as metrics from '@internal/monitoring/metrics'
 import * as crypto from 'crypto'
@@ -382,6 +382,49 @@ describe('JWT', () => {
       })
     })
 
+    test('it should preserve the invalid-key error when no asymmetric JWK matches', async () => {
+      const { publicKey, privateKey } = asymmetricKeyPairFactories.rsa()
+      const token = await new SignJWT({ sub: 'missing-asymmetric-key' })
+        .setProtectedHeader({ alg: 'RS256', kid: 'missing-key' })
+        .sign(privateKey)
+      const jwk = {
+        ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+        kid: 'different-key',
+        alg: 'RS256',
+      } as JwksConfigKey
+
+      await expect(verifyJWT(token, 'fallback-secret', { keys: [jwk] })).rejects.toMatchObject({
+        code: ErrorCode.AccessDenied,
+        message: expect.stringContaining('Received an instance of Uint8Array'),
+      })
+    })
+
+    test('it should preserve the invalid-key error without JWKS for an asymmetric algorithm', async () => {
+      const previousAlgorithm = process.env.AUTH_JWT_ALGORITHM
+      process.env.AUTH_JWT_ALGORITHM = 'RS256'
+      vi.resetModules()
+
+      try {
+        const { privateKey } = asymmetricKeyPairFactories.rsa()
+        const token = await new SignJWT({ sub: 'missing-asymmetric-jwks' })
+          .setProtectedHeader({ alg: 'RS256' })
+          .sign(privateKey)
+        const { verifyJWT: isolatedVerifyJWT } = await import('./jwt')
+
+        await expect(isolatedVerifyJWT(token, 'fallback-secret')).rejects.toMatchObject({
+          code: ErrorCode.AccessDenied,
+          message: expect.stringContaining('Received an instance of Uint8Array'),
+        })
+      } finally {
+        if (previousAlgorithm === undefined) {
+          delete process.env.AUTH_JWT_ALGORITHM
+        } else {
+          process.env.AUTH_JWT_ALGORITHM = previousAlgorithm
+        }
+        vi.resetModules()
+      }
+    })
+
     test('it should try secret if no matching jwk kty/alg found in jwks', async () => {
       const jwk = await generateHS512JWK()
       jwk.kid = 'abc123'
@@ -401,6 +444,244 @@ describe('JWT', () => {
       const jwt = await signJWT({ sub: 'things' }, hmacPrivateKeyWithoutKid, 100)
       const result = await verifyJWT(jwt, hmacPrivateKeyWithoutKid)
       expect(result.sub).toEqual('things')
+    })
+
+    test('it should import the same HMAC verification key only once', async () => {
+      const secret = crypto.randomBytes(32).toString('base64url')
+      const token = await signJWT({ sub: 'prepared-hmac-key' }, secret, 100)
+      const importKeySpy = vi.spyOn(crypto.webcrypto.subtle, 'importKey')
+
+      await expect(verifyJWT(token, secret)).resolves.toMatchObject({ sub: 'prepared-hmac-key' })
+      await expect(verifyJWT(token, secret)).resolves.toMatchObject({ sub: 'prepared-hmac-key' })
+
+      expect(importKeySpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('it should preserve permissive base64 decoding for HMAC JWKs', async () => {
+      const rawKey = Buffer.from([251, 255, 255, ...crypto.randomBytes(29)])
+      const kid = `standard-base64-hmac-${crypto.randomUUID()}`
+      const jwk = {
+        kty: 'oct',
+        k: rawKey.toString('base64'),
+        kid,
+        alg: 'HS256',
+      } as JwksConfigKey
+      const token = await new SignJWT({ sub: 'standard-base64-hmac' })
+        .setProtectedHeader({ alg: 'HS256', kid })
+        .sign(rawKey)
+      const importKeySpy = vi.spyOn(crypto.webcrypto.subtle, 'importKey')
+
+      expect(jwk.k).toMatch(/[+/]/)
+      await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).resolves.toMatchObject({
+        sub: 'standard-base64-hmac',
+      })
+      await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).resolves.toMatchObject({
+        sub: 'standard-base64-hmac',
+      })
+      expect(importKeySpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('it should share one HMAC key import across concurrent verifications', async () => {
+      const secret = crypto.randomBytes(32).toString('base64url')
+      const token = await signJWT({ sub: 'concurrent-prepared-hmac-key' }, secret, 100)
+      const originalImportKey = crypto.webcrypto.subtle.importKey.bind(crypto.webcrypto.subtle)
+      let releaseImport: () => void = () => undefined
+      const importGate = new Promise<void>((resolve) => {
+        releaseImport = resolve
+      })
+      const importKeySpy = vi
+        .spyOn(crypto.webcrypto.subtle, 'importKey')
+        .mockImplementationOnce(async (...args) => {
+          await importGate
+          return originalImportKey(...args)
+        })
+
+      const firstVerification = verifyJWT(token, secret)
+      const secondVerification = verifyJWT(token, secret)
+
+      await vi.waitFor(() => expect(importKeySpy).toHaveBeenCalledTimes(1))
+      releaseImport()
+
+      await expect(Promise.all([firstVerification, secondVerification])).resolves.toEqual([
+        expect.objectContaining({ sub: 'concurrent-prepared-hmac-key' }),
+        expect.objectContaining({ sub: 'concurrent-prepared-hmac-key' }),
+      ])
+      expect(importKeySpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('it should retry an HMAC key import after a failure', async () => {
+      const secret = crypto.randomBytes(32).toString('base64url')
+      const token = await signJWT({ sub: 'retried-prepared-hmac-key' }, secret, 100)
+      const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
+      const importKeySpy = vi
+        .spyOn(crypto.webcrypto.subtle, 'importKey')
+        .mockRejectedValueOnce(new Error('temporary key import failure'))
+
+      await expect(verifyJWT(token, secret)).rejects.toThrow('temporary key import failure')
+      await expect(verifyJWT(token, secret)).resolves.toMatchObject({
+        sub: 'retried-prepared-hmac-key',
+      })
+
+      expect(importKeySpy).toHaveBeenCalledTimes(2)
+      expect(recordSpy.mock.calls).toEqual([
+        [JWT_VERIFICATION_KEY_CACHE_NAME, 'miss'],
+        [JWT_VERIFICATION_KEY_CACHE_NAME, 'miss'],
+      ])
+    })
+
+    test('it should evict the least-recently-used prepared secret key at capacity', async () => {
+      vi.resetModules()
+
+      const actualJose = await vi.importActual<typeof import('jose')>('jose')
+      const jwtVerifyMock = vi.fn(async (_token: string, getKey: unknown) => {
+        await (getKey as (header: { alg: string }) => Promise<CryptoKey>)({ alg: 'HS256' })
+        return { payload: { sub: 'cache-capacity' } }
+      })
+      vi.doMock('jose', () => ({ ...actualJose, jwtVerify: jwtVerifyMock }))
+
+      const preparedKey = await crypto.webcrypto.subtle.importKey(
+        'raw',
+        crypto.randomBytes(32),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign', 'verify']
+      )
+      const importKeySpy = vi
+        .spyOn(crypto.webcrypto.subtle, 'importKey')
+        .mockResolvedValue(preparedKey)
+
+      try {
+        const { JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS, verifyJWT: isolatedVerifyJWT } = await import(
+          './jwt'
+        )
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        importKeySpy.mockClear()
+
+        for (let index = 0; index <= JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS; index++) {
+          await isolatedVerifyJWT('token', `capacity-secret-${index}`)
+        }
+        await isolatedVerifyJWT('token', 'capacity-secret-0')
+
+        expect(importKeySpy).toHaveBeenCalledTimes(JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS + 2)
+      } finally {
+        vi.doUnmock('jose')
+        vi.resetModules()
+      }
+    })
+
+    test('it should not let an evicted failed import delete its successful replacement', async () => {
+      vi.resetModules()
+
+      const actualJose = await vi.importActual<typeof import('jose')>('jose')
+      const jwtVerifyMock = vi.fn(async (_token: string, getKey: unknown) => {
+        await (getKey as (header: { alg: string }) => Promise<CryptoKey>)({ alg: 'HS256' })
+        return { payload: { sub: 'stale-import-failure' } }
+      })
+      vi.doMock('jose', () => ({ ...actualJose, jwtVerify: jwtVerifyMock }))
+
+      const preparedKey = await crypto.webcrypto.subtle.importKey(
+        'raw',
+        crypto.randomBytes(32),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign', 'verify']
+      )
+      const importKeySpy = vi
+        .spyOn(crypto.webcrypto.subtle, 'importKey')
+        .mockResolvedValue(preparedKey)
+
+      try {
+        const { JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS, verifyJWT: isolatedVerifyJWT } = await import(
+          './jwt'
+        )
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        importKeySpy.mockClear()
+
+        let rejectStaleImport: (error: Error) => void = () => undefined
+        const staleImport = new Promise<CryptoKey>((_resolve, reject) => {
+          rejectStaleImport = reject
+        })
+        importKeySpy.mockImplementationOnce(() => staleImport)
+
+        const staleVerification = isolatedVerifyJWT('token', 'stale-capacity-secret')
+        const staleRejection = expect(staleVerification).rejects.toThrow('stale import failed')
+
+        for (let index = 0; index < JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS; index++) {
+          await isolatedVerifyJWT('token', `replacement-capacity-secret-${index}`)
+        }
+        await isolatedVerifyJWT('token', 'stale-capacity-secret')
+
+        rejectStaleImport(new Error('stale import failed'))
+        await staleRejection
+        await isolatedVerifyJWT('token', 'stale-capacity-secret')
+
+        expect(importKeySpy).toHaveBeenCalledTimes(JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS + 2)
+      } finally {
+        vi.doUnmock('jose')
+        vi.resetModules()
+      }
+    })
+
+    test('it should import the same asymmetric verification key only once', async () => {
+      const { publicKey, privateKey } = asymmetricKeyPairFactories.rsa()
+      const kid = `prepared-rsa-key-${crypto.randomUUID()}`
+      const jwk = {
+        ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+        kid,
+        alg: 'RS256',
+      } as JwksConfigKey
+      const token = await new SignJWT({ sub: 'prepared-rsa-key' })
+        .setProtectedHeader({ alg: 'RS256', kid })
+        .sign(privateKey)
+      const importKeySpy = vi.spyOn(crypto.webcrypto.subtle, 'importKey')
+
+      await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).resolves.toMatchObject({
+        sub: 'prepared-rsa-key',
+      })
+      await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).resolves.toMatchObject({
+        sub: 'prepared-rsa-key',
+      })
+
+      expect(importKeySpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('it should re-import an asymmetric key when the JWKS object is refreshed', async () => {
+      const { publicKey, privateKey } = asymmetricKeyPairFactories.rsa()
+      const kid = `refreshed-rsa-key-${crypto.randomUUID()}`
+      const jwk = {
+        ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+        kid,
+        alg: 'RS256',
+      } as JwksConfigKey
+      const token = await new SignJWT({ sub: 'refreshed-rsa-key' })
+        .setProtectedHeader({ alg: 'RS256', kid })
+        .sign(privateKey)
+      const importKeySpy = vi.spyOn(crypto.webcrypto.subtle, 'importKey')
+
+      await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).resolves.toMatchObject({
+        sub: 'refreshed-rsa-key',
+      })
+      // a JWKS refresh yields identity-new key objects: re-import once, then cache again
+      const refreshedJwk = { ...jwk } as JwksConfigKey
+      await expect(
+        verifyJWT(token, 'unused-secret', { keys: [refreshedJwk] })
+      ).resolves.toMatchObject({ sub: 'refreshed-rsa-key' })
+      await expect(
+        verifyJWT(token, 'unused-secret', { keys: [refreshedJwk] })
+      ).resolves.toMatchObject({ sub: 'refreshed-rsa-key' })
+
+      expect(importKeySpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('it should not reuse a prepared HMAC key after secret rotation', async () => {
+      const oldSecret = crypto.randomBytes(32).toString('base64url')
+      const newSecret = crypto.randomBytes(32).toString('base64url')
+      const oldToken = await signJWT({ sub: 'old-secret' }, oldSecret, 100)
+      const newToken = await signJWT({ sub: 'new-secret' }, newSecret, 100)
+
+      await expect(verifyJWT(oldToken, oldSecret)).resolves.toMatchObject({ sub: 'old-secret' })
+      await expect(verifyJWT(newToken, newSecret)).resolves.toMatchObject({ sub: 'new-secret' })
+      await expect(verifyJWT(oldToken, newSecret)).rejects.toThrow()
     })
 
     test('it should sign and verify using our HS256 generation', async () => {
@@ -497,6 +778,7 @@ describe('JWT', () => {
 
       expect(recordSpy.mock.calls).toEqual([
         [JWT_CACHE_NAME, 'miss'],
+        [JWT_VERIFICATION_KEY_CACHE_NAME, 'miss'],
         [JWT_CACHE_NAME, 'hit'],
       ])
 
@@ -519,7 +801,9 @@ describe('JWT', () => {
 
       expect(recordSpy.mock.calls).toEqual([
         [JWT_CACHE_NAME, 'miss'],
+        [JWT_VERIFICATION_KEY_CACHE_NAME, 'miss'],
         [JWT_CACHE_NAME, 'miss'],
+        [JWT_VERIFICATION_KEY_CACHE_NAME, 'miss'],
       ])
     })
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -3,9 +3,11 @@ import {
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   JWT_CACHE_NAME,
+  JWT_VERIFICATION_KEY_CACHE_NAME,
 } from '@internal/cache'
 import { ERRORS } from '@internal/errors'
 import {
+  type CryptoKey,
   exportJWK,
   generateSecret,
   importJWK,
@@ -86,13 +88,107 @@ export function isDownloadScopedToken(payload: { scope?: SignedUrlScope }): bool
 const jwtJwksFingerprintCache = new WeakMap<object, string>()
 const encoder = new TextEncoder()
 
+// Verification keys are immutable and can be shared across tokens.
+// It's separate from the optional payload cache.
+// Even when JWT payload caching is disabled, repeated verification
+// should not re-import the same key material.
+export const JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS = 16384
+
+// Uint8Array/JWK inputs come from the tenant config/JWKS caches and are
+// object-identity stable until refresh, so their prepared keys can live
+// exactly as long as the source object with no hashing and no bound.
+const preparedObjectVerificationKeys = new WeakMap<object, Map<string, Promise<CryptoKey>>>()
+
+// String secrets cannot key a WeakMap, so bound their retention explicitly.
+const preparedSecretVerificationKeys = createLruCache<string, Promise<CryptoKey>>(
+  JWT_VERIFICATION_KEY_CACHE_NAME,
+  { max: JWT_VERIFICATION_KEY_CACHE_MAX_ITEMS }
+)
+
+function getSecretVerificationKeyCacheKey(alg: string, secret: string) {
+  return `${alg}\0${secret}`
+}
+
+function importHMACVerificationKey(key: Uint8Array, alg: string): Promise<CryptoKey> {
+  const keyData: BufferSource =
+    key.buffer instanceof ArrayBuffer ? (key as Uint8Array<ArrayBuffer>) : Uint8Array.from(key)
+
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: `SHA-${alg.slice(-3)}` },
+    false,
+    ['verify']
+  )
+}
+
+function importVerificationKey(key: Uint8Array | JwksConfigKey, alg: string): Promise<CryptoKey> {
+  if (key instanceof Uint8Array) {
+    return importHMACVerificationKey(key, alg)
+  }
+  if (key.kty === 'oct' && key.k) {
+    return importHMACVerificationKey(Buffer.from(key.k, 'base64'), alg)
+  }
+  return importJWK(key, key.alg ?? alg).then((imported) => {
+    if (imported instanceof Uint8Array) {
+      return importHMACVerificationKey(imported, alg)
+    }
+    return imported
+  })
+}
+
+function getPreparedJWTVerificationKey(
+  key: string | Uint8Array | JwksConfigKey,
+  alg: string
+): Promise<CryptoKey> {
+  if (typeof key === 'string') {
+    const cacheKey = getSecretVerificationKeyCacheKey(alg, key)
+    const cachedKey = preparedSecretVerificationKeys.get(cacheKey)
+    if (cachedKey) {
+      return cachedKey
+    }
+
+    const importedKey = importHMACVerificationKey(encoder.encode(key), alg)
+    preparedSecretVerificationKeys.set(cacheKey, importedKey)
+    importedKey.catch(() => {
+      if (preparedSecretVerificationKeys.get(cacheKey, { recordMetrics: false }) === importedKey) {
+        preparedSecretVerificationKeys.delete(cacheKey)
+      }
+    })
+    return importedKey
+  }
+
+  // Keyed per effective alg: a JWK without its own alg imports under the
+  // header alg, so the same object can yield algorithm-distinct CryptoKeys.
+  let byAlg = preparedObjectVerificationKeys.get(key)
+  if (!byAlg) {
+    byAlg = new Map()
+    preparedObjectVerificationKeys.set(key, byAlg)
+  }
+  const cachedKey = byAlg.get(alg)
+  if (cachedKey) {
+    return cachedKey
+  }
+
+  const importedKey = importVerificationKey(key, alg)
+  byAlg.set(alg, importedKey)
+  importedKey.catch(() => {
+    if (byAlg.get(alg) === importedKey) {
+      byAlg.delete(alg)
+    }
+  })
+  return importedKey
+}
+
 async function findJWKFromHeader(
   header: JWTHeaderParameters,
   secret: string,
   jwks: JwksConfig | null
 ) {
   if (!jwks || !jwks.keys) {
-    return encoder.encode(secret)
+    return JWT_HMAC_ALGOS.includes(header.alg)
+      ? getPreparedJWTVerificationKey(secret, header.alg)
+      : encoder.encode(secret)
   }
 
   if (JWT_HMAC_ALGOS.indexOf(header.alg) > -1) {
@@ -100,7 +196,7 @@ async function findJWKFromHeader(
 
     if (!header.kid && header.alg === jwtAlgorithm) {
       // jwt is probably signed with the static secret
-      return encoder.encode(secret)
+      return getPreparedJWTVerificationKey(secret, header.alg)
     }
 
     // find the first compatible "oct" key without a kid or with the matching kid
@@ -124,10 +220,10 @@ async function findJWKFromHeader(
 
     if (!jwk) {
       // jwt is probably signed with the static secret
-      return encoder.encode(secret)
+      return getPreparedJWTVerificationKey(secret, header.alg)
     }
 
-    return Buffer.from(jwk.k, 'base64')
+    return getPreparedJWTVerificationKey(jwk, header.alg)
   }
 
   // jwt is using an asymmetric algorithm
@@ -139,7 +235,8 @@ async function findJWKFromHeader(
     kty = 'OKP'
   }
 
-  // find the first key with a matching kid (or no kid if none is specified in the JWT header), the correct key type, and a compatible alg
+  // find the first key with a matching kid (or no kid if none is specified in the JWT header),
+  // the correct key type, and a compatible alg
   const jwk = jwks.keys.find((key) => {
     return (
       ((!key.kid && !header.kid) || key.kid === header.kid) &&
@@ -152,7 +249,7 @@ async function findJWKFromHeader(
     // couldn't find a matching JWK, try to use the secret
     return encoder.encode(secret)
   }
-  return await importJWK(jwk, jwk.alg ?? header.alg)
+  return getPreparedJWTVerificationKey(jwk, header.alg)
 }
 
 function getJWTVerificationKey(secret: string, jwks: JwksConfig | null): JWTVerifyGetKey {

--- a/src/internal/cache/names.ts
+++ b/src/internal/cache/names.ts
@@ -1,4 +1,5 @@
 export const JWT_CACHE_NAME = 'jwt' as const
+export const JWT_VERIFICATION_KEY_CACHE_NAME = 'jwt_verification_key' as const
 export const PGVECTOR_METRIC_CACHE_NAME = 'pgvector_metric' as const
 export const TENANT_CONFIG_CACHE_NAME = 'tenant_config' as const
 export const TENANT_JWKS_CACHE_NAME = 'tenant_jwks' as const
@@ -7,6 +8,7 @@ export const TENANT_S3_CREDENTIALS_CACHE_NAME = 'tenant_s3_credentials' as const
 
 export type CacheName =
   | typeof JWT_CACHE_NAME
+  | typeof JWT_VERIFICATION_KEY_CACHE_NAME
   | typeof PGVECTOR_METRIC_CACHE_NAME
   | typeof TENANT_CONFIG_CACHE_NAME
   | typeof TENANT_JWKS_CACHE_NAME

--- a/src/internal/monitoring/metrics.test.ts
+++ b/src/internal/monitoring/metrics.test.ts
@@ -148,6 +148,7 @@ describe('metrics registry', () => {
       { name: 'cache_evictions_total', enabled: false },
     ])
     metricsModule.recordCacheRequest('jwt', 'hit')
+    metricsModule.recordCacheRequest('jwt_verification_key', 'miss')
     metricsModule.recordCacheRequest('pgvector_metric', 'hit')
     metricsModule.recordCacheRequest('pgvector_metric', 'miss')
     metricsModule.recordCacheRequest('tenant_config', 'hit')
@@ -157,6 +158,7 @@ describe('metrics registry', () => {
     metricsModule.recordCacheRequest('tenant_pool', 'miss')
     metricsModule.recordCacheRequest('tenant_s3_credentials', 'hit')
     metricsModule.recordCacheEviction('pgvector_metric')
+    metricsModule.recordCacheEviction('jwt_verification_key')
     metricsModule.recordCacheEviction('tenant_config')
 
     const firstRequestCollection = mockMeter.invoke('cache_requests_total')
@@ -166,6 +168,10 @@ describe('metrics registry', () => {
       {
         value: 1,
         attributes: { cache: 'jwt', outcome: 'hit' },
+      },
+      {
+        value: 1,
+        attributes: { cache: 'jwt_verification_key', outcome: 'miss' },
       },
       {
         value: 1,
@@ -200,6 +206,10 @@ describe('metrics registry', () => {
     expect(secondRequestCollection[0].attributes).toBe(firstRequestCollection[0].attributes)
 
     expect(mockMeter.invoke('cache_evictions_total')).toEqual([
+      {
+        value: 1,
+        attributes: { cache: 'jwt_verification_key' },
+      },
       {
         value: 1,
         attributes: { cache: 'pgvector_metric' },

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -350,6 +350,7 @@ function createCacheMetricsState(cache: CacheName): CacheMetricsState {
 
 const cacheMetrics = {
   jwt: createCacheMetricsState('jwt'),
+  jwt_verification_key: createCacheMetricsState('jwt_verification_key'),
   pgvector_metric: createCacheMetricsState('pgvector_metric'),
   tenant_config: createCacheMetricsState('tenant_config'),
   tenant_jwks: createCacheMetricsState('tenant_jwks'),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Every verifyJWT gives a fresh key material to jose, causing web crypto to import the same HMAC or asymmetric key repeatedly.

## What is the new behavior?

Cache string/HMAC secrets in a LRU keyed by algorithm and secret
JWKs use a weak map keyed by JWK object identity and algorithm, tied to the lifetime of cached tenant/JWKS configuration.

## Additional context

This improves verify side, sign is a follow up.