### PR TITLE
feat: drop bucketid_objname and add version list test coverage

### DIFF
--- a/migrations/tenant/0072-drop-bucketid-objname-index.sql
+++ b/migrations/tenant/0072-drop-bucketid-objname-index.sql
@@ -1,0 +1,3 @@
+-- postgres-migrations disable-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS storage.bucketid_objname;

--- a/src/internal/database/migrations/migrate.test.ts
+++ b/src/internal/database/migrations/migrate.test.ts
@@ -667,6 +667,79 @@ describe('resetMigration', () => {
     expect(client.end).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects resets that would replay storage-schema after object name uniqueness is removed', async () => {
+    const client = createMigrationClient([
+      { id: 0, name: 'create-migrations-table' },
+      { id: 70, name: 'drop-bucketid-objname-index' },
+    ])
+
+    await expect(
+      resetMigration({
+        tenantId: 'tenant-reset',
+        untilMigration: 'initialmigration',
+        databaseUrl: 'postgres://tenant',
+      })
+    ).rejects.toThrow('Cannot replay storage-schema after drop-bucketid-objname-index')
+
+    const queryTexts = client.query.mock.calls.map(([statement]) =>
+      normalizeSql(getQueryText(statement))
+    )
+
+    expect(queryTexts).not.toContain('BEGIN')
+    expect(queryTexts).not.toContain('DELETE FROM migrations WHERE id > $1')
+    expect(client.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows resets after storage-schema once object name uniqueness is removed', async () => {
+    const client = createMigrationClient([
+      { id: 0, name: 'create-migrations-table' },
+      { id: 70, name: 'drop-bucketid-objname-index' },
+    ])
+
+    await expect(
+      resetMigration({
+        tenantId: 'tenant-reset',
+        untilMigration: 'objects-delete-marker-index',
+        databaseUrl: 'postgres://tenant',
+      })
+    ).resolves.toBe(true)
+
+    const deleteCall = getMigrationQueryCall(client, 'DELETE FROM migrations WHERE id >')
+    expect(deleteCall?.[0]).toMatchObject({
+      values: [69],
+    })
+  })
+
+  it('allows resets below storage-schema when it is marked completed', async () => {
+    const client = createMigrationClient([
+      { id: 0, name: 'create-migrations-table' },
+      { id: 70, name: 'drop-bucketid-objname-index' },
+    ])
+    mockLocalMigrationFiles.mockResolvedValue([
+      { id: 1, name: 'initialmigration', hash: 'hash-1' },
+      { id: 2, name: 'storage-schema', hash: 'hash-2' },
+    ])
+
+    await expect(
+      resetMigration({
+        tenantId: 'tenant-reset',
+        untilMigration: 'create-migrations-table',
+        markCompletedTillMigration: 'storage-schema',
+        databaseUrl: 'postgres://tenant',
+      })
+    ).resolves.toBe(true)
+
+    const deleteCall = getMigrationQueryCall(client, 'DELETE FROM migrations WHERE id >')
+    expect(deleteCall?.[0]).toMatchObject({
+      values: [0],
+    })
+
+    const insertCall = getMigrationQueryCall(client, 'INSERT INTO migrations')
+    expect(insertCall?.[0]).toMatchObject({
+      values: [1, 'initialmigration', 'hash-1', 2, 'storage-schema', 'hash-2'],
+    })
+  })
+
   it('rolls back, unlocks, and closes the client when mark-completed migration files are missing', async () => {
     const client = createMigrationClient([
       { id: 0, name: 'create-migrations-table' },

--- a/src/internal/database/migrations/migrate.test.ts
+++ b/src/internal/database/migrations/migrate.test.ts
@@ -168,7 +168,10 @@ function normalizeSql(sql: string): string {
   return sql.replace(/\s+/g, ' ').trim()
 }
 
-function createMigrationClient(migrations: Array<{ id: number; name: string }>): MockPgClient {
+function createMigrationClient(
+  migrations: Array<{ id: number; name: string }>,
+  resetFloorActive = false
+): MockPgClient {
   const client: MockPgClient = {
     connect: vi.fn().mockResolvedValue(undefined),
     end: vi.fn().mockResolvedValue(undefined),
@@ -182,6 +185,10 @@ function createMigrationClient(migrations: Array<{ id: number; name: string }>):
 
       if (text === 'SELECT * from migrations') {
         return { rows: migrations }
+      }
+
+      if (text.includes('AS reset_floor_active')) {
+        return { rows: [{ reset_floor_active: resetFloorActive }] }
       }
 
       return { rows: [], rowCount: 0 }
@@ -679,7 +686,9 @@ describe('resetMigration', () => {
         untilMigration: 'initialmigration',
         databaseUrl: 'postgres://tenant',
       })
-    ).rejects.toThrow('Cannot replay storage-schema after drop-bucketid-objname-index')
+    ).rejects.toThrow(
+      'Cannot replay storage-schema: storage.objects exists without the legacy bucketid_objname index; use markCompletedTillMigration to skip it'
+    )
 
     const queryTexts = client.query.mock.calls.map(([statement]) =>
       normalizeSql(getQueryText(statement))
@@ -688,6 +697,34 @@ describe('resetMigration', () => {
     expect(queryTexts).not.toContain('BEGIN')
     expect(queryTexts).not.toContain('DELETE FROM migrations WHERE id > $1')
     expect(client.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a second unsafe reset after the activation migration row was removed', async () => {
+    const client = createMigrationClient(
+      [
+        { id: 0, name: 'create-migrations-table' },
+        { id: 71, name: 'objects-delete-marker-index' },
+      ],
+      true
+    )
+
+    await expect(
+      resetMigration({
+        tenantId: 'tenant-reset',
+        untilMigration: 'initialmigration',
+        databaseUrl: 'postgres://tenant',
+      })
+    ).rejects.toThrow(
+      'Cannot replay storage-schema: storage.objects exists without the legacy bucketid_objname index; use markCompletedTillMigration to skip it'
+    )
+
+    const queryTexts = client.query.mock.calls.map(([statement]) =>
+      normalizeSql(getQueryText(statement))
+    )
+
+    expect(queryTexts.some((query) => query.includes('AS reset_floor_active'))).toBe(true)
+    expect(queryTexts).not.toContain('BEGIN')
+    expect(queryTexts).not.toContain('DELETE FROM migrations WHERE id > $1')
   })
 
   it('allows resets after storage-schema once object name uniqueness is removed', async () => {

--- a/src/internal/database/migrations/migrate.test.ts
+++ b/src/internal/database/migrations/migrate.test.ts
@@ -670,7 +670,7 @@ describe('resetMigration', () => {
   it('rejects resets that would replay storage-schema after object name uniqueness is removed', async () => {
     const client = createMigrationClient([
       { id: 0, name: 'create-migrations-table' },
-      { id: 70, name: 'drop-bucketid-objname-index' },
+      { id: 72, name: 'drop-bucketid-objname-index' },
     ])
 
     await expect(
@@ -693,7 +693,7 @@ describe('resetMigration', () => {
   it('allows resets after storage-schema once object name uniqueness is removed', async () => {
     const client = createMigrationClient([
       { id: 0, name: 'create-migrations-table' },
-      { id: 70, name: 'drop-bucketid-objname-index' },
+      { id: 72, name: 'drop-bucketid-objname-index' },
     ])
 
     await expect(
@@ -706,14 +706,14 @@ describe('resetMigration', () => {
 
     const deleteCall = getMigrationQueryCall(client, 'DELETE FROM migrations WHERE id >')
     expect(deleteCall?.[0]).toMatchObject({
-      values: [69],
+      values: [71],
     })
   })
 
   it('allows resets below storage-schema when it is marked completed', async () => {
     const client = createMigrationClient([
       { id: 0, name: 'create-migrations-table' },
-      { id: 70, name: 'drop-bucketid-objname-index' },
+      { id: 72, name: 'drop-bucketid-objname-index' },
     ])
     mockLocalMigrationFiles.mockResolvedValue([
       { id: 1, name: 'initialmigration', hash: 'hash-1' },

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -18,6 +18,7 @@ import { deriveVectorDatabaseUrl, VECTOR_DATABASE_NAME } from '../vector-store-u
 import { repairInvalidConcurrentIndexes } from './concurrent-index-guard'
 import { lastLocalMigrationName, loadMigrationFilesCached, localMigrationFiles } from './files'
 import { ProgressiveMigrations } from './progressive'
+import { MIGRATION_RESET_FLOORS } from './reset-floor'
 import { DisableConcurrentIndexTransformer, MigrationTransformer } from './transformers'
 import { DBMigration } from './types'
 
@@ -540,6 +541,8 @@ export async function resetMigration(options: {
   tenantId?: string
   untilMigration: keyof typeof DBMigration
   markCompletedTillMigration?: keyof typeof DBMigration
+  // The idempotency runner manages non-replayable migrations itself.
+  skipResetFloorValidation?: boolean
   databaseUrl: string
 }): Promise<boolean> {
   const dbConfig: ClientConfig = {
@@ -565,9 +568,26 @@ export async function resetMigration(options: {
 
       const currentLastMigration = currentTenantMigrations[currentTenantMigrations.length - 1]
       const localMigration = DBMigration[options.untilMigration]
+      const markCompletedMigration = options.markCompletedTillMigration
+        ? DBMigration[options.markCompletedTillMigration]
+        : undefined
+      const completedThroughMigration = markCompletedMigration ?? localMigration
+      const unsafeReset = MIGRATION_RESET_FLOORS.find(
+        ({ migration, activatedBy }) =>
+          currentTenantMigrations.some(
+            (currentMigration) => currentMigration.id >= DBMigration[activatedBy]
+          ) && completedThroughMigration < DBMigration[migration]
+      )
+
+      if (unsafeReset && !options.skipResetFloorValidation) {
+        throw new Error(`Cannot replay ${unsafeReset.migration} after ${unsafeReset.activatedBy}`)
+      }
 
       // This tenant migration is already at the desired migration
-      if (currentLastMigration.id === localMigration) {
+      if (
+        currentLastMigration.id === localMigration &&
+        (markCompletedMigration === undefined || currentLastMigration.id >= markCompletedMigration)
+      ) {
         return false
       }
 

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -572,15 +572,30 @@ export async function resetMigration(options: {
         ? DBMigration[options.markCompletedTillMigration]
         : undefined
       const completedThroughMigration = markCompletedMigration ?? localMigration
-      const unsafeReset = MIGRATION_RESET_FLOORS.find(
-        ({ migration, activatedBy }) =>
-          currentTenantMigrations.some(
-            (currentMigration) => currentMigration.id >= DBMigration[activatedBy]
-          ) && completedThroughMigration < DBMigration[migration]
-      )
+      let unsafeReset: (typeof MIGRATION_RESET_FLOORS)[number] | undefined
 
-      if (unsafeReset && !options.skipResetFloorValidation) {
-        throw new Error(`Cannot replay ${unsafeReset.migration} after ${unsafeReset.activatedBy}`)
+      if (!options.skipResetFloorValidation) {
+        for (const resetFloor of MIGRATION_RESET_FLOORS) {
+          if (completedThroughMigration >= DBMigration[resetFloor.migration]) {
+            continue
+          }
+
+          const activatedInHistory = currentTenantMigrations.some(
+            (currentMigration) => currentMigration.id >= DBMigration[resetFloor.activatedBy]
+          )
+          const activatedInSchema = activatedInHistory
+            ? false
+            : (await pgClient.query(resetFloor.schemaCheck)).rows[0]?.reset_floor_active === true
+
+          if (activatedInHistory || activatedInSchema) {
+            unsafeReset = resetFloor
+            break
+          }
+        }
+      }
+
+      if (unsafeReset) {
+        throw new Error(unsafeReset.errorMessage)
       }
 
       // This tenant migration is already at the desired migration

--- a/src/internal/database/migrations/reset-floor.ts
+++ b/src/internal/database/migrations/reset-floor.ts
@@ -1,0 +1,16 @@
+import { DBMigration } from './types'
+
+type MigrationName = keyof typeof DBMigration
+
+interface MigrationResetFloor {
+  migration: MigrationName
+  activatedBy: MigrationName
+}
+
+export const MIGRATION_RESET_FLOORS = [
+  {
+    // Replaying storage-schema would recreate the legacy unique bucket/name index.
+    migration: 'storage-schema',
+    activatedBy: 'drop-bucketid-objname-index',
+  },
+] as const satisfies readonly MigrationResetFloor[]

--- a/src/internal/database/migrations/reset-floor.ts
+++ b/src/internal/database/migrations/reset-floor.ts
@@ -5,6 +5,8 @@ type MigrationName = keyof typeof DBMigration
 interface MigrationResetFloor {
   migration: MigrationName
   activatedBy: MigrationName
+  schemaCheck: string
+  errorMessage: string
 }
 
 export const MIGRATION_RESET_FLOORS = [
@@ -12,5 +14,14 @@ export const MIGRATION_RESET_FLOORS = [
     // Replaying storage-schema would recreate the legacy unique bucket/name index.
     migration: 'storage-schema',
     activatedBy: 'drop-bucketid-objname-index',
+    // 0002 creates both. A table without its index means replay would recreate uniqueness.
+    schemaCheck: `
+      SELECT (
+        to_regclass('storage.objects') IS NOT NULL
+        AND to_regclass('storage.bucketid_objname') IS NULL
+      ) AS reset_floor_active
+    `,
+    errorMessage:
+      'Cannot replay storage-schema: storage.objects exists without the legacy bucketid_objname index; use markCompletedTillMigration to skip it',
   },
 ] as const satisfies readonly MigrationResetFloor[]

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -71,4 +71,5 @@ export const DBMigration = {
   'validate-bucket-lifecycle-constraints': 69,
   'list-objects-with-versions': 70,
   'objects-delete-marker-index': 71,
+  'drop-bucketid-objname-index': 72,
 } as const

--- a/src/scripts/test-migration-idempotency.ts
+++ b/src/scripts/test-migration-idempotency.ts
@@ -3,16 +3,45 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 import { resetMigration, runMigrationsOnTenant } from '@internal/database/migrations'
+import { MIGRATION_RESET_FLOORS } from '@internal/database/migrations/reset-floor'
 import { DBMigration } from '@internal/database/migrations/types'
 import { getConfig } from '../config'
 
 void (async () => {
   const { databaseURL, dbMigrationFreezeAt } = getConfig()
   const migrations = Object.keys(DBMigration) as (keyof typeof DBMigration)[]
+  const lastMigration = dbMigrationFreezeAt
+    ? DBMigration[dbMigrationFreezeAt]
+    : Math.max(...Object.values(DBMigration))
+  const activeResetFloors = MIGRATION_RESET_FLOORS.filter(
+    ({ activatedBy }) => DBMigration[activatedBy] <= lastMigration
+  )
+  const nonReplayableMigrations = new Set<keyof typeof DBMigration>(
+    activeResetFloors.map(({ migration }) => migration)
+  )
+  const firstResetFloor = activeResetFloors.at(0)?.migration ?? 'create-migrations-table'
+  const firstMigrationIndex = migrations.indexOf(firstResetFloor)
 
-  let previousMigration: keyof typeof DBMigration = 'create-migrations-table'
+  let previousMigration: keyof typeof DBMigration = firstResetFloor
 
-  for (const migration of migrations.slice(1)) {
+  for (const migration of migrations.slice(firstMigrationIndex + 1)) {
+    if (nonReplayableMigrations.has(migration)) {
+      console.log(`Skipping  migration ${migration}`)
+      await resetMigration({
+        databaseUrl: databaseURL,
+        untilMigration: previousMigration,
+        markCompletedTillMigration: migration,
+        skipResetFloorValidation: true,
+      })
+
+      if (dbMigrationFreezeAt === migration) {
+        break
+      }
+
+      previousMigration = migration
+      continue
+    }
+
     console.log(`Running   migration ${migration}`)
     await runMigrationsOnTenant({
       databaseUrl: databaseURL,
@@ -23,6 +52,7 @@ void (async () => {
     await resetMigration({
       databaseUrl: databaseURL,
       untilMigration: previousMigration,
+      skipResetFloorValidation: true,
     })
 
     console.log(`Rerunning migration ${migration}`)

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -76,9 +76,10 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
-  if (tnx) {
+  if (tnx && !tnx.isCompleted()) {
     await tnx.commit()
   }
+  tnx = undefined
   await appInstance.close()
 })
 

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1588,7 +1588,7 @@ describe('objects - list v2 versioning tests', () => {
         method: 'POST',
         url: '/object/list-v2/bucket2',
         headers: { authorization: `Bearer ${await serviceKeyAsync}` },
-        payload: { prefix: objectName, cursor: body.nextCursor, limit: 1 },
+        payload: { cursor: body.nextCursor, limit: 1 },
       })
       expect(page2.statusCode).toBe(200)
       const body2 = page2.json<{ hasNext: boolean; objects: Obj[] }>()

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -815,88 +815,85 @@ describe('objects - list v2 sorting tests', () => {
     ['flat desc', false, 'desc', ['c.txt', 'b.txt', 'a.txt']],
     ['delimiter asc', true, 'asc', ['a.txt', 'b.txt', 'c.txt']],
     ['delimiter desc', true, 'desc', ['c.txt', 'b.txt', 'a.txt']],
-  ] as const)(
-    'uses the same null timestamp fallback when paginating %s',
-    async (_path, withDelimiter, order, expectedNames) => {
-      const bucketId = `null-timestamp-${order}-${randomUUID()}`
-      const prefix = `null-timestamp-${order}-${randomUUID()}/`
-      const names = expectedNames.map((name) => `${prefix}${name}`)
+  ] as const)('uses the same null timestamp fallback when paginating %s', async (_path, withDelimiter, order, expectedNames) => {
+    const bucketId = `null-timestamp-${order}-${randomUUID()}`
+    const prefix = `null-timestamp-${order}-${randomUUID()}/`
+    const names = expectedNames.map((name) => `${prefix}${name}`)
 
-      const createBucketResponse = await appInstance.inject({
+    const createBucketResponse = await appInstance.inject({
+      method: 'POST',
+      url: '/bucket',
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+      payload: { name: bucketId },
+    })
+    expect(createBucketResponse.statusCode).toBe(200)
+
+    for (const path of names) {
+      const upload = await appInstance.inject({
         method: 'POST',
-        url: '/bucket',
+        url: `/object/${bucketId}/${path}`,
+        payload: createUpload(path, 'test content'),
         headers: {
-          authorization: `Bearer ${serviceKey}`,
+          authorization: serviceKey,
         },
-        payload: { name: bucketId },
       })
-      expect(createBucketResponse.statusCode).toBe(200)
+      expect(upload.statusCode).toBe(200)
+    }
 
-      for (const path of names) {
-        const upload = await appInstance.inject({
-          method: 'POST',
-          url: `/object/${bucketId}/${path}`,
-          payload: createUpload(path, 'test content'),
-          headers: {
-            authorization: serviceKey,
-          },
-        })
-        expect(upload.statusCode).toBe(200)
-      }
-
-      await storageTest.database.connection.query(
-        `UPDATE storage.objects
+    await storageTest.database.connection.query(
+      `UPDATE storage.objects
          SET created_at = CASE
            WHEN name IN ($2, $3) THEN NULL
            ELSE '2026-01-01 00:00:01+00'::timestamptz
          END
          WHERE bucket_id = $1 AND name = ANY($4::text[])`,
-        [bucketId, `${prefix}a.txt`, `${prefix}b.txt`, names]
-      )
+      [bucketId, `${prefix}a.txt`, `${prefix}b.txt`, names]
+    )
 
-      const listed: string[] = []
-      let cursor: string | undefined
-      do {
-          const response = await appInstance.inject({
-            method: 'POST',
-            url: `/object/list-v2/${bucketId}`,
-          headers: {
-            authorization: `Bearer ${serviceKey}`,
-          },
-          payload: {
-            with_delimiter: withDelimiter,
-            prefix,
-            limit: 1,
-            cursor,
-            sortBy: { column: 'created_at', order },
-          },
-        })
-
-        expect(response.statusCode).toBe(200)
-        const data = response.json<ListObjectsV2Result>()
-        listed.push(...data.objects.map((object) => object.name))
-        cursor = data.nextCursor
-      } while (cursor)
-
-      expect(listed).toEqual(expectedNames.map((name) => `${prefix}${name}`))
-
-      await appInstance.inject({
+    const listed: string[] = []
+    let cursor: string | undefined
+    do {
+      const response = await appInstance.inject({
         method: 'POST',
-        url: `/bucket/${bucketId}/empty`,
+        url: `/object/list-v2/${bucketId}`,
         headers: {
           authorization: `Bearer ${serviceKey}`,
+        },
+        payload: {
+          with_delimiter: withDelimiter,
+          prefix,
+          limit: 1,
+          cursor,
+          sortBy: { column: 'created_at', order },
         },
       })
 
-      await appInstance.inject({
-        method: 'DELETE',
-        url: `/bucket/${bucketId}`,
-        headers: {
-          authorization: `Bearer ${serviceKey}`,
-        },
-      })
-    }
-  )
+      expect(response.statusCode).toBe(200)
+      const data = response.json<ListObjectsV2Result>()
+      listed.push(...data.objects.map((object) => object.name))
+      cursor = data.nextCursor
+    } while (cursor)
+
+    expect(listed).toEqual(expectedNames.map((name) => `${prefix}${name}`))
+
+    await appInstance.inject({
+      method: 'POST',
+      url: `/bucket/${bucketId}/empty`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+
+    await appInstance.inject({
+      method: 'DELETE',
+      url: `/bucket/${bucketId}`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+    })
+  })
 })
 
 const LIST_V2_WILDCARD_BUCKET = `list-v2-wildcard-${randomUUID()}`
@@ -2244,6 +2241,115 @@ describe('objects - list v2 versioning tests', () => {
       tnx = undefined
     }
   }, 30_000)
+
+  test.each([
+    { order: 'asc' as const, noncurrentVersions: 'exclude' as const },
+    { order: 'desc' as const, noncurrentVersions: 'exclude' as const },
+    { order: 'asc' as const, noncurrentVersions: 'include' as const },
+    { order: 'desc' as const, noncurrentVersions: 'include' as const },
+  ])('distinguishes leaf and folder cursor boundaries ($order, $noncurrentVersions)', async ({
+    order,
+    noncurrentVersions,
+  }) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/cursor-kind-${runId}/`
+    const lowerName = `${prefix}aZ`
+    const collisionName = `${prefix}aa`
+    const siblingName = `${collisionName}!`
+    const childName = `${collisionName}/child.txt`
+    const upperName = `${prefix}ab`
+    const baseTime = Date.parse('2024-09-01T00:00:00.000Z')
+    const lowerRows = buildVersionRows('bucket2', lowerName, 1, baseTime)
+    const collisionRows = buildVersionRows('bucket2', collisionName, 2, baseTime + 100_000)
+    const siblingRows = buildVersionRows('bucket2', siblingName, 1, baseTime + 200_000)
+    const childRows = buildVersionRows('bucket2', childName, 1, baseTime + 300_000)
+    const upperRows = buildVersionRows('bucket2', upperName, 1, baseTime + 400_000)
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...lowerRows,
+      ...collisionRows,
+      ...siblingRows,
+      ...childRows,
+      ...upperRows,
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const actual: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+
+      do {
+        const response = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix,
+            with_delimiter: true,
+            noncurrentVersions,
+            sortBy: { column: 'name', order },
+            limit: 1,
+            cursor,
+          },
+        })
+        expect(response.statusCode).toBe(200)
+
+        const body = response.json<{
+          objects: Obj[]
+          folders: Obj[]
+          hasNext: boolean
+          nextCursor?: string
+        }>()
+        actual.push(
+          ...body.objects.map((object) => `object:${object.name}:${object.version}`),
+          ...body.folders.map((folder) => `folder:${folder.name}`)
+        )
+        cursor = body.hasNext ? body.nextCursor : undefined
+        pages += 1
+        expect(pages).toBeLessThan(10)
+      } while (cursor)
+
+      const collisionEntries = collisionRows
+        .filter((row) => noncurrentVersions === 'include' || row.archived_at === null)
+        .toSorted((left, right) =>
+          left.archived_at === null ? -1 : right.archived_at === null ? 1 : 0
+        )
+        .map((row) => `object:${collisionName}:${row.version}`)
+      const ascending = [
+        `object:${lowerName}:${lowerRows[0].version}`,
+        ...collisionEntries,
+        `object:${siblingName}:${siblingRows[0].version}`,
+        `folder:${collisionName}/`,
+        `object:${upperName}:${upperRows[0].version}`,
+      ]
+      const descending = [
+        `object:${upperName}:${upperRows[0].version}`,
+        `folder:${collisionName}/`,
+        `object:${siblingName}:${siblingRows[0].version}`,
+        ...collisionEntries,
+        `object:${lowerName}:${lowerRows[0].version}`,
+      ]
+
+      expect(actual).toEqual(order === 'asc' ? ascending : descending)
+      expect(new Set(actual).size).toBe(actual.length)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [
+          lowerName,
+          collisionName,
+          siblingName,
+          childName,
+          upperName,
+        ])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
 
   test('name pagination matches the model at exact, mid-key, and final-key internal batch boundaries', async () => {
     const runId = randomUUID()

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -809,6 +809,94 @@ describe('objects - list v2 sorting tests', () => {
 
     expect(listed).toEqual([firstByName, secondByName])
   })
+
+  test.each([
+    ['flat asc', false, 'asc', ['a.txt', 'b.txt', 'c.txt']],
+    ['flat desc', false, 'desc', ['c.txt', 'b.txt', 'a.txt']],
+    ['delimiter asc', true, 'asc', ['a.txt', 'b.txt', 'c.txt']],
+    ['delimiter desc', true, 'desc', ['c.txt', 'b.txt', 'a.txt']],
+  ] as const)(
+    'uses the same null timestamp fallback when paginating %s',
+    async (_path, withDelimiter, order, expectedNames) => {
+      const bucketId = `null-timestamp-${order}-${randomUUID()}`
+      const prefix = `null-timestamp-${order}-${randomUUID()}/`
+      const names = expectedNames.map((name) => `${prefix}${name}`)
+
+      const createBucketResponse = await appInstance.inject({
+        method: 'POST',
+        url: '/bucket',
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+        payload: { name: bucketId },
+      })
+      expect(createBucketResponse.statusCode).toBe(200)
+
+      for (const path of names) {
+        const upload = await appInstance.inject({
+          method: 'POST',
+          url: `/object/${bucketId}/${path}`,
+          payload: createUpload(path, 'test content'),
+          headers: {
+            authorization: serviceKey,
+          },
+        })
+        expect(upload.statusCode).toBe(200)
+      }
+
+      await storageTest.database.connection.query(
+        `UPDATE storage.objects
+         SET created_at = CASE
+           WHEN name IN ($2, $3) THEN NULL
+           ELSE '2026-01-01 00:00:01+00'::timestamptz
+         END
+         WHERE bucket_id = $1 AND name = ANY($4::text[])`,
+        [bucketId, `${prefix}a.txt`, `${prefix}b.txt`, names]
+      )
+
+      const listed: string[] = []
+      let cursor: string | undefined
+      do {
+          const response = await appInstance.inject({
+            method: 'POST',
+            url: `/object/list-v2/${bucketId}`,
+          headers: {
+            authorization: `Bearer ${serviceKey}`,
+          },
+          payload: {
+            with_delimiter: withDelimiter,
+            prefix,
+            limit: 1,
+            cursor,
+            sortBy: { column: 'created_at', order },
+          },
+        })
+
+        expect(response.statusCode).toBe(200)
+        const data = response.json<ListObjectsV2Result>()
+        listed.push(...data.objects.map((object) => object.name))
+        cursor = data.nextCursor
+      } while (cursor)
+
+      expect(listed).toEqual(expectedNames.map((name) => `${prefix}${name}`))
+
+      await appInstance.inject({
+        method: 'POST',
+        url: `/bucket/${bucketId}/empty`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+
+      await appInstance.inject({
+        method: 'DELETE',
+        url: `/bucket/${bucketId}`,
+        headers: {
+          authorization: `Bearer ${serviceKey}`,
+        },
+      })
+    }
+  )
 })
 
 const LIST_V2_WILDCARD_BUCKET = `list-v2-wildcard-${randomUUID()}`

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1553,7 +1553,7 @@ describe('objects - list v2 versioning tests', () => {
     }
   })
 
-  test('exactMatch pagination stays on the cursor key when the request prefix changes', async () => {
+  test('exactMatch pagination stays on the cursor key when the request prefix is omitted', async () => {
     const runId = randomUUID()
     const objectName = `authenticated/exact-match-${runId}.png`
     const decoyName = `${objectName}.decoy`
@@ -1588,7 +1588,7 @@ describe('objects - list v2 versioning tests', () => {
         method: 'POST',
         url: '/object/list-v2/bucket2',
         headers: { authorization: `Bearer ${await serviceKeyAsync}` },
-        payload: { prefix: decoyName, cursor: body.nextCursor, limit: 1 },
+        payload: { cursor: body.nextCursor, limit: 1 },
       })
       expect(page2.statusCode).toBe(200)
       const body2 = page2.json<{ hasNext: boolean; objects: Obj[] }>()

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -2402,7 +2402,7 @@ describe('objects - list v2 versioning tests', () => {
     }
   })
 
-  test('name pagination matches the model at exact, mid-key, and final-key internal batch boundaries', async () => {
+  test('name pagination matches the model at exact, mid-key, and final-key page boundaries', async () => {
     const runId = randomUUID()
     const prefix = `authenticated/v2-batch-model-${runId}/`
     const baseTime = Date.parse('2024-08-01T00:00:00.000Z')
@@ -2456,16 +2456,15 @@ describe('objects - list v2 versioning tests', () => {
             noncurrentVersions: 'include',
             deleteMarkers: 'include',
             sortBy: { column: 'name', order },
-            // list_objects_with_delimiter's internal batch size is 100,
-            // so the 100/101-version keys exercise exact and mid-key exits.
-            limit: 50,
+            // The 100/101-version keys end exactly on or cross a 100-row page boundary.
+            limit: 100,
           })
           const actual = result.objects.map((object) => `${object.name}::${object.version}`)
 
           expect(result.folders).toEqual([])
           expect(actual).toEqual(expectedFor(order))
           expect(new Set(actual).size).toBe(rows.length)
-          expect(result.pages).toBe(Math.ceil(rows.length / 50))
+          expect(result.pages).toBe(Math.ceil(rows.length / 100))
         }
       }
     } finally {

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -652,6 +652,7 @@ describe('objects - list v2 sorting tests', () => {
     expect(decodedCursor).not.toMatch(/(^|\n)c:/)
     expect(decodedCursor).not.toMatch(/(^|\n)n:/)
     expect(decodedCursor).not.toMatch(/(^|\n)d:/)
+    expect(decodedCursor).not.toMatch(/(^|\n)e:/)
 
     const changedFilter = await appInstance.inject({
       method: 'POST',
@@ -730,6 +731,26 @@ describe('objects - list v2 sorting tests', () => {
     const decodedCursor = Buffer.from(cursor!, 'base64').toString()
     expect(decodedCursor).toMatch(/(^|\n)n:include($|\n)/)
     expect(decodedCursor).not.toMatch(/(^|\n)d:/)
+  })
+
+  test('rejects an invalid exactMatch value in a continuation token', async () => {
+    const cursor = Buffer.from('e:invalid').toString('base64')
+    const response = await appInstance.inject({
+      method: 'POST',
+      url: `/object/list-v2/${LIST_V2_BUCKET}`,
+      headers: {
+        authorization: `Bearer ${serviceKey}`,
+      },
+      payload: {
+        with_delimiter: false,
+        cursor,
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({
+      message: expect.stringContaining('continuation token'),
+    })
   })
 
   test('uses millisecond precision consistently when paginating by timestamp', async () => {
@@ -1470,12 +1491,28 @@ describe('objects - list v2 versioning tests', () => {
           prefix: objectName,
           exactMatch: true,
           noncurrentVersions: 'include',
+          limit: 1,
         },
       })
       expect(response.statusCode).toBe(200)
-      const body = response.json<{ objects: Obj[] }>()
-      expect(body.objects).toHaveLength(2)
-      expect(body.objects.every((o) => o.name === objectName)).toBe(true)
+      const body = response.json<{ hasNext: boolean; nextCursor?: string; objects: Obj[] }>()
+      expect(body.objects).toHaveLength(1)
+      expect(body.hasNext).toBe(true)
+
+      const page2 = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list-v2/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: { prefix: objectName, cursor: body.nextCursor, limit: 1 },
+      })
+      expect(page2.statusCode).toBe(200)
+      const body2 = page2.json<{ hasNext: boolean; objects: Obj[] }>()
+      expect(body2.hasNext).toBe(false)
+
+      const objects = [...body.objects, ...body2.objects]
+      expect(objects).toHaveLength(2)
+      expect(objects.every((o) => o.name === objectName)).toBe(true)
+      expect(new Set(objects.map((o) => o.version)).size).toBe(2)
     } finally {
       const cleanupTx = await getSuperuserPostgrestClient()
       await withDeleteEnabled(cleanupTx, async (db) => {
@@ -2374,7 +2411,22 @@ describe('objects - list v2 versioning tests', () => {
       }
     })
 
-    test('an explicitly resent, mismatched filter on page 2 is rejected', async () => {
+    test.each([
+      {
+        name: 'noncurrentVersions',
+        page1: { noncurrentVersions: 'include' },
+        page2: { noncurrentVersions: 'exclude' },
+      },
+      {
+        name: 'exactMatch',
+        page1: { noncurrentVersions: 'include', exactMatch: true },
+        page2: { exactMatch: false },
+      },
+    ])('an explicitly resent, mismatched $name filter on page 2 is rejected', async ({
+      name,
+      page1: filters1,
+      page2: filters2,
+    }) => {
       const runId = randomUUID()
       const objectName = `authenticated/lock-mismatch-${runId}.png`
       await seedFourVersionKey(objectName, Date.parse('2024-03-03T00:00:00.000Z'))
@@ -2384,7 +2436,7 @@ describe('objects - list v2 versioning tests', () => {
           method: 'POST',
           url: '/object/list-v2/bucket2',
           headers: { authorization: `Bearer ${await serviceKeyAsync}` },
-          payload: { prefix: objectName, noncurrentVersions: 'include', limit: 1 },
+          payload: { prefix: objectName, limit: 1, ...filters1 },
         })
         const body1 = page1.json<{ nextCursor?: string }>()
 
@@ -2392,15 +2444,11 @@ describe('objects - list v2 versioning tests', () => {
           method: 'POST',
           url: '/object/list-v2/bucket2',
           headers: { authorization: `Bearer ${await serviceKeyAsync}` },
-          payload: {
-            prefix: objectName,
-            noncurrentVersions: 'exclude',
-            cursor: body1.nextCursor,
-          },
+          payload: { prefix: objectName, cursor: body1.nextCursor, ...filters2 },
         })
         expect(page2.statusCode).toBe(400)
         expect(page2.json()).toMatchObject({
-          message: expect.stringContaining('noncurrentVersions must match'),
+          message: expect.stringContaining(`${name} must match`),
         })
       } finally {
         const cleanupTx = await getSuperuserPostgrestClient()

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1344,6 +1344,7 @@ describe('objects - list v2 versioning tests', () => {
         expect(response.statusCode).toBe(200)
         const body = response.json<{ objects: Obj[] }>()
         const versions = body.objects.map((o) => o.version)
+        expect(versions.length).toBe(expected.length)
         expect(new Set(versions)).toEqual(new Set(expected))
       }
     } finally {

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -2357,6 +2357,51 @@ describe('objects - list v2 versioning tests', () => {
     }
   })
 
+  test.each([
+    { order: 'asc' as const, expected: 'upper.txt' },
+    { order: 'desc' as const, expected: 'lower.txt' },
+  ])('treats a multi-version startAfter boundary as strict ($order)', async ({
+    order,
+    expected,
+  }) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/start-after-${runId}/`
+    const lowerName = `${prefix}lower.txt`
+    const boundaryName = `${prefix}middle.txt`
+    const upperName = `${prefix}upper.txt`
+    const baseTime = Date.parse('2024-10-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...buildVersionRows(LIST_V2_BUCKET, lowerName, 1, baseTime),
+      ...buildVersionRows(LIST_V2_BUCKET, boundaryName, 2, baseTime + 100_000),
+      ...buildVersionRows(LIST_V2_BUCKET, upperName, 1, baseTime + 200_000),
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await storageTest.storage.from(LIST_V2_BUCKET).listObjectsV2({
+        prefix,
+        delimiter: '/',
+        startAfter: boundaryName,
+        maxKeys: 10,
+        noncurrentVersions: 'include',
+        sortBy: { column: 'name', order },
+      })
+
+      expect(result.folders).toEqual([])
+      expect(result.objects.map((object) => object.name)).toEqual([`${prefix}${expected}`])
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, LIST_V2_BUCKET, [lowerName, boundaryName, upperName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
   test('name pagination matches the model at exact, mid-key, and final-key internal batch boundaries', async () => {
     const runId = randomUUID()
     const prefix = `authenticated/v2-batch-model-${runId}/`

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -2057,6 +2057,12 @@ describe('objects - list v2 versioning tests', () => {
         is_delete_marker: true,
       },
       {
+        name: 'folder-a/',
+        version: 'folder-a-placeholder',
+        archived_at: null,
+        is_delete_marker: false,
+      },
+      {
         name: 'folder-a/child.txt',
         version: 'folder-a-current',
         archived_at: null,

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1,14 +1,70 @@
 import { randomUUID } from 'node:crypto'
+import {
+  type DatabaseTransaction,
+  getPostgresConnection,
+  getServiceKeyUser,
+} from '@internal/database'
 import { ListObjectsV2Result } from '@storage/object'
 import { FastifyInstance } from 'fastify'
 import app from '../app'
 import { getConfig } from '../config'
+import { Obj } from '../storage'
 import { useMockObject, useMockQueue } from './common'
-import { useStorage } from './utils/storage'
+import { useStorage, withDeleteEnabled } from './utils/storage'
 
-const { serviceKeyAsync } = getConfig()
+const { serviceKeyAsync, tenantId } = getConfig()
 let appInstance: FastifyInstance
 let serviceKey: string = ''
+
+let tnx: DatabaseTransaction | undefined
+async function getSuperuserPostgrestClient() {
+  const superUser = await getServiceKeyUser(tenantId)
+
+  const conn = await getPostgresConnection({
+    superUser,
+    user: superUser,
+    tenantId,
+    host: 'localhost',
+  })
+  tnx = await conn.transaction()
+
+  return tnx
+}
+
+async function insertObjects(
+  db: DatabaseTransaction,
+  objects:
+    | Array<Partial<Obj> & { bucket_id: string; name: string }>
+    | (Partial<Obj> & { bucket_id: string; name: string })
+) {
+  const rows = Array.isArray(objects) ? objects : [objects]
+
+  for (const row of rows) {
+    const entries = Object.entries(row)
+    await db.query({
+      text: `
+        INSERT INTO objects (${entries.map(([column]) => column).join(', ')})
+        VALUES (${entries.map((_, index) => `$${index + 1}`).join(', ')})
+      `,
+      values: entries.map(([, value]) => value),
+    })
+  }
+}
+
+async function deleteObjectsByName(
+  db: DatabaseTransaction,
+  bucketId: string,
+  names: string | string[]
+) {
+  await db.query({
+    text: `
+      DELETE FROM objects
+      WHERE bucket_id = $1
+        AND name = ANY($2::text[])
+    `,
+    values: [bucketId, Array.isArray(names) ? names : [names]],
+  })
+}
 
 useMockObject()
 useMockQueue()
@@ -20,6 +76,9 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  if (tnx) {
+    await tnx.commit()
+  }
   await appInstance.close()
 })
 
@@ -1132,5 +1191,1333 @@ describe('objects - list v2 startAfter and folder cursors', () => {
     } while (cursor)
 
     expect(actual).toEqual(expected.map((name) => `${prefix}${name}`))
+  })
+})
+
+describe('objects - list v2 versioning tests', () => {
+  async function listAllVersions(
+    payload: Record<string, unknown>
+  ): Promise<{ objects: Obj[]; folders: Obj[]; pages: number }> {
+    const objects: Obj[] = []
+    const folders: Obj[] = []
+    let cursor: string | undefined
+    let pages = 0
+
+    do {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list-v2/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: { ...payload, cursor },
+      })
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        objects: Obj[]
+        folders: Obj[]
+        hasNext: boolean
+        nextCursor?: string
+      }>()
+
+      objects.push(...body.objects)
+      folders.push(...body.folders)
+      cursor = body.hasNext ? body.nextCursor : undefined
+      pages += 1
+      expect(pages).toBeLessThan(20)
+    } while (cursor)
+
+    return { objects, folders, pages }
+  }
+
+  function buildVersionRows(
+    bucketId: string,
+    name: string,
+    count: number,
+    baseTime: number
+  ): Array<Partial<Obj> & { bucket_id: string; name: string }> {
+    const rows: Array<Partial<Obj> & { bucket_id: string; name: string }> = []
+    for (let i = 0; i < count; i++) {
+      const isCurrent = i === count - 1
+      const createdAt = new Date(baseTime + i * 1000).toISOString()
+      rows.push({
+        bucket_id: bucketId,
+        name,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: `v${i}-${randomUUID()}`,
+        metadata: { mimetype: 'image/png', size: 1000 + i },
+        created_at: createdAt,
+        archived_at: isCurrent ? null : createdAt,
+        is_versioned: true,
+        is_delete_marker: false,
+      })
+    }
+    return rows
+  }
+
+  test('every noncurrentVersions x deleteMarkers combination on listObjectsV2 (flat)', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/tristate-matrix-${runId}.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const rows = [
+      { version: 'archived-content-1', archivedAt: baseTime, isDeleteMarker: false },
+      { version: 'archived-marker', archivedAt: baseTime + 1000, isDeleteMarker: true },
+      { version: 'archived-content-2', archivedAt: baseTime + 2000, isDeleteMarker: false },
+      { version: 'current-content', archivedAt: null, isDeleteMarker: false },
+    ]
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(
+      seedTx,
+      rows.map((row) => ({
+        bucket_id: 'bucket2',
+        name: objectName,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: row.version,
+        metadata: { mimetype: 'image/png', size: 1000 },
+        created_at: new Date(row.archivedAt ?? baseTime + 3000).toISOString(),
+        archived_at: row.archivedAt === null ? null : new Date(row.archivedAt).toISOString(),
+        is_versioned: true,
+        is_delete_marker: row.isDeleteMarker,
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const matrix: {
+        noncurrentVersions?: 'exclude' | 'include' | 'only'
+        deleteMarkers?: 'exclude' | 'include' | 'only'
+        expected: string[]
+      }[] = [
+        { expected: ['current-content'] },
+        {
+          noncurrentVersions: 'exclude',
+          deleteMarkers: 'exclude',
+          expected: ['current-content'],
+        },
+        { noncurrentVersions: 'exclude', deleteMarkers: 'only', expected: [] },
+        {
+          noncurrentVersions: 'exclude',
+          deleteMarkers: 'include',
+          expected: ['current-content'],
+        },
+        {
+          noncurrentVersions: 'only',
+          deleteMarkers: 'exclude',
+          expected: ['archived-content-1', 'archived-content-2'],
+        },
+        { noncurrentVersions: 'only', deleteMarkers: 'only', expected: ['archived-marker'] },
+        {
+          noncurrentVersions: 'only',
+          deleteMarkers: 'include',
+          expected: ['archived-content-1', 'archived-marker', 'archived-content-2'],
+        },
+        {
+          noncurrentVersions: 'include',
+          deleteMarkers: 'exclude',
+          expected: ['archived-content-1', 'archived-content-2', 'current-content'],
+        },
+        {
+          noncurrentVersions: 'include',
+          deleteMarkers: 'only',
+          expected: ['archived-marker'],
+        },
+        {
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          expected: [
+            'archived-content-1',
+            'archived-marker',
+            'archived-content-2',
+            'current-content',
+          ],
+        },
+      ]
+
+      for (const { noncurrentVersions, deleteMarkers, expected } of matrix) {
+        const response = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: { prefix: objectName, exactMatch: true, noncurrentVersions, deleteMarkers },
+        })
+        expect(response.statusCode).toBe(200)
+        const body = response.json<{ objects: Obj[] }>()
+        const versions = body.objects.map((o) => o.version)
+        expect(new Set(versions)).toEqual(new Set(expected))
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('most-recent-first ordering within a key on listObjectsV2 (flat, noncurrentVersions include)', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/versions-order-${runId}.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, buildVersionRows('bucket2', objectName, 3, baseTime))
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list-v2/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: { prefix: objectName, exactMatch: true, noncurrentVersions: 'include' },
+      })
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ objects: Obj[] }>()
+      expect(body.objects).toHaveLength(3)
+      expect(body.objects[0].archived_at).toBeNull()
+      expect(body.objects[0].version?.startsWith('v2-')).toBe(true)
+      expect(body.objects[1].version?.startsWith('v1-')).toBe(true)
+      expect(body.objects[2].version?.startsWith('v0-')).toBe(true)
+      const versions = body.objects.map((o) => o.version)
+      expect(new Set(versions).size).toBe(3)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test("pagination does not repeat a key's current row when a page boundary lands right after it (with delimiter)", async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/current-row-boundary-${runId}.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, buildVersionRows('bucket2', objectName, 3, baseTime))
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const seen: string[] = []
+      let cursor: string | undefined
+      let pages = 0
+
+      do {
+        const response = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            exactMatch: true,
+            with_delimiter: true,
+            noncurrentVersions: 'include',
+            limit: 1,
+            cursor,
+          },
+        })
+        expect(response.statusCode).toBe(200)
+        const body = response.json<{ objects: Obj[]; hasNext: boolean; nextCursor?: string }>()
+
+        for (const o of body.objects) {
+          seen.push(o.version as string)
+        }
+
+        cursor = body.hasNext ? body.nextCursor : undefined
+        pages += 1
+        expect(pages).toBeLessThan(10)
+      } while (cursor)
+
+      expect(seen).toHaveLength(3)
+      expect(new Set(seen).size).toBe(3)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('exactMatch on listObjectsV2 matches only the literal key, not a shared prefix', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/exact-match-${runId}.png`
+    const decoyName = `${objectName}.decoy`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...buildVersionRows('bucket2', objectName, 2, baseTime),
+      ...buildVersionRows('bucket2', decoyName, 1, baseTime),
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list-v2/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix: objectName,
+          exactMatch: true,
+          noncurrentVersions: 'include',
+        },
+      })
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ objects: Obj[] }>()
+      expect(body.objects).toHaveLength(2)
+      expect(body.objects.every((o) => o.name === objectName)).toBe(true)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [objectName, decoyName])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('pagination across a multi-version key boundary returns every version exactly once (flat)', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/pagination-boundary-${runId}`
+    const keyA = `${prefix}-a.png`
+    const keyB = `${prefix}-b-boundary.png`
+    const keyC = `${prefix}-c.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...buildVersionRows('bucket2', keyA, 1, baseTime),
+      ...buildVersionRows('bucket2', keyB, 5, baseTime + 100_000),
+      ...buildVersionRows('bucket2', keyC, 1, baseTime + 200_000),
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const seen: { name: string; version: string }[] = []
+      let cursor: string | undefined
+      let pages = 0
+
+      do {
+        const response = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix,
+            noncurrentVersions: 'include',
+            limit: 3,
+            cursor,
+          },
+        })
+        expect(response.statusCode).toBe(200)
+        const body = response.json<{
+          objects: Obj[]
+          hasNext: boolean
+          nextCursor?: string
+        }>()
+
+        for (const o of body.objects) {
+          seen.push({ name: o.name, version: o.version as string })
+        }
+
+        cursor = body.hasNext ? body.nextCursor : undefined
+        pages += 1
+        expect(pages).toBeLessThan(10)
+      } while (cursor)
+
+      expect(pages).toBeGreaterThan(1)
+
+      const seenKeys = seen.map((o) => `${o.name}::${o.version}`)
+      expect(new Set(seenKeys).size).toBe(seenKeys.length)
+      expect(seen).toHaveLength(7) // 1 (a) + 5 (b) + 1 (c)
+
+      const bVersions = seen.filter((o) => o.name === keyB)
+      expect(bVersions).toHaveLength(5)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [keyA, keyB, keyC])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('pagination across a multi-version key boundary returns every version exactly once (with delimiter)', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/pagination-boundary-delim-${runId}`
+    const keyA = `${prefix}-a.png`
+    const keyB = `${prefix}-b-boundary.png`
+    const keyC = `${prefix}-c.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...buildVersionRows('bucket2', keyA, 1, baseTime),
+      ...buildVersionRows('bucket2', keyB, 5, baseTime + 100_000),
+      ...buildVersionRows('bucket2', keyC, 1, baseTime + 200_000),
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const seen: { name: string; version: string }[] = []
+      let cursor: string | undefined
+      let pages = 0
+
+      do {
+        const response = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix,
+            with_delimiter: true,
+            noncurrentVersions: 'include',
+            limit: 3,
+            cursor,
+          },
+        })
+        expect(response.statusCode).toBe(200)
+        const body = response.json<{
+          objects: Obj[]
+          hasNext: boolean
+          nextCursor?: string
+        }>()
+
+        for (const o of body.objects) {
+          seen.push({ name: o.name, version: o.version as string })
+        }
+
+        cursor = body.hasNext ? body.nextCursor : undefined
+        pages += 1
+        expect(pages).toBeLessThan(10)
+      } while (cursor)
+
+      expect(pages).toBeGreaterThan(1)
+
+      const seenKeys = seen.map((o) => `${o.name}::${o.version}`)
+      expect(new Set(seenKeys).size).toBe(seenKeys.length)
+      expect(seen).toHaveLength(7)
+
+      const bVersions = seen.filter((o) => o.name === keyB)
+      expect(bVersions).toHaveLength(5)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [keyA, keyB, keyC])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test.each([
+    ['created_at', 'asc'],
+    ['created_at', 'desc'],
+    ['updated_at', 'asc'],
+    ['updated_at', 'desc'],
+  ] as const)('paginates multiple versions exactly once when sorting by %s %s with timestamp ties', async (column, order) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/timestamp-sort-${runId}`
+    const names = [`${prefix}-a.png`, `${prefix}-b.png`, `${prefix}-c.png`]
+    const early = '2024-01-01T00:00:00.000Z'
+    const late = '2024-01-02T00:00:00.000Z'
+    const rows = names.flatMap((name, nameIndex) =>
+      ['version-a', 'version-b'].map((version, versionIndex) => ({
+        bucket_id: 'bucket2',
+        name,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version,
+        metadata: { mimetype: 'image/png', size: 1000 + versionIndex },
+        // The first two keys deliberately tie on the selected timestamps so
+        // pagination must use both name and version from the cursor.
+        created_at: nameIndex < 2 ? early : late,
+        updated_at: nameIndex < 2 ? early : late,
+        archived_at:
+          versionIndex === 0
+            ? new Date(Date.parse(early) + nameIndex * 10_000).toISOString()
+            : null,
+        is_versioned: true,
+        is_delete_marker: false,
+      }))
+    )
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix,
+        noncurrentVersions: 'include',
+        deleteMarkers: 'include',
+        sortBy: { column, order },
+        limit: 1,
+      })
+
+      expect(result.pages).toBe(6)
+      const actual = result.objects.map((object) => `${object.name}::${object.version}`)
+      const direction = order === 'asc' ? 1 : -1
+      const expected = rows
+        .slice()
+        .sort((left, right) => {
+          const timestampComparison = String(left[column]).localeCompare(String(right[column]))
+          if (timestampComparison !== 0) return timestampComparison * direction
+          const nameComparison = left.name.localeCompare(right.name)
+          if (nameComparison !== 0) return nameComparison * direction
+          return String(left.version).localeCompare(String(right.version)) * direction
+        })
+        .map((object) => `${object.name}::${object.version}`)
+
+      expect(actual).toEqual(expected)
+      expect(new Set(actual).size).toBe(rows.length)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', names)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('paginates default name-desc ordering through every version exactly once', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/name-desc-${runId}`
+    const names = [`${prefix}-a.png`, `${prefix}-b.png`, `${prefix}-c.png`]
+    const baseTime = Date.parse('2024-02-01T00:00:00.000Z')
+    const rows = names.flatMap((name, index) =>
+      buildVersionRows('bucket2', name, 3, baseTime + index * 100_000)
+    )
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix,
+        noncurrentVersions: 'include',
+        sortBy: { column: 'name', order: 'desc' },
+        limit: 2,
+      })
+      const identities = result.objects.map((object) => `${object.name}::${object.version}`)
+
+      expect(result.pages).toBeGreaterThan(1)
+      expect(identities).toHaveLength(rows.length)
+      expect(new Set(identities).size).toBe(rows.length)
+      expect(result.objects.map((object) => object.name)).toEqual(
+        result.objects
+          .map((object) => object.name)
+          .slice()
+          .sort()
+          .reverse()
+      )
+      for (const name of names) {
+        const versions = result.objects.filter((object) => object.name === name)
+        expect(versions[0].archived_at).toBeNull()
+        expect(versions.slice(1).map((object) => object.archived_at)).toEqual(
+          versions
+            .slice(1)
+            .map((object) => object.archived_at)
+            .slice()
+            .sort()
+            .reverse()
+        )
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', names)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('paginates archived-only versions without skips or duplicates', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/archived-only-${runId}`
+    const names = [`${prefix}-a.png`, `${prefix}-b.png`]
+    const rows = names.flatMap((name, index) =>
+      buildVersionRows('bucket2', name, 4, Date.parse('2024-03-01T00:00:00.000Z') + index * 100_000)
+    )
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix,
+        noncurrentVersions: 'only',
+        limit: 2,
+      })
+      const identities = result.objects.map((object) => `${object.name}::${object.version}`)
+
+      expect(result.pages).toBeGreaterThan(1)
+      expect(result.objects).toHaveLength(6)
+      expect(result.objects.every((object) => object.archived_at !== null)).toBe(true)
+      expect(new Set(identities).size).toBe(identities.length)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', names)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test.each([
+    'include',
+    'only',
+  ] as const)('paginates deleteMarkers=%s across current and archived markers', async (deleteMarkers) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/delete-marker-pages-${runId}`
+    const names = [`${prefix}-a.png`, `${prefix}-b.png`]
+    const baseTime = Date.parse('2024-04-01T00:00:00.000Z')
+    const rows = names.flatMap((name, nameIndex) => [
+      {
+        bucket_id: 'bucket2',
+        name,
+        version: `content-${nameIndex}`,
+        archived_at: new Date(baseTime + nameIndex * 10_000).toISOString(),
+        created_at: new Date(baseTime).toISOString(),
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+      {
+        bucket_id: 'bucket2',
+        name,
+        version: `archived-marker-${nameIndex}`,
+        archived_at: new Date(baseTime + nameIndex * 10_000 + 1000).toISOString(),
+        created_at: new Date(baseTime + 1000).toISOString(),
+        is_versioned: true,
+        is_delete_marker: true,
+      },
+      {
+        bucket_id: 'bucket2',
+        name,
+        version: `current-marker-${nameIndex}`,
+        archived_at: null,
+        created_at: new Date(baseTime + 2000).toISOString(),
+        is_versioned: true,
+        is_delete_marker: true,
+      },
+    ])
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix,
+        noncurrentVersions: 'include',
+        deleteMarkers,
+        limit: 1,
+      })
+      const identities = result.objects.map((object) => `${object.name}::${object.version}`)
+      const expectedCount = deleteMarkers === 'only' ? 4 : 6
+
+      expect(result.objects).toHaveLength(expectedCount)
+      expect(new Set(identities).size).toBe(expectedCount)
+      if (deleteMarkers === 'only') {
+        expect(result.objects.every((object) => object.is_delete_marker)).toBe(true)
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', names)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('collapses versioned descendants into one folder per prefix across pages', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/folder-versions-${runId}/`
+    const rootObject = `${prefix}root.png`
+    const names = [
+      rootObject,
+      `${prefix}alpha/one.png`,
+      `${prefix}alpha/two.png`,
+      `${prefix}beta/one.png`,
+    ]
+    const baseTime = Date.parse('2024-05-01T00:00:00.000Z')
+    const rows = names.flatMap((name, index) =>
+      buildVersionRows('bucket2', name, 3, baseTime + index * 100_000)
+    )
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix,
+        with_delimiter: true,
+        noncurrentVersions: 'include',
+        limit: 2,
+      })
+
+      expect(result.pages).toBeGreaterThan(1)
+      expect(result.folders.map((folder) => folder.name)).toEqual([
+        `${prefix}alpha/`,
+        `${prefix}beta/`,
+      ])
+      expect(result.objects).toHaveLength(3)
+      expect(result.objects.every((object) => object.name === rootObject)).toBe(true)
+      expect(new Set(result.objects.map((object) => object.version)).size).toBe(3)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', names)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('name pagination matches the V2 reference model across filters, directions, delimiters, and page boundaries', async () => {
+    type VersionMode = 'include' | 'only'
+    type MarkerMode = 'exclude' | 'include' | 'only'
+    type ModelRow = {
+      name: string
+      version: string
+      archived_at: string | null
+      is_delete_marker: boolean
+    }
+    type ModelEntry = {
+      kind: 'folder' | 'object'
+      name: string
+      sortName: string
+      version: string | null
+      archived_at: string | null
+    }
+
+    const runId = randomUUID()
+    const prefix = `authenticated/v2-reference-${runId}/`
+    const modelRows: ModelRow[] = [
+      { name: 'alpha.txt', version: 'alpha-current', archived_at: null, is_delete_marker: false },
+      {
+        name: 'alpha.txt',
+        version: 'alpha-archive-a',
+        archived_at: '2024-07-01T00:00:00.123789Z',
+        is_delete_marker: false,
+      },
+      {
+        name: 'alpha.txt',
+        version: 'alpha-archive-b',
+        archived_at: '2024-07-01T00:00:00.123456Z',
+        is_delete_marker: false,
+      },
+      { name: 'bravo.txt', version: 'bravo-current', archived_at: null, is_delete_marker: false },
+      {
+        name: 'bravo.txt',
+        version: 'bravo-marker',
+        archived_at: '2024-07-02T00:00:00.000Z',
+        is_delete_marker: true,
+      },
+      {
+        name: 'folder-a/child.txt',
+        version: 'folder-a-current',
+        archived_at: null,
+        is_delete_marker: false,
+      },
+      {
+        name: 'folder-a/child.txt',
+        version: 'folder-a-archive',
+        archived_at: '2024-07-03T00:00:00.000Z',
+        is_delete_marker: false,
+      },
+      {
+        name: 'folder-b/marker.txt',
+        version: 'folder-b-marker',
+        archived_at: '2024-07-04T00:00:00.000Z',
+        is_delete_marker: true,
+      },
+      {
+        name: 'zulu.txt',
+        version: 'zulu-archive',
+        archived_at: '2024-07-05T00:00:00.000Z',
+        is_delete_marker: false,
+      },
+    ]
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(
+      seedTx,
+      modelRows.map((row) => ({
+        bucket_id: 'bucket2',
+        name: `${prefix}${row.name}`,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: row.version,
+        archived_at: row.archived_at,
+        is_versioned: true,
+        is_delete_marker: row.is_delete_marker,
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    const compareC = (left: string, right: string) => (left === right ? 0 : left < right ? -1 : 1)
+    const identity = (entry: {
+      kind: 'folder' | 'object'
+      name: string
+      version?: string | null
+    }) => `${entry.kind}:${entry.name}:${entry.version ?? ''}`
+
+    const reference = (
+      withDelimiter: boolean,
+      order: 'asc' | 'desc',
+      noncurrentVersions: VersionMode,
+      deleteMarkers: MarkerMode
+    ): ModelEntry[] => {
+      const filtered = modelRows.filter(
+        (row) =>
+          (noncurrentVersions !== 'only' || row.archived_at !== null) &&
+          (deleteMarkers !== 'exclude' || !row.is_delete_marker) &&
+          (deleteMarkers !== 'only' || row.is_delete_marker)
+      )
+      const objects: ModelEntry[] = filtered
+        .filter((row) => !withDelimiter || !row.name.includes('/'))
+        .map((row) => ({
+          kind: 'object',
+          name: `${prefix}${row.name}`,
+          sortName: `${prefix}${row.name}`,
+          version: row.version,
+          archived_at: row.archived_at,
+        }))
+      const folders: ModelEntry[] = withDelimiter
+        ? [
+            ...new Set(
+              filtered.flatMap((row) => {
+                const delimiter = row.name.indexOf('/')
+                return delimiter === -1 ? [] : [`${prefix}${row.name.slice(0, delimiter + 1)}`]
+              })
+            ),
+          ].map((name) => ({
+            kind: 'folder' as const,
+            name,
+            sortName: name,
+            version: null,
+            archived_at: null,
+          }))
+        : []
+
+      return [...objects, ...folders].sort((left, right) => {
+        const nameOrder = compareC(left.sortName, right.sortName)
+        if (nameOrder !== 0) return order === 'asc' ? nameOrder : -nameOrder
+
+        const leftTime = left.archived_at === null ? 'infinity' : left.archived_at.slice(0, 23)
+        const rightTime = right.archived_at === null ? 'infinity' : right.archived_at.slice(0, 23)
+        const timestampOrder = compareC(leftTime, rightTime)
+        if (timestampOrder !== 0) return -timestampOrder
+        return compareC(left.version ?? '', right.version ?? '')
+      })
+    }
+
+    try {
+      for (const withDelimiter of [false, true]) {
+        for (const order of ['asc', 'desc'] as const) {
+          for (const noncurrentVersions of ['include', 'only'] as const) {
+            for (const deleteMarkers of ['exclude', 'include', 'only'] as const) {
+              for (const limit of [1, 2, 3]) {
+                const expected = reference(withDelimiter, order, noncurrentVersions, deleteMarkers)
+                const actual: string[] = []
+                let cursor: string | undefined
+                let page = 0
+
+                do {
+                  const response = await appInstance.inject({
+                    method: 'POST',
+                    url: '/object/list-v2/bucket2',
+                    headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+                    payload: {
+                      prefix,
+                      with_delimiter: withDelimiter,
+                      noncurrentVersions,
+                      deleteMarkers,
+                      sortBy: { column: 'name', order },
+                      limit,
+                      cursor,
+                    },
+                  })
+                  const context = JSON.stringify({
+                    withDelimiter,
+                    order,
+                    noncurrentVersions,
+                    deleteMarkers,
+                    limit,
+                    page,
+                  })
+                  expect(response.statusCode, context).toBe(200)
+                  const body = response.json<{
+                    objects: Obj[]
+                    folders: Obj[]
+                    hasNext: boolean
+                    nextCursor?: string
+                  }>()
+                  const expectedPage = expected.slice(page * limit, (page + 1) * limit)
+                  const expectedObjects = expectedPage
+                    .filter((entry) => entry.kind === 'object')
+                    .map(identity)
+                  const expectedFolders = expectedPage
+                    .filter((entry) => entry.kind === 'folder')
+                    .map(identity)
+                  const actualObjects = body.objects.map((entry) =>
+                    identity({ kind: 'object', name: entry.name, version: entry.version })
+                  )
+                  const actualFolders = body.folders.map((entry) =>
+                    identity({ kind: 'folder', name: entry.name })
+                  )
+
+                  expect(actualObjects, context).toEqual(expectedObjects)
+                  expect(actualFolders, context).toEqual(expectedFolders)
+                  expect(body.hasNext, context).toBe((page + 1) * limit < expected.length)
+                  expect(Boolean(body.nextCursor), context).toBe(body.hasNext)
+                  actual.push(...actualObjects, ...actualFolders)
+                  cursor = body.hasNext ? body.nextCursor : undefined
+                  page += 1
+                  expect(page, context).toBeLessThan(20)
+                } while (cursor)
+
+                const expectedIdentities = expected.map(identity)
+                expect(new Set(actual).size).toBe(actual.length)
+                expect(new Set(actual)).toEqual(new Set(expectedIdentities))
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(
+          db,
+          'bucket2',
+          modelRows.map((row) => `${prefix}${row.name}`)
+        )
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 30_000)
+
+  test('name pagination matches the model at exact, mid-key, and final-key internal batch boundaries', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/v2-batch-model-${runId}/`
+    const baseTime = Date.parse('2024-08-01T00:00:00.000Z')
+    const keys = [
+      { name: '000-desc-final.bin', versions: 100 },
+      { name: 'bbb-exact.bin', versions: 100 },
+      { name: 'ccc-single.bin', versions: 1 },
+      { name: 'ddd-mid-key.bin', versions: 101 },
+      { name: 'zzz-asc-final.bin', versions: 100 },
+    ]
+    const rows = keys.flatMap((key, keyIndex) =>
+      Array.from({ length: key.versions }, (_, versionIndex) => ({
+        bucket_id: 'bucket2',
+        name: `${prefix}${key.name}`,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: `${key.name}-v-${String(versionIndex).padStart(3, '0')}`,
+        archived_at:
+          versionIndex === key.versions - 1
+            ? null
+            : new Date(baseTime + keyIndex * 1_000_000 + versionIndex * 1000).toISOString(),
+        is_versioned: true,
+        is_delete_marker: false,
+      }))
+    )
+    const expectedFor = (order: 'asc' | 'desc') =>
+      rows
+        .slice()
+        .sort((left, right) => {
+          const nameOrder = left.name === right.name ? 0 : left.name < right.name ? -1 : 1
+          if (nameOrder !== 0) return order === 'asc' ? nameOrder : -nameOrder
+          if (left.archived_at === null) return -1
+          if (right.archived_at === null) return 1
+          if (left.archived_at !== right.archived_at) {
+            return left.archived_at > right.archived_at ? -1 : 1
+          }
+          return left.version < right.version ? -1 : left.version > right.version ? 1 : 0
+        })
+        .map((row) => `${row.name}::${row.version}`)
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      for (const withDelimiter of [false, true]) {
+        for (const order of ['asc', 'desc'] as const) {
+          const result = await listAllVersions({
+            prefix,
+            with_delimiter: withDelimiter,
+            noncurrentVersions: 'include',
+            deleteMarkers: 'include',
+            sortBy: { column: 'name', order },
+            // list_objects_with_delimiter's internal batch size is 100,
+            // so the 100/101-version keys exercise exact and mid-key exits.
+            limit: 50,
+          })
+          const actual = result.objects.map((object) => `${object.name}::${object.version}`)
+
+          expect(result.folders).toEqual([])
+          expect(actual).toEqual(expectedFor(order))
+          expect(new Set(actual).size).toBe(rows.length)
+          expect(result.pages).toBe(Math.ceil(rows.length / 50))
+        }
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(
+          db,
+          'bucket2',
+          keys.map((key) => `${prefix}${key.name}`)
+        )
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 20_000)
+
+  test.each([
+    ['flat asc', false, 'asc'],
+    ['flat desc', false, 'desc'],
+    ['delimiter asc', true, 'asc'],
+    ['delimiter desc', true, 'desc'],
+  ] as const)('does not skip versions whose archived_at values share a millisecond (%s)', async (_path, withDelimiter, order) => {
+    const runId = randomUUID()
+    const objectName = `authenticated/microsecond-cursor-${runId}.png`
+    const rows: Array<Partial<Obj> & { bucket_id: string; name: string }> = [
+      {
+        bucket_id: 'bucket2',
+        name: objectName,
+        version: 'current',
+        archived_at: null,
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+      // These retain distinct PostgreSQL microseconds when sent as query
+      // parameters, but all serialize to the same JavaScript millisecond.
+      // Version must therefore be the final cursor/order tiebreaker.
+      {
+        bucket_id: 'bucket2',
+        name: objectName,
+        version: 'archived-a',
+        archived_at: '2024-06-01T00:00:00.123789Z',
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+      {
+        bucket_id: 'bucket2',
+        name: objectName,
+        version: 'archived-b',
+        archived_at: '2024-06-01T00:00:00.123456Z',
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+      {
+        bucket_id: 'bucket2',
+        name: objectName,
+        version: 'archived-c',
+        archived_at: '2024-06-01T00:00:00.123123Z',
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+    ]
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const result = await listAllVersions({
+        prefix: objectName,
+        with_delimiter: withDelimiter,
+        noncurrentVersions: 'include',
+        sortBy: { column: 'name', order },
+        limit: 1,
+      })
+
+      expect(result.pages).toBe(4)
+      expect(result.objects.map((object) => object.version)).toEqual([
+        'current',
+        'archived-a',
+        'archived-b',
+        'archived-c',
+      ])
+      expect(new Set(result.objects.map((object) => object.version)).size).toBe(4)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  describe('continuation tokens lock noncurrentVersions/deleteMarkers', () => {
+    async function seedFourVersionKey(objectName: string, baseTime: number) {
+      const seedTx = await getSuperuserPostgrestClient()
+      await insertObjects(seedTx, buildVersionRows('bucket2', objectName, 4, baseTime))
+      await seedTx.commit()
+      tnx = undefined
+    }
+
+    async function seedFourVersionKeyWithMarkers(objectName: string, baseTime: number) {
+      const seedTx = await getSuperuserPostgrestClient()
+      await insertObjects(seedTx, buildVersionRows('bucket2', objectName, 4, baseTime))
+      await seedTx.query(
+        `UPDATE storage.objects
+         SET is_delete_marker = true
+         WHERE bucket_id = $1 AND name = $2
+           AND (version LIKE 'v0-%' OR version LIKE 'v1-%')`,
+        ['bucket2', objectName]
+      )
+      await seedTx.commit()
+      tnx = undefined
+    }
+
+    test('an omitted filter on page 2 inherits the token, still returning every remaining version', async () => {
+      const runId = randomUUID()
+      const objectName = `authenticated/lock-inherit-${runId}.png`
+      await seedFourVersionKey(objectName, Date.parse('2024-03-01T00:00:00.000Z'))
+
+      try {
+        const page1 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: { prefix: objectName, noncurrentVersions: 'include', limit: 1 },
+        })
+        expect(page1.statusCode).toBe(200)
+        const body1 = page1.json<{ hasNext: boolean; nextCursor?: string; objects: Obj[] }>()
+        expect(body1.hasNext).toBe(true)
+
+        // Page 2 deliberately omits noncurrentVersions entirely.
+        const page2 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: { prefix: objectName, cursor: body1.nextCursor },
+        })
+        expect(page2.statusCode).toBe(200)
+        const body2 = page2.json<{ objects: Obj[] }>()
+
+        // Still 'include' behavior inherited from the token - not reverted
+        // to current-only, and no versions from this key were skipped.
+        const versions = [...body1.objects, ...body2.objects].map((o) => o.version)
+        expect(new Set(versions).size).toBe(4)
+      } finally {
+        const cleanupTx = await getSuperuserPostgrestClient()
+        await withDeleteEnabled(cleanupTx, async (db) => {
+          await deleteObjectsByName(db, 'bucket2', objectName)
+        })
+        await cleanupTx.commit()
+        tnx = undefined
+      }
+    })
+
+    test('an explicitly resent, matching filter on page 2 is accepted', async () => {
+      const runId = randomUUID()
+      const objectName = `authenticated/lock-match-${runId}.png`
+      await seedFourVersionKey(objectName, Date.parse('2024-03-02T00:00:00.000Z'))
+
+      try {
+        const page1 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: { prefix: objectName, noncurrentVersions: 'include', limit: 1 },
+        })
+        const body1 = page1.json<{ nextCursor?: string }>()
+
+        const page2 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'include',
+            cursor: body1.nextCursor,
+          },
+        })
+        expect(page2.statusCode).toBe(200)
+      } finally {
+        const cleanupTx = await getSuperuserPostgrestClient()
+        await withDeleteEnabled(cleanupTx, async (db) => {
+          await deleteObjectsByName(db, 'bucket2', objectName)
+        })
+        await cleanupTx.commit()
+        tnx = undefined
+      }
+    })
+
+    test('an explicitly resent, mismatched filter on page 2 is rejected', async () => {
+      const runId = randomUUID()
+      const objectName = `authenticated/lock-mismatch-${runId}.png`
+      await seedFourVersionKey(objectName, Date.parse('2024-03-03T00:00:00.000Z'))
+
+      try {
+        const page1 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: { prefix: objectName, noncurrentVersions: 'include', limit: 1 },
+        })
+        const body1 = page1.json<{ nextCursor?: string }>()
+
+        const page2 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'exclude',
+            cursor: body1.nextCursor,
+          },
+        })
+        expect(page2.statusCode).toBe(400)
+        expect(page2.json()).toMatchObject({
+          message: expect.stringContaining('noncurrentVersions must match'),
+        })
+      } finally {
+        const cleanupTx = await getSuperuserPostgrestClient()
+        await withDeleteEnabled(cleanupTx, async (db) => {
+          await deleteObjectsByName(db, 'bucket2', objectName)
+        })
+        await cleanupTx.commit()
+        tnx = undefined
+      }
+    })
+
+    test('an omitted deleteMarkers filter on page 2 inherits the token value', async () => {
+      const runId = randomUUID()
+      const objectName = `authenticated/lock-markers-inherit-${runId}.png`
+      await seedFourVersionKeyWithMarkers(objectName, Date.parse('2024-03-05T00:00:00.000Z'))
+
+      try {
+        const page1 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'include',
+            deleteMarkers: 'only',
+            limit: 1,
+          },
+        })
+        expect(page1.statusCode).toBe(200)
+        const body1 = page1.json<{ hasNext: boolean; nextCursor?: string; objects: Obj[] }>()
+        expect(body1.hasNext).toBe(true)
+
+        const page2 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'include',
+            cursor: body1.nextCursor,
+          },
+        })
+        expect(page2.statusCode).toBe(200)
+        const body2 = page2.json<{ objects: Obj[] }>()
+        expect([...body1.objects, ...body2.objects]).toHaveLength(2)
+        expect(
+          [...body1.objects, ...body2.objects].every((object) => object.is_delete_marker)
+        ).toBe(true)
+      } finally {
+        const cleanupTx = await getSuperuserPostgrestClient()
+        await withDeleteEnabled(cleanupTx, async (db) => {
+          await deleteObjectsByName(db, 'bucket2', objectName)
+        })
+        await cleanupTx.commit()
+        tnx = undefined
+      }
+    })
+
+    test('an explicitly resent, mismatched deleteMarkers filter on page 2 is rejected', async () => {
+      const runId = randomUUID()
+      const objectName = `authenticated/lock-markers-mismatch-${runId}.png`
+      await seedFourVersionKeyWithMarkers(objectName, Date.parse('2024-03-06T00:00:00.000Z'))
+
+      try {
+        const page1 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'include',
+            deleteMarkers: 'only',
+            limit: 1,
+          },
+        })
+        const body1 = page1.json<{ nextCursor?: string }>()
+
+        const page2 = await appInstance.inject({
+          method: 'POST',
+          url: '/object/list-v2/bucket2',
+          headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+          payload: {
+            prefix: objectName,
+            noncurrentVersions: 'include',
+            deleteMarkers: 'exclude',
+            cursor: body1.nextCursor,
+          },
+        })
+        expect(page2.statusCode).toBe(400)
+        expect(page2.json()).toMatchObject({
+          message: expect.stringContaining('deleteMarkers must match'),
+        })
+      } finally {
+        const cleanupTx = await getSuperuserPostgrestClient()
+        await withDeleteEnabled(cleanupTx, async (db) => {
+          await deleteObjectsByName(db, 'bucket2', objectName)
+        })
+        await cleanupTx.commit()
+        tnx = undefined
+      }
+    })
+
+    test.each([
+      'n',
+      'd',
+    ])('a cursor with an unrecognized %s value is rejected rather than trusted', async (letter) => {
+      const craftedCursor = Buffer.from(`l:whatever\n${letter}:garbage`).toString('base64')
+
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list-v2/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: { prefix: 'authenticated/', cursor: craftedCursor },
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchObject({
+        message: expect.stringContaining('continuation token'),
+      })
+    })
   })
 })

--- a/src/test/object-list-v2.test.ts
+++ b/src/test/object-list-v2.test.ts
@@ -1553,7 +1553,7 @@ describe('objects - list v2 versioning tests', () => {
     }
   })
 
-  test('exactMatch on listObjectsV2 matches only the literal key, not a shared prefix', async () => {
+  test('exactMatch pagination stays on the cursor key when the request prefix changes', async () => {
     const runId = randomUUID()
     const objectName = `authenticated/exact-match-${runId}.png`
     const decoyName = `${objectName}.decoy`
@@ -1588,7 +1588,7 @@ describe('objects - list v2 versioning tests', () => {
         method: 'POST',
         url: '/object/list-v2/bucket2',
         headers: { authorization: `Bearer ${await serviceKeyAsync}` },
-        payload: { cursor: body.nextCursor, limit: 1 },
+        payload: { prefix: decoyName, cursor: body.nextCursor, limit: 1 },
       })
       expect(page2.statusCode).toBe(200)
       const body2 = page2.json<{ hasNext: boolean; objects: Obj[] }>()

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -3830,6 +3830,61 @@ describe('testing list objects', () => {
     }
   })
 
+  test('list-v1 deleteMarkers=only advances in ascending name order without duplicating rows', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const prefix = `delete-marker-asc-${runId}/`
+    const objectNames = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt', 'f.txt'].map(
+      (name) => `${prefix}${name}`
+    )
+    const markerNames = new Set(['b.txt', 'd.txt', 'f.txt'])
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(
+      seedTx,
+      objectNames.map((name) => ({
+        bucket_id: bucketName,
+        name,
+        version: `${runId}-${name}`,
+        is_delete_marker: markerNames.has(name.slice(prefix.length)),
+        is_versioned: true,
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/object/list/${bucketName}`,
+        headers: {
+          authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+        payload: {
+          prefix,
+          limit: 10,
+          offset: 0,
+          noncurrentVersions: 'exclude',
+          deleteMarkers: 'only',
+          sortBy: { column: 'name', order: 'asc' },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json<{ name: string }[]>().map((object) => object.name)).toEqual([
+        'b.txt',
+        'd.txt',
+        'f.txt',
+      ])
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, bucketName, objectNames)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
   test('searching the bucket root folder', async () => {
     const response = await appInstance.inject({
       method: 'POST',

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -4423,6 +4423,461 @@ describe('testing list objects', () => {
       tnx = undefined
     }
   })
+
+  test('applies noncurrentVersions and deleteMarkers filters on the v1 list route', async () => {
+    const runId = randomUUID()
+    const objectName = `authenticated/v1-versions-${runId}.png`
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z')
+
+    function buildVersionRows(
+      bucketId: string,
+      name: string,
+      count: number,
+      baseTime: number
+    ): Array<Partial<Obj> & { bucket_id: string; name: string }> {
+      const rows: Array<Partial<Obj> & { bucket_id: string; name: string }> = []
+      for (let i = 0; i < count; i++) {
+        const isCurrent = i === count - 1
+        const createdAt = new Date(baseTime + i * 1000).toISOString()
+        rows.push({
+          bucket_id: bucketId,
+          name,
+          owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+          version: `v${i}-${randomUUID()}`,
+          metadata: { mimetype: 'image/png', size: 1000 + i },
+          created_at: createdAt,
+          archived_at: isCurrent ? null : createdAt,
+          is_versioned: true,
+          is_delete_marker: false,
+        })
+      }
+      return rows
+    }
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...buildVersionRows('bucket2', objectName, 3, baseTime),
+      {
+        bucket_id: 'bucket2',
+        name: objectName,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: `delete-marker-${runId}`,
+        created_at: new Date(baseTime + 3000).toISOString(),
+        archived_at: new Date(baseTime + 3000).toISOString(),
+        is_versioned: true,
+        is_delete_marker: true,
+      },
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const exclude = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: { prefix: objectName, exactMatch: true, limit: 10, offset: 0 },
+      })
+      expect(exclude.statusCode).toBe(200)
+      expect(exclude.json<Obj[]>()).toHaveLength(1)
+
+      const include = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix: objectName,
+          exactMatch: true,
+          noncurrentVersions: 'include',
+          limit: 10,
+          offset: 0,
+        },
+      })
+      expect(include.statusCode).toBe(200)
+      expect(include.json<Obj[]>()).toHaveLength(3)
+
+      const archivedMarkers = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix: objectName,
+          exactMatch: true,
+          noncurrentVersions: 'only',
+          deleteMarkers: 'only',
+          limit: 10,
+          offset: 0,
+        },
+      })
+      expect(archivedMarkers.statusCode).toBe(200)
+      const markerRows = archivedMarkers.json<Obj[]>()
+      expect(markerRows).toHaveLength(1)
+      expect(markerRows[0].version).toBe(`delete-marker-${runId}`)
+      expect(markerRows[0].is_delete_marker).toBe(true)
+
+      const allRows = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix: objectName,
+          exactMatch: true,
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          limit: 10,
+          offset: 0,
+        },
+      })
+      expect(allRows.statusCode).toBe(200)
+      expect(allRows.json<Obj[]>()).toHaveLength(4)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test.each([
+    'asc',
+    'desc',
+  ] as const)('v1 list resumes within a key when versions cross its internal batch boundary (%s)', async (order) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/v1-version-batch-${runId}/`
+    const objectName = `${prefix}file.png`
+    const baseTime = Date.parse('2024-07-01T00:00:00.000Z')
+    const rows = Array.from({ length: 101 }, (_, index) => ({
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `v-${String(index).padStart(3, '0')}`,
+      created_at: new Date(baseTime + index * 1000).toISOString(),
+      archived_at: index === 100 ? null : new Date(baseTime + index * 1000).toISOString(),
+      is_versioned: true,
+      is_delete_marker: false,
+    }))
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      // limit=1 makes storage.search's internal batch size 100. Skipping the
+      // first 100 rows forces it to resume the same key in a second batch.
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix,
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          limit: 1,
+          offset: 100,
+          sortBy: { column: 'name', order },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const result = response.json<Obj[]>()
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('file.png')
+      expect(result[0].version).toBe('v-000')
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
+  test('v1 multi-version name listing matches the reference model across filters, directions, and offsets', async () => {
+    type VersionMode = 'include' | 'only'
+    type MarkerMode = 'exclude' | 'include' | 'only'
+    type ModelRow = {
+      name: string
+      version: string
+      archived_at: string | null
+      is_delete_marker: boolean
+    }
+
+    const runId = randomUUID()
+    const prefix = `authenticated/v1-reference-${runId}/`
+    const baseTime = Date.parse('2024-10-01T00:00:00.000Z')
+    const modelRows: ModelRow[] = [
+      { name: 'alpha.txt', version: 'alpha-current', archived_at: null, is_delete_marker: false },
+      {
+        name: 'alpha.txt',
+        version: 'alpha-old-b',
+        archived_at: new Date(baseTime + 2).toISOString(),
+        is_delete_marker: false,
+      },
+      {
+        name: 'alpha.txt',
+        version: 'alpha-old-a',
+        archived_at: new Date(baseTime + 1).toISOString(),
+        is_delete_marker: true,
+      },
+      {
+        name: 'beta-file',
+        version: 'beta-current',
+        archived_at: null,
+        is_delete_marker: false,
+      },
+      {
+        name: 'beta/child.txt',
+        version: 'beta-child-old',
+        archived_at: new Date(baseTime + 3).toISOString(),
+        is_delete_marker: false,
+      },
+      {
+        name: 'folder-a/child.txt',
+        version: 'folder-marker',
+        archived_at: new Date(baseTime + 4).toISOString(),
+        is_delete_marker: true,
+      },
+      { name: 'middle.txt', version: 'middle-current', archived_at: null, is_delete_marker: false },
+      {
+        name: 'zulu.txt',
+        version: 'zulu-old',
+        archived_at: new Date(baseTime + 5).toISOString(),
+        is_delete_marker: false,
+      },
+    ]
+
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(
+      seedTx,
+      modelRows.map((row) => ({
+        bucket_id: 'bucket2',
+        name: `${prefix}${row.name}`,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: row.version,
+        archived_at: row.archived_at,
+        is_versioned: true,
+        is_delete_marker: row.is_delete_marker,
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    const identity = (row: { id?: string | null; name: string; version?: string | null }) =>
+      `${row.id == null ? 'folder' : 'file'}:${row.name}:${row.version ?? ''}`
+
+    const reference = (
+      noncurrentVersions: VersionMode,
+      deleteMarkers: MarkerMode,
+      order: 'asc' | 'desc'
+    ) => {
+      const filtered = modelRows.filter(
+        (row) =>
+          (noncurrentVersions !== 'only' || row.archived_at !== null) &&
+          (deleteMarkers !== 'exclude' || !row.is_delete_marker) &&
+          (deleteMarkers !== 'only' || row.is_delete_marker)
+      )
+      const folders = [
+        ...new Set(
+          filtered.flatMap((row) => {
+            const delimiter = row.name.indexOf('/')
+            return delimiter === -1 ? [] : [row.name.slice(0, delimiter)]
+          })
+        ),
+      ].map((name) => ({
+        name,
+        sortName: `${name}/`,
+        version: null,
+        archived_at: null,
+        id: null,
+        isPrefix: true,
+      }))
+      const leaves = filtered
+        .filter((row) => !row.name.includes('/'))
+        .map((row) => ({ ...row, sortName: row.name, id: row.version, isPrefix: false }))
+
+      return [...folders, ...leaves]
+        .sort((left, right) => {
+          const leftName = left.sortName.toLowerCase()
+          const rightName = right.sortName.toLowerCase()
+          const nameOrder = leftName === rightName ? 0 : leftName < rightName ? -1 : 1
+          if (nameOrder !== 0) return order === 'asc' ? nameOrder : -nameOrder
+          if (left.isPrefix !== right.isPrefix) {
+            return Number(left.isPrefix) - Number(right.isPrefix)
+          }
+          const leftTime =
+            left.archived_at === null ? Number.POSITIVE_INFINITY : Date.parse(left.archived_at)
+          const rightTime =
+            right.archived_at === null ? Number.POSITIVE_INFINITY : Date.parse(right.archived_at)
+          if (leftTime !== rightTime) return rightTime - leftTime
+          return (left.version ?? '').localeCompare(right.version ?? '', 'en')
+        })
+        .map(identity)
+    }
+
+    try {
+      for (const order of ['asc', 'desc'] as const) {
+        for (const noncurrentVersions of ['include', 'only'] as const) {
+          for (const deleteMarkers of ['exclude', 'include', 'only'] as const) {
+            const expected = reference(noncurrentVersions, deleteMarkers, order)
+            const offsets = [...new Set([0, 1, 3, Math.max(expected.length - 1, 0)])]
+
+            for (const offset of offsets) {
+              const response = await appInstance.inject({
+                method: 'POST',
+                url: '/object/list/bucket2',
+                headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+                payload: {
+                  prefix,
+                  noncurrentVersions,
+                  deleteMarkers,
+                  limit: 3,
+                  offset,
+                  sortBy: { column: 'name', order },
+                },
+              })
+
+              expect(response.statusCode).toBe(200)
+              expect(
+                response.json<Obj[]>().map(identity),
+                JSON.stringify({ order, noncurrentVersions, deleteMarkers, offset })
+              ).toEqual(expected.slice(offset, offset + 3))
+            }
+          }
+        }
+      }
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(
+          db,
+          'bucket2',
+          modelRows.map((row) => `${prefix}${row.name}`)
+        )
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 15_000)
+
+  test.each([
+    'asc',
+    'desc',
+  ] as const)('v1 list terminates after exhausting the final multi-version key (%s)', async (order) => {
+    const runId = randomUUID()
+    const prefix = `authenticated/v1-final-version-key-${runId}/`
+    const objectName = `${prefix}file.png`
+    const baseTime = Date.parse('2024-08-01T00:00:00.000Z')
+    const rows = Array.from({ length: 300 }, (_, index) => ({
+      bucket_id: 'bucket2',
+      name: objectName,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `v-${String(index).padStart(3, '0')}`,
+      created_at: new Date(baseTime + index * 1000).toISOString(),
+      archived_at: index === 299 ? null : new Date(baseTime + index * 1000).toISOString(),
+      is_versioned: true,
+      is_delete_marker: false,
+    }))
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, rows)
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix,
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          limit: 500,
+          offset: 0,
+          sortBy: { column: 'name', order },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const result = response.json<Obj[]>()
+      expect(result).toHaveLength(300)
+      expect(new Set(result.map((object) => object.version)).size).toBe(300)
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', objectName)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 5000)
+
+  test('v1 desc listing advances to the next key after exhausting a key at a batch boundary', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/v1-desc-next-key-${runId}/`
+    const deepKey = `${prefix}zzz-deep.bin`
+    const targetKey = `${prefix}aaa-target.bin`
+    const baseTime = Date.parse('2024-09-01T00:00:00.000Z')
+    const deepRows = Array.from({ length: 100 }, (_, index) => ({
+      bucket_id: 'bucket2',
+      name: deepKey,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `deep-${String(index).padStart(3, '0')}`,
+      created_at: new Date(baseTime + index * 1000).toISOString(),
+      archived_at: index === 99 ? null : new Date(baseTime + index * 1000).toISOString(),
+      is_versioned: true,
+      is_delete_marker: false,
+    }))
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...deepRows,
+      {
+        bucket_id: 'bucket2',
+        name: targetKey,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: 'target',
+        archived_at: null,
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      // limit=2 gives an internal batch size of 100. DESC visits the 100
+      // deep-key versions first; offset consumes them, so the next batch
+      // must advance to aaa-target instead of replaying zzz-deep.
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix,
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          limit: 2,
+          offset: 100,
+          sortBy: { column: 'name', order: 'desc' },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const result = response.json<Obj[]>()
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('aaa-target.bin')
+      expect(result[0].version).toBe('target')
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [deepKey, targetKey])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 5000)
 })
 
 describe('testing GET object info response fields gated on migration', () => {

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -4878,6 +4878,85 @@ describe('testing list objects', () => {
       tnx = undefined
     }
   }, 5000)
+
+  test('v1 asc listing advances to the next key after exhausting a key at a batch boundary', async () => {
+    const runId = randomUUID()
+    const prefix = `authenticated/v1-asc-next-key-${runId}/`
+    const deepKey = `${prefix}aaa-deep.bin`
+    const siblingKey = `${deepKey}!`
+    const targetKey = `${prefix}zzz-target.bin`
+    const baseTime = Date.parse('2024-09-01T00:00:00.000Z')
+    const deepRows = Array.from({ length: 100 }, (_, index) => ({
+      bucket_id: 'bucket2',
+      name: deepKey,
+      owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+      version: `deep-${String(index).padStart(3, '0')}`,
+      created_at: new Date(baseTime + index * 1000).toISOString(),
+      archived_at: index === 99 ? null : new Date(baseTime + index * 1000).toISOString(),
+      is_versioned: true,
+      is_delete_marker: false,
+    }))
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(seedTx, [
+      ...deepRows,
+      {
+        bucket_id: 'bucket2',
+        name: siblingKey,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: 'sibling',
+        archived_at: null,
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+      {
+        bucket_id: 'bucket2',
+        name: targetKey,
+        owner: 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2',
+        version: 'target',
+        archived_at: null,
+        is_versioned: true,
+        is_delete_marker: false,
+      },
+    ])
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      // limit=2 gives an internal batch size of 100. ASC visits the 100
+      // deep-key versions first; offset consumes them, so the next batch
+      // must advance to the immediate sibling. `!` sorts after the exhausted
+      // key but before the `/` previously appended to advance the seek, so
+      // using `deepKey || '/'` here would silently skip this row.
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: '/object/list/bucket2',
+        headers: { authorization: `Bearer ${await serviceKeyAsync}` },
+        payload: {
+          prefix,
+          noncurrentVersions: 'include',
+          deleteMarkers: 'include',
+          limit: 2,
+          offset: 100,
+          sortBy: { column: 'name', order: 'asc' },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const result = response.json<Obj[]>()
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('aaa-deep.bin!')
+      expect(result[0].version).toBe('sibling')
+      expect(result[1].name).toBe('zzz-target.bin')
+      expect(result[1].version).toBe('target')
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, 'bucket2', [deepKey, siblingKey, targetKey])
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  }, 5000)
 })
 
 describe('testing GET object info response fields gated on migration', () => {

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -3775,6 +3775,61 @@ describe('testing move object', () => {
 })
 
 describe('testing list objects', () => {
+  test('list-v1 deleteMarkers=only advances in descending name order', async () => {
+    const runId = randomUUID()
+    const bucketName = 'bucket2'
+    const prefix = `delete-marker-desc-${runId}/`
+    const objectNames = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt', 'f.txt'].map(
+      (name) => `${prefix}${name}`
+    )
+    const markerNames = new Set(['b.txt', 'd.txt', 'f.txt'])
+    const seedTx = await getSuperuserPostgrestClient()
+    await insertObjects(
+      seedTx,
+      objectNames.map((name) => ({
+        bucket_id: bucketName,
+        name,
+        version: `${runId}-${name}`,
+        is_delete_marker: markerNames.has(name.slice(prefix.length)),
+        is_versioned: true,
+      }))
+    )
+    await seedTx.commit()
+    tnx = undefined
+
+    try {
+      const response = await appInstance.inject({
+        method: 'POST',
+        url: `/object/list/${bucketName}`,
+        headers: {
+          authorization: `Bearer ${await serviceKeyAsync}`,
+        },
+        payload: {
+          prefix,
+          limit: 10,
+          offset: 0,
+          noncurrentVersions: 'exclude',
+          deleteMarkers: 'only',
+          sortBy: { column: 'name', order: 'desc' },
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json<{ name: string }[]>().map((object) => object.name)).toEqual([
+        'f.txt',
+        'd.txt',
+        'b.txt',
+      ])
+    } finally {
+      const cleanupTx = await getSuperuserPostgrestClient()
+      await withDeleteEnabled(cleanupTx, async (db) => {
+        await deleteObjectsByName(db, bucketName, objectNames)
+      })
+      await cleanupTx.commit()
+      tnx = undefined
+    }
+  })
+
   test('searching the bucket root folder', async () => {
     const response = await appInstance.inject({
       method: 'POST',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Part of the two phase roll out in #1346 to drop the `bucketid_objname` and add tests