### PR TITLE
feat: accept tenantId as SigV4 signing secret for session token auth

### DIFF
--- a/src/http/plugins/signature-v4.test.ts
+++ b/src/http/plugins/signature-v4.test.ts
@@ -4,18 +4,20 @@ import Fastify from 'fastify'
 import { vi } from 'vitest'
 import { createRawSignatureV4Signer } from '../../test/utils/signature-v4'
 
-const { configState, getJwtSecretMock, verifyJwtMock } = vi.hoisted(() => ({
+const { configState, getJwtSecretMock, verifyJwtMock, getTenantConfigMock } = vi.hoisted(() => ({
   configState: {
     requestAllowXForwardedPrefix: true,
+    isMultitenant: false,
   },
   getJwtSecretMock: vi.fn(),
   verifyJwtMock: vi.fn(),
+  getTenantConfigMock: vi.fn(),
 }))
 
 vi.mock('../../config', () => ({
   getConfig: () => ({
     anonKeyAsync: Promise.resolve('anon-key'),
-    isMultitenant: false,
+    isMultitenant: configState.isMultitenant,
     jwtCachingEnabled: false,
     requestAllowXForwardedPrefix: configState.requestAllowXForwardedPrefix,
     s3ProtocolAccessKeyId: 'access-key',
@@ -39,7 +41,7 @@ vi.mock('@internal/auth', () => ({
 
 vi.mock('@internal/database', () => ({
   getJwtSecret: getJwtSecretMock,
-  getTenantConfig: vi.fn(),
+  getTenantConfig: getTenantConfigMock,
   s3CredentialsManager: {
     getS3CredentialsByAccessKey: vi.fn(),
   },
@@ -57,8 +59,9 @@ const signRawPath = createRawSignatureV4Signer(credentials, {
   method: 'GET',
 })
 
-async function buildApp(requestAllowXForwardedPrefix: boolean) {
+async function buildApp(requestAllowXForwardedPrefix: boolean, isMultitenant = false) {
   configState.requestAllowXForwardedPrefix = requestAllowXForwardedPrefix
+  configState.isMultitenant = isMultitenant
   vi.resetModules()
   getJwtSecretMock.mockResolvedValue({
     secret: 'jwt-secret',
@@ -165,6 +168,74 @@ describe('SignatureV4 plugin forwarded prefix', () => {
         code: 'SignatureDoesNotMatch',
       })
       expect(wasHandled()).toBe(false)
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+describe('SignatureV4 plugin session token secrets', () => {
+  const internalPath = '/bucket/object'
+  const sessionToken = 'session-jwt'
+
+  function signWithSessionToken(secretAccessKey: string) {
+    return createRawSignatureV4Signer(
+      {
+        ...credentials,
+        accessKeyId: 'tenant-id',
+        secretAccessKey,
+        sessionToken,
+      },
+      { method: 'GET' }
+    )(`${forwardedPrefix}${internalPath}`)
+  }
+
+  it.each([
+    { name: 'tenantId', secret: 'tenant-id' },
+    { name: 'anon key', secret: 'anon-key' },
+  ])('verifies a session token request signed with the $name as secret', async ({ secret }) => {
+    const signedRequest = await signWithSessionToken(secret)
+    const { app, wasHandled } = await buildApp(true)
+
+    try {
+      const response = await sendRequest(app, signedRequest, internalPath)
+
+      expect(response.statusCode).toBe(204)
+      expect(wasHandled()).toBe(true)
+      expect(verifyJwtMock).toHaveBeenCalledWith(sessionToken, 'jwt-secret', null)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('rejects a session token request signed with an unknown secret', async () => {
+    const signedRequest = await signWithSessionToken('unknown-secret')
+    const { app, wasHandled } = await buildApp(true)
+
+    try {
+      const response = await sendRequest(app, signedRequest, internalPath)
+
+      expect(response.statusCode).toBe(403)
+      expect(JSON.parse(response.body)).toEqual({
+        code: 'SignatureDoesNotMatch',
+      })
+      expect(wasHandled()).toBe(false)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('verifies a tenantId-signed request for a tenant without an anon key', async () => {
+    getTenantConfigMock.mockResolvedValue({ anonKey: undefined })
+    const signedRequest = await signWithSessionToken('tenant-id')
+    const { app, wasHandled } = await buildApp(true, true)
+
+    try {
+      const response = await sendRequest(app, signedRequest, internalPath)
+
+      expect(response.statusCode).toBe(204)
+      expect(wasHandled()).toBe(true)
+      expect(getTenantConfigMock).toHaveBeenCalledWith('tenant-id')
     } finally {
       await app.close()
     }

--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -258,8 +258,12 @@ async function createServerSignature(
       ? (await getTenantConfig(tenantId)).anonKey
       : await anonKeyAsync
 
-    if (!tenantAnonKey) {
-      throw ERRORS.AccessDenied('Missing tenant anon key')
+    // The session token is the real credential (verified as a JWT after the
+    // signature check). The signing secret is the tenantId itself, or the
+    // anon key for backwards compatibility.
+    const secretKeys = [tenantId]
+    if (tenantAnonKey) {
+      secretKeys.push(tenantAnonKey)
     }
 
     const signature = new SignatureV4({
@@ -270,7 +274,7 @@ async function createServerSignature(
       publicUrl: parsedPublicUrl,
       credentials: {
         accessKey: tenantId,
-        secretKey: tenantAnonKey,
+        secretKey: secretKeys,
         region: awsRegion,
         service: awsService,
       },

--- a/src/storage/protocols/s3/signature-v4.test.ts
+++ b/src/storage/protocols/s3/signature-v4.test.ts
@@ -1,7 +1,12 @@
+import { createHash, createHmac } from 'node:crypto'
 import { createServer, request as httpRequest, type IncomingHttpHeaders } from 'node:http'
 import { type AddressInfo } from 'node:net'
 import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
-import { SignatureV4, SignatureV4Service } from '@storage/protocols/s3/signature-v4'
+import {
+  EMPTY_SHA256_HASH,
+  SignatureV4,
+  SignatureV4Service,
+} from '@storage/protocols/s3/signature-v4'
 import { createRawSignatureV4Signer } from '../../../test/utils/signature-v4'
 
 const credentials = {
@@ -317,5 +322,141 @@ describe('SignatureV4 verification', () => {
         query: {},
       })
     ).resolves.toBe(true)
+  })
+})
+
+describe('SignatureV4 multiple secret candidates', () => {
+  const fallbackSecret = 'fallback-secret-key'
+
+  function multiSecretVerifier() {
+    return new SignatureV4({
+      enforceRegion: false,
+      credentials: {
+        accessKey: credentials.accessKeyId,
+        secretKey: [credentials.secretAccessKey, fallbackSecret],
+        region: credentials.region,
+        service: credentials.service,
+      },
+    })
+  }
+
+  function deriveSigningKey(secret: string, shortDate: string, region: string, service: string) {
+    const kDate = createHmac('sha256', `AWS4${secret}`).update(shortDate).digest()
+    const kRegion = createHmac('sha256', kDate).update(region).digest()
+    const kService = createHmac('sha256', kRegion).update(service).digest()
+    return createHmac('sha256', kService).update('aws4_request').digest()
+  }
+
+  const signWithFallbackSecret = createRawSignatureV4Signer({
+    ...credentials,
+    secretAccessKey: fallbackSecret,
+  })
+
+  it.each([
+    { name: 'primary', sign: signRawPath },
+    { name: 'fallback', sign: signWithFallbackSecret },
+  ])('verifies a request signed with the $name secret', async ({ sign }) => {
+    const signedRequest = await sign('/bucket/object')
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+
+    await expect(
+      multiSecretVerifier().verify(clientSignature, {
+        url: '/bucket/object',
+        headers: signedRequest.headers,
+        method: signedRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('rejects a request signed with an unknown secret', async () => {
+    const signWithUnknownSecret = createRawSignatureV4Signer({
+      ...credentials,
+      secretAccessKey: 'unknown-secret-key',
+    })
+    const signedRequest = await signWithUnknownSecret('/bucket/object')
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+
+    await expect(
+      multiSecretVerifier().verify(clientSignature, {
+        url: '/bucket/object',
+        headers: signedRequest.headers,
+        method: signedRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('validates chunk signatures with the secret that matched the seed signature', async () => {
+    const signedRequest = await signWithFallbackSecret('/bucket/object')
+    const clientSignature = SignatureV4.parseAuthorizationHeader(signedRequest.headers)
+    const chunkVerifier = multiSecretVerifier()
+
+    await expect(
+      chunkVerifier.verify(clientSignature, {
+        url: '/bucket/object',
+        headers: signedRequest.headers,
+        method: signedRequest.method,
+        query: {},
+      })
+    ).resolves.toBe(true)
+
+    const { shortDate, region, service } = clientSignature.credentials
+    const chunkHash = createHash('sha256').update('chunk-data').digest('hex')
+    const stringToSign = [
+      'AWS4-HMAC-SHA256-PAYLOAD',
+      clientSignature.longDate,
+      `${shortDate}/${region}/${service}/aws4_request`,
+      clientSignature.signature,
+      EMPTY_SHA256_HASH,
+      chunkHash,
+    ].join('\n')
+
+    const chunkSignature = (secret: string) =>
+      createHmac('sha256', deriveSigningKey(secret, shortDate, region, service))
+        .update(stringToSign)
+        .digest('hex')
+
+    expect(
+      chunkVerifier.validateChunkSignature(clientSignature, chunkHash, chunkSignature(fallbackSecret))
+    ).toBe(true)
+    expect(
+      chunkVerifier.validateChunkSignature(
+        clientSignature,
+        chunkHash,
+        chunkSignature(credentials.secretAccessKey)
+      )
+    ).toBe(false)
+  })
+
+  it('verifies a POST policy signed with the fallback secret', () => {
+    const policy = Buffer.from(
+      JSON.stringify({ expiration: '2030-01-01T00:00:00Z', conditions: [] })
+    ).toString('base64')
+    const shortDate = '20260818'
+
+    const signature = createHmac(
+      'sha256',
+      deriveSigningKey(fallbackSecret, shortDate, credentials.region, credentials.service)
+    )
+      .update(policy)
+      .digest('hex')
+
+    expect(
+      multiSecretVerifier().verifyPostPolicySignature(
+        {
+          credentials: {
+            accessKey: credentials.accessKeyId,
+            shortDate,
+            region: credentials.region,
+            service: credentials.service,
+          },
+          signature,
+          signedHeaders: [],
+          longDate: `${shortDate}T000000Z`,
+        },
+        policy
+      )
+    ).toBe(true)
   })
 })

--- a/src/storage/protocols/s3/signature-v4.test.ts
+++ b/src/storage/protocols/s3/signature-v4.test.ts
@@ -418,7 +418,11 @@ describe('SignatureV4 multiple secret candidates', () => {
         .digest('hex')
 
     expect(
-      chunkVerifier.validateChunkSignature(clientSignature, chunkHash, chunkSignature(fallbackSecret))
+      chunkVerifier.validateChunkSignature(
+        clientSignature,
+        chunkHash,
+        chunkSignature(fallbackSecret)
+      )
     ).toBe(true)
     expect(
       chunkVerifier.validateChunkSignature(

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -17,7 +17,7 @@ interface SignatureV4Options {
   allowBodyHashing?: boolean
   nonCanonicalForwardedHost?: string
   publicUrl?: URL
-  credentials: Omit<Credentials, 'shortDate'> & { secretKey: string }
+  credentials: Omit<Credentials, 'shortDate'> & { secretKey: string | string[] }
 }
 
 export interface ClientSignature {
@@ -97,9 +97,21 @@ export class SignatureV4 {
   nonCanonicalForwardedHost?: string
   publicUrl?: URL
   private readonly signingKeyCache = new Map<string, Buffer>()
+  private readonly secretKeys: string[]
+  // Index of the secret that matched during verify(); chunk signatures of a
+  // streaming upload must be validated with the same secret as the seed signature.
+  private matchedSecretIndex = 0
 
   constructor(options: SignatureV4Options) {
     this.serverCredentials = options.credentials
+    this.secretKeys = Array.isArray(options.credentials.secretKey)
+      ? options.credentials.secretKey
+      : [options.credentials.secretKey]
+
+    if (this.secretKeys.length === 0) {
+      throw new Error('SignatureV4 requires at least one secret key')
+    }
+
     this.enforceRegion = options.enforceRegion
     this.allowForwardedHeader = options.allowForwardedHeader
     this.allowBodyHashing = options.allowBodyHashing
@@ -303,9 +315,7 @@ export class SignatureV4 {
     }
 
     const serverSignature = await this.sign(clientSignature, request)
-    const clientSig = Buffer.from(clientSignature.signature)
-    const serverSig = Buffer.from(serverSignature.signature)
-    return clientSig.length === serverSig.length && crypto.timingSafeEqual(clientSig, serverSig)
+    return this.matchClientSignature(clientSignature.signature, serverSignature.signatures)
   }
 
   /**
@@ -314,10 +324,8 @@ export class SignatureV4 {
    * @param policy
    */
   verifyPostPolicySignature(clientSignature: ClientSignature, policy: string) {
-    const serverSignature = this.signPostPolicy(clientSignature, policy)
-    const clientSig = Buffer.from(clientSignature.signature)
-    const serverSig = Buffer.from(serverSignature)
-    return clientSig.length === serverSig.length && crypto.timingSafeEqual(clientSig, serverSig)
+    const serverSignatures = this.signPostPolicyCandidates(clientSignature, policy)
+    return this.matchClientSignature(clientSignature.signature, serverSignatures)
   }
 
   public validateChunkSignature(
@@ -327,7 +335,7 @@ export class SignatureV4 {
     prevSignature: string = clientSignature.signature
   ): boolean {
     const { shortDate, region, service } = clientSignature.credentials
-    const signingKey = this.getCachedSigningKey(shortDate, region, service)
+    const signingKey = this.getCachedSigningKey(shortDate, region, service, this.matchedSecretIndex)
 
     // Build the “String to Sign” for this chunk exactly per AWS:
     //    AWS4-HMAC-SHA256-PAYLOAD
@@ -353,18 +361,25 @@ export class SignatureV4 {
   }
 
   signPostPolicy(clientSignature: ClientSignature, policy: string) {
+    return this.signPostPolicyCandidates(clientSignature, policy)[0]
+  }
+
+  protected signPostPolicyCandidates(clientSignature: ClientSignature, policy: string) {
     const serverCredentials = this.serverCredentials
 
     this.validateCredentials(clientSignature.credentials)
     const selectedRegion = this.getSelectedRegion(clientSignature.credentials.region)
 
-    const signingKey = this.getCachedSigningKey(
-      clientSignature.credentials.shortDate,
-      selectedRegion,
-      serverCredentials.service
-    )
+    return this.secretKeys.map((_, index) => {
+      const signingKey = this.getCachedSigningKey(
+        clientSignature.credentials.shortDate,
+        selectedRegion,
+        serverCredentials.service,
+        index
+      )
 
-    return this.hmac(signingKey, policy).toString('hex')
+      return this.hmac(signingKey, policy).toString('hex')
+    })
   }
 
   /**
@@ -397,13 +412,18 @@ export class SignatureV4 {
       canonicalRequest
     )
 
-    const signingKey = this.getCachedSigningKey(
-      clientSignature.credentials.shortDate,
-      selectedRegion,
-      serverCredentials.service
-    )
+    const signatures = this.secretKeys.map((_, index) => {
+      const signingKey = this.getCachedSigningKey(
+        clientSignature.credentials.shortDate,
+        selectedRegion,
+        serverCredentials.service,
+        index
+      )
 
-    return { signature: this.hmac(signingKey, stringToSign).toString('hex'), canonicalRequest }
+      return this.hmac(signingKey, stringToSign).toString('hex')
+    })
+
+    return { signature: signatures[0], signatures, canonicalRequest }
   }
 
   protected async getPayloadHash(clientSignature: ClientSignature, request: SignatureRequest) {
@@ -611,13 +631,18 @@ export class SignatureV4 {
     return this.hmac(kService, 'aws4_request')
   }
 
-  private getCachedSigningKey(dateStamp: string, regionName: string, serviceName: string) {
-    const cacheKey = `${dateStamp}\0${regionName}\0${serviceName}`
+  private getCachedSigningKey(
+    dateStamp: string,
+    regionName: string,
+    serviceName: string,
+    secretIndex = 0
+  ) {
+    const cacheKey = `${secretIndex}\0${dateStamp}\0${regionName}\0${serviceName}`
     let signingKey = this.signingKeyCache.get(cacheKey)
 
     if (!signingKey) {
       signingKey = this.signingKey(
-        this.serverCredentials.secretKey,
+        this.secretKeys[secretIndex],
         dateStamp,
         regionName,
         serviceName
@@ -626,6 +651,20 @@ export class SignatureV4 {
     }
 
     return signingKey
+  }
+
+  private matchClientSignature(clientSignature: string, serverSignatures: string[]) {
+    const clientSig = Buffer.from(clientSignature)
+
+    for (const [index, candidate] of serverSignatures.entries()) {
+      const serverSig = Buffer.from(candidate)
+      if (clientSig.length === serverSig.length && crypto.timingSafeEqual(clientSig, serverSig)) {
+        this.matchedSecretIndex = index
+        return true
+      }
+    }
+
+    return false
   }
 
   protected async sha256OfRequest(req: Readable) {

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -637,12 +637,7 @@ export class SignatureV4 {
     let signingKey = this.signingKeyCache.get(cacheKey)
 
     if (!signingKey) {
-      signingKey = this.signingKey(
-        this.secretKeys[secretIndex],
-        dateStamp,
-        regionName,
-        serviceName
-      )
+      signingKey = this.signingKey(this.secretKeys[secretIndex], dateStamp, regionName, serviceName)
       this.signingKeyCache.set(cacheKey, signingKey)
     }
 

--- a/src/storage/protocols/s3/signature-v4.ts
+++ b/src/storage/protocols/s3/signature-v4.ts
@@ -324,7 +324,7 @@ export class SignatureV4 {
    * @param policy
    */
   verifyPostPolicySignature(clientSignature: ClientSignature, policy: string) {
-    const serverSignatures = this.signPostPolicyCandidates(clientSignature, policy)
+    const serverSignatures = this.signPostPolicy(clientSignature, policy)
     return this.matchClientSignature(clientSignature.signature, serverSignatures)
   }
 
@@ -361,10 +361,6 @@ export class SignatureV4 {
   }
 
   signPostPolicy(clientSignature: ClientSignature, policy: string) {
-    return this.signPostPolicyCandidates(clientSignature, policy)[0]
-  }
-
-  protected signPostPolicyCandidates(clientSignature: ClientSignature, policy: string) {
     const serverCredentials = this.serverCredentials
 
     this.validateCredentials(clientSignature.credentials)

--- a/src/test/s3-protocol.test.ts
+++ b/src/test/s3-protocol.test.ts
@@ -3321,6 +3321,67 @@ describe('S3 Protocol', () => {
       })
     })
 
+    describe('Session token authentication', () => {
+      function sessionTokenClient(secretAccessKey: string, sessionToken: string) {
+        return new S3Client({
+          endpoint: `${baseUrl}/s3`,
+          forcePathStyle: true,
+          region: storageS3Region,
+          credentials: {
+            accessKeyId: tenantId,
+            secretAccessKey,
+            sessionToken,
+          },
+        })
+      }
+
+      it.each([
+        { name: 'tenantId', secret: () => tenantId },
+        { name: 'anon key', secret: (anonKey: string) => anonKey },
+      ])('authenticates a request signed with the $name as secret', async ({ secret }) => {
+        const anonKey = await anonKeyAsync
+        const sessionClient = sessionTokenClient(secret(anonKey), anonKey)
+
+        try {
+          const resp = await sessionClient.send(new ListBucketsCommand({}))
+          expect(resp.$metadata.httpStatusCode).toBe(200)
+        } finally {
+          sessionClient.destroy()
+        }
+      })
+
+      it('rejects a request signed with an unknown secret', async () => {
+        const anonKey = await anonKeyAsync
+        const sessionClient = sessionTokenClient('unknown-secret', anonKey)
+
+        try {
+          await sessionClient.send(new ListBucketsCommand({}))
+          throw new Error('Should not reach here')
+        } catch (e) {
+          expect((e as Error).message).not.toBe('Should not reach here')
+          expect((e as S3ServiceException).$metadata.httpStatusCode).toBe(403)
+          expect((e as S3ServiceException).name).toBe('SignatureDoesNotMatch')
+        } finally {
+          sessionClient.destroy()
+        }
+      })
+
+      it('rejects a valid signature when the session token is not a valid JWT', async () => {
+        const sessionClient = sessionTokenClient(tenantId, 'not-a-jwt')
+
+        try {
+          await sessionClient.send(new ListBucketsCommand({}))
+          throw new Error('Should not reach here')
+        } catch (e) {
+          expect((e as Error).message).not.toBe('Should not reach here')
+          expect((e as S3ServiceException).$metadata.httpStatusCode).toBe(403)
+          expect((e as S3ServiceException).name).toBe('AccessDenied')
+        } finally {
+          sessionClient.destroy()
+        }
+      })
+    })
+
     describe('S3 Presigned URL', () => {
       it('can call a simple method with presigned url', async () => {
         const bucket = await createBucket(client)

--- a/src/test/utils/signature-v4.ts
+++ b/src/test/utils/signature-v4.ts
@@ -5,6 +5,7 @@ import { SignatureV4 } from '@smithy/signature-v4'
 interface RawSignatureV4Credentials {
   accessKeyId: string
   secretAccessKey: string
+  sessionToken?: string
   region: string
   service: string
 }


### PR DESCRIPTION
## What

S3 session token requests can now be signed with the **tenantId as both `accessKeyId` and `secretAccessKey`**. The anon key remains supported as the signing secret for backwards compatibility:

| Scheme | accessKeyId | secretAccessKey | sessionToken |
|---|---|---|---|
| New | tenantId | tenantId | user JWT |
| Legacy (still works) | tenantId | anon key | user JWT |

Since both schemes use the same `accessKeyId`, the server cannot tell from the request which secret the client signed with, so `SignatureV4` now accepts multiple candidate secrets: the canonical request and string-to-sign are computed once, one HMAC is derived per candidate, and each is compared with a length-guarded `timingSafeEqual`. Streaming chunk signatures and POST policies are validated with the secret that matched the seed signature.

As a side effect, the `Missing tenant anon key` rejection is gone: **tenants without an anon key can now use session token auth** by signing with the tenantId secret.

## Security

No change in posture. The tenantId is public, but the anon key is also effectively public (it ships in every frontend bundle) — the SigV4 signature in this flow never proved possession of a secret. The real authentication gate is unchanged: the session token is verified as a JWT against the tenant's JWT secret/JWKS after the signature check. The signature keeps providing request integrity binding and the x-amz-date expiry window.

## Tests

- Protocol unit tests: verify with primary/fallback secret, reject unknown secret, chunk-signature lock-in to the matched secret, POST policy with fallback secret
- Plugin unit tests: session token signed with tenantId and with anon key both pass, unknown secret → 403 `SignatureDoesNotMatch`, multitenant tenant **without** an anon key authenticates via tenantId
- Integration tests (`s3-protocol.test.ts`, real `S3Client`): both secrets authenticate, unknown secret rejected, valid signature with an invalid session token JWT still fails with 403 `AccessDenied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)