### PR TITLE
fix(auth): return clear error on missing auth header and handle configurable tus sign path

### DIFF
--- a/src/http/plugins/jwt.ts
+++ b/src/http/plugins/jwt.ts
@@ -46,6 +46,12 @@ const jwtPlugin = fastifyPlugin<JWTPluginOptions>(
         return
       }
 
+      if (!request.jwt) {
+        request.jwtPayload = { role: 'anon' }
+        request.isAuthenticated = false
+        throw ERRORS.AccessDenied('Missing authorization header')
+      }
+
       const { secret, jwks } = await getJwtSecret(request.tenantId)
 
       try {

--- a/src/http/routes/tus/lifecycle.ts
+++ b/src/http/routes/tus/lifecycle.ts
@@ -82,7 +82,10 @@ export async function onIncomingRequest(rawReq: Request, id: string, datastore: 
   req.upload.resources = [`${uploadID.bucket}/${uploadID.objectName}`]
 
   // Handle signed url requests
-  if (req.url?.startsWith(`/upload/resumable/sign`)) {
+  if (
+    req.url?.startsWith(`${tusPath}${SIGNED_URL_SUFFIX}`) ||
+    req.url?.startsWith(`/upload/resumable${SIGNED_URL_SUFFIX}`)
+  ) {
     const signature = req.headers['x-signature']
     if (!signature || (signature && typeof signature !== 'string')) {
       throw ERRORS.InvalidSignature('Missing x-signature header')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Developer Experience improvement

## What is the current behavior?

Related to #1268

1. When a client sends a request to an authenticated endpoint without an `Authorization` header, the JWT authentication plugin (`src/http/plugins/jwt.ts`) extracted an empty string `""` and attempted to verify it with `jose.jwtVerify`. This caused `jose` to throw an internal `JWSInvalid: Invalid Compact JWS` parsing error instead of an explicit error indicating that the authorization header is missing.
2. In `src/http/routes/tus/lifecycle.ts`, the signed URL check was hardcoded to `/upload/resumable/sign` rather than using the configured `tusPath` and `SIGNED_URL_SUFFIX` constants.

## What is the new behavior?

1. `jwtPlugin` now checks for missing `jwt` and returns `ERRORS.AccessDenied('Missing authorization header')` instead of querying the database for JWT secrets and invoking `verifyJWT` with an empty string.
2. `lifecycle.ts` uses `tusPath` and `SIGNED_URL_SUFFIX` constants to support configured TUS URL paths in addition to the default `/upload/resumable/sign`.
