### PR TITLE
fix: ignore bucket not found error when cleaning up iceberg resources

### DIFF
--- a/src/storage/events/iceberg/delete-iceberg-resources.test.ts
+++ b/src/storage/events/iceberg/delete-iceberg-resources.test.ts
@@ -205,6 +205,7 @@ describe('DeleteIcebergResources.handle', () => {
       { name: 'table-1', shard_key: 'shard-key-1', shard_id: 'shard-id-1' },
     ])
     restCatalog.listTables.mockResolvedValue({ identifiers: [] })
+    db.deleteAnalyticsBucket.mockResolvedValue(undefined)
     db.destroyConnection.mockReturnValue(undefined)
   })
 
@@ -229,6 +230,30 @@ describe('DeleteIcebergResources.handle', () => {
       await expect(DeleteIcebergResources.handle(makeJob() as never)).resolves.toBeUndefined()
 
       expectIcebergCleanup({ multitenant: true })
+      expect(db.deleteAnalyticsBucket).toHaveBeenCalledWith('catalog-123')
+      expect(db.destroyConnection).toHaveBeenCalled()
+    })
+
+    it('should still pass when deleteAnalyticsBucket fails with NoSuchBucket', async () => {
+      const { ERRORS } = await import('@internal/errors')
+      mockCreateStorage.mockResolvedValue({ db })
+      db.deleteAnalyticsBucket.mockRejectedValue(ERRORS.NoSuchBucket('catalog-123'))
+
+      await expect(DeleteIcebergResources.handle(makeJob() as never)).resolves.toBeUndefined()
+
+      expectIcebergCleanup({ multitenant: true })
+      expect(db.deleteAnalyticsBucket).toHaveBeenCalledWith('catalog-123')
+      expect(db.destroyConnection).toHaveBeenCalled()
+    })
+
+    it('should fail when deleteAnalyticsBucket fails with any other error', async () => {
+      mockCreateStorage.mockResolvedValue({ db })
+      db.deleteAnalyticsBucket.mockRejectedValue(new Error('connection reset'))
+
+      await expect(DeleteIcebergResources.handle(makeJob() as never)).rejects.toThrow(
+        'connection reset'
+      )
+
       expect(db.deleteAnalyticsBucket).toHaveBeenCalledWith('catalog-123')
       expect(db.destroyConnection).toHaveBeenCalled()
     })

--- a/src/storage/events/iceberg/delete-iceberg-resources.ts
+++ b/src/storage/events/iceberg/delete-iceberg-resources.ts
@@ -1,5 +1,5 @@
 import { multitenantPgExecutor } from '@internal/database'
-import { ERRORS } from '@internal/errors'
+import { ERRORS, ErrorCode, isStorageError } from '@internal/errors'
 import { BasePayload } from '@internal/queue'
 import { PgShardStoreFactory, ShardCatalog } from '@internal/sharding'
 import { getCatalogAuthStrategy, RestCatalogClient } from '@storage/protocols/iceberg/catalog'
@@ -173,8 +173,16 @@ export class DeleteIcebergResources extends BaseEvent<DeleteIcebergResourcesPayl
         })
 
         if (isMultitenant && eventStorage) {
-          // Delete the underlying bucket
-          await eventStorage.db.deleteAnalyticsBucket(job.data.catalogId)
+          try {
+            // Delete the underlying bucket
+            await eventStorage.db.deleteAnalyticsBucket(job.data.catalogId)
+          } catch (e) {
+            // if the bucket was already removed we can ignore this error
+            // this allows orphan resources to be removed (throwing would rollback)
+            if (!isStorageError(ErrorCode.NoSuchBucket, e)) {
+              throw e
+            }
+          }
         }
       })
     } finally {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `DeleteIcebergResources` job fails if the the bucket was already removed. This causes the entire transaction to rollback leaving orphan resources in the multi-tenant db.

## What is the new behavior?

Ignore `ErrorCode.NoSuchBucket` errors in `DeleteIcebergResources` when deleting the bucket
