### PR TITLE
fix: add COLLATE "C" to name in versioned-object indexes

### DIFF
--- a/migrations/tenant/0065-objects-key-version-index.sql
+++ b/migrations/tenant/0065-objects-key-version-index.sql
@@ -1,4 +1,4 @@
 -- postgres-migrations disable-transaction
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS objects_bucket_id_name_version_key
-    ON storage.objects (bucket_id, name, version) NULLS NOT DISTINCT;
+    ON storage.objects (bucket_id, name COLLATE "C", version) NULLS NOT DISTINCT;

--- a/migrations/tenant/0066-objects-current-version-index.sql
+++ b/migrations/tenant/0066-objects-current-version-index.sql
@@ -1,4 +1,4 @@
 -- postgres-migrations disable-transaction
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_current_version
-    ON storage.objects (bucket_id, name) WHERE archived_at IS NULL;
+    ON storage.objects (bucket_id, name COLLATE "C") WHERE archived_at IS NULL;

--- a/migrations/tenant/0067-objects-null-version-index.sql
+++ b/migrations/tenant/0067-objects-null-version-index.sql
@@ -1,4 +1,4 @@
 -- postgres-migrations disable-transaction
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_null_version
-    ON storage.objects (bucket_id, name) WHERE NOT is_versioned;
+    ON storage.objects (bucket_id, name COLLATE "C") WHERE NOT is_versioned;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix to add `COLLATE "C"` to the new version indexes that were added in #1341