### PR TITLE
fix: only load required cluster discovery

### DIFF
--- a/src/internal/cluster/cluster.test.ts
+++ b/src/internal/cluster/cluster.test.ts
@@ -1,0 +1,146 @@
+import { vi } from 'vitest'
+
+const { ecsLoaded, eksLoaded, getEcsClusterSize, getEksClusterSize } = vi.hoisted(() => ({
+  ecsLoaded: vi.fn(),
+  eksLoaded: vi.fn(),
+  getEcsClusterSize: vi.fn(() => Promise.resolve(2)),
+  getEksClusterSize: vi.fn(() => Promise.resolve(3)),
+}))
+
+vi.mock('@internal/monitoring', () => ({
+  logger: {
+    info: vi.fn(),
+  },
+}))
+
+vi.mock('./ecs', () => {
+  ecsLoaded()
+
+  return {
+    ClusterDiscoveryECS: class {
+      getClusterSize() {
+        return getEcsClusterSize()
+      }
+    },
+  }
+})
+
+vi.mock('./eks', () => {
+  eksLoaded()
+
+  return {
+    ClusterDiscoveryEKS: class {
+      getClusterSize() {
+        return getEksClusterSize()
+      }
+    },
+  }
+})
+
+describe('Cluster', () => {
+  const originalClusterDiscovery = process.env.CLUSTER_DISCOVERY
+
+  beforeEach(() => {
+    vi.resetModules()
+    ecsLoaded.mockClear()
+    eksLoaded.mockClear()
+    getEcsClusterSize.mockClear()
+    getEksClusterSize.mockClear()
+  })
+
+  afterEach(() => {
+    if (originalClusterDiscovery === undefined) {
+      delete process.env.CLUSTER_DISCOVERY
+    } else {
+      process.env.CLUSTER_DISCOVERY = originalClusterDiscovery
+    }
+  })
+
+  it.each([
+    { discovery: 'ECS', size: 2, selected: ecsLoaded, skipped: eksLoaded },
+    { discovery: 'EKS', size: 3, selected: eksLoaded, skipped: ecsLoaded },
+  ])('loads only the $discovery discovery implementation', async ({
+    discovery,
+    size,
+    selected,
+    skipped,
+  }) => {
+    process.env.CLUSTER_DISCOVERY = discovery
+
+    const { Cluster } = await import('./cluster')
+    const abortController = new AbortController()
+
+    try {
+      await Cluster.init(abortController.signal)
+
+      expect(Cluster.size).toBe(size)
+      expect(selected).toHaveBeenCalledTimes(1)
+      expect(skipped).not.toHaveBeenCalled()
+    } finally {
+      abortController.abort()
+    }
+  })
+
+  it('does not load a discovery implementation when CLUSTER_DISCOVERY is unset', async () => {
+    delete process.env.CLUSTER_DISCOVERY
+
+    const { Cluster } = await import('./cluster')
+
+    await Cluster.init(new AbortController().signal)
+
+    expect(Cluster.size).toBe(0)
+    expect(ecsLoaded).not.toHaveBeenCalled()
+    expect(eksLoaded).not.toHaveBeenCalled()
+  })
+
+  it('does not initialize discovery when the abort signal is already aborted', async () => {
+    process.env.CLUSTER_DISCOVERY = 'ECS'
+
+    const { Cluster } = await import('./cluster')
+    const abortController = new AbortController()
+    abortController.abort()
+
+    await Cluster.init(abortController.signal)
+
+    expect(Cluster.size).toBe(0)
+    expect(ecsLoaded).not.toHaveBeenCalled()
+    expect(eksLoaded).not.toHaveBeenCalled()
+  })
+
+  it('stops initialization when aborted while loading discovery', async () => {
+    process.env.CLUSTER_DISCOVERY = 'ECS'
+
+    const { Cluster } = await import('./cluster')
+    const abortController = new AbortController()
+
+    const initialization = Cluster.init(abortController.signal)
+    abortController.abort()
+    await initialization
+
+    expect(Cluster.size).toBe(0)
+    expect(getEcsClusterSize).not.toHaveBeenCalled()
+  })
+
+  it('does not publish or watch a cluster size when aborted while loading it', async () => {
+    process.env.CLUSTER_DISCOVERY = 'ECS'
+
+    const { Cluster } = await import('./cluster')
+    const abortController = new AbortController()
+    const intervalSpy = vi.spyOn(globalThis, 'setInterval')
+    getEcsClusterSize.mockImplementationOnce(async () => {
+      await Promise.resolve()
+      abortController.abort()
+      return 2
+    })
+
+    try {
+      await Cluster.init(abortController.signal)
+
+      expect(Cluster.size).toBe(0)
+      expect(getEcsClusterSize).toHaveBeenCalledOnce()
+      expect(intervalSpy).not.toHaveBeenCalled()
+    } finally {
+      intervalSpy.mockRestore()
+    }
+  })
+})

--- a/src/internal/cluster/cluster.ts
+++ b/src/internal/cluster/cluster.ts
@@ -1,12 +1,14 @@
 import { EventEmitter } from 'node:events'
