### PR TITLE
fix: require service role to empty a bucket

### DIFF
--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -81,25 +81,29 @@ interface EnforceJWTRoleOptions {
   roles: string[]
 }
 
+export function requireJwtRoles(fastify: FastifyInstance, roles: string[]) {
+  fastify.addHook('preHandler', (request, _reply, done) => {
+    if (!request.isAuthenticated) {
+      done(ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403))
+      return
+    }
+
+    const hasRoles = request.jwtPayload?.role && roles.includes(request.jwtPayload.role)
+
+    if (!hasRoles) {
+      done(ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403))
+      return
+    }
+
+    done()
+  })
+}
+
 export const enforceJwtRole = fastifyPlugin<EnforceJWTRoleOptions>(
   async (fastify, opts) => {
-    fastify.addHook('preHandler', (request, _reply, done) => {
-      if (!request.isAuthenticated) {
-        done(ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403))
-        return
-      }
-
-      const hasRoles = request.jwtPayload?.role && opts.roles.includes(request.jwtPayload.role)
-
-      if (!hasRoles) {
-        done(ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403))
-        return
-      }
-
-      done()
-    })
+    requireJwtRoles(fastify, opts.roles)
   },
-  { name: 'allow-invalid-jwt' }
+  { name: 'enforce-jwt-role' }
 )
 
 export function registerJwtAuth(fastify: FastifyInstance, opts: JWTPluginOptions = {}) {

--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -81,27 +81,23 @@ interface EnforceJWTRoleOptions {
   roles: string[]
 }
 
-export function requireJwtRoles(fastify: FastifyInstance, roles: string[]) {
-  fastify.addHook('preHandler', (request, _reply, done) => {
-    if (!request.isAuthenticated) {
-      done(ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403))
-      return
-    }
-
-    const hasRoles = request.jwtPayload?.role && roles.includes(request.jwtPayload.role)
-
-    if (!hasRoles) {
-      done(ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403))
-      return
-    }
-
-    done()
-  })
-}
-
 export const enforceJwtRole = fastifyPlugin<EnforceJWTRoleOptions>(
   async (fastify, opts) => {
-    requireJwtRoles(fastify, opts.roles)
+    fastify.addHook('preHandler', (request, _reply, done) => {
+      if (!request.isAuthenticated) {
+        done(ERRORS.AccessDenied('Access denied: JWT is not authenticated').withStatusCode(403))
+        return
+      }
+
+      const hasRoles = request.jwtPayload?.role && opts.roles.includes(request.jwtPayload.role)
+
+      if (!hasRoles) {
+        done(ERRORS.AccessDenied(`Access denied: Invalid role`).withStatusCode(403))
+        return
+      }
+
+      done()
+    })
   },
   { name: 'enforce-jwt-role' }
 )

--- a/src/http/routes/bucket/emptyBucket.ts
+++ b/src/http/routes/bucket/emptyBucket.ts
@@ -1,9 +1,12 @@
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import { registerJsonParserAllowingEmptyBody } from '../../plugins/empty-json-body'
+import { getConfig } from '../../../config'
+import { registerJsonParserAllowingEmptyBody, requireJwtRoles } from '../../plugins'
 import { createDefaultSchema, createResponse } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
