### PR TITLE
fix: cheaper log time function

### DIFF
--- a/src/internal/monitoring/logger.test.ts
+++ b/src/internal/monitoring/logger.test.ts
@@ -22,6 +22,7 @@ function setupLoggerMocks(configOverrides: Record<string, unknown> = {}) {
     vi.fn(() => loggerStub),
     {
       stdTimeFunctions: {
+        epochTime: vi.fn(),
         isoTime: vi.fn(),
       },
     }
@@ -177,11 +178,13 @@ describe('logger serializers', () => {
             req: (request: unknown) => unknown
             res: (reply: unknown) => unknown
           }
+          timestamp: () => string
         },
       ]
     >
     const pinoCall = pinoCalls.at(0)
     expect(pinoCall).toBeDefined()
+    expect(pinoCall![0].timestamp).toBe(pinoMock.stdTimeFunctions.epochTime)
     const serializers = pinoCall![0].serializers
     const serializedRequest = serializeRequestLog({
       id: 'trace-1',

--- a/src/internal/monitoring/logger.ts
+++ b/src/internal/monitoring/logger.ts
@@ -91,7 +91,7 @@ export const baseLogger = pino({
     res: serializeReplyLogValue,
   },
   level: logLevel,
-  timestamp: pino.stdTimeFunctions.isoTime,
+  timestamp: pino.stdTimeFunctions.epochTime,
 })
 
 registerLogStringifiers(baseLogger)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using isoTime in logger provides some readability in stdout logs. Otherwise, it's always normalized by logflare. In production environment, it nearly does nothing but does allocation of date and formatting per log.

## What is the new behavior?

Use epochTime (pino default).
Keeping the explicit form communicates the decision better.

## Additional context

This is a free win for heavy logging.
