### PR TITLE
fix: add backoff and jitter into migration scheduling

### DIFF
--- a/src/internal/database/migrations/migrate.test.ts
+++ b/src/internal/database/migrations/migrate.test.ts
@@ -1,4 +1,11 @@
+import { AsyncAbortController } from '@internal/concurrency'
 import { vi } from 'vitest'
+
+type MockEvent = {
+  payload: Record<string, unknown>
+}
+
+type MockBatchSend = (jobs: MockEvent[]) => Promise<void> | void
 
 const {
   mockRunBatchSend,
@@ -10,9 +17,11 @@ const {
   mockLastLocalMigrationName,
   mockLocalMigrationFiles,
   mockPgClientConstructor,
+  mockProgressiveStart,
+  mockConfigState,
 } = vi.hoisted(() => ({
-  mockRunBatchSend: vi.fn(),
-  mockResetBatchSend: vi.fn(),
+  mockRunBatchSend: vi.fn<MockBatchSend>(),
+  mockResetBatchSend: vi.fn<MockBatchSend>(),
   mockInfo: vi.fn(),
   mockBeginTransaction: vi.fn(),
   mockWarning: vi.fn(),
@@ -20,6 +29,10 @@ const {
   mockLastLocalMigrationName: vi.fn(),
   mockLocalMigrationFiles: vi.fn(),
   mockPgClientConstructor: vi.fn(),
+  mockProgressiveStart: vi.fn(),
+  mockConfigState: {
+    migrationStrategy: 'ON_REQUEST',
+  },
 }))
 
 vi.mock('../../../config', () => ({
@@ -33,7 +46,7 @@ vi.mock('../../../config', () => ({
     multitenantDatabaseUrl: '',
     pgQueueEnable: true,
     databaseSSLRootCert: '',
-    dbMigrationStrategy: 'ON_REQUEST',
+    dbMigrationStrategy: mockConfigState.migrationStrategy,
     dbAnonRole: 'anon',
     dbAuthenticatedRole: 'authenticated',
     dbSuperUser: 'postgres',
@@ -49,17 +62,17 @@ vi.mock('../../../config', () => ({
 vi.mock('@storage/events', () => ({
   RunMigrationsOnTenants: class {
     static batchSend = mockRunBatchSend
-    payload: Record<string, unknown>
+    payload: MockEvent['payload']
 
-    constructor(payload: Record<string, unknown>) {
+    constructor(payload: MockEvent['payload']) {
       this.payload = payload
     }
   },
   ResetMigrationsOnTenant: class {
     static batchSend = mockResetBatchSend
-    payload: Record<string, unknown>
+    payload: MockEvent['payload']
 
-    constructor(payload: Record<string, unknown>) {
+    constructor(payload: MockEvent['payload']) {
       this.payload = payload
     }
   },
@@ -110,8 +123,8 @@ vi.mock('./files', () => ({
 
 vi.mock('./progressive', () => ({
   ProgressiveMigrations: class {
-    start() {
-      return undefined
+    start(...args: unknown[]) {
+      return mockProgressiveStart(...args)
     }
   },
 }))
@@ -141,7 +154,7 @@ function getQueryText(statement: unknown): string {
   }
 
   if (statement && typeof statement === 'object' && 'text' in statement) {
-    return String((statement as { text: string }).text)
+    return String(statement.text)
   }
 
   return String(statement)
@@ -200,6 +213,61 @@ function makeTransaction() {
   }
 }
 
+async function loadStartAsyncMigrations(
+  migrationStrategy: 'ON_REQUEST' | 'PROGRESSIVE' | 'FULL_FLEET'
+) {
+  mockConfigState.migrationStrategy = migrationStrategy
+  vi.resetModules()
+  return (await import('./migrate')).startAsyncMigrations
+}
+
+const queueStrategies = ['ON_REQUEST', 'PROGRESSIVE'] as const
+
+describe('startAsyncMigrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConfigState.migrationStrategy = 'ON_REQUEST'
+  })
+
+  it.each(queueStrategies)('starts queue-driven scheduling for %s', async (strategy) => {
+    const signal = new AsyncAbortController().signal
+    const startForStrategy = await loadStartAsyncMigrations(strategy)
+
+    startForStrategy(signal)
+
+    expect(mockProgressiveStart).toHaveBeenCalledWith(signal)
+  })
+
+  it('lets asynchronous shutdown wait for an in-flight full-fleet enqueue', async () => {
+    const deferredBatch = Promise.withResolvers<void>()
+    const transaction = makeTransaction()
+    mockBeginTransaction.mockResolvedValue(transaction)
+    mockLastLocalMigrationName.mockResolvedValue('storage-schema')
+    mockQuery.mockImplementation(createTenantQueryMock([[{ id: 'tenant-a', cursor_id: 1 }], []]))
+    mockRunBatchSend.mockReturnValueOnce(deferredBatch.promise)
+    const startFullFleetMigrations = await loadStartAsyncMigrations('FULL_FLEET')
+    const abortController = new AsyncAbortController()
+
+    startFullFleetMigrations(abortController.signal)
+    expect(mockProgressiveStart).toHaveBeenCalledWith(abortController.signal)
+    await vi.waitFor(() => expect(mockRunBatchSend).toHaveBeenCalledOnce())
+
+    let abortSettled = false
+    const abortPromise = abortController.abortAsync().then(() => {
+      abortSettled = true
+    })
+    await Promise.resolve()
+
+    expect(abortSettled).toBe(false)
+
+    deferredBatch.resolve()
+    await abortPromise
+
+    expect(abortSettled).toBe(true)
+    expect(transaction.commit).toHaveBeenCalledOnce()
+  })
+})
+
 describe('migration helper request id propagation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -227,7 +295,7 @@ describe('migration helper request id propagation', () => {
 
     expect(mockRunBatchSend).toHaveBeenCalledTimes(1)
     const [[batch]] = mockRunBatchSend.mock.calls
-    expect((batch[0] as { payload: Record<string, unknown> }).payload).toMatchObject({
+    expect(batch[0].payload).toMatchObject({
       tenantId: 'tenant-a',
       sbReqId: 'sb-req-123',
       tenant: {
@@ -235,7 +303,7 @@ describe('migration helper request id propagation', () => {
         ref: 'tenant-a',
       },
     })
-    expect((batch[1] as { payload: Record<string, unknown> }).payload).toMatchObject({
+    expect(batch[1].payload).toMatchObject({
       tenantId: 'tenant-b',
       sbReqId: 'sb-req-123',
       tenant: {
@@ -277,7 +345,7 @@ describe('migration helper request id propagation', () => {
 
     expect(mockResetBatchSend).toHaveBeenCalledTimes(1)
     const [[batch]] = mockResetBatchSend.mock.calls
-    expect((batch[0] as { payload: Record<string, unknown> }).payload).toMatchObject({
+    expect(batch[0].payload).toMatchObject({
       tenantId: 'tenant-c',
       untilMigration: 'storage-schema',
       markCompletedTillMigration: 'create-migrations-table',

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -56,7 +56,6 @@ const backportMigrations = [
 export const progressiveMigrations = new ProgressiveMigrations({
   maxSize: 200,
   interval: 1000 * 5, // 5s
-  watch: pgQueueEnable,
 })
 
 /**
@@ -69,12 +68,12 @@ export function startAsyncMigrations(signal: AbortSignal) {
   }
   switch (dbMigrationStrategy) {
     case MultitenantMigrationStrategy.ON_REQUEST:
-      return
     case MultitenantMigrationStrategy.PROGRESSIVE:
       progressiveMigrations.start(signal)
       break
-    case MultitenantMigrationStrategy.FULL_FLEET:
-      runMigrationsOnAllTenants({ signal }).catch((e) => {
+    case MultitenantMigrationStrategy.FULL_FLEET: {
+      progressiveMigrations.start(signal)
+      const fullFleetMigrationRun = runMigrationsOnAllTenants({ signal }).catch((e) => {
         logger.error(
           {
             type: 'migrations',
@@ -83,7 +82,9 @@ export function startAsyncMigrations(signal: AbortSignal) {
           'migration error'
         )
       })
+      signal.addEventListener('abort', () => fullFleetMigrationRun, { once: true })
       break
+    }
     default:
       throw new Error(`Unknown migration strategy: ${dbMigrationStrategy}`)
   }

--- a/src/internal/database/migrations/progressive.test.ts
+++ b/src/internal/database/migrations/progressive.test.ts
@@ -1,28 +1,42 @@
 import { vi } from 'vitest'
 
-const { mockBatchSend, mockWarning, mockError } = vi.hoisted(() => ({
-  mockBatchSend: vi.fn(),
-  mockWarning: vi.fn(),
-  mockError: vi.fn(),
-}))
+type MockTenantConfig = {
+  migrationStatus: string | undefined
+  syncMigrationsDone: boolean
+}
+
+type MockMigrationJob = {
+  payload: Record<string, unknown> & { tenantId: string }
+}
+
+type MockBatchSend = (jobs: MockMigrationJob[]) => Promise<void> | void
+
+const { mockBatchSend, mockGetTenantConfig, mockAreMigrationsUpToDate, mockWarning, mockError } =
+  vi.hoisted(() => ({
+    mockBatchSend: vi.fn<MockBatchSend>(),
+    mockGetTenantConfig: vi.fn<(tenantId: string) => Promise<MockTenantConfig>>(),
+    mockAreMigrationsUpToDate: vi.fn<(tenantId: string) => Promise<boolean>>(),
+    mockWarning: vi.fn(),
+    mockError: vi.fn(),
+  }))
 
 vi.mock('../tenant', () => ({
-  getTenantConfig: vi.fn(),
+  getTenantConfig: mockGetTenantConfig,
   TenantMigrationStatus: {
     FAILED_STALE: 'FAILED_STALE',
   },
 }))
 
 vi.mock('@internal/database/migrations/migrate', () => ({
-  areMigrationsUpToDate: vi.fn(),
+  areMigrationsUpToDate: mockAreMigrationsUpToDate,
 }))
 
 vi.mock('@storage/events', () => ({
   RunMigrationsOnTenants: class {
     static batchSend = mockBatchSend
-    payload: Record<string, unknown>
+    payload: MockMigrationJob['payload']
 
-    constructor(payload: Record<string, unknown>) {
+    constructor(payload: MockMigrationJob['payload']) {
       this.payload = payload
     }
   },
@@ -37,262 +51,842 @@ vi.mock('../../monitoring', () => ({
   },
 }))
 
-import { areMigrationsUpToDate } from '@internal/database/migrations/migrate'
+import { AsyncAbortController } from '@internal/concurrency'
 import { ERRORS } from '@internal/errors'
-import { RunMigrationsOnTenants } from '@storage/events'
-import { getTenantConfig } from '../tenant'
 import { ProgressiveMigrations } from './progressive'
 
+const migrationsUnderTest = new Set<TestProgressiveMigrations>()
+
 class TestProgressiveMigrations extends ProgressiveMigrations {
+  private currentTime = 0
+  private randomValue = 0
+
+  constructor(options: { maxSize: number; interval: number }) {
+    super(options)
+    migrationsUnderTest.add(this)
+  }
+
   seed(...tenants: string[]) {
-    this.tenants.push(...tenants)
+    for (const tenant of tenants) {
+      this.tenants.add(tenant)
+    }
   }
 
   pending() {
     return [...this.tenants]
   }
 
-  isEmitting() {
-    return this.emittingJobs
+  hasInFlightCreateJobs() {
+    return this.inFlightCreateJobs !== undefined
   }
 
   flush(maxJobs: number) {
     return this.createJobs(maxJobs)
   }
+
+  waitForCurrentRun() {
+    return this.inFlightCreateJobs ?? Promise.resolve()
+  }
+
+  advanceTime(milliseconds: number) {
+    this.currentTime += milliseconds
+  }
+
+  async advanceBothClocksBy(timerMilliseconds: number, monotonicMilliseconds = timerMilliseconds) {
+    this.advanceTime(monotonicMilliseconds)
+    await vi.advanceTimersByTimeAsync(timerMilliseconds)
+  }
+
+  setRandom(value: number) {
+    this.randomValue = value
+  }
+
+  backoffState() {
+    return {
+      consecutiveFailures: this.consecutiveBatchSendFailures,
+      retryInMs: Math.max(this.nextBatchSendAttemptAt - this.currentTime, 0),
+    }
+  }
+
+  protected now() {
+    return this.currentTime
+  }
+
+  protected random() {
+    return this.randomValue
+  }
+
+  cleanup() {
+    this.resetBatchSendBackoff()
+  }
 }
 
-const mockGetTenantConfig = vi.mocked(getTenantConfig)
-const mockAreMigrationsUpToDate = vi.mocked(areMigrationsUpToDate)
-const mockRunMigrationsBatchSend = vi.mocked(RunMigrationsOnTenants.batchSend)
+class SettlingWindowProgressiveMigrations extends TestProgressiveMigrations {
+  onRunSettled?: () => void
+
+  protected override async createJobsBatch(maxJobs: number) {
+    await super.createJobsBatch(maxJobs)
+
+    const onRunSettled = this.onRunSettled
+    this.onRunSettled = undefined
+    if (onRunSettled) {
+      queueMicrotask(onRunSettled)
+    }
+  }
+}
+
+class ThrowOnceProgressiveMigrations extends TestProgressiveMigrations {
+  private shouldThrow = true
+
+  protected override async createJobsBatch(maxJobs: number) {
+    if (this.shouldThrow) {
+      this.shouldThrow = false
+      throw new Error('unexpected batch failure')
+    }
+
+    return super.createJobsBatch(maxJobs)
+  }
+}
+
+const mockRunMigrationsBatchSend = mockBatchSend
+const defaultOptions = { maxSize: 10, interval: 1000 }
+const defaultTenantConfig: MockTenantConfig = {
+  migrationStatus: undefined,
+  syncMigrationsDone: false,
+}
+
+function createMigrations(options: Partial<typeof defaultOptions> = {}) {
+  return new TestProgressiveMigrations({ ...defaultOptions, ...options })
+}
+
+function startMigrations(options: Partial<typeof defaultOptions> = {}) {
+  const migrations = createMigrations(options)
+  const controller = new AsyncAbortController()
+  migrations.start(controller.signal)
+
+  return { migrations, controller }
+}
+
+function sentTenantIds(callIndex = 0) {
+  return mockRunMigrationsBatchSend.mock.calls[callIndex][0].map((job) => job.payload.tenantId)
+}
+
+function isNodeTimeout(value: unknown): value is NodeJS.Timeout {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'hasRef' in value &&
+    typeof value.hasRef === 'function'
+  )
+}
 
 describe('ProgressiveMigrations', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 
-    mockGetTenantConfig.mockResolvedValue({
-      migrationStatus: undefined,
-      syncMigrationsDone: false,
-    } as Awaited<ReturnType<typeof getTenantConfig>>)
+    mockGetTenantConfig.mockResolvedValue(defaultTenantConfig)
     mockAreMigrationsUpToDate.mockResolvedValue(false)
+    mockRunMigrationsBatchSend.mockResolvedValue(undefined)
   })
 
-  it('keeps batchSend-failed tenants queued and resets emittingJobs', async () => {
+  afterEach(() => {
+    for (const migrations of migrationsUnderTest) {
+      migrations.cleanup()
+    }
+    migrationsUnderTest.clear()
+    vi.useRealTimers()
+  })
+
+  it('keeps batchSend-failed tenants queued and clears the running state', async () => {
     mockRunMigrationsBatchSend
       .mockRejectedValueOnce(new Error('queue unavailable'))
-      .mockResolvedValueOnce(undefined as never)
+      .mockResolvedValueOnce(undefined)
 
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 10,
-      interval: 1000,
-      watch: false,
-    })
+    const migrations = createMigrations()
 
     migrations.seed('tenant-a')
 
     await expect(migrations.flush(1)).resolves.toBeUndefined()
     expect(migrations.pending()).toEqual(['tenant-a'])
-    expect(migrations.isEmitting()).toBe(false)
+    expect(migrations.hasInFlightCreateJobs()).toBe(false)
     expect(mockError).toHaveBeenCalledWith(
       expect.anything(),
       '[Migrations] Error sending migration jobs batch',
       expect.objectContaining({
         type: 'migrations',
+        metadata: JSON.stringify({
+          strategy: 'progressive',
+          consecutiveFailures: 1,
+          retryDelayMs: 1000,
+        }),
       })
     )
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+    expect(migrations.pending()).toEqual(['tenant-a'])
+
+    migrations.advanceTime(999)
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+
+    migrations.advanceTime(1)
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    expect(migrations.pending()).toEqual([])
+    expect(migrations.hasInFlightCreateJobs()).toBe(false)
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 0,
+      retryInMs: 0,
+    })
+  })
+
+  it('does not retain work when batch sending is deliberately disabled', async () => {
+    mockRunMigrationsBatchSend.mockReturnValueOnce(undefined)
+
+    const migrations = createMigrations({ maxSize: 1 })
+    migrations.seed('tenant-a')
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    expect(migrations.pending()).toEqual([])
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 0,
+      retryInMs: 0,
+    })
+    expect(mockError).not.toHaveBeenCalled()
+  })
+
+  it('does not prepare tenants or shorten an active retry when another tenant arrives at capacity', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+    migrations.setRandom(1)
+    migrations.seed('tenant-a')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 2000,
+      })
+
+      await migrations.advanceBothClocksBy(500)
+      migrations.addTenant('tenant-b')
+
+      expect(mockGetTenantConfig).toHaveBeenCalledTimes(1)
+      expect(migrations.pending()).toEqual(['tenant-a', 'tenant-b'])
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 1500,
+      })
+      expect(vi.getTimerCount()).toBe(1)
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('applies jittered exponential backoff, caps it at one minute, and resets on recovery', async () => {
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable 1'))
+      .mockRejectedValueOnce(new Error('queue unavailable 2'))
+      .mockRejectedValueOnce(new Error('queue unavailable 3'))
+      .mockRejectedValueOnce(new Error('queue unavailable 4'))
+      .mockRejectedValueOnce(new Error('queue unavailable 5'))
+      .mockRejectedValueOnce(new Error('queue unavailable 6'))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('queue unavailable after recovery'))
+
+    const migrations = createMigrations()
+    migrations.setRandom(1)
+    migrations.seed('tenant-a')
+
+    for (const [index, retryDelayMs] of [2000, 4000, 8000, 16000, 32000, 60000].entries()) {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(index + 1)
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: index + 1,
+        retryInMs: retryDelayMs,
+      })
+
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(index + 1)
+      migrations.advanceTime(retryDelayMs)
+    }
 
     await expect(migrations.flush(1)).resolves.toBeUndefined()
     expect(migrations.pending()).toEqual([])
-    expect(migrations.isEmitting()).toBe(false)
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+    expect(migrations.backoffState().consecutiveFailures).toBe(0)
+
+    migrations.setRandom(0)
+    migrations.seed('tenant-b')
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(8)
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 1000,
+    })
   })
 
-  it('logs batch enqueue failures inside the batch handler', async () => {
-    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+  it('retries at the sampled jittered deadline', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable'))
+      .mockResolvedValueOnce(undefined)
 
-    const migrations = new TestProgressiveMigrations({
+    const { migrations, controller } = startMigrations({ interval: 5000 })
+    migrations.setRandom(0.5)
+    migrations.seed('tenant-a')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 7500,
+      })
+
+      await migrations.advanceBothClocksBy(5000)
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+
+      await migrations.advanceBothClocksBy(2499)
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+
+      await migrations.advanceBothClocksBy(1)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(migrations.pending()).toEqual([])
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 0,
+        retryInMs: 0,
+      })
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('honors the retry timer when the monotonic deadline lags by a fraction of a millisecond', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable'))
+      .mockResolvedValueOnce(undefined)
+
+    const { migrations, controller } = startMigrations({ interval: 5000 })
+    migrations.setRandom(0.5)
+    migrations.seed('tenant-a')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+      await migrations.advanceBothClocksBy(7500, 7499.5)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(migrations.pending()).toEqual([])
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('keeps queue wakeups alive after an unexpected batch failure', async () => {
+    vi.useFakeTimers()
+    const abortController = new AsyncAbortController()
+    const migrations = new ThrowOnceProgressiveMigrations({
       maxSize: 10,
       interval: 1000,
-      watch: false,
+    })
+    migrations.start(abortController.signal)
+
+    try {
+      migrations.addTenant('tenant-a')
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(migrations.pending()).toEqual(['tenant-a'])
+      expect(vi.getTimerCount()).toBe(1)
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(migrations.pending()).toEqual([])
+    } finally {
+      await abortController.abortAsync()
+    }
+  })
+
+  it('schedules an underfilled first batch', async () => {
+    vi.useFakeTimers()
+    const { migrations, controller } = startMigrations()
+
+    try {
+      migrations.addTenant('tenant-a')
+      migrations.addTenant('tenant-b')
+
+      expect(migrations.pending()).toEqual(['tenant-a', 'tenant-b'])
+      expect(mockRunMigrationsBatchSend).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(1)
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(migrations.pending()).toEqual([])
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('flushes a full batch without waiting for its underfilled wakeup', async () => {
+    vi.useFakeTimers()
+    const { migrations, controller } = startMigrations({ maxSize: 2 })
+
+    try {
+      migrations.addTenant('tenant-a')
+      expect(vi.getTimerCount()).toBe(1)
+
+      migrations.addTenant('tenant-b')
+      expect(vi.getTimerCount()).toBe(0)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(mockRunMigrationsBatchSend.mock.calls[0][0]).toHaveLength(2)
+      expect(migrations.pending()).toEqual([])
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('schedules remaining work after a batch that was already in flight', async () => {
+    vi.useFakeTimers()
+    const tenantConfig = Promise.withResolvers<MockTenantConfig>()
+    mockGetTenantConfig.mockReturnValueOnce(tenantConfig.promise)
+
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+
+    try {
+      migrations.addTenant('tenant-a')
+      expect(mockGetTenantConfig).toHaveBeenCalledWith('tenant-a')
+
+      migrations.addTenant('tenant-b')
+      expect(vi.getTimerCount()).toBe(0)
+
+      tenantConfig.resolve(defaultTenantConfig)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(sentTenantIds()).toEqual(['tenant-a'])
+      expect(migrations.pending()).toEqual(['tenant-b'])
+      expect(vi.getTimerCount()).toBe(1)
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(sentTenantIds(1)).toEqual(['tenant-b'])
+      expect(migrations.pending()).toEqual([])
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('keeps queue wakeups alive until a rotated preparation failure is retried', async () => {
+    vi.useFakeTimers()
+    mockGetTenantConfig.mockRejectedValueOnce(new Error('control database unavailable'))
+    mockAreMigrationsUpToDate.mockImplementation(async (tenantId) => {
+      return tenantId === 'tenant-current'
     })
 
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+    migrations.seed('tenant-retry', 'tenant-sendable', 'tenant-current')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(migrations.pending()).toEqual(['tenant-sendable', 'tenant-current', 'tenant-retry'])
+
+      for (const expectedPending of [['tenant-current', 'tenant-retry'], ['tenant-retry'], []]) {
+        await migrations.advanceBothClocksBy(1000)
+        await migrations.waitForCurrentRun()
+
+        expect(migrations.pending()).toEqual(expectedPending)
+        expect(vi.getTimerCount()).toBe(expectedPending.length > 0 ? 1 : 0)
+      }
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('resets the failure tier when an unrelated queued batch succeeds', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable 1'))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('queue unavailable 2'))
+
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+    migrations.seed('tenant-a', 'tenant-b')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(migrations.pending()).toEqual(['tenant-a'])
+      expect(vi.getTimerCount()).toBe(1)
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(3)
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 1000,
+      })
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('keeps the failure tier and queue wakeups after an unrelated no-op slice', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable 1'))
+      .mockRejectedValueOnce(new Error('queue unavailable 2'))
+    mockAreMigrationsUpToDate.mockImplementation(async (tenantId) => {
+      return tenantId === 'tenant-current'
+    })
+
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+    migrations.setRandom(1)
+    migrations.seed('tenant-a', 'tenant-current')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 2000,
+      })
+
+      await migrations.advanceBothClocksBy(2000)
+      await migrations.waitForCurrentRun()
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(migrations.pending()).toEqual(['tenant-a'])
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 1,
+        retryInMs: 0,
+      })
+      expect(vi.getTimerCount()).toBe(1)
+
+      await migrations.advanceBothClocksBy(1000)
+      await migrations.waitForCurrentRun()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(migrations.pending()).toEqual(['tenant-a'])
+      expect(migrations.backoffState()).toEqual({
+        consecutiveFailures: 2,
+        retryInMs: 4000,
+      })
+    } finally {
+      await controller.abortAsync()
+    }
+  })
+
+  it('does not let the queue timer keep the process alive', async () => {
+    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const { migrations, controller } = startMigrations()
     migrations.seed('tenant-a')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1)
+      const retryTimer = setTimeoutSpy.mock.results[0]?.value
+      expect(isNodeTimeout(retryTimer)).toBe(true)
+      if (!isNodeTimeout(retryTimer)) {
+        throw new Error('Expected setTimeout() to return a Node.js timer')
+      }
+      expect(retryTimer.hasRef()).toBe(false)
+    } finally {
+      await controller.abortAsync()
+      setTimeoutSpy.mockRestore()
+    }
+  })
+
+  it('allows an idle drain to bypass batch-send backoff', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable'))
+      .mockResolvedValueOnce(undefined)
+
+    const { migrations, controller } = startMigrations()
+    migrations.seed('tenant-a')
+
+    try {
+      await expect(migrations.flush(1)).resolves.toBeUndefined()
+      expect(migrations.backoffState().consecutiveFailures).toBe(1)
+      expect(vi.getTimerCount()).toBe(1)
+
+      await expect(migrations.drain()).resolves.toBeUndefined()
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+      expect(migrations.pending()).toEqual([])
+      expect(migrations.backoffState().consecutiveFailures).toBe(0)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      await controller.abortAsync()
+    }
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('waits for an in-flight batch and drains remaining work on shutdown', async () => {
+    vi.useFakeTimers()
+    const deferredBatch = Promise.withResolvers<void>()
+    mockRunMigrationsBatchSend
+      .mockReturnValueOnce(deferredBatch.promise)
+      .mockResolvedValueOnce(undefined)
+
+    const { migrations, controller } = startMigrations({ maxSize: 1 })
+    migrations.seed('tenant-a', 'tenant-b')
+
+    const flushPromise = migrations.flush(1)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+    expect(sentTenantIds()).toEqual(['tenant-a'])
+    expect(migrations.hasInFlightCreateJobs()).toBe(true)
+
+    let abortSettled = false
+    const abortPromise = controller.abortAsync().then(() => {
+      abortSettled = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    try {
+      expect(abortSettled).toBe(false)
+    } finally {
+      deferredBatch.resolve()
+      await Promise.all([flushPromise, abortPromise])
+    }
+
+    expect(abortSettled).toBe(true)
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
+    expect(sentTenantIds(1)).toEqual(['tenant-b'])
+    expect(migrations.pending()).toEqual([])
+    expect(migrations.hasInFlightCreateJobs()).toBe(false)
+  })
+
+  it('does not schedule another retry when the shutdown drain fails', async () => {
+    vi.useFakeTimers()
+    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+
+    const { migrations, controller } = startMigrations()
+    migrations.seed('tenant-a')
+
+    await controller.abortAsync()
+
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+    expect(migrations.pending()).toEqual(['tenant-a'])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('resets backoff before an idle drain attempt', async () => {
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable 1'))
+      .mockRejectedValueOnce(new Error('queue unavailable 2'))
+
+    const migrations = createMigrations()
+    migrations.setRandom(1)
+    migrations.seed('tenant-a')
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 2000,
+    })
 
     await expect(migrations.drain()).resolves.toBeUndefined()
 
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
     expect(migrations.pending()).toEqual(['tenant-a'])
-    expect(migrations.isEmitting()).toBe(false)
-    expect(mockError).toHaveBeenCalledTimes(1)
-    expect(mockError).toHaveBeenCalledWith(
-      expect.anything(),
-      '[Migrations] Error sending migration jobs batch',
-      expect.objectContaining({
-        type: 'migrations',
-      })
-    )
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 2000,
+    })
   })
 
-  it('keeps new tenants queued while a batch is in flight and ignores duplicate adds', async () => {
-    const deferredBatch = Promise.withResolvers<void>()
-    mockRunMigrationsBatchSend.mockReturnValueOnce(deferredBatch.promise as never)
+  it('uses the scheduler interval as a fixed delay when it exceeds the backoff cap', async () => {
+    mockRunMigrationsBatchSend
+      .mockRejectedValueOnce(new Error('queue unavailable 1'))
+      .mockRejectedValueOnce(new Error('queue unavailable 2'))
 
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 10,
-      interval: 1000,
-      watch: false,
-    })
-
+    const migrations = createMigrations({ interval: 120_000 })
+    migrations.setRandom(0)
     migrations.seed('tenant-a')
 
-    const flushPromise = migrations.flush(1)
-    await new Promise((resolve) => setImmediate(resolve))
-
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
-    expect(migrations.isEmitting()).toBe(true)
-
-    migrations.addTenant('tenant-a')
-    migrations.addTenant('tenant-b')
-
-    expect(migrations.pending()).toEqual(['tenant-a', 'tenant-b'])
-
-    deferredBatch.resolve()
-
-    await expect(flushPromise).resolves.toBeUndefined()
-    expect(migrations.pending()).toEqual(['tenant-b'])
-    expect(migrations.isEmitting()).toBe(false)
-  })
-
-  it('serializes drain with an in-flight batch and drains the remaining tenants after it finishes', async () => {
-    const deferredBatch = Promise.withResolvers<void>()
-    mockRunMigrationsBatchSend
-      .mockReturnValueOnce(deferredBatch.promise as never)
-      .mockResolvedValueOnce(undefined as never)
-
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 1,
-      interval: 1000,
-      watch: false,
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 120_000,
     })
 
+    migrations.advanceTime(120_000)
+    migrations.setRandom(1)
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 2,
+      retryInMs: 120_000,
+    })
+  })
+
+  it('clears backoff when another process empties the queue', async () => {
+    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+
+    const migrations = createMigrations()
+    migrations.seed('tenant-a')
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    migrations.advanceTime(1000)
+    mockAreMigrationsUpToDate.mockResolvedValue(true)
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+    expect(migrations.pending()).toEqual([])
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 0,
+      retryInMs: 0,
+    })
+  })
+
+  it('keeps failure history when the next attempt fails during preparation', async () => {
+    mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+
+    const migrations = createMigrations()
+    migrations.seed('tenant-a')
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+    migrations.advanceTime(1000)
+    mockGetTenantConfig.mockRejectedValue(new Error('control database unavailable'))
+
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+    expect(mockGetTenantConfig).toHaveBeenCalledTimes(2)
+    expect(migrations.pending()).toEqual(['tenant-a'])
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 0,
+    })
+  })
+
+  it('retries once when drain joins an in-flight batch that fails', async () => {
+    const deferredBatch = Promise.withResolvers<void>()
+    mockRunMigrationsBatchSend
+      .mockReturnValueOnce(deferredBatch.promise)
+      .mockRejectedValueOnce(new Error('queue still unavailable'))
+
+    const migrations = createMigrations({ maxSize: 1 })
+    migrations.setRandom(1)
     migrations.seed('tenant-a', 'tenant-b')
 
     const flushPromise = migrations.flush(1)
     await new Promise((resolve) => setImmediate(resolve))
-
     const drainPromise = migrations.drain()
 
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
-    expect(migrations.isEmitting()).toBe(true)
-
-    deferredBatch.resolve()
-
+    deferredBatch.reject(new Error('queue unavailable'))
     await expect(Promise.all([flushPromise, drainPromise])).resolves.toEqual([undefined, undefined])
 
     expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
+    expect(migrations.pending()).toEqual(['tenant-b', 'tenant-a'])
+    expect(migrations.backoffState()).toEqual({
+      consecutiveFailures: 1,
+      retryInMs: 2000,
     })
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[1][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-b',
-    })
-    expect(migrations.pending()).toEqual([])
-    expect(migrations.isEmitting()).toBe(false)
   })
 
-  it('starts a follow-up run when drain is requested in a late microtask after a batch settles', async () => {
-    const migrations = new TestProgressiveMigrations({
+  it('keeps new tenants queued while a batch is in flight and ignores duplicate adds', async () => {
+    vi.useFakeTimers()
+    const deferredBatch = Promise.withResolvers<void>()
+    mockRunMigrationsBatchSend.mockReturnValueOnce(deferredBatch.promise)
+
+    const { migrations, controller } = startMigrations()
+
+    migrations.seed('tenant-a')
+
+    try {
+      const flushPromise = migrations.flush(1)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
+      expect(migrations.hasInFlightCreateJobs()).toBe(true)
+
+      migrations.addTenant('tenant-a')
+      migrations.addTenant('tenant-b')
+
+      expect(migrations.pending()).toEqual(['tenant-a', 'tenant-b'])
+      expect(vi.getTimerCount()).toBe(0)
+
+      deferredBatch.resolve()
+
+      await expect(flushPromise).resolves.toBeUndefined()
+      expect(migrations.pending()).toEqual(['tenant-b'])
+      expect(migrations.hasInFlightCreateJobs()).toBe(false)
+    } finally {
+      deferredBatch.resolve()
+      await controller.abortAsync()
+    }
+  })
+
+  it('allows a completed tenant to be queued again without admitting duplicates', async () => {
+    const migrations = createMigrations()
+
+    migrations.seed('tenant-a')
+    await expect(migrations.flush(1)).resolves.toBeUndefined()
+
+    migrations.addTenant('tenant-a')
+    migrations.addTenant('tenant-a')
+
+    expect(migrations.pending()).toEqual(['tenant-a'])
+  })
+
+  it('starts a follow-up run when drain lands after the run settles but before cleanup', async () => {
+    const migrations = new SettlingWindowProgressiveMigrations({
       maxSize: 1,
       interval: 1000,
-      watch: false,
     })
 
-    mockRunMigrationsBatchSend
-      .mockImplementationOnce(async () => {
-        queueMicrotask(() => {
-          migrations.addTenant('tenant-b')
-          void migrations.drain()
-        })
-      })
-      .mockResolvedValueOnce(undefined as never)
+    mockRunMigrationsBatchSend.mockResolvedValue(undefined)
+    let lateDrainPromise: Promise<void> | undefined
+    migrations.onRunSettled = () => {
+      migrations.addTenant('tenant-b')
+      lateDrainPromise = migrations.drain()
+    }
 
     migrations.seed('tenant-a')
 
     await expect(migrations.flush(1)).resolves.toBeUndefined()
-    await new Promise((resolve) => setImmediate(resolve))
+    await lateDrainPromise
 
     expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(2)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
-    })
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[1][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-b',
-    })
+    expect(sentTenantIds(0)).toEqual(['tenant-a'])
+    expect(sentTenantIds(1)).toEqual(['tenant-b'])
     expect(migrations.pending()).toEqual([])
-    expect(migrations.isEmitting()).toBe(false)
+    expect(migrations.hasInFlightCreateJobs()).toBe(false)
   })
 
-  it('moves prep-failed tenants to the back so later tenants can still be scheduled', async () => {
-    mockGetTenantConfig.mockImplementation(async (tenantId) => {
-      if (tenantId === 'tenant-b') {
-        throw new Error('tenant lookup failed')
-      }
-
-      return {
-        migrationStatus: undefined,
-        syncMigrationsDone: false,
-      } as Awaited<ReturnType<typeof getTenantConfig>>
-    })
-
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 1,
-      interval: 1000,
-      watch: false,
-    })
-
-    migrations.seed('tenant-b', 'tenant-a')
-
-    await expect(migrations.flush(1)).resolves.toBeUndefined()
-    expect(migrations.pending()).toEqual(['tenant-a', 'tenant-b'])
-
-    await expect(migrations.flush(1)).resolves.toBeUndefined()
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
-    })
-    expect(migrations.pending()).toEqual(['tenant-b'])
-  })
-
-  it('moves batchSend-failed jobs behind unscheduled tenants and still drops terminal prep failures', async () => {
+  it('requeues only failed sends and retryable preparations from a mixed batch', async () => {
     mockRunMigrationsBatchSend.mockRejectedValueOnce(new Error('queue unavailable'))
+    mockAreMigrationsUpToDate.mockImplementation(async (tenantId) => {
+      return tenantId === 'tenant-current'
+    })
     mockGetTenantConfig.mockImplementation(async (tenantId) => {
       if (tenantId === 'tenant-b') {
         throw ERRORS.MissingTenantConfig(tenantId)
@@ -302,123 +896,35 @@ describe('ProgressiveMigrations', () => {
         throw new Error('tenant lookup failed')
       }
 
-      return {
-        migrationStatus: undefined,
-        syncMigrationsDone: false,
-      } as Awaited<ReturnType<typeof getTenantConfig>>
+      return defaultTenantConfig
     })
 
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 3,
-      interval: 1000,
-      watch: false,
-    })
+    const migrations = createMigrations({ maxSize: 4 })
 
-    migrations.seed('tenant-a', 'tenant-b', 'tenant-c', 'tenant-d')
+    migrations.seed('tenant-a', 'tenant-b', 'tenant-c', 'tenant-current', 'tenant-d')
 
-    await expect(migrations.flush(3)).resolves.toBeUndefined()
+    await expect(migrations.flush(4)).resolves.toBeUndefined()
 
     expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
     expect(mockRunMigrationsBatchSend.mock.calls[0][0]).toHaveLength(1)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
-    })
+    expect(sentTenantIds()).toEqual(['tenant-a'])
     expect(migrations.pending()).toEqual(['tenant-d', 'tenant-a', 'tenant-c'])
-    expect(migrations.isEmitting()).toBe(false)
-  })
-
-  it('keeps tenants queued when preparing a migration job fails', async () => {
-    mockGetTenantConfig.mockImplementation(async (tenantId) => {
-      if (tenantId === 'tenant-b') {
-        throw new Error('tenant lookup failed')
-      }
-
-      return {
-        migrationStatus: undefined,
-        syncMigrationsDone: false,
-      } as Awaited<ReturnType<typeof getTenantConfig>>
-    })
-
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 10,
-      interval: 1000,
-      watch: false,
-    })
-
-    migrations.seed('tenant-a', 'tenant-b')
-
-    await expect(migrations.flush(2)).resolves.toBeUndefined()
-
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
-    expect(mockRunMigrationsBatchSend.mock.calls[0][0]).toHaveLength(1)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
-    })
-    expect(migrations.pending()).toEqual(['tenant-b'])
-    expect(migrations.isEmitting()).toBe(false)
-    expect(mockWarning).toHaveBeenCalledWith(
-      expect.anything(),
-      '[Migrations] Failed to prepare migration job for tenant tenant-b; keeping tenant queued for retry',
-      expect.objectContaining({
-        type: 'migrations',
-        project: 'tenant-b',
-      })
-    )
-  })
-
-  it('drops tenants whose config no longer exists instead of retrying forever', async () => {
-    mockGetTenantConfig.mockImplementation(async (tenantId) => {
-      if (tenantId === 'tenant-b') {
-        throw ERRORS.MissingTenantConfig(tenantId)
-      }
-
-      return {
-        migrationStatus: undefined,
-        syncMigrationsDone: false,
-      } as Awaited<ReturnType<typeof getTenantConfig>>
-    })
-
-    const migrations = new TestProgressiveMigrations({
-      maxSize: 10,
-      interval: 1000,
-      watch: false,
-    })
-
-    migrations.seed('tenant-a', 'tenant-b')
-
-    await expect(migrations.flush(2)).resolves.toBeUndefined()
-
-    expect(mockRunMigrationsBatchSend).toHaveBeenCalledTimes(1)
-    expect(mockRunMigrationsBatchSend.mock.calls[0][0]).toHaveLength(1)
-    expect(
-      (
-        mockRunMigrationsBatchSend.mock.calls[0][0][0] as unknown as {
-          payload: { tenantId: string }
-        }
-      ).payload
-    ).toMatchObject({
-      tenantId: 'tenant-a',
-    })
-    expect(migrations.pending()).toEqual([])
-    expect(migrations.isEmitting()).toBe(false)
+    expect(migrations.hasInFlightCreateJobs()).toBe(false)
+    expect(mockWarning).toHaveBeenCalledTimes(2)
     expect(mockWarning).toHaveBeenCalledWith(
       expect.anything(),
       '[Migrations] Failed to prepare migration job for tenant tenant-b; dropping tenant from queue because it no longer exists',
       expect.objectContaining({
         type: 'migrations',
         project: 'tenant-b',
+      })
+    )
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.anything(),
+      '[Migrations] Failed to prepare migration job for tenant tenant-c; keeping tenant queued for retry',
+      expect.objectContaining({
+        type: 'migrations',
+        project: 'tenant-c',
       })
     )
   })

--- a/src/internal/database/migrations/progressive.ts
+++ b/src/internal/database/migrations/progressive.ts
@@ -6,126 +6,96 @@ import { logger, logSchema } from '../../monitoring'
 import { getTenantConfig, TenantMigrationStatus } from '../tenant'
 
 const { dbMigrationFreezeAt } = getConfig()
+const maxBatchSendBackoffMs = 60_000
+const progressiveMigrationsMetadata = JSON.stringify({ strategy: 'progressive' })
 
 export class ProgressiveMigrations {
-  protected tenants: string[] = []
-  protected emittingJobs = false
+  protected readonly tenants = new Set<string>()
   protected inFlightCreateJobs?: Promise<void>
-  protected pendingCreateJobsMax = 0
-  protected watchInterval: NodeJS.Timeout | undefined
+  protected consecutiveBatchSendFailures = 0
+  protected nextBatchSendAttemptAt = 0
+  protected batchSendTimer: NodeJS.Timeout | undefined
+  private shutdownSignal: AbortSignal | undefined
 
-  constructor(protected readonly options: { maxSize: number; interval: number; watch?: boolean }) {
-    if (typeof options.watch === 'undefined') {
-      this.options.watch = true
-    }
-  }
+  constructor(protected readonly options: { maxSize: number; interval: number }) {}
 
   start(signal: AbortSignal) {
-    this.watchTenants(signal)
+    this.shutdownSignal = signal
 
     signal.addEventListener('abort', () => {
-      if (this.watchInterval) {
-        clearInterval(this.watchInterval)
-        logSchema.info(logger, '[Migrations] Stopping', {
-          type: 'migrations',
-        })
-        this.drain().catch((e) => {
-          logSchema.error(logger, '[Migrations] Error creating migration jobs', {
-            type: 'migrations',
-            error: e,
-            metadata: JSON.stringify({
-              strategy: 'progressive',
-            }),
-          })
-        })
-      }
+      logSchema.info(logger, '[Migrations] Stopping', {
+        type: 'migrations',
+      })
+      return this.drain()
     })
   }
 
   async drain() {
-    return this.createJobs(this.tenants.length).catch((e) => {
-      logSchema.error(logger, '[Migrations] Error creating migration jobs', {
-        type: 'migrations',
-        error: e,
-        metadata: JSON.stringify({
-          strategy: 'progressive',
-        }),
-      })
-    })
+    await this.inFlightCreateJobs?.catch(() => {})
+    this.resetBatchSendBackoff()
+    return this.createJobsAndLogErrors(this.tenants.size)
   }
 
   addTenant(tenant: string) {
-    const tenantIndex = this.tenants.indexOf(tenant)
-
-    if (tenantIndex !== -1) {
+    if (this.tenants.has(tenant)) {
       return
     }
 
-    this.tenants.push(tenant)
+    this.tenants.add(tenant)
 
-    if (this.tenants.length < this.options.maxSize || this.emittingJobs) {
+    if (this.inFlightCreateJobs) {
       return
     }
 
-    this.createJobs(this.options.maxSize).catch((e) => {
-      logSchema.error(logger, '[Migrations] Error creating migration jobs', {
-        type: 'migrations',
-        error: e,
-        metadata: JSON.stringify({
-          strategy: 'progressive',
-        }),
-      })
-    })
-  }
-
-  protected watchTenants(signal: AbortSignal) {
-    if (signal.aborted || !this.options.watch) {
+    if (this.tenants.size < this.options.maxSize) {
+      this.scheduleNextBatch()
       return
     }
-    this.watchInterval = setInterval(() => {
-      if (this.emittingJobs) {
-        return
-      }
 
-      this.createJobs(this.options.maxSize).catch((e) => {
-        logSchema.error(logger, '[Migrations] Error creating migration jobs', {
-          type: 'migrations',
-          error: e,
-          metadata: JSON.stringify({
-            strategy: 'progressive',
-          }),
-        })
-      })
-    }, this.options.interval)
+    if (this.isBatchSendBackoffActive()) {
+      return
+    }
+
+    this.clearBatchSendSchedule()
+    void this.createJobsAndLogErrors(this.options.maxSize)
   }
 
   protected createJobs(maxJobs: number) {
-    this.pendingCreateJobsMax = Math.max(this.pendingCreateJobsMax, maxJobs)
-
     if (this.inFlightCreateJobs) {
       return this.inFlightCreateJobs
     }
 
-    this.emittingJobs = true
-    this.inFlightCreateJobs = this.runCreateJobs().finally(() => {
-      this.emittingJobs = false
+    this.inFlightCreateJobs = this.createJobsBatch(maxJobs).finally(() => {
       this.inFlightCreateJobs = undefined
-      this.pendingCreateJobsMax = 0
     })
 
     return this.inFlightCreateJobs
   }
 
-  protected async runCreateJobs() {
-    while (this.pendingCreateJobsMax > 0) {
-      const maxJobs = this.pendingCreateJobsMax
-      this.pendingCreateJobsMax = 0
-      await this.createJobsBatch(maxJobs)
-    }
+  private createJobsAndLogErrors(maxJobs: number) {
+    return this.createJobs(maxJobs).catch((e) => {
+      logSchema.error(logger, '[Migrations] Error creating migration jobs', {
+        type: 'migrations',
+        error: e,
+        metadata: progressiveMigrationsMetadata,
+      })
+      this.scheduleNextBatch()
+    })
   }
 
   protected async createJobsBatch(maxJobs: number) {
-    const tenantsBatch = this.tenants.slice(0, maxJobs)
+    if (this.isBatchSendBackoffActive()) {
+      return
+    }
+
+    const tenantsBatch: string[] = []
+    for (const tenant of this.tenants) {
+      if (tenantsBatch.length >= maxJobs) {
+        break
+      }
+      tenantsBatch.push(tenant)
+    }
+
     const jobs = await Promise.allSettled(
       tenantsBatch.map(async (tenant) => {
         const tenantConfig = await getTenantConfig(tenant)
@@ -154,85 +124,152 @@ export class ProgressiveMigrations {
       })
     )
 
-    const completedTenants = new Set<string>()
-    const droppedTenants = new Set<string>()
-    const retryableFailedTenants = new Set<string>()
-    const validJobs = jobs
-      .map((job, index) => {
-        const tenant = tenantsBatch[index]
+    const { retryableFailedTenants, sendableJobs } = this.classifyPreparedJobs(tenantsBatch, jobs)
 
-        if (job.status === 'rejected') {
-          // If there are more terminal errors later, we need to extend this check.
-          if (isStorageError(ErrorCode.TenantNotFound, job.reason)) {
-            droppedTenants.add(tenant)
-            logSchema.warning(
-              logger,
-              `[Migrations] Failed to prepare migration job for tenant ${tenant}; dropping tenant from queue because it no longer exists`,
-              {
-                type: 'migrations',
-                error: job.reason,
-                project: tenant,
-                metadata: JSON.stringify({
-                  strategy: 'progressive',
-                }),
-              }
-            )
-            return
-          }
-
-          retryableFailedTenants.add(tenant)
-          logSchema.warning(
-            logger,
-            `[Migrations] Failed to prepare migration job for tenant ${tenant}; keeping tenant queued for retry`,
-            {
-              type: 'migrations',
-              error: job.reason,
-              project: tenant,
-              metadata: JSON.stringify({
-                strategy: 'progressive',
-              }),
-            }
-          )
-          return
-        }
-
-        completedTenants.add(tenant)
-        return job.value
-      })
-      .filter((job) => job)
-
-    if (validJobs.length > 0) {
+    if (sendableJobs.length > 0) {
       try {
-        await RunMigrationsOnTenants.batchSend(validJobs as RunMigrationsOnTenants[])
+        await RunMigrationsOnTenants.batchSend(sendableJobs.map(({ job }) => job))
+        this.resetBatchSendBackoff()
       } catch (e) {
-        // batchSend failure: treat the would-be-completed tenants as retryable,
-        // but still honor terminal drops (TenantNotFound).
-        for (const tenant of completedTenants) {
+        for (const { tenant } of sendableJobs) {
           retryableFailedTenants.add(tenant)
         }
-        completedTenants.clear()
+        const retryDelayMs = this.deferBatchSendRetry()
         logSchema.error(logger, '[Migrations] Error sending migration jobs batch', {
           type: 'migrations',
           error: e,
           metadata: JSON.stringify({
             strategy: 'progressive',
+            consecutiveFailures: this.consecutiveBatchSendFailures,
+            retryDelayMs,
           }),
         })
       }
     }
 
-    // Cleanup runs whether batchSend succeeded or not.
-    if (completedTenants.size > 0 || droppedTenants.size > 0 || retryableFailedTenants.size > 0) {
-      const remainingTenants = this.tenants.filter(
-        (tenant) =>
-          !completedTenants.has(tenant) &&
-          !droppedTenants.has(tenant) &&
-          !retryableFailedTenants.has(tenant)
-      )
-      const failedTenantsInQueue = this.tenants.filter((tenant) =>
-        retryableFailedTenants.has(tenant)
-      )
-      this.tenants = remainingTenants.concat(failedTenantsInQueue)
+    this.reconcileTenants(tenantsBatch, retryableFailedTenants)
+
+    if (this.tenants.size === 0) {
+      this.resetBatchSendBackoff()
+    } else {
+      this.scheduleNextBatch()
     }
+  }
+
+  private classifyPreparedJobs(
+    tenantsBatch: string[],
+    jobs: PromiseSettledResult<RunMigrationsOnTenants | undefined>[]
+  ) {
+    const retryableFailedTenants = new Set<string>()
+    const sendableJobs: Array<{ tenant: string; job: RunMigrationsOnTenants }> = []
+
+    for (const [index, job] of jobs.entries()) {
+      const tenant = tenantsBatch[index]
+
+      if (job.status === 'rejected') {
+        const dropTenant = isStorageError(ErrorCode.TenantNotFound, job.reason)
+        if (!dropTenant) {
+          retryableFailedTenants.add(tenant)
+        }
+        logSchema.warning(
+          logger,
+          dropTenant
+            ? `[Migrations] Failed to prepare migration job for tenant ${tenant}; dropping tenant from queue because it no longer exists`
+            : `[Migrations] Failed to prepare migration job for tenant ${tenant}; keeping tenant queued for retry`,
+          {
+            type: 'migrations',
+            error: job.reason,
+            project: tenant,
+            metadata: progressiveMigrationsMetadata,
+          }
+        )
+        continue
+      }
+
+      if (job.value) {
+        sendableJobs.push({ tenant, job: job.value })
+      }
+    }
+
+    return { retryableFailedTenants, sendableJobs }
+  }
+
+  private reconcileTenants(tenantsBatch: string[], retryableFailedTenants: Set<string>) {
+    for (const tenant of tenantsBatch) {
+      this.tenants.delete(tenant)
+      if (retryableFailedTenants.has(tenant)) {
+        this.tenants.add(tenant)
+      }
+    }
+  }
+
+  protected now() {
+    return performance.now()
+  }
+
+  protected random() {
+    return Math.random()
+  }
+
+  private get baseDelayMs() {
+    return Math.max(this.options.interval, 1)
+  }
+
+  private isBatchSendBackoffActive() {
+    return this.now() < this.nextBatchSendAttemptAt
+  }
+
+  private deferBatchSendRetry() {
+    this.consecutiveBatchSendFailures++
+
+    const maximumDelayMs = Math.max(this.baseDelayMs, maxBatchSendBackoffMs)
+    const upperDelayMs = Math.min(
+      maximumDelayMs,
+      this.baseDelayMs * 2 ** this.consecutiveBatchSendFailures
+    )
+    const lowerDelayMs = Math.max(this.baseDelayMs, Math.floor(upperDelayMs / 2))
+    const retryDelayMs = Math.round(lowerDelayMs + (upperDelayMs - lowerDelayMs) * this.random())
+
+    this.nextBatchSendAttemptAt = this.now() + retryDelayMs
+    return retryDelayMs
+  }
+
+  private scheduleNextBatch() {
+    if (
+      this.tenants.size === 0 ||
+      !this.shutdownSignal ||
+      this.shutdownSignal.aborted ||
+      this.batchSendTimer
+    ) {
+      return
+    }
+
+    const delayMs = this.isBatchSendBackoffActive()
+      ? Math.max(this.nextBatchSendAttemptAt - this.now(), 1)
+      : this.baseDelayMs
+
+    const timer = setTimeout(() => {
+      this.clearBatchSendSchedule()
+      void this.createJobsAndLogErrors(this.options.maxSize)
+    }, delayMs)
+    this.batchSendTimer = timer
+    timer.unref()
+  }
+
+  private clearBatchSendSchedule() {
+    this.cancelBatchSendTimer()
+    this.nextBatchSendAttemptAt = 0
+  }
+
+  private cancelBatchSendTimer() {
+    if (this.batchSendTimer) {
+      clearTimeout(this.batchSendTimer)
+      this.batchSendTimer = undefined
+    }
+  }
+
+  protected resetBatchSendBackoff() {
+    this.clearBatchSendSchedule()
+    this.consecutiveBatchSendFailures = 0
   }
 }

--- a/src/start/server.test.ts
+++ b/src/start/server.test.ts
@@ -1,6 +1,18 @@
+import type { AsyncAbortController } from '@internal/concurrency'
 import { vi } from 'vitest'
 
-const bootOrder = vi.hoisted(() => [] as string[])
+type Deferred = ReturnType<typeof Promise.withResolvers<void>>
+
+const bootOrder = vi.hoisted((): string[] => [])
+const shutdownOrder = vi.hoisted((): string[] => [])
+const startupState = vi.hoisted((): { shutdownController: AsyncAbortController | undefined } => ({
+  shutdownController: undefined,
+}))
+const migrationDrainState = vi.hoisted((): { deferred: Deferred } => ({
+  deferred: Promise.withResolvers<void>(),
+}))
+const mockAdminListen = vi.hoisted(() => vi.fn())
+const serverConfigState = vi.hoisted(() => ({ isMultitenant: false }))
 
 vi.mock('@internal/monitoring/otel-tracing', () => ({}))
 vi.mock('@internal/monitoring/otel-metrics', () => ({}))
@@ -11,8 +23,9 @@ vi.mock('@internal/monitoring', () => ({
 vi.mock('@internal/cluster/cluster', () => ({
   Cluster: {
     size: 0,
-    init: vi.fn(async () => {
+    init: vi.fn(async (signal: AbortSignal) => {
       bootOrder.push('cluster.init')
+      signal.addEventListener('abort', () => shutdownOrder.push('cluster'))
     }),
     on: vi.fn(() => {
       bootOrder.push('cluster.on')
@@ -33,17 +46,27 @@ vi.mock('@internal/database', () => ({
       rebalanceAll: vi.fn(),
     },
   },
-  PubSub: { start: vi.fn(async () => {}) },
+  PubSub: {
+    start: vi.fn(async ({ signal }: { signal: AbortSignal }) => {
+      signal.addEventListener('abort', () => shutdownOrder.push('pubsub'))
+    }),
+  },
 }))
 vi.mock('@internal/database/migrations', () => ({
   runMigrationsOnTenant: vi.fn(async () => {}),
   runMultitenantMigrations: vi.fn(async () => {}),
-  startAsyncMigrations: vi.fn(),
+  startAsyncMigrations: vi.fn((signal: AbortSignal) => {
+    signal.addEventListener('abort', () => {
+      shutdownOrder.push('migrations')
+      return migrationDrainState.deferred.promise
+    })
+  }),
 }))
 vi.mock('@internal/queue', () => ({
   Queue: {
-    start: vi.fn(async () => {
+    start: vi.fn(async ({ signal }: { signal: AbortSignal }) => {
       bootOrder.push('queue.start')
+      signal.addEventListener('abort', () => shutdownOrder.push('queue'))
     }),
   },
   SYSTEM_TENANT: 'system',
@@ -60,14 +83,26 @@ vi.mock('@storage/events/upgrades/sync-catalog-ids', () => ({
   SyncCatalogIds: { invoke: vi.fn(async () => {}) },
 }))
 vi.mock('fastify', () => ({ LogController: class {} }))
-vi.mock('../admin-app', () => ({ default: vi.fn() }))
+vi.mock('../admin-app', () => ({
+  default: vi.fn(() => ({
+    server: {},
+    listen: mockAdminListen.mockImplementation(async ({ signal }: { signal: AbortSignal }) => {
+      signal.addEventListener('abort', () => shutdownOrder.push('admin'))
+    }),
+  })),
+}))
 vi.mock('../app', () => ({
-  default: vi.fn(() => ({ server: {}, listen: vi.fn(async () => {}) })),
+  default: vi.fn(() => ({
+    server: {},
+    listen: vi.fn(async ({ signal }: { signal: AbortSignal }) => {
+      signal.addEventListener('abort', () => shutdownOrder.push('api'))
+    }),
+  })),
 }))
 vi.mock('../config', () => ({
   getConfig: () => ({
     databaseURL: 'postgres://example',
-    isMultitenant: false,
+    isMultitenant: serverConfigState.isMultitenant,
     pgQueueEnable: true,
     dbMigrationFreezeAt: undefined,
     vectorBucketProvider: 's3',
@@ -84,21 +119,34 @@ vi.mock('../config', () => ({
   }),
 }))
 vi.mock('./shutdown', () => ({
-  bindShutdownSignals: vi.fn(),
+  bindShutdownSignals: vi.fn((controller: AsyncAbortController) => {
+    startupState.shutdownController = controller
+  }),
   createServerClosedPromise: vi.fn(() => Promise.resolve()),
   shutdown: vi.fn(async () => {}),
 }))
 
 describe('server boot order', () => {
+  beforeEach(() => {
+    serverConfigState.isMultitenant = false
+    migrationDrainState.deferred = Promise.withResolvers<void>()
+  })
+
   afterEach(() => {
+    migrationDrainState.deferred.resolve()
     bootOrder.length = 0
+    shutdownOrder.length = 0
+    startupState.shutdownController = undefined
     vi.restoreAllMocks()
+    vi.clearAllMocks()
     vi.resetModules()
   })
 
   test('initializes pool sizing and cluster discovery before queue workers start', async () => {
     // Track exit to find out mock gaps and silently pass the test.
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('server unexpectedly called process.exit()')
+    })
 
     await import('./server')
     await vi.waitFor(() => expect(bootOrder).toContain('queue.start'))
@@ -110,6 +158,35 @@ describe('server boot order', () => {
       'cluster.on',
       'queue.start',
     ])
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  test('drains migration producers before stopping the queue and its dependencies', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('server unexpectedly called process.exit()')
+    })
+    serverConfigState.isMultitenant = true
+
+    await import('./server')
+    await vi.waitFor(() => expect(startupState.shutdownController).toBeDefined())
+    await vi.waitFor(() => expect(bootOrder).toContain('queue.start'))
+    await vi.waitFor(() => expect(mockAdminListen).toHaveBeenCalledOnce())
+
+    const shutdownController = startupState.shutdownController
+    expect(shutdownController).toBeDefined()
+    if (!shutdownController) {
+      throw new Error('Server did not register its shutdown controller')
+    }
+
+    const abortPromise = shutdownController.abortAsync()
+    await vi.waitFor(() => {
+      expect(shutdownOrder).toEqual(['api', 'admin', 'migrations'])
+    })
+
+    migrationDrainState.deferred.resolve()
+    await abortPromise
+
+    expect(shutdownOrder).toEqual(['api', 'admin', 'migrations', 'queue', 'cluster', 'pubsub'])
     expect(exitSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/start/server.ts
+++ b/src/start/server.ts
@@ -69,6 +69,10 @@ async function main() {
     icebergShards,
     numWorkers,
   } = getConfig()
+  // Abort order: HTTP -> migrations -> queue -> dependencies.
+  const migrationShutdownGroup = shutdownSignal.nextGroup
+  const queueShutdownGroup = migrationShutdownGroup.nextGroup
+  const dependencyShutdownGroup = queueShutdownGroup.nextGroup
 
   // VECTOR_DATABASE_URL is only required when pgvector is actually going to
   // be used: single-tenant mode (it's the maintenance URL used to CREATE
@@ -96,7 +100,7 @@ async function main() {
   PgTenantConnection.poolManager.monitor()
 
   // Cluster information
-  await Cluster.init(shutdownSignal.nextGroup.signal)
+  await Cluster.init(dependencyShutdownGroup.signal)
 
   Cluster.on('change', (data) => {
     logger.info(
@@ -114,7 +118,7 @@ async function main() {
   // Queue
   if (pgQueueEnable) {
     await Queue.start({
-      signal: shutdownSignal.nextGroup.signal,
+      signal: queueShutdownGroup.signal,
       registerWorkers,
     })
 
@@ -162,12 +166,12 @@ async function main() {
 
   // Pubsub
   await PubSub.start({
-    signal: shutdownSignal.nextGroup.signal,
+    signal: dependencyShutdownGroup.signal,
   })
 
   // Start async migrations background process
   if (isMultitenant && pgQueueEnable) {
-    startAsyncMigrations(shutdownSignal.nextGroup.signal)
+    startAsyncMigrations(migrationShutdownGroup.signal)
   }
 
   // HTTP Server


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Progressive migrations can create contention when there is a new migration (ON CONFLICT DO NOTHING of exactly_once queue policy). There is no backoff or jitter so it can take some time to handle backlog.

## What is the new behavior?

There are mainly two things we can do:
1. add backoff and jitter
2. reduce contention via smaller batch size (this can cause throughput reduction in steady state even if improves under contention)

That's why starting with option 1, which also improves realiability.
Afterwards, if not enough, we can experiment with different batch sizes.
One note: increasing connection pool size won't help because problem is that hot tenant is locked by multiple instances. More connections could make it even worse.  

## Additional context

Admin uses progressive migrations as a fallback irrespective of config policy. It doesn't affect us since we use progressive but for completeness, progressive timer must be armed for other policies as well. 
