### PR TITLE
Close the connection when a request is rejected before its body is read

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -29,6 +29,37 @@ export const setErrorHandler = (
     // it will be logged in the request log plugin
     request.executionError = error
 
+    // Do not keep a connection alive when the response is produced before the request body
+    // was consumed. The remaining body cannot be drained — the client stops sending once it
+    // sees the response — so a kept-alive connection is left with an unsatisfied
+    // Content-Length. A reverse proxy that pools upstream connections (e.g. Kong, the gateway
+    // in the self-hosted stack) reuses it, and the next request's bytes are read as this
+    // request's leftover body: that request gets no response and stalls until the proxy's
+    // upstream timeout (~60s), on a caller that did nothing wrong.
+    let connectionCloseScheduled = false
+    const closeConnectionAfterResponse = () => {
+      if (connectionCloseScheduled) {
+        return
+      }
+      connectionCloseScheduled = true
+      reply.header('Connection', 'close')
+
+      reply.raw.once('finish', () => {
+        setTimeout(() => {
+          if (!request.raw.closed) {
+            request.raw.destroy()
+          }
+        }, 3000)
+      })
+    }
+
+    // `readableEnded === false` is precisely "a request body was expected and has not been
+    // fully read". It is `true` when the body was consumed and `undefined` for injected
+    // requests, so neither of those is closed unnecessarily.
+    if (request.raw.readableEnded === false) {
+      closeConnectionAfterResponse()
+    }
+
     // database error
     if (isDatabaseSlowDownError(error)) {
       return reply.status(429).send(
@@ -55,15 +86,7 @@ export const setErrorHandler = (
         renderableError.code === ErrorCode.AbortedTerminate ||
         (error instanceof StorageBackendError && error.shouldCloseConnection())
       ) {
-        reply.header('Connection', 'close')
-
-        reply.raw.once('finish', () => {
-          setTimeout(() => {
-            if (!request.raw.closed) {
-              request.raw.destroy()
-            }
-          }, 3000)
-        })
+        closeConnectionAfterResponse()
       }
 
       return reply.status(statusCode).send(

--- a/src/test/app.test.ts
+++ b/src/test/app.test.ts
@@ -61,6 +61,71 @@ describe('app request parsing', () => {
     await appInstance.close()
   })
 
+  test('closes the connection when a request is rejected before its body is read', async () => {
+    // Upload rejected before the body is read (no Authorization), with a Content-Length
+    // larger than the bytes actually sent — the rest of the body will never arrive. If the
+    // connection is kept alive it is left mid-body, and a proxy that reuses it feeds the
+    // next request's bytes into this request's body, stalling it. The response must instead
+    // ask for the connection to be closed. See error-handler.ts.
+    const outcome = await new Promise<{
+      statusLine: string
+      connectionClose: boolean
+      serverClosed: boolean
+      stalled: boolean
+    }>((resolve, reject) => {
+      const socket = net.createConnection({ host: '127.0.0.1', port })
+      let response = ''
+      let gotHeaders = false
+      const result = { statusLine: '', connectionClose: false, serverClosed: false, stalled: false }
+      const timer = setTimeout(() => {
+        result.stalled = true
+        socket.destroy()
+        resolve(result)
+      }, 4000)
+
+      socket.setEncoding('latin1')
+      socket.on('connect', () => {
+        socket.write(
+          [
+            'POST /object/photos/nobody/x.jpg HTTP/1.1',
+            'Host: 127.0.0.1',
+            'Content-Type: image/jpeg',
+            'Content-Length: 300000',
+            '',
+            '',
+          ].join('\r\n')
+        )
+        socket.write(Buffer.alloc(50_000, 0x41)) // 50 KB of a promised 300 KB, then keep the socket open
+      })
+      socket.on('data', (chunk) => {
+        response += chunk
+        if (!gotHeaders && response.includes('\r\n\r\n')) {
+          gotHeaders = true
+          const headers = response.slice(0, response.indexOf('\r\n\r\n'))
+          result.statusLine = headers.split('\r\n')[0]
+          result.connectionClose = /\r\nconnection:\s*close/i.test(headers)
+        }
+      })
+      socket.on('end', () => {
+        if (gotHeaders) {
+          result.serverClosed = true
+          clearTimeout(timer)
+          socket.destroy()
+          resolve(result)
+        }
+      })
+      socket.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+
+    expect(outcome.statusLine).toBe('HTTP/1.1 400 Bad Request')
+    expect(outcome.connectionClose).toBe(true)
+    expect(outcome.serverClosed).toBe(true)
+    expect(outcome.stalled).toBe(false)
+  })
+
   test('returns invalid_mime_type for content-type headers with tabs on the wire', async () => {
     const response = await sendRawRequest(
       port,


### PR DESCRIPTION
## Problem

When storage-api rejects an object upload **before the request body is read** (missing/invalid `authorization`, or any pre-body error), it answers with `Connection: keep-alive` and leaves the connection with an **unsatisfied `Content-Length`** — the client stops sending its body once it sees the response, so the bytes the server still expects never arrive and cannot be drained.

If a reverse proxy with an upstream keepalive pool reuses that connection — which is how Kong, the gateway in the standard self-hosted stack, is configured — the **next** request over it is read by the server as the leftover body of the rejected one. That next request never gets a response and stalls until the proxy's upstream-read timeout (~60s). The failure lands on a caller that did nothing wrong: any early-rejected upload stalls the next upload from any client that reuses the connection.

Reproduced on `supabase/storage-api:v1.60.4` behind Kong 3.9.1 (standard self-hosted stack).

### Evidence

Anonymous 300 KB `POST` straight to storage-api (no proxy) — rejected before the body is read, connection kept alive:

```
HTTP/1.1 400 Bad Request
Connection: keep-alive
Keep-Alive: timeout=61
{"statusCode":"400","error":"Error","message":"headers must have required property 'authorization'"}
curl: http=400 time=0.0026s uploaded=196608 of 307200 bytes
```

Raw socket, reusing the connection after that 400 (Content-Length 300000, only 50000 sent, then a second request on the same socket):

```
response 1: HTTP/1.1 400 Bad Request | Connection: keep-alive
REUSE -> STALLED, no response (connection poisoned)
```

End-to-end through Kong, six anonymous 300 KB uploads back to back alternate `400` / `504`-after-60s; `x-kong-upstream-latency: 60004` on the stalls. Setting `KONG_UPSTREAM_KEEPALIVE_POOL_SIZE=0` (no upstream reuse) removes the stall, confirming it is reuse of the poisoned connection.

## Fix

The error handler already closes the connection for two specific cases — `AbortedTerminate` and `StorageBackendError.shouldCloseConnection()`. This generalises that same close-after-response mechanism to **any** response produced before the request body was consumed (`request.raw.readableEnded === false`), and factors it into one helper so the finish/destroy handler is registered at most once.

Closing (rather than draining) is the correct choice here: the client has stopped sending, so the remaining body cannot be drained — the server would block on bytes that never come.

`readableEnded === false` is precisely "a request body was expected and has not been fully read"; it is `true` when the body was consumed and `undefined` for injected requests, so neither of those is closed unnecessarily.

## Test

`src/test/app.test.ts` gains a case that, over a single socket, sends an upload rejected before its body with a `Content-Length` larger than the bytes actually sent, and asserts the response carries `Connection: close` and the server closes the socket. It uses a raw socket (like the existing cases in that file) because connection reuse cannot be exercised through `inject`. The test fails on `master` (the connection is kept alive and the reused socket hangs) and passes with this change.

## Workaround for operators (no upgrade needed)

Set `KONG_UPSTREAM_KEEPALIVE_POOL_SIZE=0` on the `kong` service and recreate it; every request then gets a fresh upstream connection. Cost is one local TCP handshake per request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSBxV5ZsWLmaiD9ikcYohU)_