### PR TITLE
feat: add versioning core dark schema

### DIFF
--- a/migrations/tenant/0062-object-versioning-core.sql
+++ b/migrations/tenant/0062-object-versioning-core.sql
@@ -1,0 +1,53 @@
+-- Establish the additive, dark schema shared by object versioning and lifecycle.
+-- No bucket can be enabled until a later writer-protocol migration and constraints are removed.
+
+ALTER TABLE storage.buckets
+ADD COLUMN IF NOT EXISTS versioning_status text NOT NULL DEFAULT 'DISABLED';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_status_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_status_check CHECK (
+      versioning_status IN ('DISABLED', 'ENABLED', 'SUSPENDED')
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_standard_only_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_standard_only_check CHECK (
+      type = 'STANDARD'
+      OR versioning_status = 'DISABLED'
+    );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_versioning_dark_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_versioning_dark_check CHECK (
+      versioning_status = 'DISABLED'
+    );
+  END IF;
+END;
+$$;
+
+-- The existing nullable version column, objects_pkey(id), and bucketid_objname
+-- unique index intentionally remain unchanged in this wave.
+ALTER TABLE storage.objects
+ADD COLUMN IF NOT EXISTS archived_at timestamptz,
+ADD COLUMN IF NOT EXISTS is_delete_marker boolean NOT NULL DEFAULT false,
+ADD COLUMN IF NOT EXISTS is_versioned boolean NOT NULL DEFAULT false;

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -61,4 +61,5 @@ export const DBMigration = {
   'drop-unused-functions': 59,
   'optimize-existing-functions-again': 60,
   'mark-filename-immutable': 61,
+  'object-versioning-core': 62,
 } as const

--- a/src/test/object-versioning-schema.test.ts
+++ b/src/test/object-versioning-schema.test.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto'
+import { useStorage, withDeleteEnabled } from './utils/storage'
+
+describe('object versioning dark schema', () => {
+  const tHelper = useStorage()
+  let bucketId: string
+
+  beforeEach(async () => {
+    bucketId = `versioning-schema-${randomUUID()}`
+    await tHelper.database.createBucket({ id: bucketId, name: bucketId })
+  })
+
+  afterEach(async () => {
+    await withDeleteEnabled(tHelper.database.connection, async (transaction) => {
+      await transaction.query('DELETE FROM storage.objects WHERE bucket_id = $1', [bucketId])
+      await transaction.query('DELETE FROM storage.buckets WHERE id = $1', [bucketId])
+    })
+  })
+
+  it('keeps versioning dark', async () => {
+    const bucket = await tHelper.database.connection.query<{
+      versioning_status: string
+    }>(
+      `SELECT versioning_status
+       FROM storage.buckets
+       WHERE id = $1`,
+      [bucketId]
+    )
+
+    expect(bucket.rows[0]).toEqual({
+      versioning_status: 'DISABLED',
+    })
+
+    const objectName = 'legacy-writer.txt'
+    const inserted = await tHelper.database.connection.query<{
+      version: string | null
+      archived_at: string | null
+      is_delete_marker: boolean
+      is_versioned: boolean
+    }>(
+      `INSERT INTO storage.objects (bucket_id, name)
+       VALUES ($1, $2)
+       RETURNING version, archived_at, is_delete_marker, is_versioned`,
+      [bucketId, objectName]
+    )
+
+    expect(inserted.rows[0]).toEqual({
+      version: null,
+      archived_at: null,
+      is_delete_marker: false,
+      is_versioned: false,
+    })
+
+    await expect(
+      tHelper.database.connection.query(
+        `UPDATE storage.buckets
+         SET versioning_status = 'ENABLED'
+         WHERE id = $1`,
+        [bucketId]
+      )
+    ).rejects.toMatchObject({
+      code: '23514',
+      constraint: 'buckets_versioning_dark_check',
+    })
+
+    const bucketVersioningColumns = await tHelper.database.connection.query<{
+      attname: string
+      attnotnull: boolean
+      default_value: string | null
+    }>(`
+      SELECT
+        attribute.attname,
+        attribute.attnotnull,
+        pg_get_expr(default_value.adbin, default_value.adrelid) AS default_value
+      FROM pg_catalog.pg_attribute AS attribute
+      LEFT JOIN pg_catalog.pg_attrdef AS default_value
+        ON default_value.adrelid = attribute.attrelid
+       AND default_value.adnum = attribute.attnum
+      WHERE attribute.attrelid = 'storage.buckets'::regclass
+        AND attribute.attnum > 0
+        AND NOT attribute.attisdropped
+        AND attribute.attname = 'versioning_status'
+      ORDER BY attribute.attname
+    `)
+    expect(bucketVersioningColumns.rows).toEqual([
+      {
+        attname: 'versioning_status',
+        attnotnull: true,
+        default_value: "'DISABLED'::text",
+      },
+    ])
+
+    const bucketConstraints = await tHelper.database.connection.query<{ conname: string }>(`
+      SELECT conname
+      FROM pg_catalog.pg_constraint
+      WHERE conrelid = 'storage.buckets'::regclass
+        AND conname = ANY(ARRAY[
+          'buckets_versioning_dark_check',
+          'buckets_versioning_standard_only_check',
+          'buckets_versioning_status_check'
+        ])
+      ORDER BY conname
+    `)
+    expect(bucketConstraints.rows.map((row) => row.conname)).toEqual([
+      'buckets_versioning_dark_check',
+      'buckets_versioning_standard_only_check',
+      'buckets_versioning_status_check',
+    ])
+  })
+})

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -312,9 +312,12 @@ describe.each([
 
     const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
     expect(dbAsset).toEqual({
+      archived_at: null,
       bucket_id: bucket.id,
       created_at: expect.any(Date),
       id: expect.any(String),
+      is_delete_marker: false,
+      is_versioned: false,
       last_accessed_at: expect.any(Date),
       metadata: {
         cacheControl: 'max-age=3600',
@@ -407,9 +410,12 @@ describe.each([
 
     const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
     expect(dbAsset).toEqual({
+      archived_at: null,
       bucket_id: bucket.id,
       created_at: expect.any(Date),
       id: expect.any(String),
+      is_delete_marker: false,
+      is_versioned: false,
       last_accessed_at: expect.any(Date),
       metadata: {
         cacheControl: 'max-age=3600',
@@ -562,9 +568,12 @@ describe.each([
 
     const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
     expect(dbAsset).toEqual({
+      archived_at: null,
       bucket_id: bucket.id,
       created_at: expect.any(Date),
       id: expect.any(String),
+      is_delete_marker: false,
+      is_versioned: false,
       last_accessed_at: expect.any(Date),
       metadata: {
         cacheControl: 'max-age=3600',
@@ -832,9 +841,12 @@ describe.each([
 
       const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
       expect(dbAsset).toEqual({
+        archived_at: null,
         bucket_id: bucket.id,
         created_at: expect.any(Date),
         id: expect.any(String),
+        is_delete_marker: false,
+        is_versioned: false,
         last_accessed_at: expect.any(Date),
         metadata: {
           cacheControl: 'max-age=3600',
@@ -901,9 +913,12 @@ describe.each([
 
       const dbAsset = await storage.from(bucket.id).findObject(objectName, '*')
       expect(dbAsset).toEqual({
+        archived_at: null,
         bucket_id: bucket.id,
         created_at: expect.any(Date),
         id: expect.any(String),
+        is_delete_marker: false,
+        is_versioned: false,
         last_accessed_at: expect.any(Date),
         metadata: {
           cacheControl: 'max-age=3600',


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the new behavior?

Add versioning dark schema as a basis for versioning and lifecycles can work independently.

## Additional context

Related to #1310
