### PR TITLE
fix: repair invalid concurrently created indexes

### DIFF
--- a/src/internal/database/migrations/concurrent-index-guard.test.ts
+++ b/src/internal/database/migrations/concurrent-index-guard.test.ts
@@ -1,0 +1,240 @@
+import { loadMigrationFiles } from 'postgres-migrations'
+import type { BasicPgClient, Migration } from 'postgres-migrations/dist/types'
+import { vi } from 'vitest'
+import { repairInvalidConcurrentIndexes } from './concurrent-index-guard'
+
+function createMigration(sql: string): Migration {
+  return {
+    id: 1,
+    name: 'concurrent-index-test',
+    fileName: '0001-concurrent-index-test.sql',
+    hash: 'hash-1',
+    contents: sql,
+    sql,
+  }
+}
+
+function createClient() {
+  const query = vi.fn()
+
+  return {
+    client: { query } as unknown as BasicPgClient,
+    query,
+  }
+}
+
+describe('repairInvalidConcurrentIndexes', () => {
+  it('fails closed when a concurrent index target cannot be parsed', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(
+      'CREATE INDEX CONCURRENTLY ON storage.objects (bucket_id, name);'
+    )
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).rejects.toThrow(
+      'Cannot determine the target of a concurrent index migration'
+    )
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the name belongs to a non-index relation', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);'
+    )
+    query.mockResolvedValueOnce({
+      rows: [
+        {
+          schema_name: 'storage',
+          index_name: 'idx_objects_test',
+          indisvalid: null,
+          on_table: null,
+        },
+      ],
+    })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).rejects.toThrow(
+      'Cannot repair concurrent index idx_objects_test: its name is used by a different relation'
+    )
+    expect(query).toHaveBeenCalledOnce()
+  })
+
+  it('repairs quoted identifiers with spaces, punctuation, and embedded quotes', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX-$ objects ""test""" ON "storage schema" . "objects table" (name);'
+    )
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            schema_name: 'storage schema',
+            index_name: 'IDX-$ objects "test"',
+            indisvalid: false,
+            on_table: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([
+      { schemaName: 'storage schema', indexName: 'IDX-$ objects "test"' },
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        values: ['"storage schema" . "objects table"', 'IDX-$ objects "test"'],
+      })
+    )
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      'DROP INDEX CONCURRENTLY IF EXISTS "storage schema"."IDX-$ objects ""test"""'
+    )
+  })
+
+  it('does not drop anything when the target table does not resolve', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON missing.objects (name);'
+    )
+    query.mockResolvedValueOnce({ rows: [] })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([])
+    expect(query).toHaveBeenCalledOnce()
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: ['missing.objects', 'idx_objects_test'],
+      })
+    )
+  })
+
+  it('guards a concurrent create that does not start a line', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(
+      'SELECT 1; CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);'
+    )
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            schema_name: 'storage',
+            index_name: 'idx_objects_test',
+            indisvalid: false,
+            on_table: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([
+      { schemaName: 'storage', indexName: 'idx_objects_test' },
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      'DROP INDEX CONCURRENTLY IF EXISTS "storage"."idx_objects_test"'
+    )
+  })
+
+  it('ignores concurrent creates inside comments', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(`/*
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);
+*/
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);
+SELECT 1;`)
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([])
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('ignores concurrent creates inside strings and dollar quotes', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(`
+SELECT 'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_single ON storage.objects (name)';
+SELECT 'quoted ''CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_doubled ON storage.objects (name)'' text';
+SELECT E'escaped \\' CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_escape ON storage.objects (name)';
+SELECT $$CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_empty_tag ON storage.objects (name)$$;
+SELECT $body$CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dollar ON storage.objects (name)$body$;`)
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([])
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('finds a concurrent create after comment markers inside strings', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(`
+SELECT '-- not a comment', '/* not a comment */';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);`)
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            schema_name: 'storage',
+            index_name: 'idx_objects_test',
+            indisvalid: false,
+            on_table: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([
+      { schemaName: 'storage', indexName: 'idx_objects_test' },
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      'DROP INDEX CONCURRENTLY IF EXISTS "storage"."idx_objects_test"'
+    )
+  })
+
+  it('ignores nested block comments and finds the following concurrent create', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration(`
+/* outer comment
+  /* nested comment */
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_commented_out ON storage.objects (name);
+*/
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (name);`)
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            schema_name: 'storage',
+            index_name: 'idx_objects_test',
+            indisvalid: false,
+            on_table: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([
+      { schemaName: 'storage', indexName: 'idx_objects_test' },
+    ])
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        values: ['storage.objects', 'idx_objects_test'],
+      })
+    )
+  })
+
+  it('ignores DROP INDEX CONCURRENTLY', async () => {
+    const { client, query } = createClient()
+    const migration = createMigration('DROP INDEX CONCURRENTLY IF EXISTS idx_objects_test;')
+
+    await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toEqual([])
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('handles every checked-in tenant migration', async () => {
+    const { client, query } = createClient()
+    const migrations = await loadMigrationFiles('./migrations/tenant')
+    query.mockResolvedValue({ rows: [] })
+
+    for (const migration of migrations) {
+      await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toBeDefined()
+    }
+
+    expect(query).toHaveBeenCalledTimes(8)
+  })
+})

