### PR TITLE
fix: handle feature not enabled for s3 xml serialization

### DIFF
--- a/src/http/plugins/tenant-feature.test.ts
+++ b/src/http/plugins/tenant-feature.test.ts
@@ -1,0 +1,110 @@
+import { ErrorCode } from '@internal/errors'
+import { vi } from 'vitest'
+
+describe('requireTenantFeature', () => {
+  afterEach(() => {
+    vi.doUnmock('../../config')
+    vi.doUnmock('@internal/database')
+    vi.resetModules()
+  })
+
+  it('returns the default JSON error when no formatter is provided', async () => {
+    const { app, tenantHasFeatureMock } = await buildApp({
+      hasFeature: false,
+      isMultitenant: true,
+    })
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/probe' })
+
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toEqual({
+        error: 'FeatureNotEnabled',
+        statusCode: '403',
+        message: 'feature not enabled for this tenant',
+        code: ErrorCode.FeatureNotEnabled,
+      })
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 's3Protocol')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('continues to the route when the tenant feature is enabled', async () => {
+    const { app, tenantHasFeatureMock } = await buildApp({
+      hasFeature: true,
+      isMultitenant: true,
+    })
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/probe' })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ ok: true })
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 's3Protocol')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('skips the tenant feature lookup in single-tenant mode', async () => {
+    const { app, tenantHasFeatureMock } = await buildApp({
+      hasFeature: false,
+      isMultitenant: false,
+    })
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/probe' })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ ok: true })
+      expect(tenantHasFeatureMock).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+async function buildApp({
+  hasFeature,
+  isMultitenant,
+}: {
+  hasFeature: boolean
+  isMultitenant: boolean
+}) {
+  const tenantHasFeatureMock = vi.fn().mockResolvedValue(hasFeature)
+
+  vi.doMock('../../config', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../config')>()
+
+    return {
+      ...actual,
+      getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
+        ...actual.getConfig(options),
+        isMultitenant,
+      }),
+    }
+  })
+  vi.doMock('@internal/database', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@internal/database')>()
+
+    return {
+      ...actual,
+      tenantHasFeature: tenantHasFeatureMock,
+    }
+  })
+
+  const { default: fastify } = await import('fastify')
+  const { requireTenantFeature } = await import('./tenant-feature')
+  const app = fastify()
+
+  app.addHook('onRequest', (request, _reply, done) => {
+    request.tenantId = 'tenant-a'
+    done()
+  })
+  await app.register(requireTenantFeature('s3Protocol'))
+  app.get('/probe', async () => ({ ok: true }))
+  await app.ready()
+
+  return { app, tenantHasFeatureMock }
+}

--- a/src/http/plugins/tenant-feature.ts
+++ b/src/http/plugins/tenant-feature.ts
@@ -1,8 +1,13 @@
-import { Features, tenantHasFeature } from '@internal/database'
-import { ErrorCode } from '@internal/errors'
+import { type Features, tenantHasFeature } from '@internal/database'
+import { ErrorCode, type StorageError } from '@internal/errors'
+import type { FastifyRequest } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
 
 import { getConfig } from '../../config'
+
+type TenantFeatureOptions = {
+  formatter?: (error: StorageError, request: FastifyRequest) => unknown
+}
 
 /**
  * Requires a specific feature to be enabled for a given tenant.
@@ -11,7 +16,7 @@ import { getConfig } from '../../config'
  * For single-tenant, use environment variables to toggle features
  * @param feature
  */
-export const requireTenantFeature = (feature: keyof Features) =>
+export const requireTenantFeature = (feature: keyof Features, options?: TenantFeatureOptions) =>
   fastifyPlugin(
     async (fastify) => {
       const { isMultitenant } = getConfig()
@@ -21,12 +26,14 @@ export const requireTenantFeature = (feature: keyof Features) =>
         const hasFeature = await tenantHasFeature(request.tenantId, feature)
 
         if (!hasFeature) {
-          return reply.status(403).send({
+          const error: StorageError = {
             error: 'FeatureNotEnabled',
             statusCode: '403',
             message: 'feature not enabled for this tenant',
             code: ErrorCode.FeatureNotEnabled,
-          })
+          }
+
+          return reply.status(403).send(options?.formatter?.(error, request) ?? error)
         }
       })
     },

--- a/src/http/routes/s3/error-handler.test.ts
+++ b/src/http/routes/s3/error-handler.test.ts
@@ -3,7 +3,23 @@ import { DBError } from '@storage/database/errors'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { DatabaseError } from 'pg'
 import { vi } from 'vitest'
-import { s3ErrorHandler } from './error-handler'
+import { formatS3ErrorResponse, s3ErrorHandler } from './error-handler'
+
+describe('formatS3ErrorResponse resource normalization', () => {
+  it.each([
+    ['strips the S3 route prefix', '/s3/public/object', 'public/object'],
+    ['drops the query string', '/s3/public/object?uploads', 'public/object'],
+    ['preserves nested s3 segments', '/s3/bucket/s3/key', 'bucket/s3/key'],
+    ['normalizes a trailing slash', '/s3/public/object/', 'public/object'],
+    ['returns an empty resource for the root path', '/s3', ''],
+    ['returns an empty resource for the slash root path', '/s3/', ''],
+    ['returns an empty resource for an empty URL', '', ''],
+  ])('%s', (_case, url, expected) => {
+    expect(
+      formatS3ErrorResponse({ code: 'TestError', message: 'test error' }, { url }).Error.Resource
+    ).toBe(expected)
+  })
+})
 
 describe('s3ErrorHandler', () => {
   it('maps wrapped database slowdown errors to 429', () => {

--- a/src/http/routes/s3/error-handler.ts
+++ b/src/http/routes/s3/error-handler.ts
@@ -10,6 +10,35 @@ type ValidationIssue = {
   message?: string
 }
 
+type S3ErrorDetails = {
+  code: string
+  message: string
+}
+
+function getS3ErrorResource(url: string) {
+  return url.split('?')[0].replace('/s3', '').split('/').filter(Boolean).join('/')
+}
+
+export function formatS3ErrorResponse(error: S3ErrorDetails, request: Pick<FastifyRequest, 'url'>) {
+  return {
+    Error: {
+      Resource: getS3ErrorResource(request.url),
+      Code: error.code,
+      Message: error.message,
+    },
+  }
+}
+
+function sendS3Error(
+  reply: FastifyReply,
+  request: FastifyRequest,
+  statusCode: number,
+  code: string,
+  message: string
+) {
+  return reply.status(statusCode).send(formatS3ErrorResponse({ code, message }, request))
+}
+
 export const s3ErrorHandler = (
   error: FastifyError | Error,
   request: FastifyRequest,
@@ -18,74 +47,49 @@ export const s3ErrorHandler = (
   request.executionError = error
   const validation = getValidationIssues(error)
 
-  const resource = request.url
-    .split('?')[0]
-    .replace('/s3', '')
-    .split('/')
-    .filter((e) => e)
-    .join('/')
-
   if (validation) {
-    return reply.status(400).send({
-      Error: {
-        Resource: resource,
-        Code: ErrorCode.InvalidRequest,
-        Message: formatValidationError(validation).message,
-      },
-    })
+    return sendS3Error(
+      reply,
+      request,
+      400,
+      ErrorCode.InvalidRequest,
+      formatValidationError(validation).message
+    )
   }
 
   if (error instanceof S3ServiceException) {
-    return reply.status(error.$metadata.httpStatusCode || 500).send({
-      Error: {
-        Resource: resource,
-        Code: error.$response?.body.Code || ErrorCode.S3Error,
-        Message: error.message,
-      },
-    })
+    return sendS3Error(
+      reply,
+      request,
+      error.$metadata.httpStatusCode || 500,
+      error.$response?.body.Code || ErrorCode.S3Error,
+      error.message
+    )
   }
 
   // database error
   if (isDatabaseSlowDownError(error)) {
-    return reply.status(429).send({
-      Error: {
-        Resource: resource,
-        Code: ErrorCode.SlowDown,
-        Message: 'Too many connections issued to the database',
-      },
-    })
+    return sendS3Error(
+      reply,
+      request,
+      429,
+      ErrorCode.SlowDown,
+      'Too many connections issued to the database'
+    )
   }
 
   if (error instanceof StorageBackendError) {
-    return reply.status(error.httpStatusCode || 500).send({
-      Error: {
-        Resource: resource,
-        Code: error.code,
-        Message: error.message,
-      },
-    })
+    return sendS3Error(reply, request, error.httpStatusCode || 500, error.code, error.message)
   }
 
   const statusCode =
     'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : undefined
 
   if (statusCode && statusCode >= 400 && statusCode < 500) {
-    return reply.status(statusCode).send({
-      Error: {
-        Resource: resource,
-        Code: ErrorCode.InvalidRequest,
-        Message: error.message,
-      },
-    })
+    return sendS3Error(reply, request, statusCode, ErrorCode.InvalidRequest, error.message)
   }
 
-  return reply.status(500).send({
-    Error: {
-      Resource: resource,
-      Code: ErrorCode.InternalError,
-      Message: 'Internal Server Error',
-    },
-  })
+  return sendS3Error(reply, request, 500, ErrorCode.InternalError, 'Internal Server Error')
 }
 
 function isValidationIssueArray(value: unknown): value is ValidationIssue[] {

--- a/src/http/routes/s3/index.test.ts
+++ b/src/http/routes/s3/index.test.ts
@@ -1,0 +1,125 @@
+import { ErrorCode } from '@internal/errors'
+import fastifyPlugin from 'fastify-plugin'
+import { vi } from 'vitest'
+
+describe('S3 tenant feature gating', () => {
+  afterEach(() => {
+    vi.doUnmock('../../../config')
+    vi.doUnmock('@internal/database')
+    vi.doUnmock('../../plugins')
+    vi.resetModules()
+  })
+
+  it('returns an S3 XML 403 before downstream hooks when the tenant feature is disabled', async () => {
+    const { app, downstreamHookMock, tenantHasFeatureMock } = await buildApp(false)
+
+    try {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/s3/videos/sbio-test.txt',
+        headers: {
+          'content-type': 'text/plain',
+        },
+        payload: 'test',
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(response.headers['content-type']).toContain('application/xml')
+      expect(response.payload).toBe(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+          '<Resource>videos/sbio-test.txt</Resource>' +
+          `<Code>${ErrorCode.FeatureNotEnabled}</Code>` +
+          '<Message>feature not enabled for this tenant</Message>' +
+          '</Error>'
+      )
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 's3Protocol')
+      expect(downstreamHookMock).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('continues to downstream S3 hooks when the tenant feature is enabled', async () => {
+    const { app, downstreamHookMock, tenantHasFeatureMock } = await buildApp(true)
+
+    try {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/s3/videos/sbio-test.txt',
+        headers: {
+          'content-type': 'text/plain',
+        },
+        payload: 'test',
+      })
+
+      expect(response.statusCode).toBe(204)
+      expect(tenantHasFeatureMock).toHaveBeenCalledWith('tenant-a', 's3Protocol')
+      expect(downstreamHookMock).toHaveBeenCalledOnce()
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+async function buildApp(hasFeature: boolean) {
+  const tenantHasFeatureMock = vi.fn().mockResolvedValue(hasFeature)
+  const downstreamHookMock = vi.fn()
+  const noopPlugin = async () => {}
+  const downstreamPlugin = fastifyPlugin(async (fastify) => {
+    fastify.addHook('onRequest', async (_request, reply) => {
+      downstreamHookMock()
+      return reply.status(204).send()
+    })
+  })
+
+  vi.doMock('../../../config', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../config')>()
+
+    return {
+      ...actual,
+      getConfig: (options?: Parameters<typeof actual.getConfig>[0]) => ({
+        ...actual.getConfig(options),
+        isMultitenant: true,
+        s3ProtocolEnabled: true,
+      }),
+    }
+  })
+  vi.doMock('@internal/database', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@internal/database')>()
+
+    return {
+      ...actual,
+      tenantHasFeature: tenantHasFeatureMock,
+    }
+  })
+  vi.doMock('../../plugins', async () => {
+    const [{ requireTenantFeature }, { xmlParser }] = await Promise.all([
+      import('../../plugins/tenant-feature'),
+      import('../../plugins/xml'),
+    ])
+
+    return {
+      db: noopPlugin,
+      detectS3IcebergBucket: noopPlugin,
+      icebergRestCatalog: noopPlugin,
+      requireTenantFeature,
+      signatureV4: downstreamPlugin,
+      storage: noopPlugin,
+      xmlParser,
+    }
+  })
+
+  const { default: fastify } = await import('fastify')
+  const { default: routes } = await import('./index')
+  const app = fastify()
+
+  app.addHook('onRequest', (request, _reply, done) => {
+    request.tenantId = 'tenant-a'
+    done()
+  })
+  await app.register(routes, { prefix: '/s3' })
+  await app.ready()
+
+  return { app, downstreamHookMock, tenantHasFeatureMock }
+}

--- a/src/http/routes/s3/index.ts
+++ b/src/http/routes/s3/index.ts
@@ -12,7 +12,7 @@ import {
   storage,
   xmlParser,
 } from '../../plugins'
-import { s3ErrorHandler } from './error-handler'
+import { formatS3ErrorResponse, s3ErrorHandler } from './error-handler'
 import { findArraySchemaPaths, getRouter, RequestInput, RouteQuery } from './router'
 
 const { s3ProtocolEnabled } = getConfig()
@@ -136,7 +136,11 @@ export default async function routes(fastify: FastifyInstance) {
         }
 
         fastify.register(async (localFastify) => {
-          localFastify.register(requireTenantFeature('s3Protocol'))
+          localFastify.register(
+            requireTenantFeature('s3Protocol', {
+              formatter: formatS3ErrorResponse,
+            })
+          )
 
           const disableContentParser = routesByMethod?.some(
             (route) => route.disableContentTypeParser


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

S3 routes run under xml parser/serializer and requires a single root.
Feature not enabled short circuit response isn't so xml parser validation check converts 403 to 500. 

## What is the new behavior?

Export s3 error formatter and pass it to the tenant feature plugin as an option to directly finish the request.