### PR TITLE
fix: openapi docs for get object

### DIFF
--- a/src/http/routes/object/getObject.ts
+++ b/src/http/routes/object/getObject.ts
@@ -117,7 +117,8 @@ export default async function routes(fastify: FastifyInstance) {
       // @todo add success response schema here
       schema: {
         params: getObjectParamsSchema,
-        summary: 'Get object',
+        querystring: getObjectQuerySchema,
+        summary,
         description: 'Serve objects',
         tags: ['object'],
         response: sharedErrorResponseSchemas,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Query params are read and handled but not exposed in openapi.

## What is the new behavior?

Add query params schema and align its summaary.

## Additional context

Related to #1341
