### PR TITLE
fix: improve cdn cache manager error handling

### DIFF
--- a/src/internal/errors/codes.test.ts
+++ b/src/internal/errors/codes.test.ts
@@ -113,8 +113,7 @@ describe('normalizeRawError', () => {
     const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
       code: 'ECONNREFUSED',
     })
-    const networkError = new TypeError('fetch failed')
-    Object.assign(networkError, { cause })
+    const networkError = new TypeError('fetch failed', { cause })
 
     const error = new StorageBackendError({
       code: ErrorCode.InternalError,
@@ -130,6 +129,29 @@ describe('normalizeRawError', () => {
     expect(raw.originalError.message).toBe('fetch failed')
     expect(raw.originalError.cause.code).toBe('ECONNREFUSED')
     expect(raw.originalError.cause.message).toBe('connect ECONNREFUSED 127.0.0.1:443')
+  })
+
+  it('surfaces the individual errors wrapped by a nested AggregateError', () => {
+    const aggregate = new AggregateError(
+      [new Error('connect ECONNREFUSED 127.0.0.1:443'), new Error('connect ECONNREFUSED ::1:443')],
+      'All promises were rejected'
+    )
+
+    const error = new StorageBackendError({
+      code: ErrorCode.InternalError,
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError: aggregate,
+    })
+
+    const result = normalizeRawError(error, 'info')
+    const raw = JSON.parse(result.raw)
+
+    expect(raw.originalError.name).toBe('AggregateError')
+    expect(raw.originalError.message).toBe('All promises were rejected')
+    expect(raw.originalError.errors).toHaveLength(2)
+    expect(raw.originalError.errors[0].message).toBe('connect ECONNREFUSED 127.0.0.1:443')
+    expect(raw.originalError.errors[1].message).toBe('connect ECONNREFUSED ::1:443')
   })
 
   it('includes a nested cause stack for 5xx errors', () => {

--- a/src/internal/errors/codes.test.ts
+++ b/src/internal/errors/codes.test.ts
@@ -109,6 +109,61 @@ describe('normalizeRawError', () => {
     expect(result.raw).toBe('Failed to stringify error')
   })
 
+  it('surfaces a nested originalError/cause chain instead of collapsing it to {}', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    })
+    const networkError = new TypeError('fetch failed')
+    Object.assign(networkError, { cause })
+
+    const error = new StorageBackendError({
+      code: ErrorCode.InternalError,
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError: networkError,
+    })
+
+    const result = normalizeRawError(error, 'info')
+    const raw = JSON.parse(result.raw)
+
+    expect(raw.originalError.name).toBe('TypeError')
+    expect(raw.originalError.message).toBe('fetch failed')
+    expect(raw.originalError.cause.code).toBe('ECONNREFUSED')
+    expect(raw.originalError.cause.message).toBe('connect ECONNREFUSED 127.0.0.1:443')
+  })
+
+  it('includes a nested cause stack for 5xx errors', () => {
+    const originalError = new Error('boom')
+
+    const error = new StorageBackendError({
+      code: ErrorCode.InternalError,
+      httpStatusCode: 500,
+      message: 'Error purging cache',
+      originalError,
+    })
+
+    const result = normalizeRawError(error, 'info')
+    const raw = JSON.parse(result.raw)
+
+    expect(raw.originalError.stack).toBeTruthy()
+  })
+
+  it('omits a nested cause stack for 4xx errors', () => {
+    const originalError = new Error('boom')
+
+    const error = new StorageBackendError({
+      code: ErrorCode.InvalidRequest,
+      httpStatusCode: 400,
+      message: 'Bad request',
+      originalError,
+    })
+
+    const result = normalizeRawError(error, 'info')
+    const raw = JSON.parse(result.raw)
+
+    expect(raw.originalError.stack).toBeUndefined()
+  })
+
   it('omits pg client internals attached to Error objects', () => {
     const error = new Error('Connection terminated unexpectedly') as Error & {
       client?: unknown

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -695,6 +695,7 @@ function createErrorRawReplacer(includeStack: boolean) {
         message: value.message,
         stack: includeStack ? value.stack : undefined,
         cause: value.cause,
+        errors: value instanceof AggregateError ? value.errors : undefined,
       }
     }
 

--- a/src/internal/errors/codes.ts
+++ b/src/internal/errors/codes.ts
@@ -652,7 +652,7 @@ export function normalizeRawError(error: unknown, logLevel: string) {
       logLevel === 'debug' || statusCode >= 500 || errorCode === ErrorCode.UnknownError
 
     return {
-      raw: stringifyErrorRaw(error),
+      raw: stringifyErrorRaw(error, includeStack),
       name: error.name,
       message: error.message,
       stack: includeStack ? error.stack || '' : '',
@@ -678,13 +678,35 @@ const stableStringify = configure({
   deterministic: false,
 })
 
-function errorRawReplacer(key: string, value: unknown) {
-  return ERROR_RAW_OMITTED_KEYS.has(key) ? undefined : value
+function createErrorRawReplacer(includeStack: boolean) {
+  return function errorRawReplacer(key: string, value: unknown) {
+    if (ERROR_RAW_OMITTED_KEYS.has(key)) {
+      return undefined
+    }
+
+    // `message`/`stack`/`cause` are non-enumerable on Error instances
+    // so a nested error (e.g. `originalError`, or a `cause` chain from `fetch`/undici)
+    // would otherwise stringify to `{}` and silently drop the data needed to debug
+    // The root error is skipped. Its message/stack are already captured as separate top-level fields by normalizeRawError.
+    if (key !== '' && value instanceof Error) {
+      return {
+        ...value,
+        name: value.name,
+        message: value.message,
+        stack: includeStack ? value.stack : undefined,
+        cause: value.cause,
+      }
+    }
+
+    return value
+  }
 }
 
-function stringifyErrorRaw(error: Error): string {
+function stringifyErrorRaw(error: Error, includeStack: boolean): string {
   try {
-    return stableStringify(error, errorRawReplacer) ?? 'Failed to stringify error'
+    return (
+      stableStringify(error, createErrorRawReplacer(includeStack)) ?? 'Failed to stringify error'
+    )
   } catch {
     return 'Failed to stringify error'
   }

--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -173,11 +173,142 @@ describe('CdnCacheManager', () => {
     })
   })
 
+  it('surfaces the underlying error name for a top-level abort timeout', async () => {
+    const timeoutError = new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError'
+    )
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(timeoutError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+
+    await expect(
+      new CdnCacheManager().purge({
+        type: 'object',
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      originalError: expect.objectContaining({
+        name: 'TimeoutError',
+        message: 'The operation was aborted due to timeout',
+      }),
+    })
+  })
+
+  it('surfaces the network failure cause for non-timeout errors', async () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    })
+    const fetchError = new TypeError('fetch failed')
+    Object.assign(fetchError, { cause })
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+
+    await expect(
+      new CdnCacheManager().purge({
+        type: 'object',
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      originalError: expect.objectContaining({
+        name: 'TypeError',
+        cause: expect.objectContaining({
+          name: 'Error',
+          code: 'ECONNREFUSED',
+        }),
+      }),
+    })
+  })
+
+  it('surfaces the specific cause for a dispatcher-level headers timeout', async () => {
+    const cause = Object.assign(new Error('Headers Timeout Error'), {
+      code: 'UND_ERR_HEADERS_TIMEOUT',
+    })
+    cause.name = 'HeadersTimeoutError'
+    const fetchError = new TypeError('fetch failed')
+    Object.assign(fetchError, { cause })
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+
+    await expect(
+      new CdnCacheManager().purge({
+        type: 'object',
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      originalError: expect.objectContaining({
+        name: 'TypeError',
+        cause: expect.objectContaining({
+          name: 'HeadersTimeoutError',
+          code: 'UND_ERR_HEADERS_TIMEOUT',
+        }),
+      }),
+    })
+  })
+
+  it('surfaces the specific cause for a dispatcher-level connect timeout', async () => {
+    const cause = Object.assign(new Error('Connect Timeout Error'), {
+      code: 'UND_ERR_CONNECT_TIMEOUT',
+    })
+    cause.name = 'ConnectTimeoutError'
+    const fetchError = new TypeError('fetch failed')
+    Object.assign(fetchError, { cause })
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
+      cdnPurgeEndpointKey: 'test-key',
+    })
+
+    await expect(
+      new CdnCacheManager().purge({
+        type: 'object',
+        tenant: 'tenant-ref',
+        bucket: 'bucket-id',
+        objectName: 'folder/image.png',
+      })
+    ).rejects.toMatchObject({
+      code: 'InternalError',
+      originalError: expect.objectContaining({
+        name: 'TypeError',
+        cause: expect.objectContaining({
+          name: 'ConnectTimeoutError',
+          code: 'UND_ERR_CONNECT_TIMEOUT',
+        }),
+      }),
+    })
+  })
+
   it('requires a CDN purge endpoint URL before sending a purge request', async () => {
     const fetchMock = vi.fn<typeof fetch>()
     vi.stubGlobal('fetch', fetchMock)
 
     const { CdnCacheManager } = await importCdnCacheManager({
+      cdnPurgeEndpointURL: undefined,
       cdnPurgeEndpointKey: 'test-key',
     })
 

--- a/src/storage/cdn/cdn-cache-manager.test.ts
+++ b/src/storage/cdn/cdn-cache-manager.test.ts
@@ -173,109 +173,12 @@ describe('CdnCacheManager', () => {
     })
   })
 
-  it('surfaces the underlying error name for a top-level abort timeout', async () => {
-    const timeoutError = new DOMException(
-      'The operation was aborted due to timeout',
-      'TimeoutError'
-    )
-    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(timeoutError)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { CdnCacheManager } = await importCdnCacheManager({
-      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
-      cdnPurgeEndpointKey: 'test-key',
-    })
-
-    await expect(
-      new CdnCacheManager().purge({
-        type: 'object',
-        tenant: 'tenant-ref',
-        bucket: 'bucket-id',
-        objectName: 'folder/image.png',
-      })
-    ).rejects.toMatchObject({
-      code: 'InternalError',
-      originalError: expect.objectContaining({
-        name: 'TimeoutError',
-        message: 'The operation was aborted due to timeout',
-      }),
-    })
-  })
-
-  it('surfaces the network failure cause for non-timeout errors', async () => {
-    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
-      code: 'ECONNREFUSED',
-    })
-    const fetchError = new TypeError('fetch failed')
-    Object.assign(fetchError, { cause })
-    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { CdnCacheManager } = await importCdnCacheManager({
-      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
-      cdnPurgeEndpointKey: 'test-key',
-    })
-
-    await expect(
-      new CdnCacheManager().purge({
-        type: 'object',
-        tenant: 'tenant-ref',
-        bucket: 'bucket-id',
-        objectName: 'folder/image.png',
-      })
-    ).rejects.toMatchObject({
-      code: 'InternalError',
-      originalError: expect.objectContaining({
-        name: 'TypeError',
-        cause: expect.objectContaining({
-          name: 'Error',
-          code: 'ECONNREFUSED',
-        }),
-      }),
-    })
-  })
-
-  it('surfaces the specific cause for a dispatcher-level headers timeout', async () => {
-    const cause = Object.assign(new Error('Headers Timeout Error'), {
-      code: 'UND_ERR_HEADERS_TIMEOUT',
-    })
-    cause.name = 'HeadersTimeoutError'
-    const fetchError = new TypeError('fetch failed')
-    Object.assign(fetchError, { cause })
-    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { CdnCacheManager } = await importCdnCacheManager({
-      cdnPurgeEndpointURL: 'https://cdn.example.com/stub/cache',
-      cdnPurgeEndpointKey: 'test-key',
-    })
-
-    await expect(
-      new CdnCacheManager().purge({
-        type: 'object',
-        tenant: 'tenant-ref',
-        bucket: 'bucket-id',
-        objectName: 'folder/image.png',
-      })
-    ).rejects.toMatchObject({
-      code: 'InternalError',
-      originalError: expect.objectContaining({
-        name: 'TypeError',
-        cause: expect.objectContaining({
-          name: 'HeadersTimeoutError',
-          code: 'UND_ERR_HEADERS_TIMEOUT',
-        }),
-      }),
-    })
-  })
-
-  it('surfaces the specific cause for a dispatcher-level connect timeout', async () => {
+  it('preserves a nested cause chain on the thrown error (e.g. dispatcher timeouts)', async () => {
     const cause = Object.assign(new Error('Connect Timeout Error'), {
       code: 'UND_ERR_CONNECT_TIMEOUT',
     })
     cause.name = 'ConnectTimeoutError'
-    const fetchError = new TypeError('fetch failed')
-    Object.assign(fetchError, { cause })
+    const fetchError = new TypeError('fetch failed', { cause })
     const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(fetchError)
     vi.stubGlobal('fetch', fetchMock)
 

--- a/src/storage/cdn/cdn-cache-manager.ts
+++ b/src/storage/cdn/cdn-cache-manager.ts
@@ -6,11 +6,16 @@ import { getConfig } from '../../config'
 const { cdnPurgeEndpointURL, cdnPurgeEndpointKey } = getConfig()
 
 const CDN_PURGE_TIMEOUT_MS = 10_000
+const CDN_PURGE_CONNECT_TIMEOUT_MS = 3_000
+const CDN_PURGE_HEADERS_BODY_TIMEOUT_MS = CDN_PURGE_TIMEOUT_MS - CDN_PURGE_CONNECT_TIMEOUT_MS
 
 const dispatcher = new Agent({
   connections: 200,
   keepAliveTimeout: 1000 * 2,
   keepAliveMaxTimeout: 1000 * 2,
+  connectTimeout: CDN_PURGE_CONNECT_TIMEOUT_MS,
+  headersTimeout: CDN_PURGE_HEADERS_BODY_TIMEOUT_MS,
+  bodyTimeout: CDN_PURGE_HEADERS_BODY_TIMEOUT_MS,
 })
 
 const defaultHeaders = new Headers({

--- a/src/storage/cdn/cdn-cache-manager.ts
+++ b/src/storage/cdn/cdn-cache-manager.ts
@@ -11,8 +11,8 @@ const CDN_PURGE_HEADERS_BODY_TIMEOUT_MS = CDN_PURGE_TIMEOUT_MS - CDN_PURGE_CONNE
 
 const dispatcher = new Agent({
   connections: 200,
-  keepAliveTimeout: 1000 * 2,
-  keepAliveMaxTimeout: 1000 * 2,
+  keepAliveTimeout: 30_000,
+  keepAliveMaxTimeout: 30_000,
   connectTimeout: CDN_PURGE_CONNECT_TIMEOUT_MS,
   headersTimeout: CDN_PURGE_HEADERS_BODY_TIMEOUT_MS,
   bodyTimeout: CDN_PURGE_HEADERS_BODY_TIMEOUT_MS,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

errors lack useful information to debug failures

Example error before change

```json
{"httpStatusCode":500,"originalError":{},"userStatusCode":500,"code":"InternalError","metadata":{}}
```

## What is the new behavior?

- Adjust timeout values to help differentiate error class (similar to webhook change)
- Increase keep alive for cdn cache manager connection pool to encourage connection reuse
- Include data from original (fetch) error in logs

Example error after change

```json
{
  "httpStatusCode": 500,
  "originalError": {
    "name": "TypeError",
    "message": "fetch failed",
    "stack": "TypeError: fetch failed",
    "cause": {
      "name": "ConnectTimeoutError",
      "code": "UND_ERR_CONNECT_TIMEOUT",
      "message": "Connect Timeout Error (attempted address: localhost:1337, timeout: 3000ms)",
      "stack": "ConnectTimeoutError: Connect Timeout Error (attempted address: localhost:1337, timeout: 3000ms)\\n    at onConnectTimeout (storage/node_modules/undici/lib/core/util.js:891:19)\\n    at Immediate._onImmediate (storage/node_modules/undici/lib/core/util.js:860:11)\\n    at process.processImmediate (node:internal/timers:504:21)"
    }
  },
  "userStatusCode": 500,
  "code": "InternalError"
}
```