### PR TITLE
fix: initialize pool sizing before queue workers start

### DIFF
--- a/src/start/server.test.ts
+++ b/src/start/server.test.ts
@@ -1,0 +1,115 @@
+import { vi } from 'vitest'
+
+const bootOrder = vi.hoisted(() => [] as string[])
+
+vi.mock('@internal/monitoring/otel-tracing', () => ({}))
+vi.mock('@internal/monitoring/otel-metrics', () => ({}))
+vi.mock('@internal/monitoring', () => ({
+  logger: { info: vi.fn() },
+  logSchema: { info: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@internal/cluster/cluster', () => ({
+  Cluster: {
+    size: 0,
+    init: vi.fn(async () => {
+      bootOrder.push('cluster.init')
+    }),
+    on: vi.fn(() => {
+      bootOrder.push('cluster.on')
+    }),
+  },
+}))
+vi.mock('@internal/database', () => ({
+  listenForTenantUpdate: vi.fn(async () => {}),
+  multitenantPgExecutor: {},
+  PgTenantConnection: {
+    poolManager: {
+      setNumWorkers: vi.fn(() => {
+        bootOrder.push('poolManager.setNumWorkers')
+      }),
+      monitor: vi.fn(() => {
+        bootOrder.push('poolManager.monitor')
+      }),
+      rebalanceAll: vi.fn(),
+    },
+  },
+  PubSub: { start: vi.fn(async () => {}) },
+}))
+vi.mock('@internal/database/migrations', () => ({
+  runMigrationsOnTenant: vi.fn(async () => {}),
+  runMultitenantMigrations: vi.fn(async () => {}),
+  startAsyncMigrations: vi.fn(),
+}))
+vi.mock('@internal/queue', () => ({
+  Queue: {
+    start: vi.fn(async () => {
+      bootOrder.push('queue.start')
+    }),
+  },
+  SYSTEM_TENANT: 'system',
+}))
+vi.mock('@internal/sharding', () => ({
+  PgShardStoreFactory: class {},
+  ShardCatalog: class {
+    createShards = vi.fn(async () => {})
+  },
+}))
+vi.mock('@platformatic/globals', () => ({ getGlobal: () => undefined }))
+vi.mock('@storage/events', () => ({ registerWorkers: vi.fn() }))
+vi.mock('@storage/events/upgrades/sync-catalog-ids', () => ({
+  SyncCatalogIds: { invoke: vi.fn(async () => {}) },
+}))
+vi.mock('fastify', () => ({ LogController: class {} }))
+vi.mock('../admin-app', () => ({ default: vi.fn() }))
+vi.mock('../app', () => ({
+  default: vi.fn(() => ({ server: {}, listen: vi.fn(async () => {}) })),
+}))
+vi.mock('../config', () => ({
+  getConfig: () => ({
+    databaseURL: 'postgres://example',
+    isMultitenant: false,
+    pgQueueEnable: true,
+    dbMigrationFreezeAt: undefined,
+    vectorBucketProvider: 's3',
+    vectorDatabaseURL: undefined,
+    vectorEnabled: false,
+    vectorStoreMigrationsEnabled: false,
+    vectorS3Buckets: [],
+    icebergShards: [],
+    numWorkers: 4,
+    exposeDocs: false,
+    requestTraceHeader: undefined,
+    port: 0,
+    host: '127.0.0.1',
+  }),
+}))
+vi.mock('./shutdown', () => ({
+  bindShutdownSignals: vi.fn(),
+  createServerClosedPromise: vi.fn(() => Promise.resolve()),
+  shutdown: vi.fn(async () => {}),
+}))
+
+describe('server boot order', () => {
+  afterEach(() => {
+    bootOrder.length = 0
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  test('initializes pool sizing and cluster discovery before queue workers start', async () => {
+    // Track exit to find out mock gaps and silently pass the test.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./server')
+    await vi.waitFor(() => expect(bootOrder).toContain('queue.start'))
+
+    expect(bootOrder).toEqual([
+      'poolManager.setNumWorkers',
+      'poolManager.monitor',
+      'cluster.init',
+      'cluster.on',
+      'queue.start',
+    ])
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -88,6 +88,29 @@ async function main() {
     )
   }
 
+  // PoolManager.
+  // Pool strategies snapshot numWorkers and cluster size at
+  // creation and only rebalances cluster size, so initialization
+  // must happen before queue workers can create tenant pools.
+  PgTenantConnection.poolManager.setNumWorkers(numWorkers)
+  PgTenantConnection.poolManager.monitor()
+
+  // Cluster information
+  await Cluster.init(shutdownSignal.nextGroup.signal)
+
+  Cluster.on('change', (data) => {
+    logger.info(
+      {
+        type: 'cluster',
+        clusterSize: data.size,
+      },
+      `[Cluster] Cluster size changed to ${data.size}`
+    )
+    PgTenantConnection.poolManager.rebalanceAll({
+      clusterSize: data.size,
+    })
+  })
+
   // Queue
   if (pgQueueEnable) {
     await Queue.start({
@@ -146,26 +169,6 @@ async function main() {
   if (isMultitenant && pgQueueEnable) {
     startAsyncMigrations(shutdownSignal.nextGroup.signal)
   }
-
-  // PoolManager
-  PgTenantConnection.poolManager.setNumWorkers(numWorkers)
-  PgTenantConnection.poolManager.monitor()
-
-  // Cluster information
-  await Cluster.init(shutdownSignal.nextGroup.signal)
-
-  Cluster.on('change', (data) => {
-    logger.info(
-      {
-        type: 'cluster',
-        clusterSize: data.size,
-      },
-      `[Cluster] Cluster size changed to ${data.size}`
-    )
-    PgTenantConnection.poolManager.rebalanceAll({
-      clusterSize: data.size,
-    })
-  })
 
   // HTTP Server
   const app = await httpServer(shutdownSignal.signal)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Queue workers are started before pool sizing and cluster discovery.
Pool strategy caches num of workers but it's never rebalanced unlike cluster size.
If a strategy is cached during that window, it will be using more connections (x numWorkers) until expire (or indefinitely by capacity).

## What is the new behavior?

Do it before queue start.
It doesn't apply worker entrypoint since their multiplier is always one.

## Additional context

Seal the order via a test.
