### PR TITLE
chore: rename multigres direct connection to unsafe

### DIFF
--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -664,7 +664,9 @@ async function connect(options: {
     // rejects by default; only this connection opts into multigres
     // per-connection bypass, instead of the whole gateway being unsafe.
     // No-op against a plain postgres backend (accepted as a placeholder GUC).
-    options: `-c search_path=${searchPath} -c multigres.direct_connection=on`,
+    // direct_connection is also accepted, but multigres.unsafe_connection is
+    // more explicit and less likely to be confused with a real connection mode.
+    options: `-c search_path=${searchPath} -c multigres.unsafe_connection=on`,
     ssl,
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Current multigres `direct_connection` param is deprecated in favor of a better name, `unsafe_connection`. 

## What is the new behavior?

Use new name since it's more explicit.

## Additional context

related to https://github.com/multigres/multigres/pull/1427
related to https://github.com/supabase/storage/pull/1354