### PR TITLE
fix: set socket timeout of http handler

### DIFF
--- a/src/http/routes/tus/index.test.ts
+++ b/src/http/routes/tus/index.test.ts
@@ -1,7 +1,11 @@
 import * as http from 'node:http'
 import * as https from 'node:https'
+import type { AddressInfo } from 'node:net'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { HttpRequest } from '@smithy/protocol-http'
 import type { Server } from '@tus/server'
 import Fastify, { FastifyInstance } from 'fastify'
+import { getConfig } from '../../../config'
 import { requestContext } from '../../plugins/request-context'
 import { createTusLockS3Client, publicRoutes } from './index'
 import type { MultiPartRequest } from './lifecycle'
@@ -22,6 +26,59 @@ describe('TUS S3 clients', () => {
       client.destroy()
       httpAgent.destroy()
       httpsAgent.destroy()
+    }
+  })
+
+  test('maps STORAGE_S3_CLIENT_TIMEOUT to Smithy socketTimeout', async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('ok')
+    })
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const port = (server.address() as AddressInfo).port
+
+    const httpAgent = new http.Agent()
+    const httpsAgent = new https.Agent()
+    const client = createTusLockS3Client({ httpAgent, httpsAgent })
+
+    try {
+      const handler = client.config.requestHandler
+      expect(handler).toBeInstanceOf(NodeHttpHandler)
+      if (!(handler instanceof NodeHttpHandler)) {
+        throw new Error('expected NodeHttpHandler')
+      }
+
+      await handler.handle(
+        new HttpRequest({
+          protocol: 'http:',
+          hostname: '127.0.0.1',
+          port,
+          method: 'GET',
+          path: '/',
+          headers: { host: `127.0.0.1:${port}` },
+        })
+      )
+
+      expect(handler.httpHandlerConfigs()).toMatchObject({
+        connectionTimeout: 5000,
+        socketTimeout: getConfig().storageS3ClientTimeout,
+      })
+      expect(handler.httpHandlerConfigs().requestTimeout).toBeUndefined()
+    } finally {
+      client.destroy()
+      httpAgent.destroy()
+      httpsAgent.destroy()
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
     }
   })
 })

--- a/src/http/routes/tus/index.ts
+++ b/src/http/routes/tus/index.ts
@@ -70,7 +70,7 @@ function createTusStore(agent: { httpsAgent: https.Agent; httpAgent: http.Agent 
         requestHandler: new NodeHttpHandler({
           ...agent,
           connectionTimeout: 5000,
-          requestTimeout: storageS3ClientTimeout,
+          socketTimeout: storageS3ClientTimeout,
         }),
         bucket: storageS3Bucket,
         region: storageS3Region,
@@ -90,7 +90,7 @@ export function createTusLockS3Client(agent: { httpsAgent: https.Agent; httpAgen
     requestHandler: new NodeHttpHandler({
       ...agent,
       connectionTimeout: 5000,
-      requestTimeout: storageS3ClientTimeout,
+      socketTimeout: storageS3ClientTimeout,
     }),
     region: storageS3Region,
     endpoint: storageS3Endpoint,

--- a/src/storage/backend/index.ts
+++ b/src/storage/backend/index.ts
@@ -34,7 +34,7 @@ export function createStorageBackend<Type extends StorageBackendType>(
       endpoint: storageS3Endpoint,
       privateAssetEndpoint: storageS3PrivateAssetEndpoint,
       forcePathStyle: storageS3ForcePathStyle,
-      requestTimeout: storageS3ClientTimeout,
+      socketTimeout: storageS3ClientTimeout,
       ...(config ? config : {}),
     }
     storageBackend = new S3Backend(defaultOptions)

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import {
   AbortMultipartUploadCommand,
   CopyObjectCommand,
@@ -11,6 +13,8 @@ import {
 import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { ErrorCode, isStorageError } from '@internal/errors'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { HttpRequest } from '@smithy/protocol-http'
 import { MAX_KEYS_PER_S3_DELETE } from '@storage/limits'
 import { Readable } from 'stream'
 import { type Mock, vi } from 'vitest'
@@ -183,6 +187,63 @@ describe('S3Backend', () => {
         }
 
         vi.resetModules()
+      }
+    })
+
+    test('maps the configured timeout to Smithy socketTimeout and fails stalled requests', async () => {
+      const server = http.createServer((_req, res) => {
+        setTimeout(() => {
+          res.writeHead(200, { 'content-type': 'text/plain' })
+          res.end('ok')
+        }, 200)
+      })
+      await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      const port = (server.address() as AddressInfo).port
+
+      const backend = new S3Backend({
+        region: 'us-east-1',
+        endpoint: `http://127.0.0.1:${port}`,
+        socketTimeout: 40,
+      })
+
+      try {
+        const handler = (S3Client as unknown as Mock).mock.calls[0][0]
+          .requestHandler as NodeHttpHandler
+        expect(handler).toBeInstanceOf(NodeHttpHandler)
+
+        await expect(
+          handler.handle(
+            new HttpRequest({
+              protocol: 'http:',
+              hostname: '127.0.0.1',
+              port,
+              method: 'GET',
+              path: '/',
+              headers: { host: `127.0.0.1:${port}` },
+            })
+          )
+        ).rejects.toMatchObject({ name: 'TimeoutError' })
+
+        expect(handler.httpHandlerConfigs()).toMatchObject({
+          connectionTimeout: 5000,
+          socketTimeout: 40,
+        })
+        expect(handler.httpHandlerConfigs().requestTimeout).toBeUndefined()
+      } finally {
+        backend.close()
+        backend.agent.httpAgent.destroy()
+        backend.agent.httpsAgent.destroy()
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error)
+              return
+            }
+            resolve()
+          })
+        })
       }
     })
   })

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -57,7 +57,7 @@ export interface S3ClientOptions {
   secretKey?: string
   role?: string
   httpAgent?: InstrumentedAgent
-  requestTimeout?: number
+  socketTimeout?: number
 }
 
 /**
@@ -721,7 +721,7 @@ export class S3Backend implements StorageBackendAdapter {
         httpAgent: options.httpAgent?.httpAgent,
         httpsAgent: options.httpAgent?.httpsAgent,
         connectionTimeout: 5000,
-        requestTimeout: options.requestTimeout,
+        socketTimeout: options.socketTimeout,
       }),
     }
     if (options.endpoint) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

related to #1363, it [seems](https://github.com/smithy-lang/smithy-typescript/blob/main/packages/node-http-handler/CHANGELOG.md#440) [request timeout](https://github.com/smithy-lang/smithy-typescript/blob/c45b1ba71f199fdffb44511304ff8a06c6986795/packages/types/src/http/httpHandlerInitialization.ts#L33-L40) is repurposed for the whole request timeout and socket timeout is used for idle timeout at the moment. 

## What is the new behavior?

Map our existing timeout configuration correctly to keep the same semantics prior to bump.

## Additional context

Related to #1363
