### PR TITLE
fix: stop detached calls to fill caches with stale data

### DIFF
--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -1,10 +1,12 @@
 import { decrypt, encrypt, generateHS512JWK } from '@internal/auth'
 import {
+  CACHE_LOOKUP_WITHOUT_METRICS,
+  type CacheLookupOptions,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_JWKS_CACHE_NAME,
 } from '@internal/cache'
-import { createSingleFlightByKey } from '@internal/concurrency'
+import { createInvalidatableSingleFlightByKey } from '@internal/concurrency'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
 import { freezeJwksConfig, JwksConfig, JwksConfigKeyOCT } from '../../../config'
 import { TENANTS_JWKS_UPDATE_CHANNEL } from './channels'
@@ -13,7 +15,7 @@ import { JWKSManagerStore } from './store'
 const JWK_KIND_STORAGE_URL_SIGNING = 'storage-url-signing-key'
 const JWK_KID_SEPARATOR = '_'
 
-const tenantJwksSingleFlight = createSingleFlightByKey<JwksConfig>()
+const tenantJwksSingleFlight = createInvalidatableSingleFlightByKey<JwksConfig>()
 // Max 16,384 items. At ~2.5KB per JWKS, this uses roughly ~40MB of heap memory worst-case.
 export const TENANT_JWKS_CACHE_MAX_ITEMS = 16384
 export const TENANT_JWKS_CACHE_TTL_MS = 1000 * 60 * 60 // 1h
@@ -27,6 +29,7 @@ const tenantJwksConfigCache = createLruCache<string, JwksConfig>(TENANT_JWKS_CAC
 })
 
 export function deleteTenantJwksConfig(tenantId: string): void {
+  tenantJwksSingleFlight.invalidate(tenantId)
   tenantJwksConfigCache.delete(tenantId)
 }
 
@@ -50,7 +53,7 @@ export class JWKSManager<TRX> {
         return
       }
 
-      tenantJwksConfigCache.delete(cacheKey)
+      deleteTenantJwksConfig(cacheKey)
     })
   }
 
