### PR TITLE
feat: support addressing objects by versionId

### DIFF
--- a/.docker/docker-compose-infra-multigres-override.yml
+++ b/.docker/docker-compose-infra-multigres-override.yml
@@ -17,6 +17,9 @@ services:
       # 2 cells is the minimum: the shard bootstraps with an AtLeastN(2)
       # durability policy, so a single pooler can never elect a leader.
       MULTIGRES_NUM_CELLS: "2"
+      # Storage migrations contain trusted dynamic PL/pgSQL that the gateway's
+      # unsafe-statement analyzer intentionally rejects by default.
+      MT_UNSAFE_POOLER_MODE: "true"
     # Bootstrapping a cluster takes longer than starting a bare postgres image,
     # so allow a generous start period before the gateway answers queries.
     healthcheck:

--- a/migrations/tenant/0065-objects-key-version-index.sql
+++ b/migrations/tenant/0065-objects-key-version-index.sql
@@ -1,0 +1,4 @@
+-- postgres-migrations disable-transaction
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS objects_bucket_id_name_version_key
+    ON storage.objects (bucket_id, name, version) NULLS NOT DISTINCT;

--- a/migrations/tenant/0066-objects-current-version-index.sql
+++ b/migrations/tenant/0066-objects-current-version-index.sql
@@ -1,0 +1,4 @@
+-- postgres-migrations disable-transaction
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_current_version
+    ON storage.objects (bucket_id, name) WHERE archived_at IS NULL;

--- a/migrations/tenant/0067-objects-null-version-index.sql
+++ b/migrations/tenant/0067-objects-null-version-index.sql
@@ -1,0 +1,4 @@
+-- postgres-migrations disable-transaction
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_null_version
+    ON storage.objects (bucket_id, name) WHERE NOT is_versioned;

