### PR TITLE
fix: memoize derived jwk algorithms

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 const CONFIG_ENV_KEYS = [
   'MULTI_TENANT',
   'IS_MULTITENANT',
+  'JWT_JWKS',
   'TENANT_POOL_CACHE_TTL_MS',
   'TENANT_POOL_CACHE_HIT_LOG_SAMPLE_RATE',
   'TENANT_POOL_CACHE_MISS_LOG_SAMPLE_RATE',
@@ -82,6 +83,22 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheMissLogSampleRate).toBe(0)
     expect(config.databasePoolDrainTimeout).toBe(30_000)
     expect(config.requestHardLimitsEnabled).toBe(false)
+  })
+
+  test('freezes JWT JWKS configuration and its keys', async () => {
+    setConfigEnv({
+      JWT_JWKS: JSON.stringify({ keys: [{ kty: 'oct', k: 'secret' }] }),
+    })
+
+    const { getConfig } = await import('./config')
+    const jwks = getConfig({ reload: true }).jwtJWKS!
+
+    expect(Object.isFrozen(jwks)).toBe(true)
+    expect(Object.isFrozen(jwks.keys)).toBe(true)
+    expect(Reflect.set(jwks, 'keys', [])).toBe(false)
+    const otherKey = { kty: 'oct', k: 'other-secret' }
+    const didAppendKey = Reflect.set(jwks.keys, jwks.keys.length, otherKey)
+    expect(didAppendKey).toBe(false)
   })
 
   test('defaults automatic profiling to off with incident-safe thresholds', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,8 +51,13 @@ export interface JwksConfigKeyOKP extends JwksConfigKeyBase {
 export type JwksConfigKey = JwksConfigKeyOCT | JwksConfigKeyRSA | JwksConfigKeyEC | JwksConfigKeyOKP
 
 export interface JwksConfig {
-  keys: JwksConfigKey[]
-  urlSigningKey?: JwksConfigKeyOCT
+  readonly keys: readonly JwksConfigKey[]
+  readonly urlSigningKey?: JwksConfigKeyOCT
+}
+
+export function freezeJwksConfig(jwks: JwksConfig): JwksConfig {
+  Object.freeze(jwks.keys)
+  return Object.freeze(jwks)
 }
 
 type StorageConfigType = {
@@ -307,6 +312,9 @@ export function setEnvPaths(paths: string[]) {
 }
 
 export function mergeConfig(newConfig: Partial<StorageConfigType>) {
+  if (newConfig.jwtJWKS) {
+    freezeJwksConfig(newConfig.jwtJWKS)
+  }
   config = { ...config, ...(newConfig as Required<StorageConfigType>) }
 }
 
@@ -791,7 +799,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
 
   if (jwtJWKS) {
     try {
-      config.jwtJWKS = JSON.parse(jwtJWKS)
+      config.jwtJWKS = freezeJwksConfig(JSON.parse(jwtJWKS))
     } catch {
       throw new Error('Unable to parse JWT_JWKS value to JSON')
     }

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -6,7 +6,7 @@ import {
 } from '@internal/cache'
 import { createSingleFlightByKey } from '@internal/concurrency'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
-import { JwksConfig, JwksConfigKeyOCT } from '../../../config'
+import { freezeJwksConfig, JwksConfig, JwksConfigKeyOCT } from '../../../config'
 import { TENANTS_JWKS_UPDATE_CHANNEL } from './channels'
 import { JWKSManagerStore } from './store'
 
@@ -126,22 +126,16 @@ export class JWKSManager<TRX> {
       const data = await this.storage.listActive(tenantId)
 
       let urlSigningKey: JwksConfigKeyOCT | undefined
-      const jwksConfig: JwksConfig = {
-        keys: data.map(({ id, kind, content }) => {
-          const jwk = JSON.parse(decrypt(content))
-          jwk.kid = createJwkKid({ kind, id })
-          if (
-            kind === JWK_KIND_STORAGE_URL_SIGNING &&
-            jwk.kty === 'oct' &&
-            jwk.k &&
-            !urlSigningKey
-          ) {
-            urlSigningKey = jwk
-          }
-          return jwk
-        }),
-      }
-      jwksConfig.urlSigningKey = urlSigningKey
+      const keys = data.map(({ id, kind, content }) => {
+        const jwk = JSON.parse(decrypt(content))
+        jwk.kid = createJwkKid({ kind, id })
+        const isUrlSigningKeyKind = kind === JWK_KIND_STORAGE_URL_SIGNING
+        if (isUrlSigningKeyKind && jwk.kty === 'oct' && jwk.k && !urlSigningKey) {
+          urlSigningKey = jwk
+        }
+        return jwk
+      })
+      const jwksConfig = freezeJwksConfig({ keys, urlSigningKey })
 
       tenantJwksConfigCache.set(tenantId, jwksConfig)
 

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -408,6 +408,7 @@ describe('JWT', () => {
         expect(algorithmsAt(0)).toBe(algorithmsAt(1))
         expect(algorithmsAt(0)).not.toBe(algorithmsAt(2))
         expect(algorithmsAt(0)).toEqual(algorithmsAt(2))
+        expect(algorithmsAt(0)).toContain('RS256')
         expect(algorithmsAt(3)).toBe(algorithmsAt(4))
       } finally {
         vi.doUnmock('jose')

--- a/src/internal/auth/jwt.test.ts
+++ b/src/internal/auth/jwt.test.ts
@@ -198,6 +198,25 @@ describe('JWT', () => {
         })
       })
 
+      test('it should reject an algorithm outside the derived JWKS allowlist', async () => {
+        const { publicKey, privateKey } = asymmetricKeyPairFactories.rsa()
+        const kid = 'disallowed-ps256'
+        const jwk = {
+          ...(publicKey.export({ format: 'jwk' }) as JwksConfigKey),
+          kid,
+        } as JwksConfigKey
+
+        const token = await new SignJWT({ sub: 'disallowed-ps256' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .setProtectedHeader({ alg: 'PS256', kid })
+          .sign(privateKey)
+
+        await expect(verifyJWT(token, 'unused-secret', { keys: [jwk] })).rejects.toThrow(
+          /not allowed/
+        )
+      })
+
       test('it should reject an asymmetric JWT when the matching jwk has a different alg', async () => {
         const { publicKey, privateKey } = asymmetricKeyPairFactories['rsa']()
         const kid = 'alg-mismatch-rsa'
@@ -357,6 +376,43 @@ describe('JWT', () => {
         })
         expect(result.sub).toEqual('compatible-hmac-after-alg-mismatch')
       })
+    })
+
+    test('it should memoize derived algorithm allowlists by JWKS identity', async () => {
+      vi.resetModules()
+
+      const actualJose = await vi.importActual<typeof import('jose')>('jose')
+      const jwtVerifyMock = vi.fn().mockResolvedValue({ payload: { sub: 'algorithm-cache' } })
+      vi.doMock('jose', () => ({ ...actualJose, jwtVerify: jwtVerifyMock }))
+
+      try {
+        const { verifyJWT: isolatedVerifyJWT } = await import('./jwt')
+        const rsaJwk = {
+          ...keys[0].publicKey.export(),
+          kid: 'algorithm-cache-rsa',
+        } as JwksConfigKey
+        const cachedJwks = { keys: [rsaJwk] }
+        const refreshedJwks = { keys: [{ ...rsaJwk } as JwksConfigKey] }
+
+        await isolatedVerifyJWT('token-1', 'unused-secret', cachedJwks)
+        await isolatedVerifyJWT('token-2', 'unused-secret', cachedJwks)
+        await isolatedVerifyJWT('token-3', 'unused-secret', refreshedJwks)
+        await isolatedVerifyJWT('token-4', 'unused-secret')
+        await isolatedVerifyJWT('token-5', 'unused-secret', { keys: [] })
+
+        const algorithmsAt = (index: number) => {
+          const options = jwtVerifyMock.mock.calls[index][2] as { algorithms: string[] }
+          return options.algorithms
+        }
+
+        expect(algorithmsAt(0)).toBe(algorithmsAt(1))
+        expect(algorithmsAt(0)).not.toBe(algorithmsAt(2))
+        expect(algorithmsAt(0)).toEqual(algorithmsAt(2))
+        expect(algorithmsAt(3)).toBe(algorithmsAt(4))
+      } finally {
+        vi.doUnmock('jose')
+        vi.resetModules()
+      }
     })
 
     algFixtures.forEach(({ type, alg }) => {

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -287,7 +287,7 @@ function getJWTAlgorithms(jwks: JwksConfig | null) {
   return algorithms
 }
 
-function getJWTJwksFingerprint(jwks?: { keys: JwksConfigKey[] } | null): string {
+function getJWTJwksFingerprint(jwks?: JwksConfig | null): string {
   if (!jwks) {
     return 'null'
   }
@@ -304,7 +304,7 @@ function getJWTJwksFingerprint(jwks?: { keys: JwksConfigKey[] } | null): string 
   return fingerprint
 }
 
-function getJWTCacheKey(token: string, secret: string, jwks?: { keys: JwksConfigKey[] } | null) {
+function getJWTCacheKey(token: string, secret: string, jwks?: JwksConfig | null) {
   const hash = createHash('sha256')
     .update(token)
     .update('\0')
@@ -337,8 +337,8 @@ const jwtCache = createLruCache<string, JWTPayload>(JWT_CACHE_NAME, {
 export async function verifyJWTWithCache(
   token: string,
   secret: string,
-  jwks?: { keys: JwksConfigKey[] } | null
-) {
+  jwks?: JwksConfig | null
+): Promise<JWTPayload> {
   const cacheKey = getJWTCacheKey(token, secret, jwks)
   const cachedPayload = jwtCache.get(cacheKey)
   if (cachedPayload && cachedPayload.exp && cachedPayload.exp * 1000 > Date.now()) {
@@ -366,7 +366,7 @@ export async function verifyJWTWithCache(
 export async function verifyJWT<T>(
   token: string,
   secret: string,
-  jwks?: { keys: JwksConfigKey[] } | null
+  jwks?: JwksConfig | null
 ): Promise<JWTPayload & T> {
   try {
     const { payload } = await jwtVerify<T>(token, getJWTVerificationKey(secret, jwks || null), {

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -25,6 +25,7 @@ const JWT_HMAC_ALGOS = ['HS256', 'HS384', 'HS512']
 const JWT_RSA_ALGOS = ['RS256', 'RS384', 'RS512']
 const JWT_ECC_ALGOS = ['ES256', 'ES384', 'ES512']
 const JWT_ED_ALGOS = ['EdDSA']
+const JWT_DEFAULT_ALGOS = [jwtAlgorithm]
 const MAX_ABSOLUTE_JWT_EXPIRATION_SECONDS = Math.floor(Number.MAX_SAFE_INTEGER / 1000)
 
 /**
@@ -86,6 +87,7 @@ export function isDownloadScopedToken(payload: { scope?: SignedUrlScope }): bool
 }
 
 const jwtJwksFingerprintCache = new WeakMap<object, string>()
+const jwtAlgorithmsCache = new WeakMap<JwksConfig, string[]>()
 const encoder = new TextEncoder()
 
 // Verification keys are immutable and can be shared across tokens.
@@ -257,27 +259,31 @@ function getJWTVerificationKey(secret: string, jwks: JwksConfig | null): JWTVeri
 }
 
 function getJWTAlgorithms(jwks: JwksConfig | null) {
-  let algorithms: string[]
-
-  if (jwks && jwks.keys && jwks.keys.length) {
-    const hasRSA = jwks.keys.find((key) => key.kty === 'RSA')
-    const hasECC = jwks.keys.find((key) => key.kty === 'EC')
-    const hasED = jwks.keys.find(
-      (key) => key.kty === 'OKP' && (key.crv === 'Ed25519' || key.crv === 'Ed448')
-    )
-    const hasHS = jwks.keys.find((key) => key.kty === 'oct' && key.k)
-
-    algorithms = [
-      jwtAlgorithm,
-      ...(hasRSA ? JWT_RSA_ALGOS : []),
-      ...(hasECC ? JWT_ECC_ALGOS : []),
-      ...(hasED ? JWT_ED_ALGOS : []),
-      ...(hasHS ? JWT_HMAC_ALGOS : []),
-    ]
-  } else {
-    algorithms = [jwtAlgorithm]
+  if (!jwks?.keys?.length) {
+    return JWT_DEFAULT_ALGOS
   }
 
+  const cachedAlgorithms = jwtAlgorithmsCache.get(jwks)
+  if (cachedAlgorithms) {
+    return cachedAlgorithms
+  }
+
+  const hasRSA = jwks.keys.find((key) => key.kty === 'RSA')
+  const hasECC = jwks.keys.find((key) => key.kty === 'EC')
+  const hasED = jwks.keys.find(
+    (key) => key.kty === 'OKP' && (key.crv === 'Ed25519' || key.crv === 'Ed448')
+  )
+  const hasHS = jwks.keys.find((key) => key.kty === 'oct' && key.k)
+
+  const algorithms = [
+    jwtAlgorithm,
+    ...(hasRSA ? JWT_RSA_ALGOS : []),
+    ...(hasECC ? JWT_ECC_ALGOS : []),
+    ...(hasED ? JWT_ED_ALGOS : []),
+    ...(hasHS ? JWT_HMAC_ALGOS : []),
+  ]
+
+  jwtAlgorithmsCache.set(jwks, algorithms)
   return algorithms
 }
 

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -10,7 +10,13 @@ import {
   S3CredentialsManagerStorePg,
 } from '@storage/protocols/s3/credentials'
 import { JWTPayload } from 'jose'
-import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
+import {
+  freezeJwksConfig,
+  getConfig,
+  JwksConfig,
+  JwksConfigKey,
+  JwksConfigKeyOCT,
+} from '../../config'
 import { decrypt } from '../auth'
 import { JWKSManager, JWKSManagerStorePg } from '../auth/jwks'
 import { createInvalidatableSingleFlightByKey } from '../concurrency'
@@ -91,6 +97,7 @@ const tenantConfigCache = createLruCache<string, TenantConfig>(TENANT_CONFIG_CAC
 })
 
 const tenantConfigSingleFlight = createInvalidatableSingleFlightByKey<TenantConfig>()
+const EMPTY_JWKS_CONFIG = freezeJwksConfig({ keys: [] })
 
 export const jwksManager = new JWKSManager(new JWKSManagerStorePg(multitenantPgExecutor))
 
@@ -109,7 +116,7 @@ function getSingleTenantJwtConfig(): {
   jwks: JwksConfig
 } {
   const { jwtSecret, jwtJWKS } = getConfig()
-  const jwks = (jwtJWKS || { keys: [] }) as JwksConfig
+  const jwks = jwtJWKS || EMPTY_JWKS_CONFIG
 
   return {
     secret: jwtSecret,
@@ -147,10 +154,10 @@ function mergeTenantJwksWithLegacyKeys(
     return cachedMergedJwks
   }
 
-  const mergedJwks: JwksConfig = {
+  const mergedJwks = freezeJwksConfig({
     ...tenantJwks,
     keys: [...tenantJwks.keys, ...legacyJwks.keys],
-  }
+  })
 
   mergedByLegacyJwks.set(legacyJwks, mergedJwks)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Algorithms are derived from immutable JWKs array per verify.

## What is the new behavior?

Cache derived array by JWKs array identity.

## Additional context

This is similar to #1303 in its nature but a different knob to improve. 