-import { ClusterDiscoveryECS } from '@internal/cluster/ecs'
-import { ClusterDiscoveryEKS } from '@internal/cluster/eks'
 import { logger } from '@internal/monitoring'
 
 const clusterEvent = new EventEmitter()
 
 interface ClusterEvents {
   change: { size: number }
+}
+
+interface ClusterDiscovery {
+  getClusterSize(): Promise<number>
 }
 
 export class Cluster {
@@ -21,16 +23,38 @@ export class Cluster {
   }
 
   static async init(abortSignal: AbortSignal) {
-    let cluster: ClusterDiscoveryECS | ClusterDiscoveryEKS | null = null
+    if (abortSignal.aborted) {
+      return
+    }
+
+    let cluster: ClusterDiscovery | null = null
 
     if (process.env.CLUSTER_DISCOVERY === 'ECS') {
+      const { ClusterDiscoveryECS } = await import('./ecs')
+
+      if (abortSignal.aborted) {
+        return
+      }
+
       cluster = new ClusterDiscoveryECS()
     } else if (process.env.CLUSTER_DISCOVERY === 'EKS') {
+      const { ClusterDiscoveryEKS } = await import('./eks')
+
+      if (abortSignal.aborted) {
+        return
+      }
+
       cluster = new ClusterDiscoveryEKS()
     }
 
     if (cluster) {
-      Cluster.size = await cluster.getClusterSize()
+      const clusterSize = await cluster.getClusterSize()
+
+      if (abortSignal.aborted) {
+        return
+      }
+
+      Cluster.size = clusterSize
 
       logger.info(
         {
@@ -40,6 +64,10 @@ export class Cluster {
         },
         `[Cluster] Initial cluster size ${Cluster.size}`
       )
+
+      if (abortSignal.aborted) {
+        return
+      }
 
       Cluster.watcher = setInterval(() => {
         cluster!

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -37,6 +37,7 @@ import { StoragePgDB } from '@storage/database'
 import { Uploader } from '@storage/uploader'
 import { createHash, createHmac, randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
+import { fetch as undiciFetch } from 'undici'
 import { onTestFinished, vi } from 'vitest'
 import app from '../app'
 import { getConfig, mergeConfig } from '../config'
@@ -65,6 +66,9 @@ const {
 } = getConfig()
 const STREAMING_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
 const STREAMING_TRAILER_PAYLOAD_ALGORITHM = 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER'
+
+// Node 24's built-in fetch can duplicate Content-Length through npm Undici's dispatcher.
+// Keep byte-exact payload requests on npm Undici; FormData requests stay on native fetch.
 async function createBucket(client: S3Client, name?: string, publicRead = true) {
   let bucketName: string
   if (!name) {
@@ -195,7 +199,7 @@ async function sendAwsChunkedRequest(options: {
   })
   const encodedBody = Buffer.concat([chunk.encoded, endChunk.encoded])
 
-  const response = await fetch(signedRequest.requestUrl, {
+  const response = await undiciFetch(signedRequest.requestUrl, {
     method: 'PUT',
     headers: {
       ...signedRequest.headers,
@@ -242,7 +246,7 @@ async function sendAwsChunkedTrailerModeWithoutTrailerRequest(options: {
   })
   const encodedBody = Buffer.concat([chunk.encoded, endChunk.encoded])
 
-  const response = await fetch(signedRequest.requestUrl, {
+  const response = await undiciFetch(signedRequest.requestUrl, {
     method: 'PUT',
     headers: {
       ...signedRequest.headers,
@@ -359,7 +363,7 @@ async function sendSignedS3Request(options: {
     includeContentLength: true,
   })
 
-  const response = await fetch(signedRequest.requestUrl, {
+  const response = await undiciFetch(signedRequest.requestUrl, {
     method: options.method,
     headers: signedRequest.headers,
     body: payload,
@@ -1247,7 +1251,7 @@ describe('S3 Protocol', () => {
           })
           signedRequest.requestUrl.search = '?up%6Co%61ds'
 
-          const response = await fetch(signedRequest.requestUrl, {
+          const response = await undiciFetch(signedRequest.requestUrl, {
             method: 'POST',
             headers: signedRequest.headers,
             body: '',
@@ -3375,7 +3379,7 @@ describe('S3 Protocol', () => {
           { expiresIn: 100 }
         )
 
-        const resp = await fetch(uploadUrl, {
+        const resp = await undiciFetch(uploadUrl, {
           method: 'PUT',
           body,
           headers: {
@@ -3448,7 +3452,7 @@ describe('S3 Protocol', () => {
           { expiresIn: 100 }
         )
 
-        const resp = await fetch(uploadUrl, {
+        const resp = await undiciFetch(uploadUrl, {
           method: 'PUT',
           body,
           headers: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Both cluster discovery (ECS and EKS)is statistically loaded but actually only one of them is needed. Between two, worse part is that worker on ECS loads EKS because EKS pulls whole K8s dependency chain and takes about 20mb heap unnecessarily.

## What is the new behavior?

Load discovery lazily so only needed one is parsed and loaded. It's free heap about 20mb. 

## Additional context

If cluster isn't needed, no load will happen. Gain is even higher but not realistic since generally one is used.
There are some test changes because import order exposed a mismatch between bundled and imported undici when agent and fetch are different versions, and content length is supplied, not calculated. 