--- a/src/http/routes/object/copyObject.ts
+++ b/src/http/routes/object/copyObject.ts
@@ -11,6 +11,7 @@ const copyRequestBodySchema = {
   properties: {
     bucketId: { type: 'string', examples: ['avatars'] },
     sourceKey: { type: 'string', examples: ['folder/source.png'] },
+    sourceVersionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
     destinationBucket: { type: 'string', examples: ['users'] },
     destinationKey: { type: 'string', examples: ['folder/destination.png'] },
     metadata: {
@@ -59,13 +60,15 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      const { sourceKey, destinationKey, bucketId, destinationBucket, metadata } = request.body
+      const { sourceKey, sourceVersionId, destinationKey, bucketId, destinationBucket, metadata } =
+        request.body
 
       const destinationBucketId = destinationBucket || bucketId
       const userMetadata = request.headers['x-metadata']
 
       const result = await request.storage.from(bucketId).copyObject({
         sourceKey,
+        sourceVersionId,
         destinationBucket: destinationBucketId,
         destinationKey,
         owner: request.owner,

--- a/src/http/routes/object/deleteObject.ts
+++ b/src/http/routes/object/deleteObject.ts
@@ -12,6 +12,12 @@ const deleteObjectParamsSchema = {
   },
   required: ['bucketName', '*'],
 } as const
+const deleteObjectQuerySchema = {
+  type: 'object',
+  properties: {
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
+  },
+} as const
 const successResponseSchema = {
   type: 'object',
   properties: {
@@ -20,6 +26,7 @@ const successResponseSchema = {
 }
 interface deleteObjectRequestInterface extends AuthenticatedRequest {
   Params: FromSchema<typeof deleteObjectParamsSchema>
+  Querystring: FromSchema<typeof deleteObjectQuerySchema>
 }
 
 export default async function routes(fastify: FastifyInstance) {
@@ -27,6 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
 
   const schema = createDefaultSchema(successResponseSchema, {
     params: deleteObjectParamsSchema,
+    querystring: deleteObjectQuerySchema,
     summary,
     tags: ['object'],
   })
@@ -41,9 +49,10 @@ export default async function routes(fastify: FastifyInstance) {
     },
     async (request, response) => {
       const { bucketName } = request.params
+      const { versionId } = request.query
       const objectName = request.params['*']
 
-      await request.storage.from(bucketName).deleteObject(objectName)
+      await request.storage.from(bucketName).deleteObject(objectName, versionId)
 
       return response.status(200).send(createResponse('Successfully deleted'))
     }

--- a/src/http/routes/object/deleteObjects.ts
+++ b/src/http/routes/object/deleteObjects.ts
@@ -18,10 +18,28 @@ const deleteObjectsBodySchema = {
   properties: {
     prefixes: {
       type: 'array',
-      items: { type: 'string' },
+      items: {
+        anyOf: [
+          { type: 'string' },
+          {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              versionId: { type: 'string' },
+            },
+            required: ['path', 'versionId'],
+            additionalProperties: false,
+          },
+        ],
+      },
       minItems: 1,
       description: DELETE_OBJECTS_LIMIT_DESCRIPTION,
-      examples: [['folder/cat.png', 'folder/morecats.png']],
+      examples: [
+        [
+          'folder/cat.png',
+          { path: 'folder/dog.png', versionId: 'eaa8bdb5-2e00-4767-b5a9-d2502efe2196' },
+        ],
+      ],
     },
   },
   required: ['prefixes'],
@@ -53,7 +71,10 @@ export default async function routes(fastify: FastifyInstance) {
         operation: ROUTE_OPERATIONS.DELETE_OBJECTS,
         resources: (req: FastifyRequest<deleteObjectsInterface>) => {
           const { prefixes } = req.body
-          return prefixes.map((prefix) => `${req.params.bucketName}/${prefix}`)
+          return prefixes.map((prefix) => {
+            const path = typeof prefix === 'string' ? prefix : prefix.path
+            return `${req.params.bucketName}/${path}`
+          })
         },
       },
     },

--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -22,6 +22,7 @@ const getObjectQuerySchema = {
   type: 'object',
   properties: {
     download: { type: 'string', examples: ['filename.jpg', null] },
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
   },
 } as const
 
@@ -34,7 +35,7 @@ type GetObjectRequest = FastifyRequest<getObjectRequestInterface>
 
 async function requestHandler(request: GetObjectRequest, response: FastifyReply) {
   const { bucketName } = request.params
-  const { download } = request.query
+  const { download, versionId } = request.query
   const objectName = request.params['*']
 
   // send the object from s3
@@ -67,10 +68,12 @@ async function requestHandler(request: GetObjectRequest, response: FastifyReply)
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(objectName, 'id, version, metadata')
+      .findObject(objectName, 'id, version, metadata', undefined, versionId)
   } else {
     // request is authenticated use RLS
-    obj = await request.storage.from(bucketName).findObject(objectName, 'id, version, metadata')
+    obj = await request.storage
+      .from(bucketName)
+      .findObject(objectName, 'id, version, metadata', undefined, versionId)
   }
 
   return request.storage.renderer('asset').render(request, response, {

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -66,27 +66,22 @@ async function requestHandler(
     throw ERRORS.NoSuchBucket(bucketName)
   }
 
+  const hasVersioningColumns = await request.storage.db.hasMigration('object-versioning-core')
+  const columns = hasVersioningColumns
+    ? 'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at,archived_at,is_delete_marker,is_versioned'
+    : 'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+
   let obj: Obj
 
   if (bucket.public || publicRoute) {
     obj = await request.storage
       .asSuperUser()
       .from(bucketName)
-      .findObject(
-        objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at',
-        undefined,
-        versionId
-      )
+      .findObject(objectName, columns, undefined, versionId)
   } else {
     obj = await request.storage
       .from(bucketName)
-      .findObject(
-        objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at',
-        undefined,
-        versionId
-      )
+      .findObject(objectName, columns, undefined, versionId)
   }
 
   return request.storage.renderer(method).render(request, response, {

--- a/src/http/routes/object/getObjectInfo.ts
+++ b/src/http/routes/object/getObjectInfo.ts
@@ -19,7 +19,13 @@ const getObjectParamsSchema = {
   required: ['bucketName', '*'],
 } as const
 
-const getObjectInfoQuerySchema = transformationOptionsSchema
+const getObjectInfoQuerySchema = {
+  ...transformationOptionsSchema,
+  properties: {
+    ...transformationOptionsSchema.properties,
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
+  },
+} as const
 
 interface getObjectRequestInterface extends AuthenticatedRangeRequest {
   Params: FromSchema<typeof getObjectParamsSchema>
@@ -36,6 +42,7 @@ async function requestHandler(
 ) {
   const { bucketName } = request.params
   const objectName = request.params['*']
+  const { versionId } = request.query
 
   const s3Key = request.storage.location.getKeyLocation({
     tenantId: request.tenantId,
@@ -67,14 +74,18 @@ async function requestHandler(
       .from(bucketName)
       .findObject(
         objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at',
+        undefined,
+        versionId
       )
   } else {
     obj = await request.storage
       .from(bucketName)
       .findObject(
         objectName,
-        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at',
+        undefined,
+        versionId
       )
   }
 

--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -19,6 +19,7 @@ const getObjectQuerySchema = {
   type: 'object',
   properties: {
     download: { type: 'string', examples: ['filename.jpg', null] },
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
   },
 } as const
 
@@ -51,14 +52,14 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketName } = request.params
       const objectName = request.params['*']
-      const { download } = request.query
+      const { download, versionId } = request.query
 
       const bucketRef = request.storage.asSuperUser().from(bucketName)
       const [, obj] = await Promise.all([
         request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
           isPublic: true,
         }),
-        bucketRef.findObject(objectName, 'id,version,metadata'),
+        bucketRef.findObject(objectName, 'id,version,metadata', undefined, versionId),
       ])
 
       // send the object from s3

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -59,7 +59,7 @@ export default async function routes(fastify: FastifyInstance) {
       const { token } = request.query
       const { download } = request.query
 
-      const { url, exp } = await request.storage
+      const { url, exp, versionId } = await request.storage
         .from(request.params.bucketName)
         .verifyObjectSignature(token, request.params['*'], SIGNED_URL_SCOPE_DOWNLOAD)
 
@@ -69,7 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
       const obj = await request.storage
         .asSuperUser()
         .from(bucketName)
-        .findObject(objParts.join('/'), 'id,version,metadata')
+        .findObject(objParts.join('/'), 'id,version,metadata', undefined, versionId)
 
       return request.storage.renderer('asset').render(request, response, {
         bucket: storageS3Bucket,

--- a/src/http/routes/object/getSignedURL.ts
+++ b/src/http/routes/object/getSignedURL.ts
@@ -26,6 +26,7 @@ const getSignedURLBodySchema = {
       examples: [60000],
     },
     transform: transformationOptionsSchema,
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
   },
   required: ['expiresIn'],
 } as const
@@ -68,7 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketName } = request.params
       const objectName = request.params['*']
-      const { expiresIn } = request.body
+      const { expiresIn, versionId } = request.body
       assertValidNumericJWTExpiration(expiresIn)
 
       const urlPath = request.url.split('?').shift()
@@ -86,7 +87,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       const signedURL = await request.storage
         .from(bucketName)
-        .signObjectUrl(objectName, urlPath as string, expiresIn, transformationOptions)
+        .signObjectUrl(objectName, urlPath as string, expiresIn, transformationOptions, versionId)
 
       return response.status(200).send({ signedURL })
     }

--- a/src/http/routes/object/moveObject.ts
+++ b/src/http/routes/object/moveObject.ts
@@ -9,6 +9,7 @@ const moveObjectsBodySchema = {
   properties: {
     bucketId: { type: 'string', examples: ['avatars'] },
     sourceKey: { type: 'string', examples: ['folder/cat.png'] },
+    sourceVersionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
     destinationBucket: { type: 'string', examples: ['users'] },
     destinationKey: { type: 'string', examples: ['folder/newcat.png'] },
   },
@@ -47,13 +48,21 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      const { destinationKey, sourceKey, bucketId, destinationBucket } = request.body
+      const { destinationKey, sourceKey, sourceVersionId, bucketId, destinationBucket } =
+        request.body
 
       const destinationBucketId = destinationBucket || bucketId
 
       const move = await request.storage
         .from(bucketId)
-        .moveObject(sourceKey, destinationBucketId, destinationKey, 'standard', request.owner)
+        .moveObject(
+          sourceKey,
+          destinationBucketId,
+          destinationKey,
+          'standard',
+          request.owner,
+          sourceVersionId
+        )
 
       return response.status(200).send({
         message: 'Successfully moved',

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -23,6 +23,7 @@ const renderImageQuerySchema = {
   properties: {
     ...transformationOptionsSchema.properties,
     download: { type: 'string', examples: ['filename.png'] },
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
   },
 } as const
 
@@ -48,13 +49,13 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      const { download } = request.query
+      const { download, versionId } = request.query
       const { bucketName } = request.params
       const objectName = request.params['*']
 
       const obj = await request.storage
         .from(bucketName)
-        .findObject(objectName, 'id,version,metadata')
+        .findObject(objectName, 'id,version,metadata', undefined, versionId)
 
       const s3Key = request.storage.location.getKeyLocation({
         tenantId: request.tenantId,

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -23,6 +23,7 @@ const renderImageQuerySchema = {
   properties: {
     ...transformationOptionsSchema.properties,
     download: { type: 'string', examples: ['filename.png'] },
+    versionId: { type: 'string', examples: ['eaa8bdb5-2e00-4767-b5a9-d2502efe2196'] },
   },
 } as const
 
@@ -48,7 +49,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
-      const { download } = request.query
+      const { download, versionId } = request.query
       const { bucketName } = request.params
       const objectName = request.params['*']
 
@@ -57,7 +58,7 @@ export default async function routes(fastify: FastifyInstance) {
         request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
           isPublic: true,
         }),
-        bucketRef.findObject(objectName, 'id,version,metadata'),
+        bucketRef.findObject(objectName, 'id,version,metadata', undefined, versionId),
       ])
 
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -57,7 +57,7 @@ export default async function routes(fastify: FastifyInstance) {
       const { token } = request.query
       const { download } = request.query
 
-      const { url, transformations, exp } = await request.storage
+      const { url, transformations, exp, versionId } = await request.storage
         .from(request.params.bucketName)
         .verifyObjectSignature(token, request.params['*'], SIGNED_URL_SCOPE_DOWNLOAD)
 
@@ -67,7 +67,7 @@ export default async function routes(fastify: FastifyInstance) {
       const obj = await request.storage
         .asSuperUser()
         .from(bucketName)
-        .findObject(objParts.join('/'), 'id,version,metadata')
+        .findObject(objParts.join('/'), 'id,version,metadata', undefined, versionId)
 
       const renderer = request.storage.renderer('image') as ImageRenderer
 

--- a/src/internal/auth/jwt.ts
+++ b/src/internal/auth/jwt.ts
@@ -54,6 +54,7 @@ export type SignedToken = {
   url: string
   transformations?: string
   exp: number
+  versionId?: string
 }
 
 export type SignedUploadToken = {

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -64,4 +64,7 @@ export const DBMigration = {
   'object-versioning-core': 62,
   'fix-search-name-relative-to-prefix': 63,
   'fix-search-by-timestamp-sqli': 64,
+  'objects-key-version-index': 65,
+  'objects-current-version-index': 66,
+  'objects-null-version-index': 67,
 } as const

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -150,7 +150,8 @@ export interface Database {
   updateObject(
     bucketId: string,
     name: string,
-    data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>
+    data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>,
+    currentVersion?: string
   ): Promise<Obj>
   createObject(
     data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata' | 'version' | 'user_metadata'>

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -181,7 +181,8 @@ export interface Database {
     bucketId: string,
     objectName: string,
     columns: string,
-    filters?: Filters
+    filters?: Filters,
+    version?: string
   ): Promise<Filters['dontErrorOnEmpty'] extends true ? Obj | undefined : Obj>
 
   searchObjects(bucketId: string, prefix: string, options: SearchObjectOption): Promise<Obj[]>

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -1170,9 +1170,17 @@ export class StoragePgDB implements Database {
     bucketId: string,
     objectName: string,
     columns = 'id',
-    filters?: FindObjectFilters
+    filters?: FindObjectFilters,
+    version?: string
   ) {
     const selectedColumns = selectColumns(columns, this.objectColumnPolicy)
+    const conditions = ['name = $1', 'bucket_id = $2']
+    const values: unknown[] = [objectName, bucketId]
+
+    if (version) {
+      values.push(version)
+      conditions.push(`version = $${values.length}`)
+    }
 
     const result = await this.runQuery('FindObject', async (db, signal) => {
       return this.query<Obj>(
@@ -1181,12 +1189,11 @@ export class StoragePgDB implements Database {
           text: `
             SELECT ${selectedColumns}
             FROM storage.objects
-            WHERE name = $1
-              AND bucket_id = $2
+            WHERE ${conditions.join(' AND ')}
             LIMIT 1
             ${objectLockClause(filters)}
           `,
-          values: [objectName, bucketId],
+          values,
         },
         signal
       )

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -984,7 +984,7 @@ export class StoragePgDB implements Database {
       ]
       const values = [...update.values, bucketId, name]
 
-      if (currentVersion) {
+      if (currentVersion !== undefined) {
         values.push(currentVersion)
         conditions.push(`version = $${values.length}`)
       }
@@ -1055,7 +1055,7 @@ export class StoragePgDB implements Database {
       const conditions = ['name = $1', 'bucket_id = $2']
       const values: unknown[] = [objectName, bucketId]
 
-      if (version) {
+      if (version !== undefined) {
         values.push(version)
         conditions.push(`version = $${values.length}`)
       }
@@ -1188,7 +1188,7 @@ export class StoragePgDB implements Database {
     const conditions = ['name = $1', 'bucket_id = $2']
     const values: unknown[] = [objectName, bucketId]
 
-    if (version) {
+    if (version !== undefined) {
       values.push(version)
       conditions.push(`version = $${values.length}`)
     }

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -976,19 +976,21 @@ export class StoragePgDB implements Database {
       version: data.version,
     })
 
+    const update = buildUpdate(objectData)
+    const conditions = [
+      `bucket_id = $${update.values.length + 1}`,
+      `name = $${update.values.length + 2}`,
+    ]
+    const values = [...update.values, bucketId, name]
+
+    if (currentVersion !== undefined) {
+      values.push(currentVersion)
+      conditions.push(`version = $${values.length}`)
+    } else if (await this.hasMigration('object-versioning-core')) {
+      conditions.push('archived_at IS NULL')
+    }
+
     const result = await this.runQuery('UpdateObject', async (db, signal) => {
-      const update = buildUpdate(objectData)
-      const conditions = [
-        `bucket_id = $${update.values.length + 1}`,
-        `name = $${update.values.length + 2}`,
-      ]
-      const values = [...update.values, bucketId, name]
-
-      if (currentVersion !== undefined) {
-        values.push(currentVersion)
-        conditions.push(`version = $${values.length}`)
-      }
-
       return this.query<Obj>(
         db,
         {
@@ -1051,17 +1053,17 @@ export class StoragePgDB implements Database {
   }
 
   async deleteObject(bucketId: string, objectName: string, version?: string) {
+    const conditions = ['name = $1', 'bucket_id = $2']
+    const values: unknown[] = [objectName, bucketId]
+
+    if (version !== undefined) {
+      values.push(version)
+      conditions.push(`version = $${values.length}`)
+    } else if (await this.hasMigration('object-versioning-core')) {
+      conditions.push('archived_at IS NULL')
+    }
+
     const result = await this.runQuery('Delete Object', async (db, signal) => {
-      const conditions = ['name = $1', 'bucket_id = $2']
-      const values: unknown[] = [objectName, bucketId]
-
-      if (version !== undefined) {
-        values.push(version)
-        conditions.push(`version = $${values.length}`)
-      } else if (await this.hasMigration('object-versioning-core')) {
-        conditions.push('archived_at IS NULL')
-      }
-
       return this.query<Obj>(
         db,
         {
@@ -1084,13 +1086,13 @@ export class StoragePgDB implements Database {
       return []
     }
 
+    const conditions = ['bucket_id = $1', `${quoteIdentifier(String(by))} = ANY($2)`]
+
+    if (await this.hasMigration('object-versioning-core')) {
+      conditions.push('archived_at IS NULL')
+    }
+
     const result = await this.runQuery('DeleteObjects', async (db, signal) => {
-      const conditions = ['bucket_id = $1', `${quoteIdentifier(String(by))} = ANY($2)`]
-
-      if (await this.hasMigration('object-versioning-core')) {
-        conditions.push('archived_at IS NULL')
-      }
-
       return this.query<Obj>(
         db,
         {
@@ -1199,6 +1201,8 @@ export class StoragePgDB implements Database {
     if (version !== undefined) {
       values.push(version)
       conditions.push(`version = $${values.length}`)
+    } else if (await this.hasMigration('object-versioning-core')) {
+      conditions.push('archived_at IS NULL')
     }
 
     const result = await this.runQuery('FindObject', async (db, signal) => {
@@ -1232,6 +1236,11 @@ export class StoragePgDB implements Database {
     }
 
     const selectedColumns = selectColumns(columns, this.objectColumnPolicy)
+    const conditions = ['bucket_id = $1', 'name = ANY($2::text[])']
+
+    if (await this.hasMigration('object-versioning-core')) {
+      conditions.push('archived_at IS NULL')
+    }
 
     const result = await this.runQuery('FindObjects', async (db, signal) => {
       return this.query<Obj>(
@@ -1240,8 +1249,7 @@ export class StoragePgDB implements Database {
           text: `
             SELECT ${selectedColumns}
             FROM storage.objects
-            WHERE bucket_id = $1
-              AND name = ANY($2::text[])
+            WHERE ${conditions.join(' AND ')}
           `,
           values: [bucketId, objectNames],
         },

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -963,7 +963,8 @@ export class StoragePgDB implements Database {
   async updateObject(
     bucketId: string,
     name: string,
-    data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>
+    data: Pick<Obj, 'owner' | 'metadata' | 'version' | 'name' | 'bucket_id' | 'user_metadata'>,
+    currentVersion?: string
   ) {
     const objectData = this.normalizeRecordColumns({
       name: data.name,
@@ -977,17 +978,27 @@ export class StoragePgDB implements Database {
 
     const result = await this.runQuery('UpdateObject', async (db, signal) => {
       const update = buildUpdate(objectData)
+      const conditions = [
+        `bucket_id = $${update.values.length + 1}`,
+        `name = $${update.values.length + 2}`,
+      ]
+      const values = [...update.values, bucketId, name]
+
+      if (currentVersion) {
+        values.push(currentVersion)
+        conditions.push(`version = $${values.length}`)
+      }
+
       return this.query<Obj>(
         db,
         {
           text: `
             UPDATE storage.objects
             SET ${update.setClause}
-            WHERE bucket_id = $${update.values.length + 1}
-              AND name = $${update.values.length + 2}
+            WHERE ${conditions.join(' AND ')}
             RETURNING *
           `,
-          values: [...update.values, bucketId, name],
+          values,
         },
         signal
       )

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -1058,6 +1058,8 @@ export class StoragePgDB implements Database {
       if (version !== undefined) {
         values.push(version)
         conditions.push(`version = $${values.length}`)
+      } else if (await this.hasMigration('object-versioning-core')) {
+        conditions.push('archived_at IS NULL')
       }
 
       return this.query<Obj>(
@@ -1083,13 +1085,18 @@ export class StoragePgDB implements Database {
     }
 
     const result = await this.runQuery('DeleteObjects', async (db, signal) => {
+      const conditions = ['bucket_id = $1', `${quoteIdentifier(String(by))} = ANY($2)`]
+
+      if (await this.hasMigration('object-versioning-core')) {
+        conditions.push('archived_at IS NULL')
+      }
+
       return this.query<Obj>(
         db,
         {
           text: `
             DELETE FROM storage.objects
-            WHERE bucket_id = $1
-              AND ${quoteIdentifier(String(by))} = ANY($2)
+            WHERE ${conditions.join(' AND ')}
             RETURNING *
           `,
           values: [bucketId, objectNames],
@@ -1107,7 +1114,8 @@ export class StoragePgDB implements Database {
     }
 
     const result = await this.runQuery('DeleteObjects', async (db, signal) => {
-      const { placeholders, values } = buildTupleValues(objectNames)
+      const names = objectNames.map((entry) => entry.name)
+      const versions = objectNames.map((entry) => entry.version)
 
       return this.query<Obj>(
         db,
@@ -1115,10 +1123,10 @@ export class StoragePgDB implements Database {
           text: `
             DELETE FROM storage.objects
             WHERE bucket_id = $1
-              AND (name, version) IN (${placeholders})
+              AND (name, version) IN (SELECT * FROM unnest($2::text[], $3::text[]))
             RETURNING *
           `,
-          values: [bucketId, ...values],
+          values: [bucketId, names, versions],
         },
         signal
       )

--- a/src/storage/object-delete.test.ts
+++ b/src/storage/object-delete.test.ts
@@ -65,10 +65,16 @@ describe('ObjectStorage.deleteObject', () => {
       message: 'Access denied',
     })
 
-    expect(findObject).toHaveBeenCalledWith('bucket', 'private/file.txt', 'id,version,metadata', {
-      forUpdate: true,
-    })
-    expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt')
+    expect(findObject).toHaveBeenCalledWith(
+      'bucket',
+      'private/file.txt',
+      'id,version,metadata',
+      {
+        forUpdate: true,
+      },
+      undefined
+    )
+    expect(deleteObject).toHaveBeenCalledWith('bucket', 'private/file.txt', undefined)
     expect(backend.deleteObject).not.toHaveBeenCalled()
   })
 

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -265,15 +265,21 @@ export class ObjectStorage {
   }
 
   /**
-   * Finds an object by name
+   * Finds an object by name, optionally pinned to a specific version id
    * @param objectName
    * @param columns
    * @param filters
+   * @param version
    */
-  async findObject(objectName: string, columns = 'id', filters?: FindObjectFilters) {
+  async findObject(
+    objectName: string,
+    columns = 'id',
+    filters?: FindObjectFilters,
+    version?: string
+  ) {
     mustBeValidKey(objectName)
 
-    return this.db.findObject(this.bucketId, objectName, columns, filters)
+    return this.db.findObject(this.bucketId, objectName, columns, filters, version)
   }
 
   /**
@@ -731,9 +737,10 @@ export class ObjectStorage {
     objectName: string,
     url: string,
     expiresIn: number,
-    metadata?: Record<string, string | object | undefined>
+    metadata?: Record<string, string | object | undefined>,
+    versionId?: string
   ) {
-    await this.findObject(objectName)
+    await this.findObject(objectName, 'id', undefined, versionId)
 
     metadata = metadata || {}
     for (const key in metadata) {
@@ -757,10 +764,18 @@ export class ObjectStorage {
     const urlParts = url.split('/')
     const urlToSign = decodeURI(urlParts.splice(3).join('/'))
     const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
-    // `url` and `scope` are spread last so attacker-controlled metadata can never
-    // override the intended object path or the token scope (token-forgery defense).
+    // `url`, `scope`, and `versionId` are spread last so attacker-controlled
+    // metadata can never override the intended object path, token scope, or
+    // pinned version (token-forgery defense) - versionId itself is safe to
+    // include here regardless since it was already validated against a real
+    // version above, not taken from caller-controlled metadata.
     const token = await signJWT(
-      { ...metadata, url: urlToSign, scope: SIGNED_URL_SCOPE_DOWNLOAD },
+      {
+        ...metadata,
+        url: urlToSign,
+        scope: SIGNED_URL_SCOPE_DOWNLOAD,
+        ...(versionId ? { versionId } : {}),
+      },
       urlSigningKey,
       expiresIn
     )

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -34,6 +34,7 @@ import { CanUploadMetadata, fileUploadFromRequest, Uploader, UploadRequest } fro
 
 interface CopyObjectParams {
   sourceKey: string
+  sourceVersionId?: string
   destinationBucket: string
   destinationKey: string
   owner?: string
@@ -310,6 +311,7 @@ export class ObjectStorage {
    */
   async copyObject({
     sourceKey,
+    sourceVersionId,
     destinationBucket,
     destinationKey,
     owner,
@@ -339,7 +341,9 @@ export class ObjectStorage {
     const originObject = await this.db.findObject(
       this.bucketId,
       sourceKey,
-      'bucket_id,metadata,user_metadata,version'
+      'bucket_id,metadata,user_metadata,version',
+      undefined,
+      sourceVersionId
     )
 
     const baseMetadata = originObject.metadata || {}

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -477,7 +477,8 @@ export class ObjectStorage {
     destinationBucket: string,
     destinationObjectName: string,
     uploadType: 'standard' | 's3' | 'resumable',
-    owner?: string
+    owner?: string,
+    sourceVersionId?: string
   ) {
     mustBeValidKey(destinationObjectName)
 
@@ -496,19 +497,30 @@ export class ObjectStorage {
 
     await this.db.testPermission((db) => {
       return Promise.all([
-        db.findObject(this.bucketId, sourceObjectName, 'id'),
-        db.updateObject(this.bucketId, sourceObjectName, {
-          name: destinationObjectName,
-          version: newVersion,
-          bucket_id: destinationBucket,
-          owner,
-        }),
+        db.findObject(this.bucketId, sourceObjectName, 'id', undefined, sourceVersionId),
+        db.updateObject(
+          this.bucketId,
+          sourceObjectName,
+          {
+            name: destinationObjectName,
+            version: newVersion,
+            bucket_id: destinationBucket,
+            owner,
+          },
+          sourceVersionId
+        ),
       ])
     })
 
     const sourceObj = await this.db
       .asSuperUser()
-      .findObject(this.bucketId, sourceObjectName, 'id, version,user_metadata')
+      .findObject(
+        this.bucketId,
+        sourceObjectName,
+        'id, version,user_metadata',
+        undefined,
+        sourceVersionId
+      )
 
     if (s3SourceKey === s3DestinationKey) {
       return {
@@ -543,17 +555,23 @@ export class ObjectStorage {
           {
             forUpdate: true,
             dontErrorOnEmpty: false,
-          }
+          },
+          sourceVersionId
         )
 
-        await db.updateObject(this.bucketId, sourceObjectName, {
-          name: destinationObjectName,
-          bucket_id: destinationBucket,
-          version: newVersion,
-          owner,
-          metadata,
-          user_metadata: sourceObj.user_metadata,
-        })
+        await db.updateObject(
+          this.bucketId,
+          sourceObjectName,
+          {
+            name: destinationObjectName,
+            bucket_id: destinationBucket,
+            version: newVersion,
+            owner,
+            metadata,
+            user_metadata: sourceObj.user_metadata,
+          },
+          sourceVersionId
+        )
 
         await ObjectAdminDelete.send({
           name: sourceObjectName,

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -516,21 +516,19 @@ export class ObjectStorage {
       objectName: destinationObjectName,
     })
 
-    await this.db.testPermission((db) => {
-      return Promise.all([
-        db.findObject(this.bucketId, sourceObjectName, 'id', undefined, sourceVersionId),
-        db.updateObject(
-          this.bucketId,
-          sourceObjectName,
-          {
-            name: destinationObjectName,
-            version: newVersion,
-            bucket_id: destinationBucket,
-            owner,
-          },
-          sourceVersionId
-        ),
-      ])
+    await this.db.testPermission(async (db) => {
+      await db.findObject(this.bucketId, sourceObjectName, 'id', undefined, sourceVersionId)
+      return db.updateObject(
+        this.bucketId,
+        sourceObjectName,
+        {
+          name: destinationObjectName,
+          version: newVersion,
+          bucket_id: destinationBucket,
+          owner,
+        },
+        sourceVersionId
+      )
     })
 
     const sourceObj = await this.db

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -137,15 +137,19 @@ export class ObjectStorage {
    * and the database
    * @param objectName
    */
-  async deleteObject(objectName: string) {
+  async deleteObject(objectName: string, versionId?: string) {
     const obj = await this.db.withTransaction(async (db) => {
-      const obj = await db
-        .asSuperUser()
-        .findObject(this.bucketId, objectName, 'id,version,metadata', {
+      const obj = await db.asSuperUser().findObject(
+        this.bucketId,
+        objectName,
+        'id,version,metadata',
+        {
           forUpdate: true,
-        })
+        },
+        versionId
+      )
 
-      const deleted = await db.deleteObject(this.bucketId, objectName)
+      const deleted = await db.deleteObject(this.bucketId, objectName, versionId)
 
       if (!deleted) {
         throw ERRORS.AccessDenied('Access denied')
@@ -766,9 +770,7 @@ export class ObjectStorage {
     const { urlSigningKey } = await getJwtSecret(this.db.tenantId)
     // `url`, `scope`, and `versionId` are spread last so attacker-controlled
     // metadata can never override the intended object path, token scope, or
-    // pinned version (token-forgery defense) - versionId itself is safe to
-    // include here regardless since it was already validated against a real
-    // version above, not taken from caller-controlled metadata.
+    // pinned version (token-forgery defense)
     const token = await signJWT(
       {
         ...metadata,

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -54,6 +54,8 @@ interface CopyObjectParams {
     ifUnmodifiedSince?: Date
   }
 }
+export type DeleteObjectEntry = string | { path: string; versionId: string }
+
 export interface ListObjectsV2Result {
   folders: Obj[]
   objects: Obj[]
@@ -182,17 +184,36 @@ export class ObjectStorage {
 
   /**
    * Deletes multiple objects from the remote storage
-   * and the database
-   * @param prefixes
+   * and the database. Each entry is either a bare path (delete whichever
+   * row is currently at that path) or a {path, versionId} pair (delete that
+   * exact version only).
+   * @param entries
    */
-  async deleteObjects(prefixes: string[]) {
+  async deleteObjects(entries: DeleteObjectEntry[]) {
     const results: { name: string }[] = []
 
-    for (let i = 0; i < prefixes.length; i += MAX_OBJECTS_PER_DELETE_BATCH) {
-      const prefixesSubset = prefixes.slice(i, i + MAX_OBJECTS_PER_DELETE_BATCH)
+    for (let i = 0; i < entries.length; i += MAX_OBJECTS_PER_DELETE_BATCH) {
+      const entriesSubset = entries.slice(i, i + MAX_OBJECTS_PER_DELETE_BATCH)
+
+      const plainNames: string[] = []
+      const versionedEntries: { name: string; version: string }[] = []
+      for (const entry of entriesSubset) {
+        if (typeof entry === 'string') {
+          plainNames.push(entry)
+        } else {
+          versionedEntries.push({ name: entry.path, version: entry.versionId })
+        }
+      }
 
       await this.db.withTransaction(async (db) => {
-        const data = await db.deleteObjects(this.bucketId, prefixesSubset, 'name')
+        const data = [
+          ...(plainNames.length > 0
+            ? await db.deleteObjects(this.bucketId, plainNames, 'name')
+            : []),
+          ...(versionedEntries.length > 0
+            ? await db.deleteObjectVersions(this.bucketId, versionedEntries)
+            : []),
+        ]
 
         if (data.length > 0) {
           results.push(...data)

--- a/src/storage/renderer/info.ts
+++ b/src/storage/renderer/info.ts
@@ -29,6 +29,9 @@ export class InfoRenderer extends HeadRenderer {
         metadata: obj.user_metadata,
         last_modified: obj.updated_at,
         created_at: obj.created_at,
+        archived_at: obj.archived_at,
+        is_delete_marker: obj.is_delete_marker,
+        is_versioned: obj.is_versioned,
       },
     }
   }

--- a/src/storage/schemas/object.ts
+++ b/src/storage/schemas/object.ts
@@ -20,6 +20,9 @@ export const objectSchema = {
     user_metadata: {
       anyOf: [{ type: 'object', additionalProperties: true }, { type: 'null' }],
     },
+    archived_at: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+    is_delete_marker: { type: 'boolean' },
+    is_versioned: { type: 'boolean' },
     buckets: bucketSchema,
   },
   required: ['name'],

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -2429,6 +2429,85 @@ describe('testing deleting multiple objects', () => {
     expect(results).toHaveLength(1)
     expect(results[0].name).toBe('authenticated/delete-multiple7.png')
   })
+
+  test('bulk delete with a mix of plain paths and {path, versionId} entries', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const plainObjectName = `authenticated/bulk-delete-mixed-plain-${runId}.png`
+    const versionedObjectName = `authenticated/bulk-delete-mixed-versioned-${runId}.png`
+    const wrongVersionObjectName = `authenticated/bulk-delete-mixed-wrong-version-${runId}.png`
+    const allNames = [plainObjectName, versionedObjectName, wrongVersionObjectName]
+
+    const versionedObjectVersion = `current-${randomUUID()}`
+    const wrongVersionObjectVersion = `current-${randomUUID()}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      {
+        bucket_id: bucketName,
+        name: plainObjectName,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: `plain-${randomUUID()}`,
+        metadata: { size: 1234 },
+      },
+      {
+        bucket_id: bucketName,
+        name: versionedObjectName,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: versionedObjectVersion,
+        metadata: { size: 1234 },
+      },
+      {
+        bucket_id: bucketName,
+        name: wrongVersionObjectName,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: wrongVersionObjectVersion,
+        metadata: { size: 1234 },
+      },
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'DELETE',
+        url: `/object/${bucketName}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+        payload: {
+          prefixes: [
+            plainObjectName,
+            { path: versionedObjectName, versionId: versionedObjectVersion },
+            { path: wrongVersionObjectName, versionId: randomUUID() },
+          ],
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.deleteObjects).toHaveBeenCalled()
+
+      const results = JSON.parse(response.body)
+      expect(results).toHaveLength(2)
+      expect(results.map((row: { name: string }) => row.name)).toEqual(
+        expect.arrayContaining([plainObjectName, versionedObjectName])
+      )
+
+      const verifyTx = await getSuperuserPostgrestClient()
+      const remaining = await findObject(verifyTx, bucketName, wrongVersionObjectName)
+      expect(remaining).toBeDefined()
+      expect(remaining?.version).toBe(wrongVersionObjectVersion)
+      await verifyTx.commit()
+      tnx = undefined
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, bucketName, allNames)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
 })
 
 /**

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -17,6 +17,7 @@ import {
   getServiceKeyUser,
 } from '@internal/database'
 import { ErrorCode, StorageBackendError } from '@internal/errors'
+import { StoragePgDB } from '@storage/database'
 import { MAX_OBJECTS_PER_REQUEST } from '@storage/limits'
 import { randomUUID } from 'crypto'
 import { FastifyInstance } from 'fastify'
@@ -4334,6 +4335,112 @@ describe('testing list objects', () => {
       const cleanupTx = await getSuperuserPostgrestClient()
       await withDeleteEnabled(cleanupTx, async (db) => {
         await deleteObjectsByName(db, bucketName, objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+})
+
+describe('testing GET object info response fields gated on migration', () => {
+  const BEFORE_MIGRATION = 'mark-filename-immutable'
+
+  test('info response includes archived_at/is_delete_marker/is_versioned for a fully migrated tenant', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/info-fields-${runId}.png`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `info-fields-${runId}`,
+      metadata: { mimetype: 'image/png', size: 1234 },
+      archived_at: null,
+      is_delete_marker: false,
+      is_versioned: true,
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/object/info/authenticated/bucket2/${objectName}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.archived_at).toBeNull()
+      expect(body.is_delete_marker).toBe(false)
+      expect(body.is_versioned).toBe(true)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('info column selection omits archived_at/is_delete_marker/is_versioned for a tenant pinned before object-versioning-core', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/info-fields-gate-${runId}.png`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `info-fields-gate-${runId}`,
+      metadata: { mimetype: 'image/png', size: 1234 },
+      archived_at: null,
+      is_delete_marker: false,
+      is_versioned: true,
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    const adminUser = await getServiceKeyUser(tenantId)
+    const connection = await getPostgresConnection({
+      tenantId,
+      user: adminUser,
+      superUser: adminUser,
+      host: 'localhost',
+    })
+
+    try {
+      const pinnedDb = new StoragePgDB(connection, {
+        host: 'localhost',
+        tenantId,
+        latestMigration: BEFORE_MIGRATION,
+      })
+      expect(await pinnedDb.hasMigration('object-versioning-core')).toBe(false)
+
+      const preMigrationColumns =
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at'
+      const obj = await pinnedDb.findObject('bucket2', objectName, preMigrationColumns)
+      expect(obj).not.toHaveProperty('archived_at')
+      expect(obj).not.toHaveProperty('is_delete_marker')
+      expect(obj).not.toHaveProperty('is_versioned')
+
+      const currentDb = new StoragePgDB(connection, { host: 'localhost', tenantId })
+      expect(await currentDb.hasMigration('object-versioning-core')).toBe(true)
+
+      const postMigrationColumns =
+        'id,name,version,bucket_id,metadata,user_metadata,updated_at,created_at,archived_at,is_delete_marker,is_versioned'
+      const migratedObj = await currentDb.findObject('bucket2', objectName, postMigrationColumns)
+      expect(migratedObj).toHaveProperty('archived_at', null)
+      expect(migratedObj).toHaveProperty('is_delete_marker', false)
+      expect(migratedObj).toHaveProperty('is_versioned', true)
+    } finally {
+      connection.dispose()
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
       })
       await cleanupTx.commit()
       tnx = undefined

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -270,6 +270,165 @@ describe('testing GET object', () => {
     expect(S3Backend.prototype.headObject).not.toHaveBeenCalled()
   })
 
+  test('can get an object by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/get-by-version-${runId}.png`
+    const version = `get-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/object/authenticated/bucket2/${objectName}?versionId=${version}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.getObject).toHaveBeenCalled()
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when getting an object by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/object/authenticated/bucket2/authenticated/casestudy.png?versionId=does-not-exist',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
+
+  test('can get object info by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/get-info-by-version-${runId}.png`
+    const version = `get-info-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/object/info/authenticated/bucket2/${objectName}?versionId=${version}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when getting object info by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/object/info/authenticated/bucket2/authenticated/casestudy.png?versionId=does-not-exist',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
+
+  test('can get a public object by an existing version id', async () => {
+    const runId = randomUUID()
+    const bucketId = `public-get-by-version-${runId}`
+    const objectName = 'get-by-version.png'
+    const version = `public-get-by-version-${runId}`
+
+    const superUser = await getServiceKeyUser(tenantId)
+    const db = await getPostgresConnection({
+      superUser,
+      user: superUser,
+      tenantId,
+      host: 'localhost',
+    })
+    const setupTx = await db.transaction()
+    await insertBucket(setupTx, {
+      id: bucketId,
+      name: bucketId,
+      public: true,
+      file_size_limit: null,
+      allowed_mime_types: null,
+      type: 'STANDARD',
+    })
+    await insertObjects(setupTx, {
+      bucket_id: bucketId,
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await setupTx.commit()
+    db.dispose()
+
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/public/${bucketId}/${objectName}?versionId=${version}`,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.getObject).toHaveBeenCalled()
+  })
+
+  test('returns NoSuchKey when getting a public object by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/object/public/public-bucket-2/favicon.ico?versionId=does-not-exist',
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
+
   test('cannot get authenticated object info without the /authenticated prefix if no jwt is provided', async () => {
     const response = await appInstance.inject({
       method: 'HEAD',
@@ -1939,6 +2098,74 @@ describe('testing copy object', () => {
     expect(response.statusCode).toBe(400)
     expect(S3Backend.prototype.copyObject).not.toHaveBeenCalled()
   })
+
+  test('can copy an object by an existing source version id', async () => {
+    const runId = randomUUID()
+    const sourceKey = `authenticated/copy-by-version-source-${runId}.png`
+    const destinationKey = `authenticated/copy-by-version-destination-${runId}.png`
+    const version = `copy-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: sourceKey,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/copy',
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+        payload: {
+          bucketId: 'bucket2',
+          sourceKey,
+          sourceVersionId: version,
+          destinationKey,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.copyObject).toHaveBeenCalled()
+      const jsonResponse = response.json()
+      expect(jsonResponse.Key).toBe(`bucket2/${destinationKey}`)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [sourceKey, destinationKey])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when copying by a source version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/copy',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        bucketId: 'bucket2',
+        sourceKey: 'authenticated/casestudy.png',
+        sourceVersionId: 'does-not-exist',
+        destinationKey: 'authenticated/copy-by-version-missing.png',
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
 })
 
 /**
@@ -2000,6 +2227,62 @@ describe('testing delete object', () => {
     })
     expect(response.statusCode).toBe(400)
     expect(S3Backend.prototype.deleteObject).not.toHaveBeenCalled()
+  })
+
+  test('can delete an object by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/delete-by-version-${runId}.png`
+    const version = `delete-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'DELETE',
+        url: `/object/bucket2/${objectName}?versionId=${version}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(S3Backend.prototype.deleteObject).toHaveBeenCalled()
+      expect(response.json()).toMatchObject({
+        message: 'Successfully deleted',
+      })
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when deleting an object by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'DELETE',
+      url: '/object/bucket2/authenticated/casestudy.png?versionId=does-not-exist',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
   })
 })
 
@@ -2284,6 +2567,72 @@ describe('testing generating signed URL', () => {
 
     expect(response.statusCode).toBe(400)
     expect(JSON.parse(response.body).message).toContain('expiresIn')
+  })
+
+  test('can sign a URL by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/sign-by-version-${runId}.png`
+    const version = `sign-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/object/sign/bucket2/${objectName}`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+        payload: {
+          expiresIn: 1000,
+          versionId: version,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const result = JSON.parse(response.body)
+      expect(result.signedURL).toBeTruthy()
+
+      const token = result.signedURL.split('?token=').pop()
+      const jwtData = (await verifyJWT(token, jwtSecret)) as SignedToken
+      expect(jwtData.versionId).toBe(version)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when signing a URL by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: '/object/sign/bucket2/authenticated/casestudy.png',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+        versionId: 'does-not-exist',
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
   })
 })
 
@@ -3023,6 +3372,56 @@ describe('testing retrieving signed URL', () => {
     })
     expect(response.statusCode).toBe(400)
   })
+
+  test('get object with a token pinned to an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/redeem-by-version-${runId}.png`
+    const version = `redeem-by-version-${runId}`
+    const urlToSign = `bucket2/${objectName}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const jwtToken = await signJWT({ url: urlToSign, versionId: version }, jwtSecret, 100)
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/object/sign/${urlToSign}?token=${jwtToken}`,
+      })
+      expect(response.statusCode).toBe(200)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey for a token pinned to a version id that does not exist', async () => {
+    const urlToSign = 'bucket2/authenticated/casestudy.png'
+    const jwtToken = await signJWT({ url: urlToSign, versionId: 'does-not-exist' }, jwtSecret, 100)
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/object/sign/${urlToSign}?token=${jwtToken}`,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
 })
 
 describe('testing move object', () => {
@@ -3215,6 +3614,83 @@ describe('testing move object', () => {
     expect(response.statusCode).toBe(400)
     expect(S3Backend.prototype.copyObject).not.toHaveBeenCalled()
     expect(S3Backend.prototype.deleteObject).not.toHaveBeenCalled()
+  })
+
+  test('can move an object by an existing source version id', async () => {
+    const objectAdminDeleteSendSpy = vi.spyOn(ObjectAdminDelete, 'send')
+    const runId = randomUUID()
+    const sourceKey = `authenticated/move-by-version-source-${runId}.png`
+    const destinationKey = `authenticated/move-by-version-destination-${runId}.png`
+    const version = `move-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: sourceKey,
+      owner: '317eadce-631a-4429-a0bb-f19a7a517b4a',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/object/move`,
+        payload: {
+          bucketId: 'bucket2',
+          sourceKey,
+          sourceVersionId: version,
+          destinationKey,
+        },
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchObject({ message: 'Successfully moved' })
+      expect(S3Backend.prototype.copyObject).toHaveBeenCalled()
+      expect(objectAdminDeleteSendSpy).toHaveBeenCalled()
+
+      const conn = await getSuperuserPostgrestClient()
+      const destinationObject = await findObject(conn, 'bucket2', destinationKey)
+      expect(destinationObject).not.toBeFalsy()
+      const sourceObject = await findObject(conn, 'bucket2', sourceKey)
+      expect(sourceObject).toBeFalsy()
+      await conn.commit()
+      tnx = undefined
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [sourceKey, destinationKey])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('returns NoSuchKey when moving by a source version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: `/object/move`,
+      payload: {
+        bucketId: 'bucket2',
+        sourceKey: 'authenticated/casestudy.png',
+        sourceVersionId: 'does-not-exist',
+        destinationKey: 'authenticated/move-by-version-missing.png',
+      },
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
   })
 })
 

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -7,6 +7,13 @@ import {
   signJWT,
   verifyJWT,
 } from '@internal/auth'
+import {
+  type DatabaseTransaction,
+  getPostgresConnection,
+  getServiceKeyUser,
+} from '@internal/database'
+import { ErrorCode } from '@internal/errors'
+import { randomUUID } from 'crypto'
 import dotenv from 'dotenv'
 import { FastifyInstance } from 'fastify'
 import fs from 'fs/promises'
@@ -17,10 +24,51 @@ import { getConfig, JwksConfig, mergeConfig } from '../config'
 import { S3Backend } from '../storage/backend'
 import { ImageRenderer } from '../storage/renderer'
 import { useMockObject } from './common'
+import { withDeleteEnabled } from './utils/storage'
 
 dotenv.config({ path: '.env.test' })
-const { jwtSecret } = getConfig()
+const { jwtSecret, tenantId } = getConfig()
 let appInstance: FastifyInstance
+
+let tnx: DatabaseTransaction | undefined
+async function getSuperuserPostgrestClient() {
+  const superUser = await getServiceKeyUser(tenantId)
+
+  const conn = await getPostgresConnection({
+    superUser,
+    user: superUser,
+    tenantId,
+    host: 'localhost',
+  })
+  tnx = await conn.transaction()
+
+  return tnx
+}
+
+async function insertObjects(
+  db: DatabaseTransaction,
+  object: { bucket_id: string; name: string; owner: string; version: string; metadata: unknown }
+) {
+  const entries = Object.entries(object)
+  await db.query({
+    text: `
+      INSERT INTO objects (${entries.map(([column]) => column).join(', ')})
+      VALUES (${entries.map((_, index) => `$${index + 1}`).join(', ')})
+    `,
+    values: entries.map(([, value]) => value),
+  })
+}
+
+async function deleteObjectsByName(db: DatabaseTransaction, bucketId: string, name: string) {
+  await db.query({
+    text: `
+      DELETE FROM objects
+      WHERE bucket_id = $1
+        AND name = $2
+    `,
+    values: [bucketId, name],
+  })
+}
 
 const projectRoot = path.join(__dirname, '..', '..')
 const renderedBodyText = 'mock-rendered-image-body'
@@ -109,6 +157,10 @@ describe('image rendering routes', () => {
   })
 
   afterEach(async () => {
+    if (tnx) {
+      await tnx.commit()
+      tnx = undefined
+    }
     await appInstance.close()
     vi.restoreAllMocks()
     vi.clearAllMocks()
@@ -137,6 +189,64 @@ describe('image rendering routes', () => {
     )
   })
 
+  it('will render an authenticated image by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/render-by-version-${runId}.png`
+    const version = `render-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const { client: testClient, get: getSpy } = createMockRendererClient()
+      vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
+
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/render/image/authenticated/bucket2/${objectName}?versionId=${version}&width=100&height=100`,
+        headers: {
+          authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(getSpy).toHaveBeenCalled()
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  it('returns NoSuchKey when rendering an authenticated image by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/render/image/authenticated/bucket2/authenticated/casestudy.png?versionId=does-not-exist&width=100&height=100',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
+
   it('will render a public image applying transformations using external image processing', async () => {
     const { client: testClient, get: getSpy } = createMockRendererClient()
     vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
@@ -160,6 +270,114 @@ describe('image rendering routes', () => {
         signal: expect.any(AbortSignal),
       })
     )
+  })
+
+  it('will render a public image by an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `render-by-version-${runId}.ico`
+    const version = `render-by-version-${runId}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'public-bucket-2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/x-icon', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const { client: testClient, get: getSpy } = createMockRendererClient()
+      vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
+
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/render/image/public/public-bucket-2/${objectName}?versionId=${version}&width=100&height=100`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(getSpy).toHaveBeenCalled()
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'public-bucket-2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  it('returns NoSuchKey when rendering a public image by a version id that does not exist', async () => {
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: '/render/image/public/public-bucket-2/favicon.ico?versionId=does-not-exist&width=100&height=100',
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
+  })
+
+  it('will render a signed image at a token pinned to an existing version id', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/render-sign-by-version-${runId}.png`
+    const version = `render-sign-by-version-${runId}`
+    const urlToSign = `bucket2/${objectName}`
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, {
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version,
+      metadata: { mimetype: 'image/png', size: 1234 },
+    })
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const { client: testClient, get: getSpy } = createMockRendererClient()
+      vi.spyOn(ImageRenderer.prototype, 'getClient').mockReturnValue(testClient)
+
+      const jwtToken = await signJWT({ url: urlToSign, versionId: version }, jwtSecret, 100)
+      const response = await appInstance.inject({
+        method: 'GET',
+        url: `/render/image/sign/${urlToSign}?token=${jwtToken}&width=100&height=100`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(getSpy).toHaveBeenCalled()
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  it('returns NoSuchKey for a signed image token pinned to a version id that does not exist', async () => {
+    const urlToSign = 'bucket2/authenticated/casestudy.png'
+    const jwtToken = await signJWT({ url: urlToSign, versionId: 'does-not-exist' }, jwtSecret, 100)
+    const response = await appInstance.inject({
+      method: 'GET',
+      url: `/render/image/sign/${urlToSign}?token=${jwtToken}&width=100&height=100`,
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'not_found',
+      message: 'Object not found',
+      code: ErrorCode.NoSuchKey,
+    })
   })
 
   describe('gravity query transformations', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently we don't allow users to specify version id

## What is the new behavior?

Can now pin get, head, info, sign, copy, move, delete, and deleteObjectets to a specific object version via versionId. Also added additional indexes.

## Additional context

Left out  S3 API changes for now as well. Will be done in a follow up PR.

Only one version can exist per object today, so `versionId` just reselects the same object you'd already get by default but this lays groundwork for real multi-version support later.
