### PR TITLE
fix: make multigres unsafe-statement bypass a per-connection setting

### DIFF
--- a/.docker/docker-compose-infra-multigres-override.yml
+++ b/.docker/docker-compose-infra-multigres-override.yml
@@ -17,9 +17,6 @@ services:
       # 2 cells is the minimum: the shard bootstraps with an AtLeastN(2)
       # durability policy, so a single pooler can never elect a leader.
       MULTIGRES_NUM_CELLS: "2"
-      # Storage migrations contain trusted dynamic PL/pgSQL that the gateway's
-      # unsafe-statement analyzer intentionally rejects by default.
-      MT_UNSAFE_POOLER_MODE: "true"
     # Bootstrapping a cluster takes longer than starting a bare postgres image,
     # so allow a generous start period before the gateway answers queries.
     healthcheck:

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -660,7 +660,11 @@ async function connect(options: {
   const dbConfig: ClientConfig = {
     connectionString,
     connectionTimeoutMillis: 60_000,
-    options: `-c search_path=${searchPath}`,
+    // Migrations run trusted dynamic PL/pgSQL that a multigres gateway
+    // rejects by default; only this connection opts into multigres
+    // per-connection bypass, instead of the whole gateway being unsafe.
+    // No-op against a plain postgres backend (accepted as a placeholder GUC).
+    options: `-c search_path=${searchPath} -c multigres.direct_connection=on`,
     ssl,
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The original fix we had (https://github.com/supabase/storage/pull/1341/changes/b90e390f0176a29161d9877d5bf6b87dd0c2f0a3) for this error

```
StorageBackendError: Migration failed. Reason: An error occurred running 'storage-schema'. Rolled back this migration. No further migrations were run. Reason: EXECUTE of a runtime-built statement inside a PL/pgSQL body is not supported: the statement text is not a constant, so it cannot be checked for unsafe session-state changes
```

is no longer a valid flag since this change https://github.com/multigres/multigres/pull/1424

Updating the migrations client to use this `multigres.direct_connection` setting instead