### PR TITLE
fix: add subscription_tier to tenant admin endpoints and database

### DIFF
--- a/migrations/multitenant/0029-subscription-tier-column.sql
+++ b/migrations/multitenant/0029-subscription-tier-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS subscription_tier text NULL;

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -45,6 +45,7 @@ const patchSchema = {
       serviceKey: { type: 'string' },
       tracingMode: { type: 'string' },
       disableEvents: { type: 'array', items: { type: 'string' }, nullable: true },
+      subscriptionTier: { type: 'string' },
       features: {
         type: 'object',
         properties: {
@@ -135,6 +136,7 @@ interface tenantDBInterface {
   feature_vector_buckets_max_buckets?: number
   feature_vector_buckets_max_indexes?: number
   disable_events?: string[] | null
+  subscription_tier?: string | null
 }
 
 const { dbMigrationFreezeAt, adminReturnTenantSensitiveData, urlSigningJwkType } = getConfig()
@@ -292,6 +294,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrations_status,
         tracing_mode,
         disable_events,
+        subscription_tier,
       }) => ({
         id,
         ...(adminReturnTenantSensitiveData
@@ -339,6 +342,7 @@ export default async function routes(fastify: FastifyInstance) {
           },
         },
         disableEvents: disable_events,
+        subscriptionTier: subscription_tier ?? undefined,
       })
     )
   })
@@ -376,6 +380,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrations_status,
         tracing_mode,
         disable_events,
+        subscription_tier,
       } = tenant
 
       const capabilities = await getTenantCapabilities(request.params.tenantId)
@@ -432,6 +437,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrationStatus: migrations_status,
         tracingMode: tracing_mode,
         disableEvents: disable_events,
+        subscriptionTier: subscription_tier ?? undefined,
       }
     }
   )
@@ -454,6 +460,7 @@ export default async function routes(fastify: FastifyInstance) {
         maxConnections,
         tracingMode,
         disableEvents,
+        subscriptionTier,
       } = request.body
 
       await insertTenantAndGenerateJwk(tenantId, {
@@ -485,6 +492,7 @@ export default async function routes(fastify: FastifyInstance) {
         migrations_status: null,
         tracing_mode: tracingMode,
         disable_events: disableEvents,
+        subscription_tier: subscriptionTier,
       })
 
       try {
@@ -520,6 +528,7 @@ export default async function routes(fastify: FastifyInstance) {
         maxConnections,
         tracingMode,
         disableEvents,
+        subscriptionTier,
       } = request.body
       const { tenantId } = request.params
 
@@ -553,6 +562,7 @@ export default async function routes(fastify: FastifyInstance) {
             : features?.imageTransformation?.maxResolution,
         tracing_mode: tracingMode,
         disable_events: disableEvents,
+        subscription_tier: subscriptionTier,
       })
 
       if (databaseUrl) {
@@ -593,6 +603,7 @@ export default async function routes(fastify: FastifyInstance) {
         maxConnections,
         tracingMode,
         disableEvents,
+        subscriptionTier,
       } = request.body
       const { tenantId } = request.params
 
@@ -642,6 +653,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       if (tracingMode) {
         tenantInfo.tracing_mode = tracingMode
+      }
+
+      if (subscriptionTier) {
+        tenantInfo.subscription_tier = subscriptionTier
       }
 
       tenantInfo.feature_iceberg_catalog = features?.icebergCatalog?.enabled

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -37,6 +37,7 @@ export interface TenantConfigRow {
   migrations_version?: string | null
   tracing_mode?: string | null
   disable_events?: string[] | null
+  subscription_tier?: string | null
   cursor_id?: number
   created_at?: Date
 }
@@ -68,6 +69,7 @@ const tenantWritableColumns = [
   'migrations_version',
   'tracing_mode',
   'disable_events',
+  'subscription_tier',
 ] as const satisfies readonly (keyof TenantConfigRow)[]
 
 type TenantWritableColumn = (typeof tenantWritableColumns)[number]

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -46,6 +46,7 @@ interface TenantConfig {
   syncMigrationsDone?: boolean
   tracingMode?: string
   disableEvents?: string[]
+  subscriptionTier?: string
 }
 
 type GetTenantConfigOptions = {
@@ -225,6 +226,7 @@ export async function getTenantConfig(
         migrations_status,
         tracing_mode,
         disable_events,
+        subscription_tier,
       } = tenant
 
       const serviceKey = decrypt(service_key)
@@ -274,6 +276,7 @@ export async function getTenantConfig(
         migrationsRun: false,
         tracingMode: tracing_mode ?? undefined,
         disableEvents: disable_events ?? undefined,
+        subscriptionTier: subscription_tier ?? undefined,
       }
       return config
     },

--- a/src/test/tenant-pg-store-runtime.test.ts
+++ b/src/test/tenant-pg-store-runtime.test.ts
@@ -185,6 +185,7 @@ describe('pg store runtime selection', () => {
           },
         },
         disableEvents: ['ObjectCreated:*'],
+        subscriptionTier: 'tier_pro',
       },
       headers: {
         apikey: process.env.ADMIN_API_KEYS,
@@ -203,6 +204,7 @@ describe('pg store runtime selection', () => {
           enabled: true,
         },
       },
+      subscriptionTier: 'tier_pro',
     })
 
     const jwksConfig = await jwksManager.getJwksTenantConfig(tenantId)

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -46,6 +46,7 @@ const payload = {
   migrationStatus: 'COMPLETED',
   migrationVersion,
   tracingMode: 'basic',
+  subscriptionTier: 'tier_pro',
   capabilities: {
     list_V2: true,
     iceberg_catalog: true,
@@ -89,6 +90,7 @@ const payload2 = {
   migrationStatus: 'COMPLETED',
   migrationVersion,
   tracingMode: 'basic',
+  subscriptionTier: 'tier_free',
   capabilities: {
     list_V2: true,
     iceberg_catalog: true,
@@ -151,6 +153,7 @@ function createEncryptedTenantRow(
     migrations_status: tenantPayload.migrationStatus,
     tracing_mode: tenantPayload.tracingMode,
     disable_events: tenantPayload.disableEvents,
+    subscription_tier: tenantPayload.subscriptionTier,
   }
 }
 
@@ -372,6 +375,7 @@ describe('Tenant configs', () => {
       expect(singleJSON.maxConnections).toBe(payload.maxConnections)
       expect(singleJSON.features).toEqual(payload.features)
       expect(singleJSON.tracingMode).toBe(payload.tracingMode)
+      expect(singleJSON.subscriptionTier).toBe(payload.subscriptionTier)
 
       const listResponse = await isolatedApp!.inject({
         method: 'GET',


### PR DESCRIPTION
## What is the current behavior?

The tenant config admin api ignores the `subscription_tier` value if present

## What is the new behavior?

Accept `subscription_tier` in tenant body and persist along with other tenant config