### PR TITLE
fix: malformed xml error code

### DIFF
--- a/src/http/plugins/xml.test.ts
+++ b/src/http/plugins/xml.test.ts
@@ -370,6 +370,7 @@ describe('xmlParser plugin', () => {
       })
 
       expect(response.statusCode).toBe(400)
+      expect(response.json().code).toBe('MalformedXML')
       expect(response.json().message).toContain('Invalid XML payload')
     } finally {
       await app.close()
@@ -391,6 +392,7 @@ describe('xmlParser plugin', () => {
       })
 
       expect(response.statusCode).toBe(400)
+      expect(response.json().code).toBe('MalformedXML')
       expect(response.json().message).toBe('Invalid XML payload: Unescaped ampersand')
     } finally {
       await app.close()

--- a/src/http/plugins/xml.ts
+++ b/src/http/plugins/xml.ts
@@ -236,7 +236,7 @@ export const xmlParser = fastifyPlugin(
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error)
             done(
-              Object.assign(ERRORS.InvalidRequest(`Invalid XML payload: ${message}`), {
+              Object.assign(ERRORS.MalformedXML(`Invalid XML payload: ${message}`), {
                 statusCode: 400,
               })
             )

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -9,6 +9,7 @@ export enum ErrorCode {
   NoSuchUpload = 'NoSuchUpload',
   InvalidJWT = 'InvalidJWT',
   InvalidRequest = 'InvalidRequest',
+  MalformedXML = 'MalformedXML',
   TenantNotFound = 'TenantNotFound',
   EntityTooLarge = 'EntityTooLarge',
   InternalError = 'InternalError',
@@ -157,6 +158,14 @@ export const ERRORS = {
       code: ErrorCode.InvalidRequest,
       httpStatusCode: 400,
       message: message || 'Invalid Request',
+      originalError: error,
+    }),
+
+  MalformedXML: (message: string, error?: Error) =>
+    new StorageBackendError({
+      code: ErrorCode.MalformedXML,
+      httpStatusCode: 400,
+      message,
       originalError: error,
     }),
 

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -1431,7 +1431,7 @@ describe('S3 Protocol', () => {
         expect(malformedCompleteResp.data).toContain(
           '<Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
         )
-        expect(malformedCompleteResp.data).toContain('<Code>InvalidRequest</Code>')
+        expect(malformedCompleteResp.data).toContain('<Code>MalformedXML</Code>')
         expect(malformedCompleteResp.data).toContain('<Message>Invalid XML payload:')
 
         await expectMultipartUploadToRemainPending(client, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

We return invalid request on broken xml but s3 returns malformed xml.

## What is the new behavior?

Align with s3.

## Additional context

Doesn't touch invalid JSON or schema validation, which are still invalid request.