@@ -115,31 +118,33 @@ export class JWKSManager<TRX> {
    * for quick subsequent access. Only includes jwks marked as active
    * @param tenantId
    */
-  async getJwksTenantConfig(tenantId: string): Promise<JwksConfig> {
-    const cachedJwks = tenantJwksConfigCache.get(tenantId)
+  async getJwksTenantConfig(tenantId: string, options?: CacheLookupOptions): Promise<JwksConfig> {
+    const cachedJwks = tenantJwksConfigCache.get(tenantId, options)
 
     if (cachedJwks !== undefined) {
       return cachedJwks
     }
 
-    return tenantJwksSingleFlight(tenantId, async () => {
-      const data = await this.storage.listActive(tenantId)
+    return tenantJwksSingleFlight(tenantId, {
+      load: async () => {
+        const data = await this.storage.listActive(tenantId)
 
-      let urlSigningKey: JwksConfigKeyOCT | undefined
-      const keys = data.map(({ id, kind, content }) => {
-        const jwk = JSON.parse(decrypt(content))
-        jwk.kid = createJwkKid({ kind, id })
-        const isUrlSigningKeyKind = kind === JWK_KIND_STORAGE_URL_SIGNING
-        if (isUrlSigningKeyKind && jwk.kty === 'oct' && jwk.k && !urlSigningKey) {
-          urlSigningKey = jwk
-        }
-        return jwk
-      })
-      const jwksConfig = freezeJwksConfig({ keys, urlSigningKey })
+        let urlSigningKey: JwksConfigKeyOCT | undefined
+        const keys = data.map(({ id, kind, content }) => {
+          const jwk = JSON.parse(decrypt(content))
+          jwk.kid = createJwkKid({ kind, id })
+          const isUrlSigningKeyKind = kind === JWK_KIND_STORAGE_URL_SIGNING
+          if (isUrlSigningKeyKind && jwk.kty === 'oct' && jwk.k && !urlSigningKey) {
+            urlSigningKey = jwk
+          }
+          return jwk
+        })
+        const jwksConfig = freezeJwksConfig({ keys, urlSigningKey })
 
-      tenantJwksConfigCache.set(tenantId, jwksConfig)
-
-      return jwksConfig
+        return jwksConfig
+      },
+      retry: () => this.getJwksTenantConfig(tenantId, CACHE_LOOKUP_WITHOUT_METRICS),
+      commit: (jwksConfig) => tenantJwksConfigCache.set(tenantId, jwksConfig),
     })
   }
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import {
+  CACHE_LOOKUP_WITHOUT_METRICS,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   JWT_CACHE_NAME,
@@ -153,7 +154,9 @@ function getPreparedJWTVerificationKey(
     const importedKey = importHMACVerificationKey(encoder.encode(key), alg)
     preparedSecretVerificationKeys.set(cacheKey, importedKey)
     importedKey.catch(() => {
-      if (preparedSecretVerificationKeys.get(cacheKey, { recordMetrics: false }) === importedKey) {
+      if (
+        preparedSecretVerificationKeys.get(cacheKey, CACHE_LOOKUP_WITHOUT_METRICS) === importedKey
+      ) {
         preparedSecretVerificationKeys.delete(cacheKey)
       }
     })

--- a/src/internal/cache/adapter.ts
+++ b/src/internal/cache/adapter.ts
@@ -2,6 +2,10 @@ export type CacheLookupOptions = {
   recordMetrics?: boolean
 }
 
+export const CACHE_LOOKUP_WITHOUT_METRICS = Object.freeze<CacheLookupOptions>({
+  recordMetrics: false,
+})
+
 export type CacheLookupOutcome = 'hit' | 'miss'
 
 export type CacheStats = {

--- a/src/internal/cache/monitoring.test.ts
+++ b/src/internal/cache/monitoring.test.ts
@@ -1,4 +1,5 @@
 import {
+  CACHE_LOOKUP_WITHOUT_METRICS,
   createLruCache,
   createTtlCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
@@ -48,8 +49,8 @@ describe('cache telemetry helpers', () => {
 
     cache.set('hit', { ok: true })
 
-    expect(cache.get('hit', { recordMetrics: false })).toEqual({ ok: true })
-    expect(cache.get('miss', { recordMetrics: false })).toBeUndefined()
+    expect(cache.get('hit', CACHE_LOOKUP_WITHOUT_METRICS)).toEqual({ ok: true })
+    expect(cache.get('miss', CACHE_LOOKUP_WITHOUT_METRICS)).toBeUndefined()
 
     expect(recordSpy).not.toHaveBeenCalled()
   })
@@ -64,7 +65,7 @@ describe('cache telemetry helpers', () => {
 
     cache.set('hit', { ok: true })
 
-    expect(cache.get('hit', { recordMetrics: false })).toEqual({ ok: true })
+    expect(cache.get('hit', CACHE_LOOKUP_WITHOUT_METRICS)).toEqual({ ok: true })
     expect(getSpy).toHaveBeenCalledTimes(1)
     expect(recordSpy).not.toHaveBeenCalled()
 

--- a/src/internal/concurrency/single-flight.test.ts
+++ b/src/internal/concurrency/single-flight.test.ts
@@ -1,6 +1,8 @@
 import {
   createInvalidatableSingleFlightByKey,
   createSingleFlightByKey,
+  MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS,
+  SingleFlightInvalidationLimitError,
 } from '@internal/concurrency'
 import { vi } from 'vitest'
 
@@ -82,70 +84,472 @@ describe('createSingleFlightByKey', () => {
 })
 
 describe('createInvalidatableSingleFlightByKey', () => {
-  it('detaches the current flight so a later caller starts a replacement', async () => {
+  it('retries detached success through the replacement flight without committing stale data', async () => {
     const singleFlight = createInvalidatableSingleFlightByKey<string>()
-    const firstWork = Promise.withResolvers<string>()
-    const secondWork = Promise.withResolvers<string>()
-    const work = vi
-      .fn<(isCurrent: () => boolean) => Promise<string>>()
-      .mockReturnValueOnce(firstWork.promise)
-      .mockReturnValueOnce(secondWork.promise)
+    const staleWork = Promise.withResolvers<string>()
+    const freshWork = Promise.withResolvers<string>()
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(staleWork.promise)
+      .mockReturnValueOnce(freshWork.promise)
+      .mockResolvedValueOnce('newer')
+    const commit = vi.fn()
+    const retry = vi.fn(() => read())
+    const read = (): Promise<string> =>
+      singleFlight('tenant-a', {
+        load,
+        retry,
+        commit,
+      })
 
-    const first = singleFlight.run('tenant-a', work)
+    const stale = read()
     expect(singleFlight.invalidate('tenant-a')).toBe(true)
-    const second = singleFlight.run('tenant-a', work)
+    const fresh = read()
+    const joinedFresh = read()
 
-    expect(work).toHaveBeenCalledTimes(2)
+    expect(fresh).not.toBe(stale)
+    expect(joinedFresh).toBe(fresh)
+    expect(load).toHaveBeenCalledTimes(2)
 
-    firstWork.resolve('detached')
-    secondWork.resolve('current')
+    staleWork.resolve('stale')
+    await Promise.resolve()
 
-    await expect(first).resolves.toBe('detached')
-    await expect(second).resolves.toBe('current')
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+
+    freshWork.resolve('fresh')
+    await expect(Promise.all([stale, fresh, joinedFresh])).resolves.toEqual([
+      'fresh',
+      'fresh',
+      'fresh',
+    ])
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('fresh')
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
+
+    await expect(read()).resolves.toBe('newer')
+    expect(load).toHaveBeenCalledTimes(3)
+    expect(commit).toHaveBeenLastCalledWith('newer')
   })
 
-  it('exposes whether a flight still owns the key', async () => {
+  it('retries detached failure through the replacement flight without exposing the stale error', async () => {
     const singleFlight = createInvalidatableSingleFlightByKey<string>()
-    const firstWork = Promise.withResolvers<string>()
-    const secondWork = Promise.withResolvers<string>()
-    let firstIsCurrent: (() => boolean) | undefined
-    let secondIsCurrent: (() => boolean) | undefined
+    const staleWork = Promise.withResolvers<string>()
+    const freshWork = Promise.withResolvers<string>()
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(staleWork.promise)
+      .mockReturnValueOnce(freshWork.promise)
+    const commit = vi.fn()
+    const retry = vi.fn(() => read())
+    const read = (): Promise<string> =>
+      singleFlight('tenant-a', {
+        load,
+        retry,
+        commit,
+      })
 
-    const first = singleFlight.run('tenant-a', (isCurrent) => {
-      firstIsCurrent = isCurrent
-      return firstWork.promise
-    })
-    singleFlight.invalidate('tenant-a')
-    const second = singleFlight.run('tenant-a', (isCurrent) => {
-      secondIsCurrent = isCurrent
-      return secondWork.promise
-    })
+    const stale = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    const fresh = read()
+    const joinedFresh = read()
 
-    expect(firstIsCurrent?.()).toBe(false)
-    expect(secondIsCurrent?.()).toBe(true)
+    staleWork.reject(new Error('detached failure'))
+    await Promise.resolve()
 
-    firstWork.resolve('detached')
-    secondWork.resolve('current')
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
 
-    await expect(first).resolves.toBe('detached')
-    await expect(second).resolves.toBe('current')
+    freshWork.resolve('fresh')
+    await expect(Promise.all([stale, fresh, joinedFresh])).resolves.toEqual([
+      'fresh',
+      'fresh',
+      'fresh',
+    ])
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('fresh')
   })
 
-  it('does not let a detached flight remove its replacement', async () => {
+  it('propagates a replacement failure to callers of the detached flight', async () => {
     const singleFlight = createInvalidatableSingleFlightByKey<string>()
-    const firstWork = Promise.withResolvers<string>()
-    const secondWork = Promise.withResolvers<string>()
+    const staleWork = Promise.withResolvers<string>()
+    const replacementWork = Promise.withResolvers<string>()
+    const replacementFailure = new Error('replacement failure')
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(staleWork.promise)
+      .mockReturnValueOnce(replacementWork.promise)
+      .mockResolvedValueOnce('recovered')
+    const retry = vi.fn(() => read())
+    const commit = vi.fn()
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
 
-    const first = singleFlight.run('tenant-a', () => firstWork.promise)
-    singleFlight.invalidate('tenant-a')
-    const second = singleFlight.run('tenant-a', () => secondWork.promise)
+    const detached = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    const replacement = read()
 
-    firstWork.resolve('detached')
-    await expect(first).resolves.toBe('detached')
+    staleWork.resolve('stale')
+    await Promise.resolve()
+    replacementWork.reject(replacementFailure)
 
+    await expect(Promise.allSettled([detached, replacement])).resolves.toEqual([
+      { status: 'rejected', reason: replacementFailure },
+      { status: 'rejected', reason: replacementFailure },
+    ])
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
+
+    await expect(read()).resolves.toBe('recovered')
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('recovered')
+  })
+
+  it('chains two detached generations through the current replacement', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const work = Array.from({ length: 3 }, () => Promise.withResolvers<string>())
+    let loadIndex = 0
+    const load = vi.fn(() => work[loadIndex++].promise)
+    const retry = vi.fn(() => read())
+    const commit = vi.fn()
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
+
+    const first = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    const second = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    const current = read()
+
+    work[0].resolve('first-stale')
+    work[1].resolve('second-stale')
+    await Promise.resolve()
+
+    expect(retry).toHaveBeenCalledTimes(2)
+    expect(commit).not.toHaveBeenCalled()
+
+    work[2].resolve('current')
+
+    await expect(Promise.all([first, second, current])).resolves.toEqual([
+      'current',
+      'current',
+      'current',
+    ])
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('current')
+  })
+
+  it('uses the canonical retry path when no replacement flight exists', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const staleWork = Promise.withResolvers<string>()
+    const retry = vi.fn().mockResolvedValue('fresh')
+    const commit = vi.fn()
+
+    const stale = singleFlight('tenant-a', {
+      load: () => staleWork.promise,
+      retry,
+      commit,
+    })
     expect(singleFlight.invalidate('tenant-a')).toBe(true)
 
-    secondWork.resolve('replacement')
-    await expect(second).resolves.toBe('replacement')
+    staleWork.resolve('stale')
+
+    await expect(stale).resolves.toBe('fresh')
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('hands off an invalidated caller without waiting for its stale load to settle', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const staleWork = Promise.withResolvers<string>()
+    const retry = vi.fn().mockResolvedValue('fresh')
+    const commit = vi.fn()
+    let outcome: { status: 'fulfilled'; value: string } | { status: 'rejected'; reason: unknown }
+
+    const detached = singleFlight('tenant-a', {
+      load: () => staleWork.promise,
+      retry,
+      commit,
+    })
+    void detached.then(
+      (value) => {
+        outcome = { status: 'fulfilled', value }
+      },
+      (reason) => {
+        outcome = { status: 'rejected', reason }
+      }
+    )
+
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(outcome!).toEqual({ status: 'fulfilled', value: 'fresh' })
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
+
+    staleWork.resolve('stale')
+    await Promise.resolve()
+
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('hands off a hung stale caller to an existing replacement', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const staleWork = Promise.withResolvers<string>()
+    const replacementWork = Promise.withResolvers<string>()
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(staleWork.promise)
+      .mockReturnValueOnce(replacementWork.promise)
+    const retry = vi.fn(() => read())
+    const commit = vi.fn()
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
+
+    const stale = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    const replacement = read()
+
+    replacementWork.resolve('fresh')
+
+    await expect(Promise.all([stale, replacement])).resolves.toEqual(['fresh', 'fresh'])
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('fresh')
+
+    staleWork.resolve('stale')
+    await Promise.resolve()
+
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up after the canonical retry path throws synchronously', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const staleWork = Promise.withResolvers<string>()
+    const retryFailure = new Error('synchronous retry failure')
+    const load = vi.fn().mockReturnValueOnce(staleWork.promise).mockResolvedValueOnce('recovered')
+    const retry = vi.fn((): Promise<string> => {
+      throw retryFailure
+    })
+    const commit = vi.fn()
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
+
+    const detached = read()
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    staleWork.resolve('stale')
+
+    await expect(detached).rejects.toBe(retryFailure)
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(commit).not.toHaveBeenCalled()
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
+
+    await expect(read()).resolves.toBe('recovered')
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('recovered')
+  })
+
+  it('propagates a current failure without retrying or committing it', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const failure = new Error('current failure')
+    const retry = vi.fn().mockResolvedValue('unexpected retry')
+    const commit = vi.fn()
+
+    await expect(
+      singleFlight('tenant-a', {
+        load: vi.fn().mockRejectedValue(failure),
+        retry,
+        commit,
+      })
+    ).rejects.toBe(failure)
+
+    expect(retry).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('cleans up the current flight when committing its result throws', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const commitFailure = new Error('commit failure')
+    const load = vi.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('recovered')
+    const retry = vi.fn().mockResolvedValue('unexpected retry')
+    const commit = vi.fn().mockImplementationOnce(() => {
+      throw commitFailure
+    })
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
+
+    const first = read()
+    const joined = read()
+
+    expect(joined).toBe(first)
+    await expect(Promise.allSettled([first, joined])).resolves.toEqual([
+      { status: 'rejected', reason: commitFailure },
+      { status: 'rejected', reason: commitFailure },
+    ])
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
+
+    await expect(read()).resolves.toBe('recovered')
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(retry).not.toHaveBeenCalled()
+    expect(commit).toHaveBeenCalledTimes(2)
+    expect(commit).toHaveBeenLastCalledWith('recovered')
+  })
+
+  it('bounds consecutive invalidation handoffs and lets a later chain recover', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const loadCount = MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 2
+    const work = Array.from({ length: loadCount }, () => Promise.withResolvers<string>())
+    let loadIndex = 0
+    const load = vi.fn(() => work[loadIndex++].promise)
+    const commit = vi.fn()
+    const retry = vi.fn(() => read())
+    const read = (): Promise<string> =>
+      singleFlight('tenant-a', {
+        load,
+        retry,
+        commit,
+      })
+
+    const firstOutcome = read().then(
+      (value) => ({ status: 'fulfilled' as const, value }),
+      (reason) => ({ status: 'rejected' as const, reason })
+    )
+
+    for (let handoff = 0; handoff < MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS; handoff++) {
+      expect(singleFlight.invalidate('tenant-a')).toBe(true)
+      void read()
+      work[handoff].resolve(`stale-${handoff}`)
+      await Promise.resolve()
+    }
+
+    expect(load).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1)
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+
+    await expect(firstOutcome).resolves.toEqual({
+      status: 'rejected',
+      reason: expect.any(SingleFlightInvalidationLimitError),
+    })
+
+    work[MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS].resolve('exhausted-stale')
+    await Promise.resolve()
+
+    expect(retry).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS)
+    expect(commit).not.toHaveBeenCalled()
+
+    const recovered = read()
+    work[MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1].resolve('fresh')
+
+    await expect(recovered).resolves.toBe('fresh')
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('fresh')
+  })
+
+  it('rejects every pending generation when the invalidation handoff limit is exhausted', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const loadCount = MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1
+    const work = Array.from({ length: loadCount }, () => Promise.withResolvers<string>())
+    const outcomes: Array<
+      { status: 'fulfilled'; value: string } | { status: 'rejected'; reason: unknown }
+    > = []
+    let loadIndex = 0
+    const load = vi.fn(() => work[loadIndex++].promise)
+    const retry = vi.fn(() => read())
+    const commit = vi.fn()
+    const read = (): Promise<string> => singleFlight('tenant-a', { load, retry, commit })
+
+    for (let generation = 0; generation < loadCount; generation++) {
+      const flight = read()
+      void flight.then(
+        (value) => outcomes.push({ status: 'fulfilled', value }),
+        (reason) => outcomes.push({ status: 'rejected', reason })
+      )
+      expect(singleFlight.invalidate('tenant-a')).toBe(true)
+    }
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(load).toHaveBeenCalledTimes(loadCount)
+    expect(outcomes).toHaveLength(loadCount)
+    expect(outcomes).toEqual(
+      Array.from({ length: loadCount }, () => ({
+        status: 'rejected',
+        reason: expect.any(SingleFlightInvalidationLimitError),
+      }))
+    )
+    expect(retry).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('stops canonical retries after the invalidation handoff limit', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const loadCount = MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1
+    const work = Array.from({ length: loadCount }, () => Promise.withResolvers<string>())
+    let loadIndex = 0
+    const load = vi.fn(() => work[loadIndex++].promise)
+    const commit = vi.fn()
+    const retry = vi.fn(() => read())
+    const read = (): Promise<string> =>
+      singleFlight('tenant-a', {
+        load,
+        retry,
+        commit,
+      })
+
+    const first = read()
+
+    for (let handoff = 0; handoff < MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS; handoff++) {
+      expect(singleFlight.invalidate('tenant-a')).toBe(true)
+      work[handoff].resolve(`stale-${handoff}`)
+      await Promise.resolve()
+    }
+
+    expect(retry).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS)
+    expect(load).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1)
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+
+    await expect(first).rejects.toBeInstanceOf(SingleFlightInvalidationLimitError)
+
+    work[MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS].resolve('exhausted-stale')
+    await Promise.resolve()
+
+    expect(retry).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('preserves the handoff limit when retry synchronously invalidates its replacement', async () => {
+    const singleFlight = createInvalidatableSingleFlightByKey<string>()
+    const reentrantInvalidationCap = MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 8
+    let reentrantInvalidations = 0
+    const load = vi.fn(() => new Promise<string>(() => undefined))
+    let read: () => Promise<string>
+    const retry = vi.fn(() => {
+      const replacement = read()
+
+      if (reentrantInvalidations < reentrantInvalidationCap) {
+        reentrantInvalidations++
+        expect(singleFlight.invalidate('tenant-a')).toBe(true)
+      }
+
+      return replacement
+    })
+    read = (): Promise<string> => singleFlight('tenant-a', { load, retry })
+
+    const firstOutcome = read().then(
+      (value) => ({ status: 'fulfilled' as const, value }),
+      (reason) => ({ status: 'rejected' as const, reason })
+    )
+    expect(singleFlight.invalidate('tenant-a')).toBe(true)
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(retry).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS)
+    expect(reentrantInvalidations).toBe(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS)
+    expect(load).toHaveBeenCalledTimes(MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS + 1)
+    await expect(firstOutcome).resolves.toEqual({
+      status: 'rejected',
+      reason: expect.any(SingleFlightInvalidationLimitError),
+    })
+    expect(singleFlight.invalidate('tenant-a')).toBe(false)
   })
 })

--- a/src/internal/concurrency/single-flight.ts
+++ b/src/internal/concurrency/single-flight.ts
@@ -1,43 +1,181 @@
-export function createInvalidatableSingleFlightByKey<T>(): {
-  run(key: string, load: (isCurrent: () => boolean) => Promise<T>): Promise<T>
+export type InvalidatableSingleFlightTask<T> = {
+  // Loads a value without publishing it to shared state.
+  load(): Promise<T>
+  // Re-enters the canonical read path after this generation is detached.
+  retry(): Promise<T>
+  // Publishes a current result; must not synchronously invalidate the same key.
+  commit?(value: T): void
+}
+
+export type InvalidatableSingleFlightByKey<T> = {
+  (key: string, task: InvalidatableSingleFlightTask<T>): Promise<T>
   invalidate(key: string): boolean
-} {
-  const inFlightMap = new Map<string, Promise<T>>()
+}
 
-  return {
-    run(key, load) {
-      const inFlight = inFlightMap.get(key)
-      if (inFlight) {
-        return inFlight
+// Tenant writes can invalidate locally and again through Postgres notifications.
+// Allow a generous burst while still bounding pathological generation churn.
+export const MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS = 16
+
+export class SingleFlightInvalidationLimitError extends Error {
+  readonly code = 'SINGLE_FLIGHT_INVALIDATION_LIMIT'
+
+  constructor() {
+    super(
+      `Single-flight invalidation limit of ${MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS} handoffs exceeded`
+    )
+    this.name = 'SingleFlightInvalidationLimitError'
+  }
+}
+
+type InvalidatableSingleFlightChain<T> = {
+  current?: {
+    promise: Promise<T>
+    handoff(): void
+  }
+  handoffs: number
+  pendingRejectors: Set<(reason?: unknown) => void>
+}
+
+// Deduplicates same-key work while allowing an invalidation to detach the
+// current flight. Invalidation schedules detached callers to retry through the
+// current read path, joining a replacement flight when one exists. Only a
+// current generation can commit its result.
+//
+// A bounded handoff chain prevents sustained invalidations from keeping callers
+// and reloads alive indefinitely.
+export function createInvalidatableSingleFlightByKey<T>(): InvalidatableSingleFlightByKey<T> {
+  const inFlightMap = new Map<string, InvalidatableSingleFlightChain<T>>()
+
+  const singleFlight = (key: string, task: InvalidatableSingleFlightTask<T>): Promise<T> => {
+    let chain = inFlightMap.get(key)
+    const inFlight = chain?.current?.promise
+    if (inFlight) {
+      return inFlight
+    }
+
+    if (!chain) {
+      chain = { handoffs: 0, pendingRejectors: new Set() }
+      inFlightMap.set(key, chain)
+    }
+
+    const { promise, resolve, reject } = Promise.withResolvers<T>()
+    const clearChainIfIdle = () => {
+      if (inFlightMap.get(key) === chain && chain.current === undefined) {
+        inFlightMap.delete(key)
       }
-
-      const { promise, resolve, reject } = Promise.withResolvers<T>()
-      inFlightMap.set(key, promise)
-
-      const isCurrent = () => inFlightMap.get(key) === promise
-      const deleteInFlight = () => {
-        if (isCurrent()) {
-          inFlightMap.delete(key)
-        }
+    }
+    let settled = false
+    let handoffStarted = false
+    const settleResolve = (value: T) => {
+      if (settled) {
+        return
       }
+      settled = true
+      chain.pendingRejectors.delete(settleReject)
+      resolve(value)
+      clearChainIfIdle()
+    }
+    const settleReject = (reason?: unknown) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      chain.pendingRejectors.delete(settleReject)
+      reject(reason)
+      clearChainIfIdle()
+    }
+    chain.pendingRejectors.add(settleReject)
 
-      void promise.then(deleteInFlight, deleteInFlight)
+    const isCurrent = () => inFlightMap.get(key) === chain && chain.current?.promise === promise
+    const clearCurrent = () => {
+      if (isCurrent()) {
+        inFlightMap.delete(key)
+      }
+    }
+    const retryCurrent = () => {
+      if (settled || handoffStarted) {
+        return
+      }
+      handoffStarted = true
 
       try {
-        void Promise.resolve(load(isCurrent)).then(resolve, reject)
+        void task.retry().then(settleResolve, settleReject)
       } catch (error) {
-        reject(error)
+        settleReject(error)
+      }
+    }
+    chain.current = { promise, handoff: retryCurrent }
+
+    const handleSuccess = (value: T) => {
+      if (!isCurrent()) {
+        retryCurrent()
+        return
       }
 
-      return promise
-    },
-    invalidate(key) {
-      return inFlightMap.delete(key)
-    },
+      try {
+        task.commit?.(value)
+      } catch (error) {
+        clearCurrent()
+        settleReject(error)
+        return
+      }
+
+      clearCurrent()
+      settleResolve(value)
+    }
+
+    const handleFailure = (error: unknown) => {
+      if (!isCurrent()) {
+        retryCurrent()
+        return
+      }
+
+      clearCurrent()
+      settleReject(error)
+    }
+
+    try {
+      void task.load().then(handleSuccess, handleFailure)
+    } catch (error) {
+      handleFailure(error)
+    }
+
+    return promise
   }
+
+  singleFlight.invalidate = (key: string) => {
+    const chain = inFlightMap.get(key)
+    const current = chain?.current
+    if (!chain || !current) {
+      return false
+    }
+
+    chain.current = undefined
+    chain.handoffs++
+
+    if (chain.handoffs > MAX_INVALIDATABLE_SINGLE_FLIGHT_HANDOFFS) {
+      const error = new SingleFlightInvalidationLimitError()
+      if (inFlightMap.get(key) === chain) {
+        inFlightMap.delete(key)
+      }
+      for (const rejectPending of [...chain.pendingRejectors]) {
+        rejectPending(error)
+      }
+    } else {
+      // Cache owners delete their entry in the same synchronous invalidation block.
+      queueMicrotask(current.handoff)
+    }
+
+    return true
+  }
+
+  return singleFlight
 }
 
 export function createSingleFlightByKey<T>() {
   const singleFlight = createInvalidatableSingleFlightByKey<T>()
-  return (key: string, load: () => Promise<T>) => singleFlight.run(key, load)
+
+  return (key: string, fn: () => Promise<T>) => {
+    return singleFlight(key, { load: fn, retry: fn })
+  }
 }

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -1,4 +1,5 @@
 import {
+  CACHE_LOOKUP_WITHOUT_METRICS,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_CONFIG_CACHE_NAME,
@@ -191,92 +192,92 @@ export async function getTenantConfig(
     return cachedConfig
   }
 
-  return tenantConfigSingleFlight.run(tenantId, async (isCurrent) => {
-    const tenant = await getTenantConfigRow(tenantId)
+  return tenantConfigSingleFlight(tenantId, {
+    load: async () => {
+      const tenant = await getTenantConfigRow(tenantId)
 
-    if (!tenant) {
-      throw ERRORS.MissingTenantConfig(tenantId)
-    }
-    const {
-      anon_key,
-      database_url,
-      file_size_limit,
-      jwt_secret,
-      jwks,
-      service_key,
-      feature_purge_cache,
-      feature_image_transformation,
-      feature_s3_protocol,
-      feature_iceberg_catalog,
-      feature_iceberg_catalog_max_catalogs,
-      feature_iceberg_catalog_max_namespaces,
-      feature_iceberg_catalog_max_tables,
-      feature_vector_buckets,
-      feature_vector_buckets_max_buckets,
-      feature_vector_buckets_max_indexes,
-      image_transformation_max_resolution,
-      database_pool_url,
-      max_connections,
-      delete_objects_limit,
-      migrations_version,
-      migrations_status,
-      tracing_mode,
-      disable_events,
-    } = tenant
+      if (!tenant) {
+        throw ERRORS.MissingTenantConfig(tenantId)
+      }
+      const {
+        anon_key,
+        database_url,
+        file_size_limit,
+        jwt_secret,
+        jwks,
+        service_key,
+        feature_purge_cache,
+        feature_image_transformation,
+        feature_s3_protocol,
+        feature_iceberg_catalog,
+        feature_iceberg_catalog_max_catalogs,
+        feature_iceberg_catalog_max_namespaces,
+        feature_iceberg_catalog_max_tables,
+        feature_vector_buckets,
+        feature_vector_buckets_max_buckets,
+        feature_vector_buckets_max_indexes,
+        image_transformation_max_resolution,
+        database_pool_url,
+        max_connections,
+        delete_objects_limit,
+        migrations_version,
+        migrations_status,
+        tracing_mode,
+        disable_events,
+      } = tenant
 
-    const serviceKey = decrypt(service_key)
-    const jwtSecret = decrypt(jwt_secret)
+      const serviceKey = decrypt(service_key)
+      const jwtSecret = decrypt(jwt_secret)
 
-    const config = {
-      anonKey: decrypt(anon_key),
-      databaseUrl: decrypt(database_url),
-      databasePoolUrl: database_pool_url ? decrypt(database_pool_url) : undefined,
-      fileSizeLimit: Number(file_size_limit),
-      jwtSecret,
-      jwks: jwks ? { keys: jwks.keys ?? [] } : jwks,
-      serviceKey,
-      serviceKeyPayload: { role: dbServiceRole },
-      maxConnections: max_connections ? Number(max_connections) : undefined,
-      deleteObjectsLimit:
-        delete_objects_limit === null ||
-        delete_objects_limit === undefined ||
-        delete_objects_limit <= 0
-          ? undefined
-          : Number(delete_objects_limit),
-      features: {
-        imageTransformation: {
-          enabled: Boolean(feature_image_transformation),
-          maxResolution: image_transformation_max_resolution,
+      const config = {
+        anonKey: decrypt(anon_key),
+        databaseUrl: decrypt(database_url),
+        databasePoolUrl: database_pool_url ? decrypt(database_pool_url) : undefined,
+        fileSizeLimit: Number(file_size_limit),
+        jwtSecret,
+        jwks: jwks ? { keys: jwks.keys ?? [] } : jwks,
+        serviceKey,
+        serviceKeyPayload: { role: dbServiceRole },
+        maxConnections: max_connections ? Number(max_connections) : undefined,
+        deleteObjectsLimit:
+          delete_objects_limit === null ||
+          delete_objects_limit === undefined ||
+          delete_objects_limit <= 0
+            ? undefined
+            : Number(delete_objects_limit),
+        features: {
+          imageTransformation: {
+            enabled: Boolean(feature_image_transformation),
+            maxResolution: image_transformation_max_resolution,
+          },
+          s3Protocol: {
+            enabled: Boolean(feature_s3_protocol),
+          },
+          purgeCache: {
+            enabled: Boolean(feature_purge_cache),
+          },
+          icebergCatalog: {
+            enabled: Boolean(feature_iceberg_catalog),
+            maxNamespaces: feature_iceberg_catalog_max_namespaces ?? 0,
+            maxTables: feature_iceberg_catalog_max_tables ?? 0,
+            maxCatalogs: feature_iceberg_catalog_max_catalogs ?? 0,
+          },
+          vectorBuckets: {
+            enabled: Boolean(feature_vector_buckets),
+            maxBuckets: feature_vector_buckets_max_buckets ?? 0,
+            maxIndexes: feature_vector_buckets_max_indexes ?? 0,
+          },
         },
-        s3Protocol: {
-          enabled: Boolean(feature_s3_protocol),
-        },
-        purgeCache: {
-          enabled: Boolean(feature_purge_cache),
-        },
-        icebergCatalog: {
-          enabled: Boolean(feature_iceberg_catalog),
-          maxNamespaces: feature_iceberg_catalog_max_namespaces ?? 0,
-          maxTables: feature_iceberg_catalog_max_tables ?? 0,
-          maxCatalogs: feature_iceberg_catalog_max_catalogs ?? 0,
-        },
-        vectorBuckets: {
-          enabled: Boolean(feature_vector_buckets),
-          maxBuckets: feature_vector_buckets_max_buckets ?? 0,
-          maxIndexes: feature_vector_buckets_max_indexes ?? 0,
-        },
-      },
-      migrationVersion: migrations_version as keyof typeof DBMigration | undefined,
-      migrationStatus: migrations_status as TenantMigrationStatus | undefined,
-      migrationsRun: false,
-      tracingMode: tracing_mode ?? undefined,
-      disableEvents: disable_events ?? undefined,
-    }
-    if (isCurrent()) {
-      tenantConfigCache.set(tenantId, config)
-    }
-
-    return config
+        migrationVersion: migrations_version as keyof typeof DBMigration | undefined,
+        migrationStatus: migrations_status as TenantMigrationStatus | undefined,
+        migrationsRun: false,
+        tracingMode: tracing_mode ?? undefined,
+        disableEvents: disable_events ?? undefined,
+      }
+      return config
+    },
+    retry: () => getTenantConfig(tenantId, CACHE_LOOKUP_WITHOUT_METRICS),
+    commit: (config) => tenantConfigCache.set(tenantId, config),
   })
 }
 

--- a/src/storage/protocols/s3/credentials/manager.ts
+++ b/src/storage/protocols/s3/credentials/manager.ts
@@ -1,11 +1,13 @@
 import crypto from 'node:crypto'
 import { decrypt, encrypt } from '@internal/auth'
 import {
+  CACHE_LOOKUP_WITHOUT_METRICS,
+  type CacheLookupOptions,
   createLruCache,
   DEFAULT_CACHE_PURGE_STALE_INTERVAL_MS,
   TENANT_S3_CREDENTIALS_CACHE_NAME,
 } from '@internal/cache'
-import { createSingleFlightByKey } from '@internal/concurrency'
+import { createInvalidatableSingleFlightByKey } from '@internal/concurrency'
 import { ERRORS } from '@internal/errors'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
 import { getConfig } from '../../../../config'
@@ -29,7 +31,12 @@ const tenantS3CredentialsCache = createLruCache<string, S3Credentials>(
   }
 )
 
-const s3CredentialsSingleFlight = createSingleFlightByKey<S3Credentials>()
+const s3CredentialsSingleFlight = createInvalidatableSingleFlightByKey<S3Credentials>()
+
+function deleteTenantS3CredentialsCache(cacheKey: string): void {
+  s3CredentialsSingleFlight.invalidate(cacheKey)
+  tenantS3CredentialsCache.delete(cacheKey)
+}
 
 export class S3CredentialsManager {
   private dbServiceRole: string
@@ -48,7 +55,7 @@ export class S3CredentialsManager {
         return
       }
 
-      tenantS3CredentialsCache.delete(cacheKey)
+      deleteTenantS3CredentialsCache(cacheKey)
     })
   }
 
@@ -98,26 +105,33 @@ export class S3CredentialsManager {
     }
   }
 
-  async getS3CredentialsByAccessKey(tenantId: string, accessKey: string): Promise<S3Credentials> {
+  async getS3CredentialsByAccessKey(
+    tenantId: string,
+    accessKey: string,
+    options?: CacheLookupOptions
+  ): Promise<S3Credentials> {
     const cacheKey = `${tenantId}:${accessKey}`
-    const cachedCredentials = tenantS3CredentialsCache.get(cacheKey)
+    const cachedCredentials = tenantS3CredentialsCache.get(cacheKey, options)
 
     if (cachedCredentials !== undefined) {
       return cachedCredentials
     }
 
-    return s3CredentialsSingleFlight(cacheKey, async () => {
-      const data = await this.storage.getOneByAccessKey(tenantId, accessKey)
+    return s3CredentialsSingleFlight(cacheKey, {
+      load: async () => {
+        const data = await this.storage.getOneByAccessKey(tenantId, accessKey)
 
-      if (!data) {
-        throw ERRORS.MissingS3Credentials()
-      }
+        if (!data) {
+          throw ERRORS.MissingS3Credentials()
+        }
 
-      data.secretKey = decrypt(data.secretKey)
+        data.secretKey = decrypt(data.secretKey)
 
-      tenantS3CredentialsCache.set(cacheKey, data)
-
-      return data
+        return data
+      },
+      retry: () =>
+        this.getS3CredentialsByAccessKey(tenantId, accessKey, CACHE_LOOKUP_WITHOUT_METRICS),
+      commit: (data) => tenantS3CredentialsCache.set(cacheKey, data),
     })
   }
 

--- a/src/test/tenant-jwks.test.ts
+++ b/src/test/tenant-jwks.test.ts
@@ -13,7 +13,7 @@ mergeConfig({
 })
 
 import { encrypt, signJWT } from '@internal/auth'
-import { JWKSManagerStorePg } from '@internal/auth/jwks'
+import { deleteTenantJwksConfig, JWKSManagerStorePg } from '@internal/auth/jwks'
 import { TENANTS_JWKS_UPDATE_CHANNEL } from '@internal/auth/jwks/channels'
 import { UrlSigningJwkGenerator } from '@internal/auth/jwks/generator'
 import { TENANT_JWKS_CACHE_NAME } from '@internal/cache'
@@ -29,7 +29,7 @@ import { PostgresPubSub } from '@internal/pubsub'
 import dotenv from 'dotenv'
 import * as migrate from '../internal/database/migrations/migrate'
 import { adminApp, mockQueue } from './common'
-import { assertLogicalLookupMetrics } from './utils/cache-metrics'
+import { assertLogicalLookupMetrics, getCacheRequestCalls } from './utils/cache-metrics'
 import { mockCreateLruCache } from './utils/cache-mock'
 import { waitForEventually } from './utils/promise'
 
@@ -397,6 +397,93 @@ describe('Tenant jwks configs', () => {
       expect(listActiveSpy).toHaveBeenCalledTimes(1)
       results.forEach((result, i) => expect(result).toEqual(results[i === 0 ? 1 : 0]))
     } finally {
+      listActiveSpy.mockRestore()
+    }
+  })
+
+  test('JWKS invalidation cannot be undone by an older in-flight load', async () => {
+    const lookupTenantId = 'jwks-invalidation-during-load'
+    const staleJwk = {
+      id: 'stale-key',
+      kind: 'storage-url-signing-key',
+      content: encrypt(JSON.stringify({ kty: 'oct', k: 'stale-secret' })),
+    }
+    const freshJwk = {
+      id: 'fresh-key',
+      kind: 'storage-url-signing-key',
+      content: encrypt(JSON.stringify({ kty: 'oct', k: 'fresh-secret' })),
+    }
+    const staleRequest = Promise.withResolvers<Array<typeof staleJwk>>()
+    const listActiveSpy = vi
+      .spyOn(jwksManager['storage'], 'listActive')
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockResolvedValueOnce([freshJwk])
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
+
+    try {
+      recordSpy.mockClear()
+      const staleLookup = jwksManager.getJwksTenantConfig(lookupTenantId)
+      await vi.waitFor(() => expect(listActiveSpy).toHaveBeenCalledTimes(1))
+
+      deleteTenantJwksConfig(lookupTenantId)
+
+      await expect(staleLookup).resolves.toMatchObject({
+        keys: [expect.objectContaining({ kid: 'storage-url-signing-key_fresh-key' })],
+      })
+      expect(listActiveSpy).toHaveBeenCalledTimes(2)
+      expect(getCacheRequestCalls(recordSpy, TENANT_JWKS_CACHE_NAME)).toEqual([
+        [TENANT_JWKS_CACHE_NAME, 'miss'],
+      ])
+
+      staleRequest.resolve([staleJwk])
+      await new Promise<void>((resolve) => setImmediate(resolve))
+
+      await expect(jwksManager.getJwksTenantConfig(lookupTenantId)).resolves.toMatchObject({
+        keys: [expect.objectContaining({ kid: 'storage-url-signing-key_fresh-key' })],
+      })
+      expect(getCacheRequestCalls(recordSpy, TENANT_JWKS_CACHE_NAME)).toEqual([
+        [TENANT_JWKS_CACHE_NAME, 'miss'],
+        [TENANT_JWKS_CACHE_NAME, 'hit'],
+      ])
+    } finally {
+      deleteTenantJwksConfig(lookupTenantId)
+      listActiveSpy.mockRestore()
+      recordSpy.mockRestore()
+    }
+  })
+
+  test('JWKS invalidation retries an older in-flight load that fails', async () => {
+    const lookupTenantId = 'jwks-invalidation-error'
+    const freshJwk = {
+      id: 'fresh-key-after-error',
+      kind: 'storage-url-signing-key',
+      content: encrypt(JSON.stringify({ kty: 'oct', k: 'fresh-secret' })),
+    }
+    const staleRequest = Promise.withResolvers<never>()
+    const listActiveSpy = vi
+      .spyOn(jwksManager['storage'], 'listActive')
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockResolvedValueOnce([freshJwk])
+
+    try {
+      const staleLookup = jwksManager.getJwksTenantConfig(lookupTenantId)
+      await vi.waitFor(() => expect(listActiveSpy).toHaveBeenCalledTimes(1))
+
+      deleteTenantJwksConfig(lookupTenantId)
+      const freshLookup = jwksManager.getJwksTenantConfig(lookupTenantId)
+      staleRequest.reject(new Error('detached JWKS load failed'))
+
+      await expect(Promise.all([staleLookup, freshLookup])).resolves.toEqual([
+        expect.objectContaining({
+          keys: [expect.objectContaining({ kid: 'storage-url-signing-key_fresh-key-after-error' })],
+        }),
+        expect.objectContaining({
+          keys: [expect.objectContaining({ kid: 'storage-url-signing-key_fresh-key-after-error' })],
+        }),
+      ])
+      expect(listActiveSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      deleteTenantJwksConfig(lookupTenantId)
       listActiveSpy.mockRestore()
     }
   })

--- a/src/test/tenant-s3-credentials.test.ts
+++ b/src/test/tenant-s3-credentials.test.ts
@@ -25,7 +25,7 @@ import { PostgresPubSub } from '@internal/pubsub'
 import dotenv from 'dotenv'
 import * as migrate from '../internal/database/migrations/migrate'
 import { adminApp } from './common'
-import { assertLogicalLookupMetrics } from './utils/cache-metrics'
+import { assertLogicalLookupMetrics, getCacheRequestCalls } from './utils/cache-metrics'
 
 dotenv.config({ path: '.env.test' })
 
@@ -337,6 +337,101 @@ describe('Tenant S3 credentials', () => {
       results.forEach((result, i) => expect(result).toEqual(results[i === 0 ? 1 : 0]))
       expect(results[0].accessKey).toBe(createJson.access_key)
     } finally {
+      getByKeySpy.mockRestore()
+    }
+  })
+
+  test('S3 credential invalidation cannot be undone by an older in-flight load', async () => {
+    const lookupTenantId = 's3-invalidation-during-load'
+    const accessKey = 'invalidation-access-key'
+    const cacheKey = `${lookupTenantId}:${accessKey}`
+    const claims = { role: 'service_role' }
+    const staleCredentials = {
+      accessKey,
+      secretKey: encrypt('stale-secret'),
+      claims,
+    }
+    const freshCredentials = {
+      accessKey,
+      secretKey: encrypt('fresh-secret'),
+      claims,
+    }
+    const staleRequest = Promise.withResolvers<typeof staleCredentials>()
+    const getByKeySpy = vi
+      .spyOn(s3CredentialsManager['storage'], 'getOneByAccessKey')
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockResolvedValueOnce(freshCredentials)
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
+
+    try {
+      recordSpy.mockClear()
+      const staleLookup = s3CredentialsManager.getS3CredentialsByAccessKey(
+        lookupTenantId,
+        accessKey
+      )
+      await vi.waitFor(() => expect(getByKeySpy).toHaveBeenCalledTimes(1))
+
+      pubSub.subscriber.notifications.emit('tenants_s3_credentials_update', cacheKey)
+
+      await expect(staleLookup).resolves.toMatchObject({ secretKey: 'fresh-secret' })
+      expect(getByKeySpy).toHaveBeenCalledTimes(2)
+      expect(getCacheRequestCalls(recordSpy, TENANT_S3_CREDENTIALS_CACHE_NAME)).toEqual([
+        [TENANT_S3_CREDENTIALS_CACHE_NAME, 'miss'],
+      ])
+
+      staleRequest.resolve(staleCredentials)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+
+      await expect(
+        s3CredentialsManager.getS3CredentialsByAccessKey(lookupTenantId, accessKey)
+      ).resolves.toMatchObject({ secretKey: 'fresh-secret' })
+      expect(getCacheRequestCalls(recordSpy, TENANT_S3_CREDENTIALS_CACHE_NAME)).toEqual([
+        [TENANT_S3_CREDENTIALS_CACHE_NAME, 'miss'],
+        [TENANT_S3_CREDENTIALS_CACHE_NAME, 'hit'],
+      ])
+    } finally {
+      pubSub.subscriber.notifications.emit('tenants_s3_credentials_update', cacheKey)
+      getByKeySpy.mockRestore()
+      recordSpy.mockRestore()
+    }
+  })
+
+  test('S3 credential invalidation retries an older in-flight load that fails', async () => {
+    const lookupTenantId = 's3-invalidation-error'
+    const accessKey = 'invalidation-error-access-key'
+    const cacheKey = `${lookupTenantId}:${accessKey}`
+    const freshCredentials = {
+      accessKey,
+      secretKey: encrypt('fresh-secret'),
+      claims: { role: 'service_role' },
+    }
+    const staleRequest = Promise.withResolvers<never>()
+    const getByKeySpy = vi
+      .spyOn(s3CredentialsManager['storage'], 'getOneByAccessKey')
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockResolvedValueOnce(freshCredentials)
+
+    try {
+      const staleLookup = s3CredentialsManager.getS3CredentialsByAccessKey(
+        lookupTenantId,
+        accessKey
+      )
+      await vi.waitFor(() => expect(getByKeySpy).toHaveBeenCalledTimes(1))
+
+      pubSub.subscriber.notifications.emit('tenants_s3_credentials_update', cacheKey)
+      const freshLookup = s3CredentialsManager.getS3CredentialsByAccessKey(
+        lookupTenantId,
+        accessKey
+      )
+      staleRequest.reject(new Error('detached S3 credential load failed'))
+
+      await expect(Promise.all([staleLookup, freshLookup])).resolves.toEqual([
+        expect.objectContaining({ secretKey: 'fresh-secret' }),
+        expect.objectContaining({ secretKey: 'fresh-secret' }),
+      ])
+      expect(getByKeySpy).toHaveBeenCalledTimes(2)
+    } finally {
+      pubSub.subscriber.notifications.emit('tenants_s3_credentials_update', cacheKey)
       getByKeySpy.mockRestore()
     }
   })

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -19,7 +19,7 @@ import * as metrics from '@internal/monitoring/metrics'
 import dotenv from 'dotenv'
 import * as migrate from '../internal/database/migrations/migrate'
 import { adminApp } from './common'
-import { assertLogicalLookupMetrics } from './utils/cache-metrics'
+import { assertLogicalLookupMetrics, getCacheRequestCalls } from './utils/cache-metrics'
 import { mockCreateLruCache } from './utils/cache-mock'
 
 dotenv.config({ path: '.env.test' })
@@ -1099,7 +1099,7 @@ describe('Tenant configs', () => {
     }
   })
 
-  test('An invalidated config load cannot repopulate the cache', async () => {
+  test('An invalidated config load retries through the current generation', async () => {
     const tenantId = 'tenant-config-invalidation-race'
     const oldTenant = {
       ...createEncryptedTenantRow(tenantId),
@@ -1114,24 +1114,64 @@ describe('Tenant configs', () => {
       .spyOn(multitenantPgExecutor, 'query')
       .mockReturnValueOnce(oldQuery.promise)
       .mockResolvedValueOnce(mockTenantQueryResult(newTenant))
+    const recordSpy = vi.spyOn(metrics, 'recordCacheRequest')
 
     try {
+      recordSpy.mockClear()
       const staleLookup = getTenantConfig(tenantId)
-      onTenantConfigChange(tenantId)
-      const currentLookup = getTenantConfig(tenantId)
+      await vi.waitFor(() => expect(querySpy).toHaveBeenCalledTimes(1))
 
-      await expect(currentLookup).resolves.toMatchObject({
+      onTenantConfigChange(tenantId)
+
+      await expect(staleLookup).resolves.toMatchObject({
         databaseUrl: 'postgres://new-host',
       })
+      expect(querySpy).toHaveBeenCalledTimes(2)
+      expect(getCacheRequestCalls(recordSpy, TENANT_CONFIG_CACHE_NAME)).toEqual([
+        [TENANT_CONFIG_CACHE_NAME, 'miss'],
+      ])
 
       oldQuery.resolve(mockTenantQueryResult(oldTenant))
-      await expect(staleLookup).resolves.toMatchObject({
-        databaseUrl: 'postgres://old-host',
-      })
+      await new Promise<void>((resolve) => setImmediate(resolve))
 
       await expect(getTenantConfig(tenantId)).resolves.toMatchObject({
         databaseUrl: 'postgres://new-host',
       })
+      expect(getCacheRequestCalls(recordSpy, TENANT_CONFIG_CACHE_NAME)).toEqual([
+        [TENANT_CONFIG_CACHE_NAME, 'miss'],
+        [TENANT_CONFIG_CACHE_NAME, 'hit'],
+      ])
+    } finally {
+      deleteTenantConfig(tenantId)
+      querySpy.mockRestore()
+      recordSpy.mockRestore()
+    }
+  })
+
+  test('An invalidated config load that fails retries through the current generation', async () => {
+    const tenantId = 'tenant-config-invalidation-error'
+    const freshTenant = {
+      ...createEncryptedTenantRow(tenantId),
+      database_url: encrypt('postgres://fresh-host-after-error'),
+    }
+    const staleQuery = Promise.withResolvers<never>()
+    const querySpy = vi
+      .spyOn(multitenantPgExecutor, 'query')
+      .mockReturnValueOnce(staleQuery.promise)
+      .mockResolvedValueOnce(mockTenantQueryResult(freshTenant))
+
+    try {
+      const staleLookup = getTenantConfig(tenantId)
+      await vi.waitFor(() => expect(querySpy).toHaveBeenCalledTimes(1))
+
+      onTenantConfigChange(tenantId)
+      const currentLookup = getTenantConfig(tenantId)
+      staleQuery.reject(new Error('detached tenant config load failed'))
+
+      await expect(Promise.all([staleLookup, currentLookup])).resolves.toEqual([
+        expect.objectContaining({ databaseUrl: 'postgres://fresh-host-after-error' }),
+        expect.objectContaining({ databaseUrl: 'postgres://fresh-host-after-error' }),
+      ])
       expect(querySpy).toHaveBeenCalledTimes(2)
     } finally {
       deleteTenantConfig(tenantId)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In #1269, we added invalidatable single flight only for tenant configs and it didn't have a capability to join ongoing flight.
  
## What is the new behavior?

Extend the primitive to rejoin/retry so that it doesn't bubble errors in every change and use it in JWK/S3 creds because they are prone to the same race. These caches have update age on get which would keep stale indefinitely for hot tenants.

## Additional context

Related to #1269 
Related to #1257 