### PR TITLE
fix: support url signing jwt kid with or without kind prefix for forward compat

### DIFF
--- a/src/internal/auth/jwks/channels.ts
+++ b/src/internal/auth/jwks/channels.ts
@@ -1,1 +1,0 @@
-export const TENANTS_JWKS_UPDATE_CHANNEL = 'tenants_jwks_update'

--- a/src/internal/auth/jwks/constants.ts
+++ b/src/internal/auth/jwks/constants.ts
@@ -1,0 +1,4 @@
+export const TENANTS_JWKS_UPDATE_CHANNEL = 'tenants_jwks_update'
+
+// Reserved `kind` values for a tenant's url-signing key lifecycle.
+export const JWK_KIND_STORAGE_URL_SIGNING = 'storage-url-signing-key'

--- a/src/internal/auth/jwks/kid.ts
+++ b/src/internal/auth/jwks/kid.ts
@@ -1,0 +1,15 @@
+import { JWK_KIND_STORAGE_URL_SIGNING } from './constants'
+
+export const JWK_KID_SEPARATOR = '_'
+
+const LEGACY_URL_SIGNING_KID_PREFIX = `${JWK_KIND_STORAGE_URL_SIGNING}${JWK_KID_SEPARATOR}`
+
+/**
+ * Strips a legacy "<kind>_" prefix, but only for the (pre-existing) signing kind - other kids
+ * (custom addJwk kinds, standby kids, or the current bare-id format) are returned unchanged.
+ */
+export function normalizeUrlSigningKid(kid: string): string {
+  return kid.startsWith(LEGACY_URL_SIGNING_KID_PREFIX)
+    ? kid.slice(LEGACY_URL_SIGNING_KID_PREFIX.length)
+    : kid
+}

--- a/src/internal/auth/jwks/manager.ts
+++ b/src/internal/auth/jwks/manager.ts
@@ -10,11 +10,9 @@ import {
 import { createInvalidatableSingleFlightByKey } from '@internal/concurrency'
 import { isStringMessage, PubSubAdapter } from '@internal/pubsub'
 import { freezeJwksConfig, JwksConfig, JwksConfigKeyOCT } from '../../../config'
-import { TENANTS_JWKS_UPDATE_CHANNEL } from './channels'
+import { JWK_KIND_STORAGE_URL_SIGNING, TENANTS_JWKS_UPDATE_CHANNEL } from './constants'
+import { JWK_KID_SEPARATOR } from './kid'
 import { JWKSManagerStore } from './store'
-
-const JWK_KIND_STORAGE_URL_SIGNING = 'storage-url-signing-key'
-const JWK_KID_SEPARATOR = '_'
 
 const tenantJwksSingleFlight = createInvalidatableSingleFlightByKey<JwksConfig>()
 // Max 16,384 items. At ~2.5KB per JWKS, this uses roughly ~40MB of heap memory worst-case.

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -20,6 +20,7 @@ import {
   SignJWT,
 } from 'jose'
 import { getConfig, JwksConfig, JwksConfigKey, JwksConfigKeyOCT } from '../../config'
+import { normalizeUrlSigningKid } from './jwks/kid'
 
 const { jwtAlgorithm } = getConfig()
 
@@ -241,6 +242,20 @@ function getPreparedJWTSigningKey(key: string | JwksConfigKeyOCT, alg: string): 
   )
 }
 
+// Jwk's kid was simplified to use just the tenants_jwks row's bare uuid
+// Historically we embedded the kind resulting in a kid in the format "<kind>_<id>"
+// So a header's kid must be normalized to its id suffix before comparing against a jwk's (bare) kid
+// this is to support existing JWTs that were already signed using the legacy format
+function kidsMatch(keyKid: string | undefined, headerKid: string | undefined): boolean {
+  if (keyKid === undefined || headerKid === undefined) {
+    return false
+  }
+  // Bare-to-bare is the common case (and the only one post-rollout), so check it directly first.
+  return (
+    keyKid === headerKid || normalizeUrlSigningKid(keyKid) === normalizeUrlSigningKid(headerKid)
+  )
+}
+
 async function findJWKFromHeader(
   header: JWTHeaderParameters,
   secret: string,
@@ -263,7 +278,7 @@ async function findJWKFromHeader(
     // find the first compatible "oct" key without a kid or with the matching kid
     let mismatchedJwk: JwksConfigKey | undefined
     const jwk = jwks.keys.find((key) => {
-      if ((!key.kid || key.kid === header.kid) && key.kty === 'oct' && key.k) {
+      if ((!key.kid || kidsMatch(key.kid, header.kid)) && key.kty === 'oct' && key.k) {
         if (key.alg !== undefined && key.alg !== header.alg) {
           mismatchedJwk ??= key
           return false

--- a/src/test/tenant-jwks.test.ts
+++ b/src/test/tenant-jwks.test.ts
@@ -14,7 +14,7 @@ mergeConfig({
 
 import { encrypt, signJWT } from '@internal/auth'
 import { deleteTenantJwksConfig, JWKSManagerStorePg } from '@internal/auth/jwks'
-import { TENANTS_JWKS_UPDATE_CHANNEL } from '@internal/auth/jwks/channels'
+import { TENANTS_JWKS_UPDATE_CHANNEL } from '@internal/auth/jwks/constants'
 import { UrlSigningJwkGenerator } from '@internal/auth/jwks/generator'
 import { TENANT_JWKS_CACHE_NAME } from '@internal/cache'
 import {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

JWT verification expects kid to contain a kind prefix and exactly match. An [upcoming PR](https://github.com/supabase/storage/pull/1257) removes the kind prefix which could briefly cause verification faliures during deployment. 

## What is the new behavior?

Port kid normalization code from #1257 to support kid with or without kind.

## Additional context

This must be deployed fully first so the kid verification is forward compatible during deployment. After this is deployed the rest of the changes in #1257 can be deployed.
