### PR TITLE
fix: release db conn on response close for tus

### DIFF
--- a/src/http/routes/tus/lifecycle.test.ts
+++ b/src/http/routes/tus/lifecycle.test.ts
@@ -79,6 +79,31 @@ describe('tus lifecycle logging', () => {
     expect(dispose).toHaveBeenCalledOnce()
   })
 
+  it('disposes the db when the response closes without finishing', async () => {
+    const { dispose, rawReq, response } = createRawTusRequest({
+      method: 'HEAD',
+    })
+
+    await onIncomingRequest(rawReq, uploadId, {} as DataStore)
+
+    response.emit('close')
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('disposes the db only once when a finished response subsequently closes', async () => {
+    const { dispose, rawReq, response } = createRawTusRequest({
+      method: 'HEAD',
+    })
+
+    await onIncomingRequest(rawReq, uploadId, {} as DataStore)
+
+    response.emit('finish')
+    response.emit('close')
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
   it('logs upload metadata parse failures with sbReqId through logSchema', async () => {
     const warningSpy = vi.spyOn(logSchema, 'warning').mockImplementation(() => undefined)
     const { rawReq, reqLog } = createRawTusRequest({

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -66,9 +66,16 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
     throw ERRORS.InternalError(undefined, 'Response object is missing')
   }
 
-  res.on('finish', () => {
+  const disposeConnection = () => {
+    // A response can close without finishing when the client disconnects after
+    // the request body has completed. Remove both listeners so finish + close
+    // cannot retain the callback or dispose the request lease twice.
+    res.off('finish', disposeConnection)
+    res.off('close', disposeConnection)
     req.upload.db.dispose()
-  })
+  }
+  res.once('finish', disposeConnection)
+  res.once('close', disposeConnection)
 
   const uploadID = UploadId.fromString(id)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Client can disconnect after the request body has already completed but it's not an abort anymore either. In that case, request db handle will stay alive. 

## What is the new behavior?

Register finish (normal) and close (disconnect after upload) once. Whichever fires, disarm and call dispose.

## Additional context

This could keep res, db, storage around in the closure.