### PR TITLE
fix: settle contended TUS lock waits on abort

### DIFF
--- a/src/storage/protocols/tus/postgres-locker.test.ts
+++ b/src/storage/protocols/tus/postgres-locker.test.ts
@@ -1,5 +1,13 @@
+import { ERRORS } from '@internal/errors'
 import { PubSubAdapter } from '@internal/pubsub'
-import { LockNotifier } from './postgres-locker'
+import { Database } from '../../database'
+import { LockNotifier, PgLock } from './postgres-locker'
+
+class TestPgLock extends PgLock {
+  acquire(db: Database, id: string, signal: AbortSignal) {
+    return this.acquireLock(db, id, signal)
+  }
+}
 
 class FakePubSub implements PubSubAdapter {
   readonly startSpy = vi.fn(async () => undefined)
@@ -70,5 +78,30 @@ describe('LockNotifier', () => {
 
     expect(pubSub.subscribeSpy).toHaveBeenCalledWith('REQUEST_LOCK_RELEASE', notifier.handler)
     expect(pubSub.unsubscribeSpy).toHaveBeenCalledWith('REQUEST_LOCK_RELEASE', notifier.handler)
+  })
+})
+
+describe('PgLock', () => {
+  it('stops waiting for a contended lock when acquisition is aborted', async () => {
+    const pubSub = new FakePubSub()
+    const notifier = new LockNotifier(pubSub)
+    const mustLockObject = vi.fn(async () => {
+      throw ERRORS.ResourceLocked()
+    })
+    const db = { mustLockObject } as unknown as Database
+    const lock = new TestPgLock('tenant/bucket/object/version', db, notifier)
+    const controller = new AbortController()
+
+    const acquisition = lock.acquire(db, 'tenant/bucket/object/version', controller.signal)
+
+    await vi.waitFor(() => expect(pubSub.publishSpy).toHaveBeenCalledOnce())
+    controller.abort()
+
+    const outcome = await Promise.race([
+      acquisition.then(() => 'settled'),
+      new Promise((resolve) => setImmediate(() => resolve('pending'))),
+    ])
+
+    expect(outcome).toBe('settled')
   })
 })

--- a/src/storage/protocols/tus/postgres-locker.ts
+++ b/src/storage/protocols/tus/postgres-locker.ts
@@ -83,7 +83,11 @@ export class PgLock implements Lock {
               onAbort = () => {
                 abortController.abort()
               }
-              stopSignal.addEventListener('abort', onAbort)
+              if (stopSignal.aborted) {
+                abortController.abort()
+              } else {
+                stopSignal.addEventListener('abort', onAbort, { once: true })
+              }
 
               const acquired = await Promise.race([
                 this.waitTimeout(5000, abortController.signal),
@@ -102,6 +106,9 @@ export class PgLock implements Lock {
               })
             } finally {
               abortController.abort()
+              if (onAbort) {
+                stopSignal.removeEventListener('abort', onAbort)
+              }
             }
           },
           {
@@ -139,14 +146,7 @@ export class PgLock implements Lock {
       } catch (e) {
         if (e instanceof StorageBackendError && e.code === ErrorCode.ResourceLocked) {
           await this.notifier.release(id)
-          await new Promise((resolve) => {
-            const timeoutId = setTimeout(resolve, 500)
-            const cleanup = () => {
-              clearTimeout(timeoutId)
-              signal.removeEventListener('abort', cleanup)
-            }
-            signal.addEventListener('abort', cleanup, { once: true })
-          })
+          await this.waitTimeout(500, signal)
           continue
         }
         throw e
@@ -157,15 +157,19 @@ export class PgLock implements Lock {
   }
 
   protected waitTimeout(timeout: number, signal: AbortSignal) {
-    return new Promise((resolve) => {
-      const timeoutId = setTimeout(() => {
+    return new Promise<boolean>((resolve) => {
+      if (signal.aborted) {
         resolve(false)
-      }, timeout)
-      const onAbort = () => {
-        clearTimeout(timeoutId)
-        signal.removeEventListener('abort', onAbort)
+        return
       }
-      signal.addEventListener('abort', onAbort, { once: true })
+
+      const finish = () => {
+        clearTimeout(timeoutId)
+        signal.removeEventListener('abort', finish)
+        resolve(false)
+      }
+      const timeoutId = setTimeout(finish, timeout)
+      signal.addEventListener('abort', finish, { once: true })
     })
   }
 }


### PR DESCRIPTION
Fixes #1344

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When PostgreSQL-backed TUS lock acquisition is waiting on a contended resource, aborting the acquisition clears both retry timers without resolving either promise. Both branches of the acquisition race can remain pending until the surrounding transaction timeout.

## What is the new behavior?

Abort-aware lock waits now settle and remove their listeners on both timeout and abort. The contention backoff reuses that behavior, already-aborted signals are honored, and the outer stop-signal listener is removed when acquisition finishes.

## Tests

Added a deterministic regression test that enters the ResourceLocked retry path, aborts after the release request is published, and verifies acquisition settles on the next event-loop turn.

Validated with:

- Focused PostgreSQL TUS locker tests: 4 passed
- Full unit suite: 137 files, 1,740 tests passed
- npm run lint
- npm run build
- git diff --check

## Additional context

#1115 also touches this file as part of a broader database transaction refactor, but its contended retry wait retains the same abort-time pending-promise behavior.