### PR TITLE
fix: adjust keep alive and request timeout for webhook calls

### DIFF
--- a/src/storage/events/lifecycle/webhook.ts
+++ b/src/storage/events/lifecycle/webhook.ts
@@ -14,10 +14,12 @@ const {
   webhookQueueMaxFreeSockets,
 } = getConfig()
 const WEBHOOK_TIMEOUT_MS = 4000
-const webhookKeepAliveTimeoutMs = Math.min(
-  Math.max(webhookQueueMaxFreeSockets, 1) * 1000,
-  WEBHOOK_TIMEOUT_MS
-)
+// headersTimeout/bodyTimeout only start counting after connect finishes, but the AbortSignal
+// below starts at fetch time and covers connect too — so it needs its own budget on top of
+// WEBHOOK_TIMEOUT_MS, or it always wins the race and the dispatcher timeouts can never fire.
+const WEBHOOK_CONNECT_TIMEOUT_MS = 2000
+const WEBHOOK_TOTAL_TIMEOUT_MS = WEBHOOK_TIMEOUT_MS + WEBHOOK_CONNECT_TIMEOUT_MS
+const webhookKeepAliveTimeoutMs = Math.max(webhookQueueMaxFreeSockets, 1) * 1000
 
 interface WebhookEvent {
   event: {
@@ -51,6 +53,8 @@ const dispatcher = new Agent({
   // so use the old knob to make idle sockets expire sooner when a small free pool is desired.
   keepAliveTimeout: webhookKeepAliveTimeoutMs,
   keepAliveMaxTimeout: webhookKeepAliveTimeoutMs,
+  headersTimeout: WEBHOOK_TIMEOUT_MS,
+  bodyTimeout: WEBHOOK_TIMEOUT_MS,
 })
 
 const defaultHeaders = new Headers({
@@ -68,7 +72,7 @@ async function assertOkResponse(response: Response) {
 
 function normalizeWebhookError(error: unknown) {
   if (error instanceof DOMException && error.name === 'TimeoutError') {
-    return new Error(`timeout of ${WEBHOOK_TIMEOUT_MS}ms exceeded`)
+    return new Error(`timeout of ${WEBHOOK_TOTAL_TIMEOUT_MS}ms exceeded`)
   }
 
   if (error instanceof Error) {
@@ -85,7 +89,7 @@ const client: WebhookClient = {
       body: JSON.stringify(payload),
       headers: defaultHeaders,
       dispatcher,
-      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+      signal: AbortSignal.timeout(WEBHOOK_TOTAL_TIMEOUT_MS),
     }
 
     const response = await fetch(url, requestInit)

--- a/src/storage/events/lifecycle/webhook.ts
+++ b/src/storage/events/lifecycle/webhook.ts
@@ -172,10 +172,11 @@ export class Webhook extends BaseEvent<WebhookEvent> {
       })
     } catch (e) {
       const error = normalizeWebhookError(e)
+      const cause = error?.cause ? ` (${String(error.cause)})` : ''
 
       logger.error(
         {
-          error: error.message,
+          error: error.message + cause,
           jodId: job.id,
           type: 'event',
           event: job.data.event.type,

--- a/src/test/queue-mocks.test.ts
+++ b/src/test/queue-mocks.test.ts
@@ -176,7 +176,7 @@ describe('Webhook queue handlers', () => {
     const { Webhook } = await loadWebhookModule()
 
     await expect(Webhook.handle(makeJob() as never)).rejects.toThrow(
-      'Failed to send webhook for event ObjectCreated:Post to https://example.com/webhook: timeout of 4000ms exceeded'
+      'Failed to send webhook for event ObjectCreated:Post to https://example.com/webhook: timeout of 6000ms exceeded'
     )
 
     expect(mockLogEvent).toHaveBeenCalledWith(
@@ -190,7 +190,7 @@ describe('Webhook queue handlers', () => {
     )
     expect(mockLoggerError).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: 'timeout of 4000ms exceeded',
+        error: 'timeout of 6000ms exceeded',
         tenantId: 'tenant-a',
         reqId: 'req-123',
         sbReqId: 'sb-req-123',


### PR DESCRIPTION
## What is the current behavior?

Keep alive timeout is capped at the request timeout. Most connections are re-established (and DNS re-resolved) from
scratch on every request. This causes Webhooks to occasionally fail with `timeout of 4000ms
exceeded` before the request reaches its destination.

## What is the new behavior?

- Base keep alive timeout on the number of free sockets (no longer capped at the request
  timeout) so connections can actually be reused
- Split `headersTimeout`/`bodyTimeout` from the overall request timeout, so a stalled response
  is distinguishable from a stalled connection
- Add error cause to error message. The default error message gives no useful details.
  - Example: `fetch failed` becomes `fetch failed (HeadersTimeoutError: Headers Timeout Error)`