--- a/src/internal/database/migrations/concurrent-index-guard.ts
+++ b/src/internal/database/migrations/concurrent-index-guard.ts
@@ -1,0 +1,244 @@
+import type { BasicPgClient, Migration } from 'postgres-migrations/dist/types'
+
+const IDENTIFIER_START = /[A-Za-z_]/u
+const IDENTIFIER_CONTINUATION = /[A-Za-z0-9_$]/u
+const DOLLAR_TAG_CONTINUATION = /[A-Za-z0-9_]/u
+const IDENTIFIER = String.raw`(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)`
+const CONCURRENT_INDEX_CREATE_START = /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\b/giu
+const CONCURRENT_INDEX_CREATE = new RegExp(
+  String.raw`\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:IF\s+NOT\s+EXISTS\s+)?(?<index>${IDENTIFIER})\s+ON\s+(?:ONLY\s+)?(?<table>${IDENTIFIER}(?:\s*\.\s*${IDENTIFIER})?)`,
+  'giu'
+)
+
+interface ConcurrentIndexTarget {
+  indexName: string
+  tableReference: string
+}
+
+interface IndexState {
+  schema_name: string
+  index_name: string
+  indisvalid: boolean | null
+  on_table: boolean | null
+}
+
+export interface RepairedConcurrentIndex {
+  schemaName: string
+  indexName: string
+}
+
+// A failed CREATE INDEX CONCURRENTLY can leave an invalid index behind.
+// A retry with IF NOT EXISTS would otherwise skip the build and record
+// the migration as complete. Remove only the invalid index targeted by
+// the pending migration.
+export async function repairInvalidConcurrentIndexes(
+  client: BasicPgClient,
+  migration: Migration
+): Promise<RepairedConcurrentIndex[]> {
+  const targets = concurrentIndexTargets(migration.sql)
+  const repaired: RepairedConcurrentIndex[] = []
+
+  for (const target of targets) {
+    const result = await client.query({
+      text: `
+        SELECT
+          n.nspname AS schema_name,
+          c.relname AS index_name,
+          i.indisvalid,
+          i.indrelid = pg_catalog.to_regclass($1) AS on_table
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname = $2
+          AND c.relnamespace = (
+            SELECT relnamespace
+            FROM pg_catalog.pg_class
+            WHERE oid = pg_catalog.to_regclass($1)
+          )
+      `,
+      values: [target.tableReference, target.indexName],
+    })
+
+    const state = result.rows[0] as IndexState | undefined
+    if (!state) {
+      continue
+    }
+
+    if (state.on_table === true && state.indisvalid === true) {
+      continue
+    }
+
+    if (state.on_table === true && state.indisvalid === false) {
+      await client.query(
+        `DROP INDEX CONCURRENTLY IF EXISTS ${escapeAndQuoteIdentifier(
+          state.schema_name
+        )}.${escapeAndQuoteIdentifier(state.index_name)}`
+      )
+      repaired.push({
+        schemaName: state.schema_name,
+        indexName: state.index_name,
+      })
+      continue
+    }
+
+    throw new Error(
+      `Cannot repair concurrent index ${target.indexName}: its name is used by a different relation`
+    )
+  }
+
+  return repaired
+}
+
+function concurrentIndexTargets(sql: string): ConcurrentIndexTarget[] {
+  const source = skipSqlLiteralsAndComments(sql)
+  const targets = Array.from(source.matchAll(CONCURRENT_INDEX_CREATE), (match) => ({
+    indexName: unquoteIdentifier(match.groups?.index ?? ''),
+    tableReference: match.groups?.table ?? '',
+  }))
+  const concurrentCreates = source.match(CONCURRENT_INDEX_CREATE_START)?.length ?? 0
+
+  if (targets.length !== concurrentCreates) {
+    throw new Error('Cannot determine the target of a concurrent index migration')
+  }
+
+  return targets
+}
+
+// Preserve quoted identifiers and replace comments and literals with spaces.
+function skipSqlLiteralsAndComments(sql: string): string {
+  const source: string[] = []
+  let copyStart = 0
+  let position = 0
+
+  while (position < sql.length) {
+    const character = sql[position]
+    let end: number | undefined
+
+    if (sql.startsWith('--', position)) {
+      end = skipLineComment(sql, position + 2)
+    } else if (sql.startsWith('/*', position)) {
+      end = skipBlockComment(sql, position + 2)
+    } else if (character === "'") {
+      end = skipSingleQuotedString(sql, position)
+    } else if (character === '$') {
+      const delimiter = dollarQuoteDelimiter(sql, position)
+      if (delimiter) {
+        const closingDelimiter = sql.indexOf(delimiter, position + delimiter.length)
+        end = closingDelimiter === -1 ? sql.length : closingDelimiter + delimiter.length
+      }
+    } else if (character === '"') {
+      position = skipQuotedIdentifier(sql, position)
+      continue
+    }
+
+    if (end === undefined) {
+      position++
+      continue
+    }
+
+    source.push(sql.slice(copyStart, position), ' ')
+    position = end
+    copyStart = end
+  }
+
+  source.push(sql.slice(copyStart))
+  return source.join('')
+}
+
+function skipLineComment(sql: string, start: number): number {
+  let position = start
+  while (position < sql.length && sql[position] !== '\n' && sql[position] !== '\r') {
+    position++
+  }
+  return position
+}
+
+function skipBlockComment(sql: string, start: number): number {
+  let depth = 1
+  let position = start
+
+  while (position < sql.length && depth > 0) {
+    if (sql.startsWith('/*', position)) {
+      depth++
+      position += 2
+    } else if (sql.startsWith('*/', position)) {
+      depth--
+      position += 2
+    } else {
+      position++
+    }
+  }
+
+  return position
+}
+
+function skipSingleQuotedString(sql: string, start: number): number {
+  const escapeBackslashes =
+    (sql[start - 1] === 'E' || sql[start - 1] === 'e') &&
+    (start < 2 || !IDENTIFIER_CONTINUATION.test(sql[start - 2]))
+  let position = start + 1
+
+  while (position < sql.length) {
+    if (escapeBackslashes && sql[position] === '\\') {
+      position += 2
+    } else if (sql[position] === "'" && sql[position + 1] === "'") {
+      position += 2
+    } else if (sql[position] === "'") {
+      return position + 1
+    } else {
+      position++
+    }
+  }
+
+  return position
+}
+
+function dollarQuoteDelimiter(sql: string, start: number): string | undefined {
+  if (start > 0 && IDENTIFIER_CONTINUATION.test(sql[start - 1])) {
+    return undefined
+  }
+
+  let position = start + 1
+  if (sql[position] === '$') {
+    return '$$'
+  }
+
+  if (!IDENTIFIER_START.test(sql[position] ?? '')) {
+    return undefined
+  }
+
+  position++
+  while (position < sql.length && DOLLAR_TAG_CONTINUATION.test(sql[position])) {
+    position++
+  }
+
+  return sql[position] === '$' ? sql.slice(start, position + 1) : undefined
+}
+
+function skipQuotedIdentifier(sql: string, start: number): number {
+  let position = start + 1
+
+  while (position < sql.length) {
+    if (sql[position] === '"' && sql[position + 1] === '"') {
+      position += 2
+    } else if (sql[position] === '"') {
+      return position + 1
+    } else {
+      position++
+    }
+  }
+
+  return position
+}
+
+function unquoteIdentifier(identifier: string): string {
+  if (identifier.startsWith('"')) {
+    return identifier.slice(1, -1).replaceAll('""', '"')
+  }
+
+  return identifier.toLowerCase()
+}
+
+function escapeAndQuoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`
+}

--- a/src/internal/database/migrations/migrate.test.ts
+++ b/src/internal/database/migrations/migrate.test.ts
@@ -1,4 +1,5 @@
 import { AsyncAbortController } from '@internal/concurrency'
+import type { BasicPgClient } from 'postgres-migrations/dist/types'
 import { vi } from 'vitest'
 
 type MockEvent = {
@@ -15,6 +16,7 @@ const {
   mockWarning,
   mockQuery,
   mockLastLocalMigrationName,
+  mockLoadMigrationFilesCached,
   mockLocalMigrationFiles,
   mockPgClientConstructor,
   mockProgressiveStart,
@@ -27,6 +29,7 @@ const {
   mockWarning: vi.fn(),
   mockQuery: vi.fn(),
   mockLastLocalMigrationName: vi.fn(),
+  mockLoadMigrationFilesCached: vi.fn(),
   mockLocalMigrationFiles: vi.fn(),
   mockPgClientConstructor: vi.fn(),
   mockProgressiveStart: vi.fn(),
@@ -54,7 +57,7 @@ vi.mock('../../../config', () => ({
     dbInstallRoles: false,
     dbRefreshMigrationHashesOnMismatch: false,
     dbMigrationFreezeAt: undefined,
-    icebergShards: 0,
+    icebergShards: [],
     multitenantDatabaseQueryTimeout: 1000,
   }),
 }))
@@ -117,7 +120,7 @@ vi.mock('../pool', () => ({
 
 vi.mock('./files', () => ({
   lastLocalMigrationName: mockLastLocalMigrationName,
-  loadMigrationFilesCached: vi.fn(),
+  loadMigrationFilesCached: mockLoadMigrationFilesCached,
   localMigrationFiles: mockLocalMigrationFiles,
 }))
 
@@ -130,6 +133,7 @@ vi.mock('./progressive', () => ({
 }))
 
 import {
+  migrate,
   obtainLockOnMultitenantDB,
   resetMigration,
   resetMigrationsOnTenants,
@@ -187,6 +191,74 @@ function createMigrationClient(migrations: Array<{ id: number; name: string }>):
   mockPgClientConstructor.mockReturnValue(client)
 
   return client
+}
+
+function createMigrationRunnerClient(
+  indexRows: unknown[],
+  accessMethod = 'heap'
+): MockPgClient & BasicPgClient {
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    end: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    query: vi.fn(async (statement: unknown): Promise<QueryResult> => {
+      const text = normalizeSql(getQueryText(statement))
+
+      if (text === 'SHOW default_table_access_method') {
+        return { rows: [{ default_table_access_method: accessMethod }] }
+      }
+
+      if (text === 'SELECT pg_try_advisory_lock(-8525285245963000605);') {
+        return { rows: [{ pg_try_advisory_lock: true }] }
+      }
+
+      if (text.includes("c.relkind = 'r'")) {
+        return { rows: [{ exists: true }] }
+      }
+
+      if (text.startsWith('SELECT * FROM migrations WHERE id <=')) {
+        return { rows: [] }
+      }
+
+      if (text.includes('pg_catalog.to_regclass')) {
+        return { rows: indexRows }
+      }
+
+      return { rows: [], rowCount: 1 }
+    }),
+  } as MockPgClient & BasicPgClient
+}
+
+function setPendingConcurrentIndexMigration(options: { unique?: boolean } = {}) {
+  const sql = `-- postgres-migrations disable-transaction
+CREATE ${options.unique ? 'UNIQUE ' : ''}INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test
+  ON storage.objects (bucket_id, name);`
+
+  mockLoadMigrationFilesCached.mockResolvedValue([
+    {
+      id: 1,
+      name: 'objects-test-index',
+      fileName: '0001-objects-test-index.sql',
+      hash: 'hash-1',
+      contents: sql,
+      sql,
+    },
+  ])
+
+  return sql
+}
+
+function runTestMigrations(client: BasicPgClient) {
+  return migrate({
+    client,
+    migrationsDirectory: './migrations/test',
+    migrationsTableSchema: 'storage',
+    waitForLock: false,
+  })
+}
+
+function migrationQueryTexts(client: MockPgClient) {
+  return client.query.mock.calls.map(([statement]) => normalizeSql(getQueryText(statement)))
 }
 
 function getMigrationQueryCall(client: MockPgClient, sql: string) {
@@ -390,6 +462,112 @@ describe('migration helper request id propagation', () => {
         sbReqId: 'sb-req-123',
         error: rollbackError,
       })
+    )
+  })
+})
+
+describe('concurrent index migration recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('drops an invalid index before retrying its pending concurrent create', async () => {
+    const sql = setPendingConcurrentIndexMigration({ unique: true })
+    const client = createMigrationRunnerClient([
+      {
+        schema_name: 'storage',
+        index_name: 'idx_objects_test',
+        indisvalid: false,
+        on_table: true,
+      },
+    ])
+
+    await expect(runTestMigrations(client)).resolves.toHaveLength(1)
+
+    const queryTexts = migrationQueryTexts(client)
+    const catalogCheck = queryTexts.findIndex((text) => text.includes('pg_catalog.to_regclass'))
+    const invalidIndexDrop = queryTexts.indexOf(
+      'DROP INDEX CONCURRENTLY IF EXISTS "storage"."idx_objects_test"'
+    )
+    const createIndex = queryTexts.indexOf(normalizeSql(sql))
+    const recordMigration = queryTexts.findIndex((text) =>
+      text.startsWith('INSERT INTO migrations')
+    )
+    const catalogCall = client.query.mock.calls[catalogCheck]?.[0]
+
+    expect(catalogCheck).toBeGreaterThan(-1)
+    expect(catalogCall).toMatchObject({
+      values: ['storage.objects', 'idx_objects_test'],
+    })
+    expect(invalidIndexDrop).toBeGreaterThan(catalogCheck)
+    expect(createIndex).toBeGreaterThan(invalidIndexDrop)
+    expect(recordMigration).toBeGreaterThan(createIndex)
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.anything(),
+      '[Migrations] Removed invalid indexes before retry',
+      expect.objectContaining({
+        type: 'migrations',
+        metadata: JSON.stringify({
+          migrationId: 1,
+          migrationName: 'objects-test-index',
+          indexes: [{ schemaName: 'storage', indexName: 'idx_objects_test' }],
+        }),
+      })
+    )
+  })
+
+  it('keeps a valid target index when only the migration record was lost', async () => {
+    const sql = setPendingConcurrentIndexMigration()
+    const client = createMigrationRunnerClient([
+      {
+        schema_name: 'storage',
+        index_name: 'idx_objects_test',
+        indisvalid: true,
+        on_table: true,
+      },
+    ])
+
+    await expect(runTestMigrations(client)).resolves.toHaveLength(1)
+
+    const queryTexts = migrationQueryTexts(client)
+
+    expect(queryTexts.some((text) => text.startsWith('DROP INDEX'))).toBe(false)
+    expect(queryTexts).toContain(normalizeSql(sql))
+    expect(queryTexts.some((text) => text.startsWith('INSERT INTO migrations'))).toBe(true)
+  })
+
+  it('fails closed when the name belongs to an index on another table', async () => {
+    const sql = setPendingConcurrentIndexMigration()
+    const client = createMigrationRunnerClient([
+      {
+        schema_name: 'storage',
+        index_name: 'idx_objects_test',
+        indisvalid: true,
+        on_table: false,
+      },
+    ])
+
+    await expect(runTestMigrations(client)).rejects.toThrow(
+      'its name is used by a different relation'
+    )
+
+    const queryTexts = migrationQueryTexts(client)
+
+    expect(queryTexts).not.toContain(normalizeSql(sql))
+    expect(queryTexts.some((text) => text.startsWith('INSERT INTO migrations'))).toBe(false)
+  })
+
+  it('does not run the PostgreSQL guard after Oriole removes CONCURRENTLY', async () => {
+    setPendingConcurrentIndexMigration()
+    const client = createMigrationRunnerClient([], 'orioledb')
+
+    await expect(runTestMigrations(client)).resolves.toHaveLength(1)
+
+    const queryTexts = migrationQueryTexts(client)
+
+    expect(queryTexts.some((text) => text.includes('pg_catalog.to_regclass'))).toBe(false)
+    expect(queryTexts).toContain(
+      'CREATE INDEX IF NOT EXISTS idx_objects_test ON storage.objects (bucket_id, name);'
     )
   })
 })

--- a/src/internal/database/migrations/migrate.ts
+++ b/src/internal/database/migrations/migrate.ts
@@ -15,6 +15,7 @@ import { getSslSettings } from '../postgres/ssl'
 import { getTenantConfig, TenantMigrationStatus } from '../tenant'
 import { TenantConfigStorePg } from '../tenant-store-pg'
 import { deriveVectorDatabaseUrl, VECTOR_DATABASE_NAME } from '../vector-store-url'
+import { repairInvalidConcurrentIndexes } from './concurrent-index-guard'
 import { lastLocalMigrationName, loadMigrationFilesCached, localMigrationFiles } from './files'
 import { ProgressiveMigrations } from './progressive'
 import { DisableConcurrentIndexTransformer, MigrationTransformer } from './transformers'
@@ -888,10 +889,21 @@ function runMigrations({
               }
             : migration
 
-          const result = await runMigration(
-            migrationTableName,
-            client
-          )(runMigrationTransformers(runnableMigration, transformers))
+          const transformedMigration = runMigrationTransformers(runnableMigration, transformers)
+          const repairedIndexes = await repairInvalidConcurrentIndexes(client, transformedMigration)
+
+          if (repairedIndexes.length > 0) {
+            logSchema.warning(logger, '[Migrations] Removed invalid indexes before retry', {
+              type: 'migrations',
+              metadata: JSON.stringify({
+                migrationId: migration.id,
+                migrationName: migration.name,
+                indexes: repairedIndexes,
+              }),
+            })
+          }
+
+          const result = await runMigration(migrationTableName, client)(transformedMigration)
           completedMigrations.push(result)
         } catch (e) {
           throw ERRORS.DatabaseError(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Concurrent index creation can fail, retry would skips due to exists check.

## What is the new behavior?

For index migrations, extract targets and probe if index is valid or not.
If invalid, drop the index so that runner can recreate.
This makes the migration retryable.

## Additional context

Related to https://github.com/supabase/storage/pull/1353 and needed before.
