### PR TITLE
chore: handle test flakes

### DIFF
--- a/src/admin-app.test.ts
+++ b/src/admin-app.test.ts
@@ -1,11 +1,16 @@
 import { vi } from 'vitest'
+import buildAdmin from './admin-app'
 import { stripFiniteKeyword } from './http/finite'
 
 const lastLocalMigrationName = vi.hoisted(() => vi.fn())
 const onTenantConfigChange = vi.hoisted(() => vi.fn())
 const tenantConfigUpdate = vi.hoisted(() => vi.fn())
-const adminApiKey = 'test-admin-api-key'
-const originalServerAdminApiKeys = process.env.SERVER_ADMIN_API_KEYS
+const { adminApiKey, originalServerAdminApiKeys } = vi.hoisted(() => {
+  const originalServerAdminApiKeys = process.env.SERVER_ADMIN_API_KEYS
+  const adminApiKey = 'test-admin-api-key'
+  process.env.SERVER_ADMIN_API_KEYS = adminApiKey
+  return { adminApiKey, originalServerAdminApiKeys }
+})
 
 vi.mock('@internal/database', async () => {
   const actual = await vi.importActual<typeof import('@internal/database')>('@internal/database')
@@ -30,8 +35,6 @@ vi.mock('@internal/database/migrations', async () => {
 })
 
 async function buildAdminApp(options: { exposeDocs?: boolean } = {}) {
-  vi.resetModules()
-  const { default: buildAdmin } = await import('./admin-app')
   const app = buildAdmin(options)
   await app.ready()
   return app

--- a/src/http/plugins/signature-v4.ts
+++ b/src/http/plugins/signature-v4.ts
@@ -133,8 +133,10 @@ async function authorizeRequestSignV4(
       alg: 'sha256',
       limitInMemoryBytes: 1024 * 1024 * 5, // 5MB
     })
-    hashStreamComposer = compose(new ByteLimitTransformStream(1024 * 1024 * 20), byteHasherStream)
-    hashStreamComposer!.digestHex = byteHasherStream.digestHex.bind(byteHasherStream)
+    hashStreamComposer = Object.assign(
+      compose(new ByteLimitTransformStream(1024 * 1024 * 20), byteHasherStream),
+      { digestHex: byteHasherStream.digestHex.bind(byteHasherStream) }
+    )
   }
 
   const isVerified = await signatureV4.verify(clientSignature, {

--- a/src/internal/streams/hash-stream.test.ts
+++ b/src/internal/streams/hash-stream.test.ts
@@ -420,17 +420,14 @@ describe('HashSpillWritable', () => {
     const fixedTimestamp = 1234567890123
     vi.spyOn(Date, 'now').mockReturnValue(fixedTimestamp)
 
+    const sinks: HashSpillWritable[] = []
+    let jobs: Promise<string>[] = []
     try {
-      const jobs = Array.from({ length: N }, async (_, idx) => {
+      jobs = Array.from({ length: N }, async (_, idx) => {
         const payload = randBuf(limit + 50 + idx)
         const sink = new HashSpillWritable({ limitInMemoryBytes: limit, tmpRoot })
+        sinks.push(sink)
         await pipeline(readableFrom(payload), sink)
-
-        // Verify file was created successfully despite same timestamp
-        const spillPath = await findSpillFilePath(tmpRoot)
-        expect(spillPath).not.toBeNull()
-
-        await sink.cleanup()
         return sink.digestHex()
       })
 
@@ -438,10 +435,27 @@ describe('HashSpillWritable', () => {
       const digests = await Promise.all(jobs)
       expect(digests).toHaveLength(N)
 
-      await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
+      // Verify all N unique directories exist concurrently despite identical timestamps
+      const entries = await dirEntries(tmpRoot)
+      const spillDirs = entries.filter((n) => n.startsWith('hashspill-'))
+      expect(spillDirs).toHaveLength(N)
+
+      // Verify each directory contains exactly one spill file with the mocked timestamp prefix
+      for (const dirName of spillDirs) {
+        const files = await fsp.readdir(path.join(tmpRoot, dirName))
+        expect(files).toHaveLength(1)
+        expect(files[0].startsWith(`${fixedTimestamp}-`)).toBe(true)
+      }
     } finally {
-      vi.restoreAllMocks()
+      try {
+        await Promise.allSettled(jobs)
+        await Promise.all(sinks.map((s) => s.cleanup()))
+      } finally {
+        vi.restoreAllMocks()
+      }
     }
+
+    await expect(waitForHashspillDirs(tmpRoot, 0)).resolves.toBe(0)
   })
 
   test('concurrent readers on same spilled stream with mixed cleanup strategies', async () => {

--- a/src/internal/streams/types.d.ts
+++ b/src/internal/streams/types.d.ts
@@ -1,3 +1,0 @@
-declare module 'stream' {
-  export function compose<A extends Stream, B extends Stream>(s1: A, s2: B): B & A
-}


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Two tests are flaky.

## What is the new behavior?

Hash-spill test [has a race](https://github.com/supabase/storage/actions/runs/33666702277/job/100370485530?pr=1357). 
Admin test app test is unnnecessarily heavy due to reset modules from previous implementations and times out, drop it.

## Additional context

Type changes come from import order changes and a kind of modernization.

Related to #1357
