### PR TITLE
chore: keep reason, instance, version in file names by default

### DIFF
--- a/src/scripts/pprof-client.test.ts
+++ b/src/scripts/pprof-client.test.ts
@@ -241,10 +241,12 @@ describe('executePprofCommand list', () => {
       `https://example.com/admin/debug/pprof/profiles/download?key=${encodeURIComponent(profiles[0].key)}`,
       `https://example.com/admin/debug/pprof/profiles/download?key=${encodeURIComponent(profiles[1].key)}`,
     ])
-    expect(await fs.readdir(tempDir)).toEqual([
-      'auto-cpu-2026-07-13T14-00-00-000Z-cc8065289c6e.pprof.gz',
-      'auto-heap-2026-07-13T14-00-01-000Z-aabbccddeeff.pprof.gz',
-    ])
+    expect((await fs.readdir(tempDir)).sort()).toEqual(
+      [
+        'auto-cpu-2026-07-13T14-00-00-000Z-reason-1.2.3-host-cc8065289c6e.pprof.gz',
+        'auto-heap-2026-07-13T14-00-01-000Z-reason-1.2.3-host-aabbccddeeff.pprof.gz',
+      ].sort()
+    )
   })
 
   it('downloads only the returned page unless all pages are requested', async () => {

--- a/src/scripts/pprof-client.ts
+++ b/src/scripts/pprof-client.ts
@@ -194,11 +194,16 @@ async function generateFlame(profilePath: string, enabled: boolean) {
 function bulkDownloadFilename(profile: PprofArchivedProfile) {
   const key = profile.key.match(/^v1\/(auto|manual)\/\d{13}-([a-f0-9]{12})\/(cpu|heap)\//)
   const startedAt = new Date(profile.startedAt)
-  if (!key || Number.isNaN(startedAt.getTime())) {
+  const metadata = [profile.reason, profile.build, profile.hostname]
+  if (
+    !key ||
+    Number.isNaN(startedAt.getTime()) ||
+    metadata.some((value) => !/^[a-z0-9][a-z0-9.-]{0,63}$/.test(value))
+  ) {
     throw new Error(`Invalid profile returned by list: ${profile.key}`)
   }
   const timestamp = startedAt.toISOString().replace(/[:.]/g, '-')
-  return `${key[1]}-${key[3]}-${timestamp}-${key[2]}.pprof.gz`
+  return `${key[1]}-${key[3]}-${timestamp}-${metadata.join('-')}-${key[2]}.pprof.gz`
 }
 
 async function fetchProfilePages(


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Metadata isn't added into pprof downloaded files by default.

## What is the new behavior?

Add reason, version and instance into filenames to harvest historical easier.

## Additional context

Local helper script only.
