### PR TITLE
fix(s3): reject wrong-length signatures instead of throwing

### DIFF
--- a/src/storage/protocols/s3/signature-v4-stream.test.ts
+++ b/src/storage/protocols/s3/signature-v4-stream.test.ts
@@ -620,4 +620,37 @@ describe('ChunkSignatureV4Parser', () => {
     ).toBe(true)
     expect(signingKeySpy).toHaveBeenCalledTimes(1)
   })
+
+  test('rejects a wrong-length chunk signature instead of throwing', () => {
+    const secretKey = 'secret-key'
+    const signer = new TestSignatureV4({
+      enforceRegion: false,
+      credentials: {
+        accessKey: 'access-key',
+        secretKey,
+        region: 'us-east-1',
+        service: 's3',
+      },
+    })
+    const clientSignature = {
+      credentials: {
+        accessKey: 'access-key',
+        shortDate: '20260406',
+        region: 'us-east-1',
+        service: 's3',
+      },
+      signature: 'f'.repeat(64),
+      signedHeaders: ['host'],
+      longDate: '20260406T120000Z',
+    }
+
+    expect(
+      signer.validateChunkSignature(
+        clientSignature,
+        'a'.repeat(64),
+        'abc',
+        clientSignature.signature
+      )
+    ).toBe(false)
+  })
 })

--- a/src/storage/protocols/s3/signature-v4.test.ts
+++ b/src/storage/protocols/s3/signature-v4.test.ts
@@ -190,6 +190,24 @@ describe('SignatureV4 verification', () => {
     ).resolves.toBe(false)
   })
 
+  it('rejects a wrong-length signature instead of throwing', async () => {
+    const signedRequest = await signWithAwsClient('object')
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+
+    await expect(
+      verifier.verify(
+        { ...clientSignature, signature: 'abc' },
+        {
+          url: requestTarget(signedRequest),
+          prefix: forwardedPrefix,
+          headers: signedRequest.headers,
+          method: signedRequest.method,
+          query: signedRequest.query,
+        }
+      )
+    ).resolves.toBe(false)
+  })
+
   it('verifies a raw percent-encoded parent segment over HTTP', async () => {
     const rawPath = `${forwardedPrefix}/bucket/folder/%2E%2E/object`
     const signedRequest = await signRawPath(rawPath)

--- a/src/storage/protocols/s3/signature-v4.test.ts
+++ b/src/storage/protocols/s3/signature-v4.test.ts
@@ -208,6 +208,29 @@ describe('SignatureV4 verification', () => {
     ).resolves.toBe(false)
   })
 
+  it('rejects a wrong-length POST policy signature instead of throwing', () => {
+    const policy = Buffer.from(
+      JSON.stringify({ expiration: '2030-01-01T00:00:00Z', conditions: [] })
+    ).toString('base64')
+
+    expect(
+      verifier.verifyPostPolicySignature(
+        {
+          credentials: {
+            accessKey: credentials.accessKeyId,
+            shortDate: '20260818',
+            region: credentials.region,
+            service: credentials.service,
+          },
+          signature: 'abc',
+          signedHeaders: [],
+          longDate: '20260818T000000Z',
+        },
+        policy
+      )
+    ).toBe(false)
+  })
+
   it('verifies a raw percent-encoded parent segment over HTTP', async () => {
     const rawPath = `${forwardedPrefix}/bucket/folder/%2E%2E/object`
     const signedRequest = await signRawPath(rawPath)

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -303,10 +303,9 @@ export class SignatureV4 {
     }
 
     const serverSignature = await this.sign(clientSignature, request)
-    return crypto.timingSafeEqual(
-      Buffer.from(clientSignature.signature),
-      Buffer.from(serverSignature.signature)
-    )
+    const clientSig = Buffer.from(clientSignature.signature)
+    const serverSig = Buffer.from(serverSignature.signature)
+    return clientSig.length === serverSig.length && crypto.timingSafeEqual(clientSig, serverSig)
   }
 
   /**
@@ -316,10 +315,9 @@ export class SignatureV4 {
    */
   verifyPostPolicySignature(clientSignature: ClientSignature, policy: string) {
     const serverSignature = this.signPostPolicy(clientSignature, policy)
-    return crypto.timingSafeEqual(
-      Buffer.from(clientSignature.signature),
-      Buffer.from(serverSignature)
-    )
+    const clientSig = Buffer.from(clientSignature.signature)
+    const serverSig = Buffer.from(serverSignature)
+    return clientSig.length === serverSig.length && crypto.timingSafeEqual(clientSig, serverSig)
   }
 
   public validateChunkSignature(

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -348,8 +348,8 @@ export class SignatureV4 {
 
     // 4) HMAC it with the derived key and compare
     const expected = this.hmac(signingKey, stringToSign)
-
-    return crypto.timingSafeEqual(expected, Buffer.from(chunkSignature, 'hex'))
+    const clientSig = Buffer.from(chunkSignature, 'hex')
+    return clientSig.length === expected.length && crypto.timingSafeEqual(expected, clientSig)
   }
 
   signPostPolicy(clientSignature: ClientSignature, policy: string) {


### PR DESCRIPTION
Closes #1336

A signature that isn't 64 chars long makes `verify()` throw instead of returning false, because `crypto.timingSafeEqual` needs equal-length buffers. The RangeError isn't a StorageBackendError, so it surfaces as a 500 rather than a 403.

Guarded the length before the compare in both `verify()` and `verifyPostPolicySignature()`, so a wrong-length signature returns false and the caller responds with 403. Same thing the streaming parser already does with its hex check.

Added a test that a wrong-length signature resolves to false instead of throwing.