+
+const { dbServiceRole } = getConfig()
 
 const emptyBucketParamsSchema = {
   type: 'object',
@@ -35,6 +38,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.register(async (f) => {
     registerJsonParserAllowingEmptyBody(f)
+    requireJwtRoles(f, [dbServiceRole])
 
     f.post<emptyBucketRequestInterface>(
       '/:bucketId/empty',

--- a/src/http/routes/bucket/emptyBucket.ts
+++ b/src/http/routes/bucket/emptyBucket.ts
@@ -1,12 +1,9 @@
 import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import { getConfig } from '../../../config'
-import { registerJsonParserAllowingEmptyBody, requireJwtRoles } from '../../plugins'
+import { registerJsonParserAllowingEmptyBody } from '../../plugins'
 import { createDefaultSchema, createResponse } from '../../routes-helper'
 import { AuthenticatedRequest } from '../../types'
 import { ROUTE_OPERATIONS } from '../operations'
-
-const { dbServiceRole } = getConfig()
 
 const emptyBucketParamsSchema = {
   type: 'object',
@@ -38,7 +35,6 @@ export default async function routes(fastify: FastifyInstance) {
 
   fastify.register(async (f) => {
     registerJsonParserAllowingEmptyBody(f)
-    requireJwtRoles(f, [dbServiceRole])
 
     f.post<emptyBucketRequestInterface>(
       '/:bucketId/empty',

--- a/src/http/routes/bucket/index.ts
+++ b/src/http/routes/bucket/index.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify'
+import { getConfig } from '../../../config'
 import { setRestNotFoundHandler } from '../../not-found-handler'
 import { db, registerJwtAuth, storage } from '../../plugins'
 import createBucket from './createBucket'
@@ -7,6 +8,8 @@ import emptyBucket from './emptyBucket'
 import getAllBuckets from './getAllBuckets'
 import getBucket from './getBucket'
 import updateBucket from './updateBucket'
+
+const { dbServiceRole } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
   setRestNotFoundHandler(fastify)
@@ -17,10 +20,19 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(storage)
 
     fastify.register(createBucket)
-    fastify.register(emptyBucket)
     fastify.register(getAllBuckets)
     fastify.register(getBucket)
     fastify.register(updateBucket)
     fastify.register(deleteBucket)
+  })
+
+  fastify.register(async function serviceRoleOnly(fastify) {
+    registerJwtAuth(fastify, {
+      enforceJwtRoles: [dbServiceRole],
+    })
+    fastify.register(db)
+    fastify.register(storage)
+
+    fastify.register(emptyBucket)
   })
 }

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StorageBackendAdapter } from './backend'
+import { Database } from './database'
+import { ObjectAdminDeleteAllBefore } from './events'
+import { StorageObjectLocator } from './locator'
+import { Storage } from './storage'
+
+function createStorage(dbOverrides: Partial<Database> = {}) {
+  const deleteObject = vi.fn()
+  const testPermission = vi.fn()
+  const db = {
+    tenantId: 'tenant-id',
+    reqId: 'req-id',
+    sbReqId: 'sb-req-id',
+    tenant: vi.fn(() => ({ ref: 'tenant-id', host: 'localhost' })),
+    findBucketById: vi.fn().mockResolvedValue({ name: 'bucket' }),
+    testPermission,
+    countObjectsInBucket: vi.fn().mockResolvedValue(1),
+    listObjects: vi.fn().mockResolvedValue([{ id: 'object-id', name: 'visible.txt' }]),
+    deleteObject,
+    ...dbOverrides,
+  } as unknown as Database
+  const storage = new Storage({} as StorageBackendAdapter, db, {} as StorageObjectLocator)
+
+  return {
+    db,
+    deleteObject,
+    storage,
+    testPermission,
+  }
+}
+
+describe('Storage.emptyBucket', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('enqueues deletion without probing object or bucket permissions', async () => {
+    const send = vi.spyOn(ObjectAdminDeleteAllBefore, 'send').mockResolvedValue(undefined)
+    const { deleteObject, storage, testPermission } = createStorage()
+
+    await storage.emptyBucket('bucket')
+
+    expect(testPermission).not.toHaveBeenCalled()
+    expect(deleteObject).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('does not enqueue when the bucket is already empty', async () => {
+    const send = vi.spyOn(ObjectAdminDeleteAllBefore, 'send').mockResolvedValue(undefined)
+    const { storage } = createStorage({
+      listObjects: vi.fn().mockResolvedValue([]),
+    })
+
+    await storage.emptyBucket('bucket')
+
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -334,20 +334,11 @@ export class Storage {
       )
     }
 
-    const objects = await this.db.listObjects(bucketId, 'id, name', 1, before)
+    const objects = await this.db.listObjects(bucketId, 'id', 1, before)
     if (!objects || objects.length < 1) {
       // the bucket is already empty
       return
     }
-
-    // ensure delete permissions
-    await this.db.testPermission(async (db) => {
-      const deleted = await db.deleteObject(bucketId, objects[0].name)
-
-      if (!deleted) {
-        throw ERRORS.NoSuchKey(objects[0].name)
-      }
-    })
 
     // use queue to recursively delete all objects created before the specified time
     await ObjectAdminDeleteAllBefore.send({

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -922,7 +922,7 @@ describe('testing EMPTY bucket', () => {
       method: 'POST',
       url: `/bucket/${bucketId}/empty`,
       headers: {
-        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        authorization: `Bearer ${serviceKey}`,
         'content-type': 'application/json',
       },
       payload: '',
@@ -986,7 +986,7 @@ describe('testing EMPTY bucket', () => {
     }
   })
 
-  test('user is able to empty a bucket', async () => {
+  test('user is not able to empty a bucket without service role', async () => {
     const bucketId = `empty-bucket-${randomUUID()}`
     const objectNames = [`fixtures/${randomUUID()}`]
 
@@ -1001,13 +1001,37 @@ describe('testing EMPTY bucket', () => {
           authorization: `Bearer ${authenticatedKey}`,
         },
       })
-      expect(response.statusCode).toBe(200)
-      const responseJSON = response.json()
-      expect(responseJSON.message).toBe(
-        'Empty bucket has been queued. Completion may take up to an hour.'
-      )
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        error: 'Unauthorized',
+        message: 'Access denied: Invalid role',
+        code: ErrorCode.AccessDenied,
+      })
     } finally {
       await cleanupBucket(bucketId, objectNames)
+    }
+  })
+
+  test('user is not able to empty a bucket without authentication', async () => {
+    const bucketId = `empty-bucket-unauthenticated-${randomUUID()}`
+
+    try {
+      await createBucket(bucketId)
+
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/bucket/${bucketId}/empty`,
+        headers: {
+          authorization: `Bearer invalid-token`,
+        },
+      })
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchObject({
+        error: 'Unauthorized',
+        code: ErrorCode.AccessDenied,
+      })
+    } finally {
+      await cleanupBucket(bucketId)
     }
   })
 
@@ -1079,7 +1103,7 @@ describe('testing EMPTY bucket', () => {
           authorization: `Bearer ${anonKey}`,
         },
       })
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(403)
     } finally {
       await cleanupBucket(bucketId)
     }
@@ -1107,23 +1131,28 @@ describe('testing EMPTY bucket', () => {
       method: 'POST',
       url: `/bucket/${bucketId}/empty`,
       headers: {
-        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        authorization: `Bearer ${serviceKey}`,
       },
     })
     expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({
+      error: 'Bucket not found',
+      message: 'Bucket not found',
+      code: ErrorCode.NoSuchBucket,
+    })
   })
 
-  test('user is able to empty an already empty bucket', async () => {
+  test('service role is able to empty an already empty bucket', async () => {
     const bucketId = `empty-bucket-already-empty-${randomUUID()}`
 
     try {
-      await createBucket(bucketId)
+      await createBucket(bucketId, serviceKey)
 
       const response = await appInstance.inject({
         method: 'POST',
         url: `/bucket/${bucketId}/empty`,
         headers: {
-          authorization: `Bearer ${authenticatedKey}`,
+          authorization: `Bearer ${serviceKey}`,
         },
       })
       expect(response.statusCode).toBe(200)

--- a/src/test/rls_tests.yaml
+++ b/src/test/rls_tests.yaml
@@ -182,17 +182,29 @@ tests:
         status: 400
         message: "Access denied"
 
-  - description: "Will not empty a bucket without delete permission on objects"
+  - description: "Will not empty a bucket without service role"
     policies:
       - read_only_all_buckets
       - read_only_all_objects
+      - update_only_all_buckets
+      - delete_only_all_objects
     asserts:
       - operation: object.seed
         status: 200
 
       - operation: bucket.empty
-        status: 400
-        error: "Object not found"
+        status: 403
+        error: "Access denied: Invalid role"
+
+  - description: "Will empty a bucket with service role"
+    policies: []
+    asserts:
+      - operation: object.seed
+        status: 200
+
+      - operation: bucket.empty
+        role: service
+        status: 200
 
   - description: "Will only able to insert objects when authenticated"
     policies:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Checking object delete permission to empty bucket.

## What is the new behavior?

Requiring service role directly.

