### PR TITLE
fix: handle more imgproxy error gracefully

### DIFF
--- a/src/storage/renderer/image.test.ts
+++ b/src/storage/renderer/image.test.ts
@@ -120,6 +120,23 @@ function stubSuccessfulImageFetch(headers: Record<string, string> = {}) {
   return fetchMock
 }
 
+async function expectMappedImgproxyError(
+  status: number,
+  body: string,
+  expected: Record<string, unknown>
+) {
+  vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockResolvedValue(new Response(body, { status })))
+
+  const { ImageRenderer } = await loadRendererModule()
+
+  await expect(
+    new ImageRenderer(createBackend('local:///tmp/cat.png')).getAsset(
+      createRequest(),
+      createRenderOptions()
+    )
+  ).rejects.toMatchObject(expected)
+}
+
 async function waitForCondition(condition: () => boolean) {
   const deadline = Date.now() + 500
 
@@ -799,89 +816,56 @@ describe('ImageRenderer fetch client', () => {
   })
 
   it.each([
-    [
-      500,
-      "Can't download source image: Image is not compatible with heic/avif",
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
-    [
-      500,
-      "Can't download source image: Image is not compatible with future/format",
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
+    [500, "Can't download source image: Image is not compatible with heic/avif"],
+    [500, "Can't download source image: Image is not compatible with future/format"],
     [
       422,
       "Can't download source image: Source image resolution is too big",
-      400,
       'The source image resolution is too large to process',
     ],
     [
       422,
       "Can't download source image: Source image frame resolution is too big",
-      400,
       'The source image frame resolution is too large to process',
     ],
     [
       422,
       "Can't download source image: Source image file is too big",
-      400,
       'The source image file is too large to process',
     ],
-    [
-      422,
-      "Can't download source image: Source image type not supported",
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
-    [
-      500,
-      "Can't download source image: invalid TIFF format: image dimensions are not specified",
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
+    [422, "Can't download source image: Source image type not supported"],
+    [500, "Can't download source image: invalid TIFF format: image dimensions are not specified"],
     [
       500,
       'glib: XML parse error: warning code=100 (3) in (null):8:23: xmlns: URI ns_sfw; is not absolute',
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
-    [422, 'Invalid source image', 400, 'The source image is invalid or unsupported for rendering'],
-    [
-      422,
-      'Invalid source image \n',
-      400,
-      'The source image is invalid or unsupported for rendering',
     ],
     [
-      422,
-      'Broken or unsupported image',
-      400,
-      'The source image is invalid or unsupported for rendering',
+      500,
+      "source: bad seek to 3022366\nheif: Invalid input: No 'hvcC' box: No hvcC property in hvc1 type image (2.106)",
     ],
-    [
-      422,
-      'Broken or unsupported image \t',
-      400,
-      'The source image is invalid or unsupported for rendering',
-    ],
-  ])('maps imgproxy source-image validation error %# (%i)', async (upstreamStatusCode, body, expectedStatusCode, expectedMessage) => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(body, {
-        status: upstreamStatusCode,
-      })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { ImageRenderer } = await loadRendererModule()
-    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
-    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
-
-    expect(result).toMatchObject({
+    [422, 'Invalid source image'],
+    [422, 'Invalid source image \n'],
+    [422, 'Broken or unsupported image'],
+    [422, 'Broken or unsupported image \t'],
+    [500, "Can't download source image: invalid JPEG format: missing SOF marker"],
+    [500, "Can't download source image: webp: invalid format"],
+    [500, "Can't download source image: Invalid box data size"],
+    [500, "Can't download source image: Invalid ftyp data"],
+    [500, "Can't download source image: Invalid meta data"],
+    [500, "Can't download source image: Invalid ispe data"],
+    [500, "Can't download source image: Dimensions data wasn't found in meta box"],
+    [422, 'VipsJpeg: Invalid JPEG file structure: two SOI markers'],
+    [422, 'pngload_buffer: libspng read error'],
+    [422, 'pngload_source: libspng read error\n/vips/vips.go:136'],
+    [422, 'tiff2vips: unable to read header'],
+    [422, 'webp2vips: unable to read pixels'],
+    [422, 'gif2vips: unable to read header'],
+    [422, 'Broken or unsupported SVG image'],
+  ])('maps imgproxy source-image validation error %# (%i)', async (upstreamStatusCode, body, expectedMessage = 'The source image is invalid or unsupported for rendering') => {
+    await expectMappedImgproxyError(upstreamStatusCode, body, {
       code: 'InvalidRequest',
-      httpStatusCode: expectedStatusCode,
-      userStatusCode: expectedStatusCode,
+      httpStatusCode: 400,
+      userStatusCode: 400,
       message: expectedMessage,
     })
   })
@@ -893,18 +877,7 @@ describe('ImageRenderer fetch client', () => {
     ],
     [422, "Can't download source image: local:///tmp/private-source.jpg: unsupported source state"],
   ])('sanitizes unrecognized imgproxy source-image error %# (%i)', async (upstreamStatusCode, body) => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(body, {
-        status: upstreamStatusCode,
-      })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { ImageRenderer } = await loadRendererModule()
-    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
-    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
-
-    expect(result).toMatchObject({
+    await expectMappedImgproxyError(upstreamStatusCode, body, {
       code: 'InvalidRequest',
       httpStatusCode: upstreamStatusCode,
       userStatusCode: 400,
@@ -925,19 +898,24 @@ describe('ImageRenderer fetch client', () => {
     [503, 'Timeout', 503, 400, 'Image request timed out'],
     [422, '<html>upstream debug</html>', 422, 400, 'Invalid image request'],
     [502, '<html>upstream failure</html>', 502, 400, 'Internal error'],
+    [500, 'heif: Memory allocation error', 500, 500, 'Internal error'],
+    [500, 'source: bad seek to 3022366', 500, 500, 'Internal error'],
+    [500, "Can't download source image: unexpected EOF", 500, 500, 'Internal error'],
+    [
+      500,
+      "Can't download source image: Invalid meta data from upstream server",
+      500,
+      500,
+      'Internal error',
+    ],
+    [500, 'VipsForeignSave: unable to write output', 500, 500, 'Internal error'],
+    [404, 'Source is unreachable', 404, 400, 'Unable to download source image'],
+    [504, 'Source is unreachable', 504, 400, 'Unable to download source image'],
+    [422, 'Source response is incomplete', 422, 400, 'Unable to download source image'],
+    [422, 'Failed to detect source image type', 422, 400, 'Unable to determine source image type'],
+    [404, 'Invalid source URL', 404, 400, 'Invalid image source'],
   ])('maps imgproxy production public error %# (%i)', async (upstreamStatusCode, body, expectedStatusCode, expectedUserStatusCode, expectedMessage) => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(body, {
-        status: upstreamStatusCode,
-      })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    const { ImageRenderer } = await loadRendererModule()
-    const renderer = new ImageRenderer(createBackend('local:///tmp/cat.png'))
-    const result = await renderer.getAsset(createRequest(), createRenderOptions()).catch((e) => e)
-
-    expect(result).toMatchObject({
+    await expectMappedImgproxyError(upstreamStatusCode, body, {
       httpStatusCode: expectedStatusCode,
       userStatusCode: expectedUserStatusCode,
       message: expectedMessage,

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -65,6 +65,7 @@ const IMGPROXY_TOO_MANY_REQUESTS_MESSAGE = 'Too many requests'
 const IMGPROXY_REQUEST_TIMED_OUT_MESSAGE = 'Image request timed out'
 const IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE =
   'The source image is invalid or unsupported for rendering'
+const IMGPROXY_SOURCE_IMAGE_TYPE_UNDETERMINED_MESSAGE = 'Unable to determine source image type'
 const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
   {
     message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
@@ -80,7 +81,29 @@ const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
   },
   {
     message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /^Can't download source image: invalid JPEG format:/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /^Can't download source image: webp: invalid format$/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern:
+      /^Can't download source image: (?:Invalid (?:box data size|(?:ftyp|meta|ispe) data)|Dimensions data wasn't found in meta box)$/i,
+  },
+  {
+    // v3 classifies load_buffer; v4 classifies load_source and any *2vips.
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /^(?:\S+load_(?:buffer|source)|\S+2vips|VipsJpeg): /i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
     pattern: /XML parse error:/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
+    pattern: /heif: Invalid input:/i,
   },
   {
     message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
@@ -88,7 +111,7 @@ const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
   },
   {
     message: IMGPROXY_SOURCE_IMAGE_INVALID_OR_UNSUPPORTED_MESSAGE,
-    pattern: /^Broken or unsupported image$/i,
+    pattern: /^Broken or unsupported (?:SVG )?image$/i,
   },
   {
     message: 'The source image resolution is too large to process',
@@ -106,7 +129,11 @@ const IMGPROXY_SOURCE_IMAGE_BAD_REQUESTS = [
 const IMGPROXY_PUBLIC_ERRORS = [
   {
     message: IMGPROXY_SOURCE_IMAGE_ERROR_MESSAGE,
-    pattern: /^Source image is unreachable$/i,
+    pattern: /^Source (?:image )?is unreachable$/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_ERROR_MESSAGE,
+    pattern: /^Source response is incomplete$/i,
   },
   {
     message: IMGPROXY_INVALID_TRANSFORMATION_MESSAGE,
@@ -114,7 +141,11 @@ const IMGPROXY_PUBLIC_ERRORS = [
   },
   {
     message: IMGPROXY_INVALID_SOURCE_MESSAGE,
-    pattern: /^Invalid source$/i,
+    pattern: /^Invalid source(?: URL)?$/i,
+  },
+  {
+    message: IMGPROXY_SOURCE_IMAGE_TYPE_UNDETERMINED_MESSAGE,
+    pattern: /^Failed to detect source image type$/i,
   },
   {
     message: IMGPROXY_REJECTED_REQUEST_MESSAGE,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some imgproxy developer messages aren't handled and should have been 400 as well, falls through and becomes 500 instead. 

## What is the new behavior?

Add new matchers and cover them

## Additional context

Dry test setup.