### PR TITLE
fix: free iceberg shards slots by catalog id, not name

### DIFF
--- a/src/http/routes/admin/iceberg-admin.test.ts
+++ b/src/http/routes/admin/iceberg-admin.test.ts
@@ -1,0 +1,98 @@
+import fastify from 'fastify'
+import { vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  config: { isMultitenant: true, pgQueueEnable: true, adminApiKeys: 'test-admin-key' },
+}))
+vi.mock('../../../config', () => ({ getConfig: () => mocks.config }))
+vi.mock('@internal/database', () => ({ multitenantPgExecutor: {} }))
+vi.mock('@internal/database/tenant', () => ({}))
+vi.mock('@internal/queue', () => ({ SYSTEM_TENANT: { ref: '', host: '' } }))
+vi.mock('@storage/events/iceberg', () => ({ DeleteIcebergResources: {} }))
+vi.mock('@storage/events/iceberg/reclaim-shard-slots', () => ({
+  ReclaimIcebergShardSlots: { send: mocks.send },
+}))
+
+import routes from './iceberg-admin'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.send.mockResolvedValue('job-id')
+  mocks.config.isMultitenant = true
+  mocks.config.pgQueueEnable = true
+})
+async function request(payload: Record<string, unknown>, apikey = 'test-admin-key') {
+  const app = fastify()
+  app.register(routes, { prefix: '/tenants' })
+  try {
+    return await app.inject({
+      method: 'POST',
+      url: '/tenants/iceberg/reclaim-shard-slots',
+      headers: { apikey },
+      payload,
+    })
+  } finally {
+    await app.close()
+  }
+}
+
+it('defaults to a regional dry-run and returns a correlation ID', async () => {
+  const response = await request({})
+  expect(response.statusCode).toBe(202)
+  const body = response.json()
+  expect(body).toMatchObject({ dryRun: true, jobId: 'job-id' })
+  expect(mocks.send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runId: body.runId,
+      dryRun: true,
+      tenantId: undefined,
+      shardId: undefined,
+      afterReservationId: undefined,
+    })
+  )
+})
+it('accepts explicit reclamation with tenant and shard filters', async () => {
+  const response = await request({ dryRun: false, tenantId: 'tenant-a', shardId: '4' })
+  expect(response.statusCode).toBe(202)
+  expect(mocks.send).toHaveBeenCalledWith(
+    expect.objectContaining({ dryRun: false, tenantId: 'tenant-a', shardId: '4' })
+  )
+})
+it('requires an admin API key', async () => {
+  expect((await request({}, 'wrong-key')).statusCode).toBe(401)
+  expect(mocks.send).not.toHaveBeenCalled()
+})
+it.each([
+  true,
+  false,
+])('accepts a resume cursor with dryRun=%s and unchanged scope', async (dryRun) => {
+  const afterReservationId = '22222222-2222-4222-8222-222222222222'
+  const response = await request({ dryRun, tenantId: 'tenant-a', shardId: '4', afterReservationId })
+  expect(response.statusCode).toBe(202)
+  expect(mocks.send).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({ dryRun, tenantId: 'tenant-a', shardId: '4', afterReservationId })
+  )
+})
+it.each([
+  { shardId: '-1' },
+  { shardId: 'bad' },
+  { tenantId: '' },
+  { dryRun: 'invalid' },
+  { afterReservationId: '' },
+  { afterReservationId: 'not-a-uuid' },
+  { afterReservationId: '22222222-2222-4222-8222-22222222222z' },
+  { afterReservationId: 'urn:uuid:22222222-2222-4222-8222-222222222222' },
+])('rejects invalid scope or mode %j', async (payload) => {
+  expect((await request(payload)).statusCode).toBe(400)
+  expect(mocks.send).not.toHaveBeenCalled()
+})
+it.each(['isMultitenant', 'pgQueueEnable'] as const)('requires %s', async (flag) => {
+  mocks.config[flag] = false
+  expect((await request({})).statusCode).toBe(400)
+  expect(mocks.send).not.toHaveBeenCalled()
+})
+it('does not report success when enqueueing is suppressed', async () => {
+  mocks.send.mockResolvedValue(null)
+  expect((await request({})).statusCode).toBe(409)
+})

--- a/src/http/routes/admin/iceberg-admin.ts
+++ b/src/http/routes/admin/iceberg-admin.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from 'node:crypto'
 import { multitenantPgExecutor } from '@internal/database'
+import { SYSTEM_TENANT } from '@internal/queue'
 import { DeleteIcebergResources } from '@storage/events/iceberg'
+import { ReclaimIcebergShardSlots } from '@storage/events/iceberg/reclaim-shard-slots'
+import { UUID_PATTERN } from '@storage/limits'
 import { FastifyInstance } from 'fastify'
 import { getConfig } from '../../../config'
 import { registerApiKeyAuth } from '../../plugins/apikey'
@@ -27,6 +31,53 @@ function getOrphanIcebergCatalogs() {
 
 export default async function routes(fastify: FastifyInstance) {
   registerApiKeyAuth(fastify)
+
+  fastify.post<{
+    Body: { dryRun?: boolean; tenantId?: string; shardId?: string; afterReservationId?: string }
+  }>(
+    '/iceberg/reclaim-shard-slots',
+    {
+      schema: {
+        tags: ['iceberg'],
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            dryRun: { type: 'boolean', default: true },
+            tenantId: { type: 'string', minLength: 1, maxLength: 255 },
+            shardId: { type: 'string', pattern: '^[1-9][0-9]{0,17}$' },
+            afterReservationId: {
+              type: 'string',
+              pattern: UUID_PATTERN,
+              description:
+                'Scan reservation IDs greater than this UUID. Earlier allocations remain unresolved.',
+            },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { isMultitenant, pgQueueEnable } = getConfig()
+      if (!isMultitenant || !pgQueueEnable) {
+        return reply.code(400).send({
+          error: 'This endpoint only supports multitenant mode with the queue enabled',
+        })
+      }
+      const runId = randomUUID()
+      const dryRun = request.body.dryRun !== false
+      const jobId = await ReclaimIcebergShardSlots.send({
+        runId,
+        dryRun,
+        tenantId: request.body.tenantId,
+        shardId: request.body.shardId,
+        afterReservationId: request.body.afterReservationId,
+        tenant: SYSTEM_TENANT,
+        sbReqId: request.sbReqId,
+      })
+      if (!jobId) return reply.code(409).send({ error: 'Reclamation job was not queued' })
+      return reply.code(202).send({ runId, jobId, dryRun })
+    }
+  )
 
   fastify.get(
     '/iceberg/orphan-catalogs',

--- a/src/storage/events/iceberg/index.ts
+++ b/src/storage/events/iceberg/index.ts
@@ -1,3 +1,4 @@
 export * from '../upgrades/sync-catalog-ids'
 export * from './delete-iceberg-resources'
+export * from './reclaim-shard-slots'
 export * from './reconcile-catalog'

--- a/src/storage/events/iceberg/reclaim-shard-slots.test.ts
+++ b/src/storage/events/iceberg/reclaim-shard-slots.test.ts
@@ -1,0 +1,78 @@
+import type { Job } from 'pg-boss'
+import { vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  batch: vi.fn(),
+  config: {
+    isMultitenant: true,
+    icebergCatalogUrl: 'http://catalog',
+    icebergCatalogAuthType: 'none',
+  },
+  info: vi.fn(),
+}))
+vi.mock('../../../config', () => ({ getConfig: () => mocks.config }))
+vi.mock('@internal/database', () => ({ multitenantPgExecutor: {} }))
+vi.mock('@internal/monitoring', () => ({ logger: {}, logSchema: { info: mocks.info } }))
+vi.mock('@internal/queue', () => ({
+  Event: class {
+    static send = vi.fn()
+  },
+}))
+vi.mock('@storage/protocols/iceberg/catalog', () => ({
+  getCatalogAuthStrategy: vi.fn(),
+  RestCatalogClient: class {},
+}))
+vi.mock('@storage/protocols/iceberg/catalog/reclaim-shard-slots', () => ({
+  IcebergShardSlotReclaimer: class {
+    runBatch = mocks.batch
+  },
+}))
+
+import {
+  ReclaimIcebergShardSlots,
+  type ReclaimIcebergShardSlotsPayload,
+} from './reclaim-shard-slots'
+
+const payload: ReclaimIcebergShardSlotsPayload = {
+  runId: 'run',
+  dryRun: true,
+  tenant: { ref: '', host: '' },
+}
+const job = { data: payload } as Job<ReclaimIcebergShardSlotsPayload>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.config.isMultitenant = true
+})
+it('chains a bounded batch with unchanged scope and dry-run mode', async () => {
+  mocks.batch.mockResolvedValue({ scanned: 100, nextAfterReservationId: 'next-id' })
+  const send = vi.spyOn(ReclaimIcebergShardSlots, 'send').mockResolvedValue('next-job')
+  await ReclaimIcebergShardSlots.handle(job)
+  expect(send).toHaveBeenCalledExactlyOnceWith({ ...payload, afterReservationId: 'next-id' })
+  expect(mocks.info).toHaveBeenCalledOnce()
+  expect(ReclaimIcebergShardSlots.getSendOptions(payload).singletonKey).not.toBe(
+    ReclaimIcebergShardSlots.getSendOptions({ ...payload, afterReservationId: 'next-id' })
+      .singletonKey
+  )
+})
+it('finishes without enqueueing when no continuation remains', async () => {
+  mocks.batch.mockResolvedValue({ scanned: 0 })
+  const send = vi.spyOn(ReclaimIcebergShardSlots, 'send')
+  await ReclaimIcebergShardSlots.handle(job)
+  expect(send).not.toHaveBeenCalled()
+})
+it('fails for retry if a continuation cannot be queued', async () => {
+  mocks.batch.mockResolvedValue({ scanned: 100, nextAfterReservationId: 'next-id' })
+  vi.spyOn(ReclaimIcebergShardSlots, 'send').mockRejectedValue(new Error('queue unavailable'))
+  await expect(ReclaimIcebergShardSlots.handle(job)).rejects.toThrow('queue unavailable')
+})
+it('accepts a deduplicated continuation', async () => {
+  mocks.batch.mockResolvedValue({ scanned: 100, nextAfterReservationId: 'next-id' })
+  vi.spyOn(ReclaimIcebergShardSlots, 'send').mockResolvedValue(null)
+  await expect(ReclaimIcebergShardSlots.handle(job)).resolves.toBeUndefined()
+})
+it('rejects single-tenant execution', async () => {
+  mocks.config.isMultitenant = false
+  await expect(ReclaimIcebergShardSlots.handle(job)).rejects.toThrow('multitenant')
+  expect(mocks.batch).not.toHaveBeenCalled()
+})

--- a/src/storage/events/iceberg/reclaim-shard-slots.ts
+++ b/src/storage/events/iceberg/reclaim-shard-slots.ts
@@ -1,0 +1,72 @@
+import { multitenantPgExecutor } from '@internal/database'
+import { logger, logSchema } from '@internal/monitoring'
+import { type BasePayload, Event } from '@internal/queue'
+import { getCatalogAuthStrategy, RestCatalogClient } from '@storage/protocols/iceberg/catalog'
+import {
+  IcebergShardSlotReclaimer,
+  type ReclaimShardSlotsOptions,
+} from '@storage/protocols/iceberg/catalog/reclaim-shard-slots'
+import type { Job, SendOptions } from 'pg-boss'
+import { getConfig } from '../../../config'
+
+export interface ReclaimIcebergShardSlotsPayload extends BasePayload, ReclaimShardSlotsOptions {
+  runId: string
+}
+
+export class ReclaimIcebergShardSlots extends Event<ReclaimIcebergShardSlotsPayload> {
+  static allowSync = false
+  static queueName = 'reclaim-iceberg-shard-slots'
+
+  static getQueueOptions() {
+    return { name: this.queueName, policy: 'exactly_once' } as const
+  }
+
+  static getWorkerOptions() {
+    return { includeMetadata: true, concurrentTaskCount: 1 }
+  }
+
+  static getSendOptions(payload: ReclaimIcebergShardSlotsPayload): SendOptions {
+    return {
+      singletonKey: `${payload.runId}:${payload.afterReservationId ?? 'start'}`,
+      expireInMinutes: 15,
+      retryLimit: 3,
+      retryDelay: 30,
+      retryBackoff: true,
+    }
+  }
+
+  static async handle(job: Job<ReclaimIcebergShardSlotsPayload>) {
+    const config = getConfig()
+    if (!config.isMultitenant)
+      throw new Error('Iceberg shard reclamation requires multitenant mode')
+    const catalog = new RestCatalogClient({
+      catalogUrl: config.icebergCatalogUrl,
+      auth: getCatalogAuthStrategy(config.icebergCatalogAuthType),
+      timeoutMs: 3000,
+    })
+    const result = await new IcebergShardSlotReclaimer(multitenantPgExecutor, catalog).runBatch(
+      job.data
+    )
+
+    if (result.nextAfterReservationId) {
+      const nextJobId = await this.send({
+        ...job.data,
+        afterReservationId: result.nextAfterReservationId,
+      })
+      if (nextJobId === undefined) throw new Error('Reclamation continuation was not queued')
+    }
+
+    logSchema.info(logger, '[Iceberg] Shard reclamation batch completed', {
+      type: 'iceberg-shard-reclamation',
+      sbReqId: job.data.sbReqId,
+      metadata: JSON.stringify({
+        runId: job.data.runId,
+        dryRun: job.data.dryRun !== false,
+        tenantId: job.data.tenantId,
+        shardId: job.data.shardId,
+        afterReservationId: job.data.afterReservationId,
+        ...result,
+      }),
+    })
+  }
+}

--- a/src/storage/events/workers.ts
+++ b/src/storage/events/workers.ts
@@ -1,6 +1,7 @@
 import { Queue } from '@internal/queue'
 import { PurgeCdnCache } from './cdn/purge-cdn-cache'
 import { DeleteIcebergResources } from './iceberg/delete-iceberg-resources'
+import { ReclaimIcebergShardSlots } from './iceberg/reclaim-shard-slots'
 import { ReconcileIcebergCatalog } from './iceberg/reconcile-catalog'
 import { JwksCreateSigningSecret } from './jwks/jwks-create-signing-secret'
 import { JwksRollUrlSigningKey } from './jwks/jwks-roll-url-signing-key'
@@ -25,6 +26,7 @@ export function registerWorkers() {
   Queue.register(JwksRollUrlSigningKey)
   Queue.register(MoveJobs)
   Queue.register(ReconcileIcebergCatalog)
+  Queue.register(ReclaimIcebergShardSlots)
   Queue.register(DeleteIcebergResources)
   Queue.register(SyncCatalogIds)
 }

--- a/src/storage/protocols/iceberg/catalog/index.ts
+++ b/src/storage/protocols/iceberg/catalog/index.ts
@@ -5,9 +5,9 @@ import {
 } from '@storage/protocols/iceberg/catalog/rest-catalog-client'
 import { getConfig } from '../../../../config'
 
-const { storageS3Region, icebergCatalogToken } = getConfig()
-
 export function getCatalogAuthStrategy(authType: string): CatalogAuthType {
+  const { storageS3Region, icebergCatalogToken } = getConfig()
+
   switch (authType) {
     case 'sigv4':
       return new SignV4Auth({ region: storageS3Region })

--- a/src/storage/protocols/iceberg/catalog/reclaim-shard-slots.test.ts
+++ b/src/storage/protocols/iceberg/catalog/reclaim-shard-slots.test.ts
@@ -1,0 +1,317 @@
+import type { DatabaseTransactionalExecutor } from '@internal/database'
+import { DatabaseError } from 'pg'
+import { IcebergError, IcebergErrorType } from './errors'
+import { IcebergShardSlotReclaimer, RECLAIM_BATCH_SIZE } from './reclaim-shard-slots'
+import { BearerTokenAuth, RestCatalogClient } from './rest-catalog-client'
+
+const namespaceId = '11111111-1111-4111-8111-111111111111'
+const candidate = {
+  id: '22222222-2222-4222-8222-222222222222',
+  shard_id: '1',
+  slot_no: 0,
+  tenant_id: 'tenant-a',
+  shard_key: 'shard-1',
+  resource_id: `iceberg-table::catalog-id::${namespaceId}/table`,
+}
+const options = { dryRun: false }
+const missing = new IcebergError('missing', IcebergErrorType.NoSuchTableException, 404)
+
+function setup() {
+  const query = vi.fn(async (statement: string | { text: string }) => {
+    const sql = typeof statement === 'string' ? statement : statement.text
+    return { rows: sql.includes('SELECT r.id') ? [{ id: candidate.id }] : [] }
+  })
+  const tnx = { query, commit: vi.fn(), rollback: vi.fn(), isCompleted: () => false }
+  const db = {
+    query: vi.fn().mockResolvedValue({ rows: [candidate] }),
+    beginTransaction: vi.fn().mockResolvedValue(tnx),
+  }
+  const catalog = {
+    listNamespaces: vi.fn().mockResolvedValue({ namespaces: [] }),
+    tableExists: vi.fn().mockRejectedValue(missing),
+    loadTable: vi.fn().mockRejectedValue(missing),
+  }
+  const executor = db as DatabaseTransactionalExecutor
+  const reclaimer = new IcebergShardSlotReclaimer(executor, catalog)
+  const writes = () =>
+    query.mock.calls.filter(([s]) => typeof s !== 'string' && s.text.includes('updated_slots'))
+  return { db, tnx, catalog, reclaimer, writes, executor }
+}
+
+describe('IcebergShardSlotReclaimer', () => {
+  it.each([
+    'catalog-id',
+    'warehouse-name',
+  ])('reclaims a verified orphan keyed by %s', async (key) => {
+    const t = setup()
+    t.db.query.mockResolvedValue({
+      rows: [{ ...candidate, resource_id: `iceberg-table::${key}::${namespaceId}/table` }],
+    })
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ reclaimed: 1, scanned: 1 })
+    expect(t.catalog.tableExists).toHaveBeenCalledWith({
+      warehouse: 'shard-1',
+      namespace: `tenant-a_${namespaceId.replaceAll('-', '_')}`,
+      table: 'table',
+    })
+    expect(t.writes()).toHaveLength(1)
+    expect(t.tnx.commit).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    {},
+    { dryRun: true },
+  ])('reports dry-run candidates without changing allocations for %j', async (dryRunOptions) => {
+    const t = setup()
+    expect(await t.reclaimer.runBatch(dryRunOptions)).toMatchObject({
+      reclaimable: 1,
+      reclaimed: 0,
+      reclaimedReservationIds: [candidate.id],
+    })
+    expect(t.writes()).toHaveLength(0)
+  })
+
+  it('keeps local tables without checking upstream table existence', async () => {
+    const t = setup()
+    t.tnx.query.mockResolvedValue({ rows: [{ id: candidate.id }] })
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ localTable: 1 })
+    expect(t.catalog.tableExists).not.toHaveBeenCalled()
+    expect(t.writes()).toHaveLength(0)
+  })
+
+  it('validates the warehouse before opening a transaction, once per shard per batch', async () => {
+    const t = setup()
+    t.db.query.mockResolvedValue({ rows: [candidate, { ...candidate, slot_no: 1 }] })
+    t.catalog.listNamespaces.mockImplementation(async () => {
+      expect(t.db.beginTransaction).not.toHaveBeenCalled()
+      return { namespaces: [] }
+    })
+
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ reclaimed: 2 })
+    expect(t.catalog.listNamespaces).toHaveBeenCalledExactlyOnceWith({
+      warehouse: candidate.shard_key,
+      pageSize: 1,
+    })
+    expect(t.tnx.commit.mock.invocationCallOrder[0]).toBeLessThan(
+      t.db.beginTransaction.mock.invocationCallOrder[1]
+    )
+  })
+
+  it('keeps upstream tables with missing local metadata', async () => {
+    const t = setup()
+    t.catalog.tableExists.mockResolvedValue(undefined)
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ upstreamTable: 1 })
+    expect(t.catalog.loadTable).not.toHaveBeenCalled()
+    expect(t.writes()).toHaveLength(0)
+  })
+
+  describe('HEAD 404 confirmation', () => {
+    afterEach(() => vi.unstubAllGlobals())
+
+    function setupHttpConfirmation() {
+      const t = setup()
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(Response.json({ namespaces: [] }))
+        .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      vi.stubGlobal('fetch', fetchMock)
+      const client = new RestCatalogClient({
+        catalogUrl: 'https://catalog.example/v1',
+        auth: new BearerTokenAuth({ token: 'test' }),
+      })
+      const reclaimer = new IcebergShardSlotReclaimer(t.executor, client)
+      return { ...t, reclaimer, fetchMock, client }
+    }
+
+    it('keeps a table when GET succeeds after HEAD returned 404', async () => {
+      const t = setupHttpConfirmation()
+      t.fetchMock.mockResolvedValueOnce(Response.json({ metadata: {} }))
+
+      expect(await t.reclaimer.runBatch(options)).toMatchObject({
+        upstreamTable: 1,
+        reclaimable: 0,
+        reclaimed: 0,
+      })
+      expect(t.fetchMock.mock.calls.map(([, init]) => init?.method)).toEqual(['GET', 'HEAD', 'GET'])
+      expect(t.fetchMock.mock.calls[2][0]).toEqual(t.fetchMock.mock.calls[1][0])
+      expect(t.writes()).toHaveLength(0)
+      expect(t.tnx.commit).toHaveBeenCalledOnce()
+    })
+
+    it.each([
+      IcebergErrorType.NoSuchTableException,
+      IcebergErrorType.NoSuchNamespaceException,
+    ])('accepts a structured GET 404 with %s', async (type) => {
+      for (const dryRun of [true, false]) {
+        const t = setupHttpConfirmation()
+        t.fetchMock.mockResolvedValueOnce(
+          Response.json({ error: { message: 'missing', type, code: 404 } }, { status: 404 })
+        )
+
+        expect(await t.reclaimer.runBatch({ dryRun })).toMatchObject({
+          reclaimable: dryRun ? 1 : 0,
+          reclaimed: dryRun ? 0 : 1,
+        })
+        expect(t.writes()).toHaveLength(dryRun ? 0 : 1)
+        expect(t.tnx.commit).toHaveBeenCalledOnce()
+      }
+    })
+
+    it.each([
+      { name: 'empty 404', status: 404, body: null, contentType: 'application/json' },
+      { name: 'HTML 404', status: 404, body: '<html>Not found</html>', contentType: 'text/html' },
+      { name: 'malformed JSON 404', status: 404, body: '{', contentType: 'application/json' },
+      { name: 'unstructured JSON 404', status: 404, body: '{}', contentType: 'application/json' },
+      {
+        name: 'HTTP 500 with a missing-table envelope',
+        status: 500,
+        body: JSON.stringify({
+          error: { message: 'missing', type: 'NoSuchTableException', code: 404 },
+        }),
+        contentType: 'application/json',
+      },
+      {
+        name: 'HTTP 404 with an internal-error envelope',
+        status: 404,
+        body: JSON.stringify({
+          error: { message: 'failed', type: 'InternalServerError', code: 500 },
+        }),
+        contentType: 'application/json',
+      },
+    ])('preserves the allocation on $name', async ({ status, body, contentType }) => {
+      const t = setupHttpConfirmation()
+      t.fetchMock.mockResolvedValueOnce(
+        new Response(body, { status, headers: { 'Content-Type': contentType } })
+      )
+
+      await expect(t.reclaimer.runBatch(options)).rejects.toThrow('Iceberg catalog error envelope')
+      expect(t.writes()).toHaveLength(0)
+      expect(t.tnx.rollback).toHaveBeenCalledOnce()
+      expect(t.tnx.commit).not.toHaveBeenCalled()
+    })
+
+    it('preserves the allocation when the confirmation request fails', async () => {
+      const t = setupHttpConfirmation()
+      t.fetchMock.mockRejectedValueOnce(new Error('timeout'))
+
+      await expect(t.reclaimer.runBatch(options)).rejects.toThrow()
+      expect(t.writes()).toHaveLength(0)
+      expect(t.tnx.rollback).toHaveBeenCalledOnce()
+    })
+
+    it('does not treat an authorization error as confirmed table absence', async () => {
+      const t = setupHttpConfirmation()
+      vi.spyOn(t.client.auth, 'authorize').mockImplementation((request) => {
+        if (request.method === 'GET' && request.url.includes('/tables/')) throw missing
+        return request
+      })
+
+      await expect(t.reclaimer.runBatch(options)).rejects.toThrow('Failed to authorize')
+      expect(t.fetchMock).toHaveBeenCalledTimes(2)
+      expect(t.writes()).toHaveLength(0)
+      expect(t.tnx.rollback).toHaveBeenCalledOnce()
+    })
+  })
+
+  it.each([
+    new Error('timeout'),
+    new IcebergError('denied', IcebergErrorType.NotAuthorizedException, 403),
+    new IcebergError('internal', IcebergErrorType.InternalServerError, 500),
+    new IcebergError('ambiguous', IcebergErrorType.InternalServerError, 404),
+  ])('does not reclaim on upstream error: %s', async (error) => {
+    const t = setup()
+    t.catalog.tableExists.mockRejectedValue(error)
+    await expect(t.reclaimer.runBatch(options)).rejects.toBe(error)
+    expect(t.writes()).toHaveLength(0)
+    expect(t.tnx.rollback).toHaveBeenCalledOnce()
+  })
+
+  it('does not treat a missing warehouse as a missing table', async () => {
+    const t = setup()
+    t.catalog.listNamespaces.mockRejectedValue(missing)
+    await expect(t.reclaimer.runBatch(options)).rejects.toBe(missing)
+    expect(t.db.beginTransaction).not.toHaveBeenCalled()
+    expect(t.catalog.tableExists).not.toHaveBeenCalled()
+    expect(t.writes()).toHaveLength(0)
+  })
+
+  it('skips a reservation changed since discovery', async () => {
+    const t = setup()
+    t.tnx.query.mockResolvedValue({ rows: [] })
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ changed: 1 })
+    expect(t.catalog.tableExists).not.toHaveBeenCalled()
+    expect(t.writes()).toHaveLength(0)
+  })
+
+  it.each(['55P03', '57014'])('rolls back and skips %s, then continues the batch', async (code) => {
+    const t = setup()
+    const next = { ...candidate, id: '33333333-3333-4333-8333-333333333333', slot_no: 1 }
+    t.db.query.mockResolvedValue({ rows: [candidate, next] })
+    t.tnx.query.mockRejectedValueOnce(
+      Object.assign(new DatabaseError('contention', 0, 'error'), { code })
+    )
+
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({
+      scanned: 2,
+      skipped: 1,
+      reclaimed: 1,
+      reclaimedReservationIds: [next.id],
+    })
+    expect(t.tnx.rollback).toHaveBeenCalledOnce()
+    expect(t.tnx.rollback.mock.invocationCallOrder[0]).toBeLessThan(
+      t.db.beginTransaction.mock.invocationCallOrder[1]
+    )
+    expect(t.tnx.commit).toHaveBeenCalledOnce()
+    expect(t.writes()).toHaveLength(1)
+  })
+
+  it('propagates other SQL errors', async () => {
+    const t = setup()
+    const error = Object.assign(new DatabaseError('connection lost', 0, 'error'), { code: '08006' })
+    t.tnx.query.mockRejectedValueOnce(error)
+    await expect(t.reclaimer.runBatch(options)).rejects.toBe(error)
+    expect(t.tnx.rollback).toHaveBeenCalledOnce()
+  })
+
+  it('does not skip when rollback fails', async () => {
+    const t = setup()
+    const contentionError = Object.assign(new DatabaseError('contention', 0, 'error'), {
+      code: '55P03',
+    })
+    t.tnx.query.mockRejectedValueOnce(contentionError)
+    const rollbackError = new Error('rollback failed')
+    t.tnx.rollback.mockRejectedValueOnce(rollbackError)
+    await expect(t.reclaimer.runBatch(options)).rejects.toBe(rollbackError)
+    expect(rollbackError.cause).toBe(contentionError)
+    expect(t.tnx.commit).not.toHaveBeenCalled()
+  })
+
+  it('skips malformed resource identities', async () => {
+    const t = setup()
+    t.db.query.mockResolvedValue({ rows: [{ ...candidate, resource_id: 'invalid' }] })
+    expect(await t.reclaimer.runBatch(options)).toMatchObject({ unsupported: 1 })
+    expect(t.db.beginTransaction).not.toHaveBeenCalled()
+  })
+
+  it('passes filters and cursor to discovery and returns a continuation for a full batch', async () => {
+    const t = setup()
+    t.db.query.mockResolvedValue({
+      rows: Array.from({ length: RECLAIM_BATCH_SIZE }, () => ({
+        ...candidate,
+        resource_id: 'invalid',
+      })),
+    })
+    const result = await t.reclaimer.runBatch({
+      ...options,
+      tenantId: 'tenant-a',
+      shardId: '1',
+      afterReservationId: candidate.id,
+    })
+    expect(t.db.query.mock.calls[0][0].values).toEqual([
+      'tenant-a',
+      '1',
+      candidate.id,
+      RECLAIM_BATCH_SIZE,
+    ])
+    expect(result.nextAfterReservationId).toBe(candidate.id)
+  })
+})

--- a/src/storage/protocols/iceberg/catalog/reclaim-shard-slots.ts
+++ b/src/storage/protocols/iceberg/catalog/reclaim-shard-slots.ts
@@ -1,0 +1,234 @@
+import type { DatabaseTransaction, DatabaseTransactionalExecutor } from '@internal/database'
+import { logger, logSchema } from '@internal/monitoring'
+import { PgShardStoreFactory, ShardCatalog } from '@internal/sharding'
+import { DatabaseError } from 'pg'
+import { icebergResourceLockKey } from '../resource-lock'
+import { IcebergError, IcebergErrorType } from './errors'
+import type { RestCatalogClient } from './rest-catalog-client'
+
+export const RECLAIM_BATCH_SIZE = 100
+
+export interface ReclaimShardSlotsOptions {
+  runId?: string
+  dryRun?: boolean
+  tenantId?: string
+  shardId?: string
+  afterReservationId?: string
+}
+
+interface Candidate {
+  id: string
+  shard_id: string
+  slot_no: number
+  tenant_id: string
+  resource_id: string
+  shard_key: string
+}
+
+type Outcome =
+  | 'reclaimed'
+  | 'reclaimable'
+  | 'localTable'
+  | 'upstreamTable'
+  | 'changed'
+  | 'unsupported'
+  | 'skipped'
+
+// Both historical catalog-name and current catalog-ID keys contain the namespace UUID.
+const resourcePattern =
+  /^iceberg-table::.+::([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/([^/]+)$/i
+
+export class IcebergShardSlotReclaimer {
+  constructor(
+    private readonly db: DatabaseTransactionalExecutor,
+    private readonly catalog: Pick<
+      RestCatalogClient,
+      'tableExists' | 'loadTable' | 'listNamespaces'
+    >
+  ) {}
+
+  async runBatch(options: ReclaimShardSlotsOptions) {
+    const verifiedShards = new Set<string>()
+
+    const { rows } = await this.db.query<Candidate>({
+      text: `
+        SELECT r.id, r.shard_id::text, r.slot_no, r.tenant_id, r.resource_id, s.shard_key
+        FROM public.shard_reservation r
+        JOIN public.shard s ON s.id = r.shard_id AND s.kind = 'iceberg-table'
+        JOIN public.shard_slots sl ON sl.shard_id = r.shard_id AND sl.slot_no = r.slot_no
+          AND sl.tenant_id = r.tenant_id AND sl.resource_id = r.resource_id
+        WHERE r.kind = 'iceberg-table' AND r.status = 'confirmed'
+          AND ($1::text IS NULL OR r.tenant_id = $1)
+          AND ($2::bigint IS NULL OR r.shard_id = $2)
+          AND r.id > $3::uuid
+        ORDER BY r.id
+        LIMIT $4
+      `,
+      values: [
+        options.tenantId ?? null,
+        options.shardId ?? null,
+        options.afterReservationId ?? '00000000-0000-0000-0000-000000000000',
+        RECLAIM_BATCH_SIZE,
+      ],
+    })
+
+    const counts: Record<Outcome, number> = {
+      reclaimed: 0,
+      reclaimable: 0,
+      localTable: 0,
+      upstreamTable: 0,
+      changed: 0,
+      unsupported: 0,
+      skipped: 0,
+    }
+    const reclaimedReservationIds: string[] = []
+    for (const candidate of rows) {
+      const outcome = await this.inspect(candidate, options.dryRun !== false, verifiedShards)
+      counts[outcome]++
+      if (outcome === 'reclaimed' || outcome === 'reclaimable') {
+        reclaimedReservationIds.push(candidate.id)
+      }
+      if (outcome === 'reclaimed') {
+        // Keep an audit record even if a later candidate fails and the batch is retried.
+        logSchema.info(logger, '[Iceberg] Shard allocation reclaimed', {
+          type: 'iceberg-shard-reclamation',
+          project: candidate.tenant_id,
+          metadata: JSON.stringify({ runId: options.runId, ...candidate }),
+        })
+      }
+    }
+
+    return {
+      scanned: rows.length,
+      ...counts,
+      reclaimedReservationIds,
+      nextAfterReservationId:
+        rows.length === RECLAIM_BATCH_SIZE ? rows[rows.length - 1].id : undefined,
+    }
+  }
+
+  private async inspect(
+    candidate: Candidate,
+    dryRun: boolean,
+    verifiedShards: Set<string>
+  ): Promise<Outcome> {
+    const match = resourcePattern.exec(candidate.resource_id)
+    if (!match || !candidate.tenant_id) return 'unsupported'
+    const namespaceId = match[1].toLowerCase()
+    const tableName = match[2]
+
+    // Validate the endpoint without holding writer locks. A warehouse 404 is not
+    // evidence of table absence; the table check still runs under the locks below.
+    if (!verifiedShards.has(candidate.shard_key)) {
+      await this.catalog.listNamespaces({ warehouse: candidate.shard_key, pageSize: 1 })
+      verifiedShards.add(candidate.shard_key)
+    }
+
+    const tnx = await this.db.beginTransaction()
+    try {
+      await tnx.query("SET LOCAL lock_timeout = '2s'")
+      await tnx.query("SET LOCAL statement_timeout = '5s'")
+      // Bypass PgMetastore's error mapping so 55P03/57014 reach the skip handler.
+      const store = new PgShardStoreFactory(tnx).autocommit()
+      for (const key of [
+        icebergResourceLockKey('namespace', `${candidate.tenant_id}:${namespaceId}`),
+        candidate.resource_id,
+      ]) {
+        await store.advisoryLockByString(key)
+      }
+
+      const outcome = await this.inspectLocked(tnx, candidate, namespaceId, tableName, dryRun)
+      await tnx.commit()
+      return outcome
+    } catch (error) {
+      try {
+        await tnx.rollback()
+      } catch (rollbackError) {
+        if (rollbackError instanceof Error) rollbackError.cause = error
+        throw rollbackError
+      }
+      if (error instanceof DatabaseError && (error.code === '55P03' || error.code === '57014')) {
+        return 'skipped'
+      }
+      throw error
+    }
+  }
+
+  private async inspectLocked(
+    tnx: DatabaseTransaction,
+    candidate: Candidate,
+    namespaceId: string,
+    tableName: string,
+    dryRun: boolean
+  ): Promise<Outcome> {
+    // A delayed job must never free a slot that has been reused since discovery.
+    const current = await tnx.query({
+      text: `
+        SELECT r.id
+        FROM public.shard_slots sl
+        JOIN public.shard_reservation r ON r.shard_id = sl.shard_id AND r.slot_no = sl.slot_no
+        WHERE r.id = $1::uuid AND r.status = 'confirmed'
+          AND r.resource_id = $4 AND r.tenant_id = $5
+          AND sl.shard_id = $2::bigint AND sl.slot_no = $3
+          AND sl.resource_id = $4 AND sl.tenant_id = $5
+        FOR UPDATE OF sl, r
+      `,
+      values: [
+        candidate.id,
+        candidate.shard_id,
+        candidate.slot_no,
+        candidate.resource_id,
+        candidate.tenant_id,
+      ],
+    })
+    if (current.rows.length === 0) return 'changed'
+
+    // Keep allocations for any matching local table, including legacy name-keyed records.
+    const local = await tnx.query({
+      text: `
+        SELECT 1 FROM public.iceberg_tables
+        WHERE tenant_id = $1 AND namespace_id = $2::uuid AND name = $3
+        LIMIT 1
+      `,
+      values: [candidate.tenant_id, namespaceId, tableName],
+    })
+    if (local.rows.length > 0) return 'localTable'
+
+    const table = {
+      warehouse: candidate.shard_key,
+      namespace: `${candidate.tenant_id}_${namespaceId.replaceAll('-', '_')}`,
+      table: tableName,
+    }
+    try {
+      await this.catalog.tableExists(table)
+      return 'upstreamTable'
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error
+    }
+
+    // HEAD has no error body: a proxy 404 looks like a missing table. Confirm
+    // absence with a structured catalog GET 404 while still holding writer locks.
+    try {
+      await this.catalog.loadTable(table, { requireStructuredErrors: true })
+      return 'upstreamTable'
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error
+    }
+
+    if (dryRun) return 'reclaimable'
+    await new ShardCatalog(new PgShardStoreFactory(tnx)).freeByLocation(
+      candidate.shard_id,
+      candidate.slot_no
+    )
+    return 'reclaimed'
+  }
+}
+
+function isMissingTableError(error: unknown): error is IcebergError {
+  return (
+    error instanceof IcebergError &&
+    error.code === 404 &&
+    (error.type === IcebergErrorType.NoSuchTableException ||
+      error.type === IcebergErrorType.NoSuchNamespaceException)
+  )
+}

--- a/src/storage/protocols/iceberg/catalog/reconciler.test.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.test.ts
@@ -1,21 +1,9 @@
 import { type DatabaseTransaction, multitenantPgExecutor } from '@internal/database'
+import { logger, logSchema } from '@internal/monitoring'
 import { ShardCatalog } from '@internal/sharding'
+import { IcebergError, IcebergErrorType } from './errors'
 import { IcebergCatalogReconciler } from './reconciler'
 import type { RestCatalogClient } from './rest-catalog-client'
-
-function createReconciler() {
-  return new IcebergCatalogReconciler({} as RestCatalogClient) as unknown as {
-    findCatalogByName: (
-      tnx: { query: ReturnType<typeof vi.fn> },
-      tenantId: string,
-      catalogName: string
-    ) => Promise<unknown>
-    findFirstCatalog: (
-      tnx: { query: ReturnType<typeof vi.fn> },
-      tenantId: string
-    ) => Promise<unknown>
-  }
-}
 
 function getLastStatement(query: ReturnType<typeof vi.fn>): string {
   const [statement] = query.mock.calls.at(-1) || []
@@ -33,9 +21,68 @@ describe('IcebergCatalogReconciler', () => {
   })
 
   it.each([
-    true,
-    false,
-  ])('uses catalog IDs when an allocation exists: %s', async (hasAllocation) => {
+    {
+      hasAllocation: true,
+      legacyAllocation: true,
+      secondTableError: undefined,
+      restoredNames: ['table', 'second-table', 'third-table'],
+    },
+    {
+      hasAllocation: true,
+      secondTableError: undefined,
+      restoredNames: ['table', 'second-table', 'third-table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: undefined,
+      restoredNames: ['table', 'second-table', 'third-table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: new IcebergError(
+        'table disappeared',
+        IcebergErrorType.NoSuchTableException,
+        404
+      ),
+      restoredNames: ['table', 'third-table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: new IcebergError(
+        'ambiguous 404',
+        IcebergErrorType.InternalServerError,
+        404
+      ),
+      restoredNames: ['table', 'third-table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: new Error('timeout'),
+      restoredNames: ['table', 'third-table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: new Error('timeout'),
+      rollbackError: new Error('rollback failed'),
+      restoredNames: ['table'],
+    },
+    {
+      hasAllocation: false,
+      secondTableError: new IcebergError(
+        'table disappeared',
+        IcebergErrorType.NoSuchTableException,
+        404
+      ),
+      rollbackError: new Error('rollback failed'),
+      restoredNames: ['table'],
+    },
+  ])('restores $restoredNames with allocation=$hasAllocation, second table error=$secondTableError', async ({
+    hasAllocation,
+    legacyAllocation,
+    secondTableError,
+    rollbackError,
+    restoredNames,
+  }) => {
     const shard = {
       id: 1,
       kind: 'iceberg-table' as const,
@@ -45,13 +92,22 @@ describe('IcebergCatalogReconciler', () => {
       status: 'active' as const,
       created_at: '2026-01-01T00:00:00Z',
     }
-    const query = vi
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: 'catalog-id', name: 'warehouse' }] })
-      .mockResolvedValue({ rows: [] })
+    const query = vi.fn(async (statement: string | { text: string }) => {
+      const sql = typeof statement === 'string' ? statement : statement.text
+      return {
+        rows: sql.includes('FROM iceberg_namespaces n')
+          ? [{ id: 'catalog-id', name: 'warehouse' }]
+          : legacyAllocation && sql.includes('renamed_reservation')
+            ? [{ slot_no: 0 }]
+            : [],
+      }
+    })
     const commit = vi.fn().mockResolvedValue(undefined)
     const rollback = vi.fn().mockResolvedValue(undefined)
-    vi.spyOn(multitenantPgExecutor, 'beginTransaction').mockResolvedValue({
+    if (rollbackError) rollback.mockRejectedValue(rollbackError)
+    const logError = vi.spyOn(logSchema, 'error').mockImplementation(() => {})
+    vi.spyOn(logSchema, 'warning').mockImplementation(() => {})
+    const begin = vi.spyOn(multitenantPgExecutor, 'beginTransaction').mockResolvedValue({
       query,
       commit,
       rollback,
@@ -67,7 +123,7 @@ describe('IcebergCatalogReconciler', () => {
     const find = vi
       .spyOn(ShardCatalog.prototype, 'findShardByResourceId')
       .mockImplementation(async (resource) =>
-        hasAllocation && resource.bucketName === 'catalog-id' ? shard : null
+        hasAllocation && !legacyAllocation && resource.bucketName === 'catalog-id' ? shard : null
       )
     const reserve = vi.spyOn(ShardCatalog.prototype, 'reserve').mockResolvedValue({
       reservationId: 'reservation-id',
@@ -80,52 +136,85 @@ describe('IcebergCatalogReconciler', () => {
     const restCatalog = {
       listNamespaces: vi.fn().mockResolvedValue({ namespaces: [['tenant-id_namespace_id']] }),
       listTables: vi.fn().mockResolvedValue({
-        identifiers: [{ namespace: ['tenant-id_namespace_id'], name: 'table' }],
+        identifiers: ['table', 'second-table', 'third-table'].map((name) => ({
+          namespace: ['tenant-id_namespace_id'],
+          name,
+        })),
       }),
-      loadNamespaceMetadata: vi
-        .fn()
-        .mockResolvedValue({ properties: { 'bucket-name': 'warehouse' } }),
-      loadTable: vi.fn().mockResolvedValue({
-        metadata: { location: 's3://shard-1/table', 'table-uuid': 'remote-table-id' },
+      loadNamespaceMetadata: vi.fn(),
+      loadTable: vi.fn().mockImplementation(async ({ table }) => {
+        expect(begin.mock.calls.length).toBe(
+          commit.mock.calls.length + rollback.mock.calls.length + 1
+        )
+        expect(getLastStatement(query)).toContain('pg_advisory_xact_lock')
+        if (secondTableError && table === 'second-table') {
+          throw secondTableError
+        }
+        return { metadata: { location: 's3://shard-1/table', 'table-uuid': 'remote-table-id' } }
       }),
     }
 
-    await new IcebergCatalogReconciler(restCatalog as unknown as RestCatalogClient).reconcile()
-
-    const resource = {
-      kind: 'iceberg-table',
-      tenantId: 'tenant-id',
-      bucketName: 'catalog-id',
-      logicalName: 'namespace-id/table',
-    }
-    expect(find).toHaveBeenCalledExactlyOnceWith(resource)
-    if (hasAllocation) {
-      expect(reserve).not.toHaveBeenCalled()
-      expect(confirm).not.toHaveBeenCalled()
+    const work = new IcebergCatalogReconciler(
+      restCatalog as unknown as RestCatalogClient
+    ).reconcile()
+    if (rollbackError) {
+      await expect(work).rejects.toMatchObject({ cause: rollbackError })
     } else {
-      expect(reserve).toHaveBeenCalledExactlyOnceWith({ ...resource, shardId: 1 })
-      expect(confirm).toHaveBeenCalledExactlyOnceWith('reservation-id', resource)
+      await work
     }
-    expect(getLastStatement(query)).toContain('INSERT INTO iceberg_tables')
-    expect(commit).toHaveBeenCalledOnce()
-    expect(rollback).not.toHaveBeenCalled()
-  })
 
-  it('ignores soft-deleted catalogs when finding an upstream orphan catalog by name', async () => {
-    const query = vi.fn().mockResolvedValue({ rows: [] })
-    const reconciler = createReconciler()
+    expect(restCatalog.loadNamespaceMetadata).not.toHaveBeenCalled()
 
-    await reconciler.findCatalogByName({ query }, 'tenant-id', 'catalog-name')
-
-    expect(getLastStatement(query)).toContain('deleted_at IS NULL')
-  })
-
-  it('ignores soft-deleted catalogs when falling back to the first tenant catalog', async () => {
-    const query = vi.fn().mockResolvedValue({ rows: [] })
-    const reconciler = createReconciler()
-
-    await reconciler.findFirstCatalog({ query }, 'tenant-id')
-
-    expect(getLastStatement(query)).toContain('deleted_at IS NULL')
+    for (const name of restoredNames) {
+      const resource = {
+        kind: 'iceberg-table',
+        tenantId: 'tenant-id',
+        bucketName: 'catalog-id',
+        logicalName: `namespace-id/${name}`,
+      }
+      expect(find).toHaveBeenCalledWith(resource)
+      if (hasAllocation) {
+        expect(reserve).not.toHaveBeenCalled()
+        expect(confirm).not.toHaveBeenCalled()
+      } else {
+        expect(reserve).toHaveBeenCalledWith({ ...resource, shardId: 1 })
+        expect(confirm).toHaveBeenCalledWith('reservation-id', resource)
+      }
+    }
+    const inserts = query.mock.calls.filter(
+      ([statement]) =>
+        typeof statement !== 'string' && statement.text.includes('INSERT INTO iceberg_tables')
+    )
+    expect(inserts).toHaveLength(restoredNames.length)
+    expect(begin).toHaveBeenCalledTimes(restoredNames.length + (secondTableError ? 1 : 0))
+    expect(commit).toHaveBeenCalledTimes(restoredNames.length)
+    expect(rollback).toHaveBeenCalledTimes(secondTableError ? 1 : 0)
+    if (
+      secondTableError &&
+      (rollbackError ||
+        !(
+          secondTableError instanceof IcebergError &&
+          secondTableError.type === IcebergErrorType.NoSuchTableException
+        ))
+    ) {
+      expect(logError).toHaveBeenCalledExactlyOnceWith(
+        logger,
+        '[IcebergCatalogReconciler] Failed to restore table',
+        expect.objectContaining({
+          error: rollbackError
+            ? expect.objectContaining({ cause: rollbackError })
+            : secondTableError,
+          project: 'tenant-id',
+          metadata: JSON.stringify({
+            shardId: 1,
+            shardKey: 'shard-1',
+            namespaceId: 'namespace-id',
+            table: 'second-table',
+          }),
+        })
+      )
+    } else {
+      expect(logError).not.toHaveBeenCalled()
+    }
   })
 })

--- a/src/storage/protocols/iceberg/catalog/reconciler.test.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.test.ts
@@ -1,3 +1,5 @@
+import { type DatabaseTransaction, multitenantPgExecutor } from '@internal/database'
+import { ShardCatalog } from '@internal/sharding'
 import { IcebergCatalogReconciler } from './reconciler'
 import type { RestCatalogClient } from './rest-catalog-client'
 
@@ -26,6 +28,89 @@ function getLastStatement(query: ReturnType<typeof vi.fn>): string {
 }
 
 describe('IcebergCatalogReconciler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    true,
+    false,
+  ])('uses catalog IDs when an allocation exists: %s', async (hasAllocation) => {
+    const shard = {
+      id: 1,
+      kind: 'iceberg-table' as const,
+      shard_key: 'shard-1',
+      capacity: 1000,
+      next_slot: 1,
+      status: 'active' as const,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: 'catalog-id', name: 'warehouse' }] })
+      .mockResolvedValue({ rows: [] })
+    const commit = vi.fn().mockResolvedValue(undefined)
+    const rollback = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(multitenantPgExecutor, 'beginTransaction').mockResolvedValue({
+      query,
+      commit,
+      rollback,
+    } as unknown as DatabaseTransaction)
+    vi.spyOn(multitenantPgExecutor, 'query').mockResolvedValue({
+      rows: [],
+      rowCount: 0,
+      command: 'SELECT',
+      oid: 0,
+      fields: [],
+    })
+    vi.spyOn(ShardCatalog.prototype, 'listShardByKind').mockResolvedValue([shard])
+    const find = vi
+      .spyOn(ShardCatalog.prototype, 'findShardByResourceId')
+      .mockImplementation(async (resource) =>
+        hasAllocation && resource.bucketName === 'catalog-id' ? shard : null
+      )
+    const reserve = vi.spyOn(ShardCatalog.prototype, 'reserve').mockResolvedValue({
+      reservationId: 'reservation-id',
+      shardId: '1',
+      shardKey: 'shard-1',
+      slotNo: 0,
+      leaseExpiresAt: '2099-01-01T00:00:00Z',
+    })
+    const confirm = vi.spyOn(ShardCatalog.prototype, 'confirm').mockResolvedValue(undefined)
+    const restCatalog = {
+      listNamespaces: vi.fn().mockResolvedValue({ namespaces: [['tenant-id_namespace_id']] }),
+      listTables: vi.fn().mockResolvedValue({
+        identifiers: [{ namespace: ['tenant-id_namespace_id'], name: 'table' }],
+      }),
+      loadNamespaceMetadata: vi
+        .fn()
+        .mockResolvedValue({ properties: { 'bucket-name': 'warehouse' } }),
+      loadTable: vi.fn().mockResolvedValue({
+        metadata: { location: 's3://shard-1/table', 'table-uuid': 'remote-table-id' },
+      }),
+    }
+
+    await new IcebergCatalogReconciler(restCatalog as unknown as RestCatalogClient).reconcile()
+
+    const resource = {
+      kind: 'iceberg-table',
+      tenantId: 'tenant-id',
+      bucketName: 'catalog-id',
+      logicalName: 'namespace-id/table',
+    }
+    expect(find).toHaveBeenCalledExactlyOnceWith(resource)
+    if (hasAllocation) {
+      expect(reserve).not.toHaveBeenCalled()
+      expect(confirm).not.toHaveBeenCalled()
+    } else {
+      expect(reserve).toHaveBeenCalledExactlyOnceWith({ ...resource, shardId: 1 })
+      expect(confirm).toHaveBeenCalledExactlyOnceWith('reservation-id', resource)
+    }
+    expect(getLastStatement(query)).toContain('INSERT INTO iceberg_tables')
+    expect(commit).toHaveBeenCalledOnce()
+    expect(rollback).not.toHaveBeenCalled()
+  })
+
   it('ignores soft-deleted catalogs when finding an upstream orphan catalog by name', async () => {
     const query = vi.fn().mockResolvedValue({ rows: [] })
     const reconciler = createReconciler()

--- a/src/storage/protocols/iceberg/catalog/reconciler.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.ts
@@ -1,16 +1,28 @@
 import { type DatabaseTransaction, multitenantPgExecutor } from '@internal/database'
 import { logger, logSchema } from '@internal/monitoring'
-import { PgShardStoreFactory, ShardCatalog, ShardRow } from '@internal/sharding'
+import { PgShardStoreFactory, ShardCatalog, type ShardResource, ShardRow } from '@internal/sharding'
 import {
   ListTableResponse,
   RestCatalogClient,
 } from '@storage/protocols/iceberg/catalog/rest-catalog-client'
 import { TableIndex } from '@storage/protocols/iceberg/metastore'
+import { PgMetastore } from '@storage/protocols/iceberg/pg'
 import { IcebergCatalog } from '@storage/schemas'
+import { IcebergError, IcebergErrorType } from './errors'
 
 type NamespaceWithShardInfo = TableIndex & { shard_id?: string; shard_key?: string }
 type CatalogRow = Pick<IcebergCatalog, 'id' | 'name'>
 type ReconcilerTransaction = DatabaseTransaction
+
+class ReconciliationRollbackError extends Error {}
+
+function rethrowRollbackFailure(results: PromiseSettledResult<unknown>[]) {
+  for (const result of results) {
+    if (result.status === 'rejected' && result.reason instanceof ReconciliationRollbackError) {
+      throw result.reason
+    }
+  }
+}
 
 /**
  * Highly experimental reconciler for iceberg catalogs
@@ -34,7 +46,7 @@ export class IcebergCatalogReconciler {
     const sharding = this.createShardCatalog()
     const shards = await sharding.listShardByKind('iceberg-table')
 
-    await Promise.allSettled(
+    const shardResults = await Promise.allSettled(
       shards.map(async (shard) => {
         const namespaces = this.listNamespaces(shard.shard_key)
 
@@ -58,15 +70,17 @@ export class IcebergCatalogReconciler {
                 tableBatch.map((t) => t.name)
               )
 
-              await Promise.allSettled([
+              const results = await Promise.allSettled([
                 this.deleteLocalOrphanTables(shard, dbTables, tableBatch),
                 this.syncUpstreamOrphanTables(shard, tenantId, dbNamespaceId, dbTables, tableBatch),
               ])
+              rethrowRollbackFailure(results)
             }
           }
         }
       })
     )
+    rethrowRollbackFailure(shardResults)
   }
 
   private async deleteLocalOrphanTables(
@@ -107,69 +121,55 @@ export class IcebergCatalogReconciler {
       return
     }
 
-    await this.withTransaction(async (tnx) => {
-      await Promise.all(
-        tablesMissing.map(async (table) => {
-          const namespaceResp = await this.restCatalog.loadNamespaceMetadata({
-            warehouse: shard.shard_key,
-            namespace: table.namespace[0],
-          })
-
+    for (const table of tablesMissing) {
+      try {
+        await this.withTransaction(async (tnx) => {
+          // Serialize metadata restoration with create/drop and orphan allocation reclamation.
+          await new PgMetastore(tnx, { multiTenant: true, schema: 'public' }).lockResource(
+            'namespace',
+            `${tenantId}:${namespaceId}`
+          )
+          // Re-read the table under the writer lock so a concurrent drop cannot
+          // turn a prefetched response into stale restored metadata.
           const tableResp = await this.restCatalog.loadTable({
             warehouse: shard.shard_key,
             namespace: table.namespace[0],
             table: table.name,
           })
 
-          let catalogName = namespaceResp.properties?.['bucket-name'] as string | undefined
-          let catalog = catalogName
-            ? await this.findCatalogByName(tnx, tenantId, catalogName)
-            : undefined
-
+          const catalog = await this.findNamespaceCatalog(tnx, tenantId, namespaceId)
           if (!catalog) {
-            catalog = await this.findFirstCatalog(tnx, tenantId)
-
-            if (!catalog) {
-              // There is no catalog in the user database, meaning that the only thing we can do
-              // is delete the table from the upstream catalog
-              await this.restCatalog.dropTable({
-                warehouse: shard.shard_key,
-                namespace: table.namespace[0],
-                table: table.name,
-              })
-
-              // Also special case here, since the tenant has no catalog, we can free up the shard slots
-              await this.clearTenantShardSlots(tnx, shard.id, tenantId)
-              return
-            }
-
-            catalogName = catalog.name
+            throw new Error(
+              'Cannot restore table without an active catalog owning the local namespace'
+            )
           }
 
           const sharder = shardCatalog.withTnx(tnx)
-          const existingShard = await sharder.findShardByResourceId({
+          const resource: ShardResource = {
             kind: 'iceberg-table',
             tenantId,
             bucketName: catalog.id,
             logicalName: `${namespaceId}/${table.name}`,
-          })
+          }
+          const existingShard = await sharder.findShardByResourceId(resource)
 
-          if (!existingShard) {
+          if (
+            !existingShard &&
+            !(await this.migrateLegacyAllocation(
+              tnx,
+              shard.id,
+              tenantId,
+              catalog,
+              resource.logicalName
+            ))
+          ) {
             // Reserve a shard for this table
             const { reservationId } = await sharder.reserve({
-              kind: 'iceberg-table',
-              tenantId,
-              bucketName: catalog.id,
-              logicalName: `${namespaceId}/${table.name}`,
+              ...resource,
               shardId: shard.id,
             })
 
-            await sharder.confirm(reservationId, {
-              kind: 'iceberg-table',
-              tenantId,
-              bucketName: catalog.id,
-              logicalName: `${namespaceId}/${table.name}`,
-            })
+            await sharder.confirm(reservationId, resource)
           }
 
           await this.insertIcebergTable(tnx, {
@@ -184,8 +184,28 @@ export class IcebergCatalogReconciler {
             remote_table_id: tableResp.metadata['table-uuid'],
           })
         })
-      )
-    })
+      } catch (error) {
+        // A table can disappear between listing and acquiring its namespace lock.
+        if (
+          error instanceof IcebergError &&
+          error.code === 404 &&
+          error.type === IcebergErrorType.NoSuchTableException
+        )
+          continue
+        logSchema.error(logger, '[IcebergCatalogReconciler] Failed to restore table', {
+          type: 'iceberg-reconciliation',
+          project: tenantId,
+          error,
+          metadata: JSON.stringify({
+            shardId: shard.id,
+            shardKey: shard.shard_key,
+            namespaceId,
+            table: table.name,
+          }),
+        })
+        if (error instanceof ReconciliationRollbackError) throw error
+      }
+    }
   }
 
   private async deleteUpstreamEmptyNamespaces(namespaces: NamespaceWithShardInfo[]) {
@@ -215,6 +235,63 @@ export class IcebergCatalogReconciler {
 
   private createShardCatalog() {
     return new ShardCatalog(new PgShardStoreFactory(multitenantPgExecutor))
+  }
+
+  private async migrateLegacyAllocation(
+    tnx: ReconcilerTransaction,
+    shardId: number,
+    tenantId: string,
+    catalog: CatalogRow,
+    logicalName: string
+  ): Promise<boolean> {
+    if (catalog.name === catalog.id) return false
+    const legacyResourceId = `iceberg-table::${catalog.name}::${logicalName}`
+    const resourceId = `iceberg-table::${catalog.id}::${logicalName}`
+    const store = new PgShardStoreFactory(tnx).autocommit()
+    // The caller holds the namespace lock. Also serialize with reservations under
+    // either key, including older writers that still use the catalog name.
+    for (const key of [legacyResourceId, resourceId].sort()) {
+      await store.advisoryLockByString(key)
+    }
+
+    // Confirmed reservations keep their original lease timestamp. Only pending
+    // leases expire; remove obsolete reservation metadata without freeing slots.
+    await tnx.query({
+      text: `
+        DELETE FROM shard_reservation
+        WHERE tenant_id = $1 AND kind = 'iceberg-table' AND resource_id = $2
+          AND (
+            status IN ('cancelled', 'expired')
+            OR (status = 'pending' AND lease_expires_at < now())
+          )
+      `,
+      values: [tenantId, resourceId],
+    })
+
+    const result = await tnx.query({
+      text: `
+        WITH legacy AS (
+          SELECT r.id, r.shard_id, r.slot_no
+          FROM shard_reservation r
+          JOIN shard_slots sl ON sl.shard_id = r.shard_id AND sl.slot_no = r.slot_no
+            AND sl.tenant_id = r.tenant_id AND sl.resource_id = r.resource_id
+          WHERE r.kind = 'iceberg-table' AND r.status = 'confirmed'
+            AND r.shard_id = $1 AND r.tenant_id = $2 AND r.resource_id = $3
+          FOR UPDATE OF sl, r
+        ), renamed_reservation AS (
+          UPDATE shard_reservation r SET resource_id = $4
+          FROM legacy
+          WHERE r.id = legacy.id
+          RETURNING r.shard_id, r.slot_no
+        )
+        UPDATE shard_slots sl SET resource_id = $4
+        FROM renamed_reservation r
+        WHERE sl.shard_id = r.shard_id AND sl.slot_no = r.slot_no
+        RETURNING sl.slot_no
+      `,
+      values: [shardId, tenantId, legacyResourceId, resourceId],
+    })
+    return result.rows.length > 0
   }
 
   private async listNamespacesWithShardInfo(): Promise<NamespaceWithShardInfo[]> {
@@ -271,71 +348,31 @@ export class IcebergCatalogReconciler {
           error: rollbackError,
           metadata: JSON.stringify({ originalError: String(e) }),
         })
+        throw new ReconciliationRollbackError('Failed to rollback reconciliation transaction', {
+          cause: rollbackError,
+        })
       }
       throw e
     }
   }
 
-  private async findCatalogByName(
+  private async findNamespaceCatalog(
     tnx: ReconcilerTransaction,
     tenantId: string,
-    catalogName: string
+    namespaceId: string
   ): Promise<CatalogRow | undefined> {
     const result = await tnx.query<CatalogRow>({
       text: `
-        SELECT id, name
-        FROM iceberg_catalogs
-        WHERE tenant_id = $1
-          AND name = $2
-          AND deleted_at IS NULL
-        LIMIT 1
+        SELECT c.id, c.name
+        FROM iceberg_namespaces n
+        JOIN iceberg_catalogs c ON c.id = n.catalog_id
+        WHERE n.id = $1::uuid AND n.tenant_id = $2 AND c.tenant_id = $2
+          AND c.deleted_at IS NULL
+        FOR SHARE OF n, c
       `,
-      values: [tenantId, catalogName],
+      values: [namespaceId, tenantId],
     })
-
     return result.rows[0]
-  }
-
-  private async findFirstCatalog(
-    tnx: ReconcilerTransaction,
-    tenantId: string
-  ): Promise<CatalogRow | undefined> {
-    const result = await tnx.query<CatalogRow>({
-      text: `
-        SELECT id, name
-        FROM iceberg_catalogs
-        WHERE tenant_id = $1
-          AND deleted_at IS NULL
-        LIMIT 1
-      `,
-      values: [tenantId],
-    })
-
-    return result.rows[0]
-  }
-
-  private async clearTenantShardSlots(
-    tnx: ReconcilerTransaction,
-    shardId: number,
-    tenantId: string
-  ): Promise<void> {
-    const statement = `
-      WITH updated_slots AS (
-        UPDATE shard_slots
-          SET resource_id = null, tenant_id = null
-          WHERE shard_id = $1
-            AND tenant_id = $2
-          RETURNING shard_id, slot_no
-      ),
-      deleted_reservations AS (
-         DELETE FROM shard_reservation
-           WHERE shard_id = $1
-             AND tenant_id = $2
-      )
-      SELECT 1;
-    `
-
-    await tnx.query({ text: statement, values: [shardId, tenantId] })
   }
 
   private async insertIcebergTable(

--- a/src/storage/protocols/iceberg/catalog/reconciler.ts
+++ b/src/storage/protocols/iceberg/catalog/reconciler.ts
@@ -150,7 +150,7 @@ export class IcebergCatalogReconciler {
           const existingShard = await sharder.findShardByResourceId({
             kind: 'iceberg-table',
             tenantId,
-            bucketName: catalog.name,
+            bucketName: catalog.id,
             logicalName: `${namespaceId}/${table.name}`,
           })
 
@@ -159,7 +159,7 @@ export class IcebergCatalogReconciler {
             const { reservationId } = await sharder.reserve({
               kind: 'iceberg-table',
               tenantId,
-              bucketName: catalog.name,
+              bucketName: catalog.id,
               logicalName: `${namespaceId}/${table.name}`,
               shardId: shard.id,
             })
@@ -167,7 +167,7 @@ export class IcebergCatalogReconciler {
             await sharder.confirm(reservationId, {
               kind: 'iceberg-table',
               tenantId,
-              bucketName: catalog.name,
+              bucketName: catalog.id,
               logicalName: `${namespaceId}/${table.name}`,
             })
           }

--- a/src/storage/protocols/iceberg/catalog/rest-catalog-client.ts
+++ b/src/storage/protocols/iceberg/catalog/rest-catalog-client.ts
@@ -67,6 +67,7 @@ type FetchRequestInput = {
   headers?: Record<string, string>
   notFoundResource?: NotFoundResource
   conflictResource?: CatalogResource
+  requireStructuredErrors?: boolean
 }
 
 interface CatalogAuth {
@@ -537,7 +538,11 @@ export class RestCatalogClient {
         body,
       })
     } catch (error) {
-      if (error instanceof IcebergError || error instanceof StorageBackendError) {
+      // In strict mode, only an HTTP response may establish a catalog error.
+      if (
+        (!input.requireStructuredErrors && error instanceof IcebergError) ||
+        error instanceof StorageBackendError
+      ) {
         throw error
       }
       throw ERRORS.InternalError(toError(error), 'Failed to authorize Iceberg catalog request')
@@ -585,7 +590,8 @@ export class RestCatalogClient {
           response.status,
           jsonResponse,
           input.notFoundResource,
-          input.conflictResource
+          input.conflictResource,
+          input.requireStructuredErrors
         )
       }
 
@@ -627,16 +633,21 @@ export class RestCatalogClient {
     status: number,
     data: unknown,
     notFoundResource?: NotFoundResource,
-    conflictResource?: CatalogResource
+    conflictResource?: CatalogResource,
+    requireStructuredErrors = false
   ): IcebergError {
     // Only trust the response body when it matches the spec envelope
     // ({ error: { message, type, code } }). Otherwise the body is opaque
     // and the HTTP status is the only signal we have.
-    if (isIcebergErrorEnvelope(data)) {
-      return IcebergError.fromResponse(data)
+    const error = isIcebergErrorEnvelope(data) ? IcebergError.fromResponse(data) : undefined
+    if (requireStructuredErrors && (!error || error.code !== status)) {
+      throw ERRORS.InternalError(
+        new Error(`Unconfirmed Iceberg error response (HTTP ${status})`),
+        'Iceberg catalog error envelope is missing or disagrees with HTTP status'
+      )
     }
 
-    return this.createErrorByStatusCode(status, notFoundResource, conflictResource)
+    return error ?? this.createErrorByStatusCode(status, notFoundResource, conflictResource)
   }
 
   /**
@@ -834,9 +845,10 @@ export class RestCatalogClient {
    *
    * @see https://iceberg.apache.org/spec/api/#load-table
    * @param params Request parameters identifying the table to load
+   * @param options Require a structured error envelope matching the HTTP status when confirming absence
    * @returns The table metadata and location
    */
-  async loadTable(params: LoadTableRequest) {
+  async loadTable(params: LoadTableRequest, options?: { requireStructuredErrors?: boolean }) {
     const warehouse = this.getEncodedWarehouse(params.warehouse)
     return this.requestRequired<LoadTableResult>(
       {
@@ -844,6 +856,7 @@ export class RestCatalogClient {
         method: 'GET',
         params: { snapshots: params.snapshots },
         notFoundResource: 'table',
+        requireStructuredErrors: options?.requireStructuredErrors,
       },
       'Empty Iceberg loadTable response body'
     )

--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.test.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.test.ts
@@ -6,7 +6,7 @@ import { IcebergErrorType } from './errors'
 import type { CatalogAuthType } from './rest-catalog-client'
 import { TenantAwareRestCatalog } from './tenant-catalog'
 
-function createCatalog(metastore: Partial<Metastore>) {
+function createCatalog(metastore: Partial<Metastore>, sharding: Partial<Sharder> = {}) {
   const auth: CatalogAuthType = {
     authorize: (req) => req,
   }
@@ -16,7 +16,7 @@ function createCatalog(metastore: Partial<Metastore>) {
     restCatalogUrl: 'https://catalog.example.com/v1',
     metastore: metastore as unknown as Metastore,
     auth,
-    sharding: {} as Sharder,
+    sharding: sharding as Sharder,
     limits: {
       maxCatalogsCount: 10,
       maxNamespaceCount: 10,
@@ -335,6 +335,77 @@ describe('TenantAwareRestCatalog metadata loads', () => {
 describe('TenantAwareRestCatalog resource mutations', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('frees the same shard resource it allocated when the catalog ID differs from its name', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ namespace: ['tenant-id_namespace_id'] }))
+      .mockResolvedValueOnce(
+        Response.json({
+          metadata: { location: 's3://shard-1/table', 'table-uuid': 'remote-table-id' },
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(Response.json({ identifiers: [] }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const store = {
+      findCatalogByName: vi.fn().mockResolvedValue({ id: 'catalog-id', name: 'warehouse' }),
+      findNamespaceByName: vi.fn().mockResolvedValue({ id: 'namespace-id', name: 'namespace' }),
+      findTableByName: vi
+        .fn()
+        .mockRejectedValueOnce(ERRORS.NoSuchKey('table'))
+        .mockResolvedValue({ name: 'table', shard_id: '1', shard_key: 'shard-1' }),
+      lockResource: vi.fn().mockResolvedValue(undefined),
+      countTables: vi.fn().mockResolvedValue(0),
+      getTnx: vi.fn().mockReturnValue({}),
+      createTable: vi.fn().mockResolvedValue(undefined),
+      dropTable: vi.fn().mockResolvedValue(undefined),
+    }
+    const withTnx = vi.fn()
+    const sharding = {
+      withTnx,
+      reserve: vi.fn<Sharder['reserve']>().mockResolvedValue({
+        reservationId: 'reservation-id',
+        shardId: '1',
+        shardKey: 'shard-1',
+        slotNo: 0,
+        leaseExpiresAt: '2099-01-01T00:00:00Z',
+      }),
+      confirm: vi.fn<Sharder['confirm']>().mockResolvedValue(undefined),
+      freeByResource: vi.fn<Sharder['freeByResource']>().mockResolvedValue(undefined),
+    }
+    withTnx.mockReturnValue(sharding)
+    const catalog = createCatalog(
+      { ...store, transaction: vi.fn(async (callback) => callback(store)) },
+      sharding
+    )
+
+    await catalog.createTable({
+      warehouse: 'warehouse',
+      namespace: 'namespace',
+      name: 'table',
+      schema: { type: 'struct', fields: [] },
+      spec: { fields: [] },
+    })
+    await catalog.dropTable({
+      warehouse: 'warehouse',
+      namespace: 'namespace',
+      table: 'table',
+      purgeRequested: true,
+    })
+
+    const resource = {
+      tenantId: 'tenant-id',
+      kind: 'iceberg-table',
+      bucketName: 'catalog-id',
+      logicalName: 'namespace-id/table',
+    }
+    expect(sharding.reserve).toHaveBeenCalledExactlyOnceWith(resource)
+    expect(sharding.confirm).toHaveBeenCalledExactlyOnceWith('reservation-id', resource)
+    expect(sharding.freeByResource).toHaveBeenCalledExactlyOnceWith('1', resource)
   })
 
   it('maps a local missing namespace row to NoSuchNamespaceException for createTable', async () => {

--- a/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
+++ b/src/storage/protocols/iceberg/catalog/tenant-catalog.ts
@@ -587,7 +587,7 @@ export class TenantAwareRestCatalog extends RestCatalogClient {
         logicalName: `${namespace.id}/${params.table}`,
         tenantId: this.tenantId,
         kind: 'iceberg-table',
-        bucketName: params.warehouse,
+        bucketName: catalog.id,
       })
 
       // Catalog call to drop the table

--- a/src/storage/protocols/iceberg/pg.ts
+++ b/src/storage/protocols/iceberg/pg.ts
@@ -23,6 +23,7 @@ import {
   NamespaceIndex,
   TableIndex,
 } from './metastore'
+import { icebergResourceLockKey } from './resource-lock'
 
 export class PgMetastore implements Metastore<DatabaseTransaction> {
   constructor(
@@ -31,7 +32,7 @@ export class PgMetastore implements Metastore<DatabaseTransaction> {
   ) {}
 
   async lockResource(resourceType: string, resourceId: string): Promise<void> {
-    const lockId = hashStringToInt(`${resourceType}:${resourceId}`)
+    const lockId = hashStringToInt(icebergResourceLockKey(resourceType, resourceId))
     await this.query('SELECT pg_advisory_xact_lock($1::bigint)', [String(lockId)])
   }
 

--- a/src/storage/protocols/iceberg/resource-lock.ts
+++ b/src/storage/protocols/iceberg/resource-lock.ts
@@ -1,0 +1,3 @@
+export function icebergResourceLockKey(resourceType: string, resourceId: string): string {
+  return `${resourceType}:${resourceId}`
+}

--- a/src/test/iceberg-reclaim-shard-slots.test.ts
+++ b/src/test/iceberg-reclaim-shard-slots.test.ts
@@ -1,0 +1,709 @@
+import { randomUUID } from 'node:crypto'
+import {
+  type DatabaseTransaction,
+  type DatabaseTransactionalExecutor,
+  multitenantPgExecutor,
+} from '@internal/database'
+import { runMultitenantMigrations } from '@internal/database/migrations'
+import { PgPoolExecutor } from '@internal/database/pg-connection'
+import { PgShardStoreFactory, ShardCatalog } from '@internal/sharding'
+import { IcebergError, IcebergErrorType } from '@storage/protocols/iceberg/catalog/errors'
+import {
+  IcebergShardSlotReclaimer,
+  type ReclaimShardSlotsOptions,
+} from '@storage/protocols/iceberg/catalog/reclaim-shard-slots'
+import { IcebergCatalogReconciler } from '@storage/protocols/iceberg/catalog/reconciler'
+import type { RestCatalogClient } from '@storage/protocols/iceberg/catalog/rest-catalog-client'
+import { PgMetastore } from '@storage/protocols/iceberg/pg'
+import { Pool } from 'pg'
+import { getConfig } from '../config'
+
+const missing = new IcebergError('missing', IcebergErrorType.NoSuchTableException, 404)
+
+describe('Iceberg reclamation and restoration with PostgreSQL', () => {
+  let pool: Pool
+  let db: PgPoolExecutor
+  let namespaceId: string
+  let catalogId: string
+  let tenantId: string
+  let shardId: string
+  let shardKey: string
+  let options: { dryRun: boolean; shardId: string }
+  const applicationName = `reclaim-test-${randomUUID()}`
+  const upstream = {
+    listNamespaces: vi.fn().mockResolvedValue({ namespaces: [] }),
+    tableExists: vi.fn().mockRejectedValue(missing),
+    loadTable: vi.fn().mockRejectedValue(missing),
+  }
+  beforeAll(async () => {
+    await runMultitenantMigrations()
+    const { multitenantDatabaseUrl } = getConfig()
+    if (!multitenantDatabaseUrl) throw new Error('Multitenant test database URL is required')
+    pool = new Pool({
+      connectionString: multitenantDatabaseUrl,
+      application_name: applicationName,
+      max: 5,
+    })
+    db = new PgPoolExecutor(pool)
+  })
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    upstream.tableExists.mockRejectedValue(missing)
+    upstream.loadTable.mockRejectedValue(missing)
+    upstream.listNamespaces.mockResolvedValue({ namespaces: [] })
+    namespaceId = randomUUID()
+    catalogId = randomUUID()
+    tenantId = `reclaim-${catalogId}`
+    shardKey = `reclaim-${randomUUID()}`
+    const shard = await pool.query(
+      "INSERT INTO shard (kind, shard_key, capacity, status, next_slot) VALUES ('iceberg-table', $1, 1000, 'active', 1000) RETURNING id",
+      [shardKey]
+    )
+    shardId = String(shard.rows[0].id)
+    options = { dryRun: false, shardId }
+    await pool.query('INSERT INTO iceberg_catalogs (id, name, tenant_id) VALUES ($1,$2,$3)', [
+      catalogId,
+      catalogId,
+      tenantId,
+    ])
+    await pool.query(
+      'INSERT INTO iceberg_namespaces (id, tenant_id, bucket_name, name, catalog_id) VALUES ($1,$2,$3,$4,$5)',
+      [namespaceId, tenantId, catalogId, namespaceId, catalogId]
+    )
+  })
+  afterAll(async () => {
+    await pool?.end()
+  })
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await pool.query('DELETE FROM iceberg_tables WHERE catalog_id = $1', [catalogId])
+    await pool.query('DELETE FROM iceberg_namespaces WHERE catalog_id = $1', [catalogId])
+    await pool.query('DELETE FROM iceberg_catalogs WHERE id = $1', [catalogId])
+    await pool.query('DELETE FROM shard_reservation WHERE shard_id = $1', [shardId])
+    await pool.query('DELETE FROM shard WHERE id = $1', [shardId])
+  })
+
+  function runBatch(opts: ReclaimShardSlotsOptions = options) {
+    return new IcebergShardSlotReclaimer(db, upstream).runBatch(opts)
+  }
+
+  function getReservations(columns = '*') {
+    return pool
+      .query(`SELECT ${columns} FROM shard_reservation WHERE shard_id = $1 ORDER BY slot_no`, [
+        shardId,
+      ])
+      .then((result) => result.rows)
+  }
+
+  function getReservationById(id: string, columns = '*') {
+    return pool
+      .query(`SELECT ${columns} FROM shard_reservation WHERE id = $1`, [id])
+      .then((result) => result.rows)
+  }
+
+  function getSlots(columns = '*') {
+    return pool
+      .query(`SELECT ${columns} FROM shard_slots WHERE shard_id = $1 ORDER BY slot_no`, [shardId])
+      .then((result) => result.rows)
+  }
+
+  async function snapshotAllocations() {
+    return { reservations: await getReservations(), slots: await getSlots() }
+  }
+
+  function metastore(executor: DatabaseTransactionalExecutor | DatabaseTransaction = db) {
+    return new PgMetastore(executor, { multiTenant: true, schema: 'public' })
+  }
+
+  function lockNamespace(executor: DatabaseTransactionalExecutor | DatabaseTransaction) {
+    return metastore(executor).lockResource('namespace', `${tenantId}:${namespaceId}`)
+  }
+
+  async function waitForAdvisoryLockWait() {
+    await vi.waitFor(
+      async () => {
+        const waits = await pool.query(
+          "SELECT 1 FROM pg_stat_activity WHERE application_name = $1 AND wait_event = 'advisory'",
+          [applicationName]
+        )
+        expect(waits.rowCount).toBe(1)
+      },
+      { timeout: 1000 }
+    )
+  }
+
+  async function seed({
+    namespace = namespaceId,
+    slot = 0,
+    tenant = tenantId,
+    key = catalogId,
+    status = 'confirmed',
+  }: {
+    namespace?: string
+    slot?: number
+    tenant?: string
+    key?: string
+    status?: string
+  } = {}) {
+    const id = randomUUID()
+    const resource = `iceberg-table::${key}::${namespace}/table-${slot}`
+    await pool.query(
+      'INSERT INTO shard_slots (shard_id, slot_no, tenant_id, resource_id) VALUES ($1,$2,$3,$4)',
+      [shardId, slot, tenant, resource]
+    )
+    await pool.query(
+      `INSERT INTO shard_reservation (id,kind,tenant_id,resource_id,shard_id,slot_no,status,lease_expires_at)
+      VALUES ($1,'iceberg-table',$2,$3,$6,$4,$5,now() + interval '1 day')`,
+      [id, tenant, resource, slot, status, shardId]
+    )
+    return id
+  }
+  function insertLocal(
+    name = 'table-0',
+    executor: DatabaseTransactionalExecutor | DatabaseTransaction = db
+  ) {
+    return metastore(executor).createTable({
+      tenantId,
+      namespaceId,
+      name,
+      bucketId: catalogId,
+      bucketName: catalogId,
+      shardId,
+      shardKey,
+      location: `s3://${catalogId}/${name}`,
+    })
+  }
+
+  async function restoreLegacyTable(
+    targetNamespaceId: string,
+    location: string | null = `s3://${shardKey}/table-0`,
+    tableNames = ['table-0']
+  ) {
+    await pool.query('UPDATE iceberg_catalogs SET name = $1 WHERE id = $2', [
+      'warehouse',
+      catalogId,
+    ])
+    const { rows } = await pool.query('SELECT * FROM shard WHERE id = $1', [shardId])
+    vi.spyOn(ShardCatalog.prototype, 'listShardByKind').mockResolvedValue(rows)
+    vi.spyOn(multitenantPgExecutor, 'query').mockImplementation(db.query.bind(db))
+    vi.spyOn(multitenantPgExecutor, 'beginTransaction').mockImplementation(
+      db.beginTransaction.bind(db)
+    )
+    const namespace = `${tenantId}_${targetNamespaceId.replaceAll('-', '_')}`
+    const catalog = {
+      listNamespaces: vi.fn().mockResolvedValue({ namespaces: [[namespace]] }),
+      listTables: vi.fn().mockResolvedValue({
+        identifiers: tableNames.map((name) => ({ namespace: [namespace], name })),
+      }),
+      dropTable: vi.fn(),
+      loadTable: vi.fn().mockImplementation(async ({ table }: { table: string }) => ({
+        metadata: {
+          location: table === 'table-0' ? location : `s3://${shardKey}/${table}`,
+          'table-uuid': randomUUID(),
+        },
+      })),
+    }
+    await new IcebergCatalogReconciler(catalog as unknown as RestCatalogClient).reconcile()
+    return catalog
+  }
+
+  it('restores each namespace to its local owner', async () => {
+    const otherNamespaceId = randomUUID()
+    const otherCatalogId = randomUUID()
+    await pool.query('INSERT INTO iceberg_catalogs (id, name, tenant_id) VALUES ($1,$2,$3)', [
+      otherCatalogId,
+      'other-warehouse',
+      tenantId,
+    ])
+    try {
+      await pool.query(
+        'INSERT INTO iceberg_namespaces (id, tenant_id, bucket_name, name, catalog_id) VALUES ($1,$2,$3,$4,$5)',
+        [otherNamespaceId, tenantId, 'other-warehouse', otherNamespaceId, otherCatalogId]
+      )
+      await seed()
+      await restoreLegacyTable(namespaceId, undefined, ['table-0'])
+      await seed({ namespace: otherNamespaceId, slot: 1, key: otherCatalogId })
+      await restoreLegacyTable(otherNamespaceId, undefined, ['table-1'])
+      expect(
+        (
+          await pool.query(
+            'SELECT name, catalog_id::text, bucket_name FROM iceberg_tables WHERE tenant_id = $1 ORDER BY name',
+            [tenantId]
+          )
+        ).rows
+      ).toEqual([
+        { name: 'table-0', catalog_id: catalogId, bucket_name: 'warehouse' },
+        { name: 'table-1', catalog_id: otherCatalogId, bucket_name: 'other-warehouse' },
+      ])
+      expect(await getReservations('id')).toHaveLength(2)
+    } finally {
+      await pool.query('DELETE FROM iceberg_catalogs WHERE id = $1', [otherCatalogId])
+    }
+  })
+
+  it.each([
+    'missing namespace',
+    'deleted catalog',
+    'namespace tenant',
+    'catalog tenant',
+  ])('preserves upstream and allocation when ownership is unresolved: %s', async (reason) => {
+    await seed()
+    if (reason === 'missing namespace') {
+      await pool.query('DELETE FROM iceberg_namespaces WHERE id = $1', [namespaceId])
+    } else if (reason === 'deleted catalog') {
+      await pool.query('UPDATE iceberg_catalogs SET deleted_at = now() WHERE id = $1', [catalogId])
+    } else if (reason === 'namespace tenant') {
+      await pool.query('UPDATE iceberg_namespaces SET tenant_id = $1 WHERE id = $2', [
+        `${tenantId}-other`,
+        namespaceId,
+      ])
+    } else {
+      await pool.query('UPDATE iceberg_catalogs SET tenant_id = $1 WHERE id = $2', [
+        `${tenantId}-other`,
+        catalogId,
+      ])
+    }
+    const before = await snapshotAllocations()
+    const upstreamCatalog = await restoreLegacyTable(namespaceId)
+    expect(upstreamCatalog.dropTable).not.toHaveBeenCalled()
+    expect(await snapshotAllocations()).toEqual(before)
+    expect(
+      (await pool.query('SELECT id FROM iceberg_tables WHERE namespace_id = $1', [namespaceId]))
+        .rows
+    ).toEqual([])
+  })
+
+  it('restores a legacy allocation on a full shard and frees it using the catalog ID', async () => {
+    const reservationId = await seed({ key: 'warehouse' })
+    await pool.query('UPDATE shard SET capacity = 1, next_slot = 1 WHERE id = $1', [shardId])
+    await restoreLegacyTable(namespaceId)
+    const resourceId = `iceberg-table::${catalogId}::${namespaceId}/table-0`
+    expect(await getReservations('id, resource_id, slot_no')).toEqual([
+      { id: reservationId, resource_id: resourceId, slot_no: 0 },
+    ])
+    expect(await getSlots('resource_id')).toEqual([{ resource_id: resourceId }])
+    expect(
+      (
+        await pool.query('SELECT shard_id::text FROM iceberg_tables WHERE catalog_id = $1', [
+          catalogId,
+        ])
+      ).rows
+    ).toEqual([{ shard_id: shardId }])
+    const sharder = new ShardCatalog(new PgShardStoreFactory(db))
+    await sharder.freeByResource(shardId, {
+      kind: 'iceberg-table',
+      tenantId,
+      bucketName: catalogId,
+      logicalName: `${namespaceId}/table-0`,
+    })
+    expect(await getReservations('id')).toEqual([])
+    expect(await getSlots('resource_id')).toEqual([{ resource_id: null }])
+  })
+
+  it('rolls back invalid restored metadata and restores the next table', async () => {
+    const id = await seed({ key: 'warehouse' })
+    await seed({ slot: 1, key: 'warehouse' })
+    await restoreLegacyTable(namespaceId, null, ['table-0', 'table-1'])
+    const resourceId = `iceberg-table::warehouse::${namespaceId}/table-0`
+    expect(await getReservationById(id, 'resource_id')).toEqual([{ resource_id: resourceId }])
+    expect(await getSlots('resource_id')).toEqual([
+      { resource_id: resourceId },
+      { resource_id: `iceberg-table::${catalogId}::${namespaceId}/table-1` },
+    ])
+    expect(
+      (await pool.query('SELECT name FROM iceberg_tables WHERE catalog_id = $1', [catalogId])).rows
+    ).toEqual([{ name: 'table-1' }])
+    expect(await getReservations('resource_id')).toEqual([
+      { resource_id: resourceId },
+      { resource_id: `iceberg-table::${catalogId}::${namespaceId}/table-1` },
+    ])
+  })
+
+  async function seedCanonicalConflict(status: string, leaseExpired = false) {
+    const id = await seed({ slot: 1, status })
+    await pool.query(
+      'UPDATE shard_slots SET resource_id = NULL WHERE shard_id = $1 AND slot_no = 1',
+      [shardId]
+    )
+    await pool.query(
+      'UPDATE shard_reservation SET resource_id = $1, lease_expires_at = now() + $2::interval WHERE id = $3',
+      [
+        `iceberg-table::${catalogId}::${namespaceId}/table-0`,
+        leaseExpired ? '-1 hour' : '1 hour',
+        id,
+      ]
+    )
+    return id
+  }
+
+  it.each([
+    'pending',
+    'confirmed',
+  ])('preserves a conflicting canonical %s reservation', async (status) => {
+    const id = await seed({ key: 'warehouse' })
+    const canonicalId = await seedCanonicalConflict(status, status === 'confirmed')
+    await restoreLegacyTable(namespaceId)
+    expect(await getReservationById(id, 'resource_id')).toEqual([
+      { resource_id: `iceberg-table::warehouse::${namespaceId}/table-0` },
+    ])
+    expect(
+      (await pool.query('SELECT id FROM iceberg_tables WHERE catalog_id = $1', [catalogId])).rows
+    ).toEqual([])
+    expect(await getReservationById(canonicalId, 'status')).toEqual([{ status }])
+  })
+
+  it.each([
+    'cancelled',
+    'expired',
+    'pending',
+  ])('removes a stale canonical %s reservation before legacy migration', async (status) => {
+    const id = await seed({ key: 'warehouse' })
+    const staleId = await seedCanonicalConflict(status, status === 'pending')
+    await restoreLegacyTable(namespaceId)
+    const resourceId = `iceberg-table::${catalogId}::${namespaceId}/table-0`
+    expect(await getReservations('id, resource_id, slot_no')).toEqual([
+      { id, resource_id: resourceId, slot_no: 0 },
+    ])
+    expect(await getSlots('resource_id')).toEqual([
+      { resource_id: resourceId },
+      { resource_id: null },
+    ])
+    expect(
+      (await pool.query('SELECT name FROM iceberg_tables WHERE catalog_id = $1', [catalogId])).rows
+    ).toEqual([{ name: 'table-0' }])
+    expect(await getReservationById(staleId, 'id')).toEqual([])
+  })
+
+  it.each([
+    'tenant',
+    'slot resource',
+    'status',
+  ])('does not migrate a legacy allocation with a mismatched %s', async (mismatch) => {
+    const id = await seed({ key: 'warehouse' })
+    await pool.query('UPDATE shard SET capacity = 1, next_slot = 1 WHERE id = $1', [shardId])
+    if (mismatch === 'tenant') {
+      await pool.query('UPDATE shard_reservation SET tenant_id = $1 WHERE id = $2', [
+        'other-tenant',
+        id,
+      ])
+    } else if (mismatch === 'slot resource') {
+      await pool.query('UPDATE shard_slots SET resource_id = $1 WHERE shard_id = $2', [
+        'other-resource',
+        shardId,
+      ])
+    } else {
+      await pool.query("UPDATE shard_reservation SET status = 'pending' WHERE id = $1", [id])
+    }
+    const before = await snapshotAllocations()
+    await restoreLegacyTable(namespaceId)
+    expect(await snapshotAllocations()).toEqual(before)
+    expect(
+      (await pool.query('SELECT id FROM iceberg_tables WHERE catalog_id = $1', [catalogId])).rows
+    ).toEqual([])
+  })
+
+  it('reclaims historical ID and name keys atomically and reuses the freed capacity', async () => {
+    await seed()
+    await seed({ slot: 1, key: 'warehouse' })
+    expect(await runBatch()).toMatchObject({ scanned: 2, reclaimed: 2 })
+    expect(await getReservations()).toEqual([])
+    expect(await getSlots('resource_id, tenant_id')).toEqual([
+      { resource_id: null, tenant_id: null },
+      { resource_id: null, tenant_id: null },
+    ])
+    const shardCatalog = new ShardCatalog(new PgShardStoreFactory(db))
+    const resource = {
+      kind: 'iceberg-table' as const,
+      tenantId,
+      bucketName: catalogId,
+      logicalName: `${namespaceId}/replacement`,
+    }
+    const reservation = await shardCatalog.reserve({ ...resource, shardId: Number(shardId) })
+    await shardCatalog.confirm(reservation.reservationId, resource)
+    expect(reservation.slotNo).toBe(0)
+    expect(
+      (await pool.query('SELECT next_slot FROM shard WHERE id = $1', [shardId])).rows[0].next_slot
+    ).toBe(1000)
+    await insertLocal('replacement')
+    expect(await runBatch()).toMatchObject({
+      scanned: 1,
+      localTable: 1,
+      reclaimed: 0,
+    })
+  })
+
+  it('reclaims fresh confirmed orphans while preserving live tables and pending reservations', async () => {
+    await seed()
+    await seed({ slot: 1 })
+    const freshOrphanId = await seed({ slot: 2 })
+    await seed({ slot: 3, status: 'pending' })
+    await insertLocal()
+    upstream.tableExists.mockImplementation(async ({ table }) => {
+      if (table === 'table-2') throw missing
+    })
+    expect(await runBatch()).toMatchObject({
+      scanned: 3,
+      localTable: 1,
+      upstreamTable: 1,
+      reclaimed: 1,
+      reclaimedReservationIds: [freshOrphanId],
+    })
+    expect(await getReservations()).toHaveLength(3)
+  })
+
+  it('honors tenant/shard filters and dry-run without changing rows', async () => {
+    await seed()
+    await seed({ slot: 1, tenant: `${tenantId}-other` })
+    expect(await runBatch({ ...options, dryRun: true, tenantId, shardId })).toMatchObject({
+      scanned: 1,
+      reclaimable: 1,
+      reclaimed: 0,
+    })
+    expect(await runBatch({ ...options, shardId: '0' })).toMatchObject({ scanned: 0 })
+    expect(await getReservations()).toHaveLength(2)
+  })
+
+  it('continues after a full page without skipping the remaining allocations', async () => {
+    await pool.query(
+      `
+      INSERT INTO shard_slots (shard_id, slot_no, tenant_id, resource_id)
+      SELECT $1, n, $2, $3 || n FROM generate_series(0, 100) n
+    `,
+      [shardId, tenantId, `iceberg-table::${catalogId}::${namespaceId}/table-`]
+    )
+    await pool.query(
+      `
+      INSERT INTO shard_reservation
+        (kind, tenant_id, resource_id, shard_id, slot_no, status, lease_expires_at)
+      SELECT 'iceberg-table', tenant_id, resource_id, shard_id, slot_no,
+        'confirmed', now() FROM shard_slots WHERE shard_id = $1
+    `,
+      [shardId]
+    )
+    const first = await runBatch()
+    expect(first).toMatchObject({ scanned: 100, reclaimed: 100 })
+    expect(first.nextAfterReservationId).toBeDefined()
+    const second = await runBatch({
+      ...options,
+      afterReservationId: first.nextAfterReservationId,
+    })
+    expect(second).toMatchObject({ scanned: 1, reclaimed: 1 })
+    expect(second.nextAfterReservationId).toBeUndefined()
+    expect(await getReservations()).toEqual([])
+  })
+
+  it('rolls back when upstream absence cannot be established', async () => {
+    await seed()
+    upstream.tableExists.mockRejectedValue(new Error('timeout'))
+    await expect(runBatch()).rejects.toThrow('timeout')
+    expect(await getReservations()).toHaveLength(1)
+    expect((await getSlots('resource_id'))[0].resource_id).not.toBeNull()
+  })
+
+  it.each([
+    'present',
+    'unconfirmed',
+  ])('preserves both allocation rows when GET is %s after HEAD 404', async (result) => {
+    await seed()
+    const before = await snapshotAllocations()
+    if (result === 'present') {
+      upstream.loadTable.mockResolvedValueOnce({ metadata: {} })
+      expect(await runBatch()).toMatchObject({ upstreamTable: 1, reclaimed: 0 })
+    } else {
+      const error = new Error('Unconfirmed Iceberg error response')
+      upstream.loadTable.mockRejectedValueOnce(error)
+      await expect(runBatch()).rejects.toBe(error)
+    }
+    expect(upstream.loadTable).toHaveBeenCalledOnce()
+    expect(await snapshotAllocations()).toEqual(before)
+  })
+
+  it('does not free a reservation replaced after candidate discovery', async () => {
+    const oldId = await seed()
+    const originalBegin = db.beginTransaction.bind(db)
+    vi.spyOn(db, 'beginTransaction').mockImplementationOnce(async () => {
+      await pool.query('UPDATE shard_reservation SET id = $1 WHERE id = $2', [randomUUID(), oldId])
+      return originalBegin()
+    })
+    expect(await runBatch()).toMatchObject({
+      changed: 1,
+      reclaimed: 0,
+    })
+    expect(upstream.tableExists).not.toHaveBeenCalled()
+    expect(await getReservations()).toHaveLength(1)
+  })
+
+  it.each([
+    'resource_id',
+    'tenant_id',
+  ])('preserves an allocation when reservation %s changes after discovery', async (field) => {
+    const id = await seed()
+    const resourceId = `iceberg-table::${catalogId}::${namespaceId}/table-0`
+    const replacement =
+      field === 'resource_id' ? `${resourceId}-replacement` : `${tenantId}-replacement`
+    const originalBegin = db.beginTransaction.bind(db)
+    vi.spyOn(db, 'beginTransaction').mockImplementationOnce(async () => {
+      await pool.query(`UPDATE shard_reservation SET ${field} = $1 WHERE id = $2`, [
+        replacement,
+        id,
+      ])
+      return originalBegin()
+    })
+
+    expect(await runBatch()).toMatchObject({
+      scanned: 1,
+      changed: 1,
+      reclaimed: 0,
+    })
+    expect(upstream.tableExists).not.toHaveBeenCalled()
+    expect(await getReservationById(id, 'id, resource_id, tenant_id')).toEqual([
+      {
+        id,
+        resource_id: field === 'resource_id' ? replacement : resourceId,
+        tenant_id: field === 'tenant_id' ? replacement : tenantId,
+      },
+    ])
+    expect(await getSlots('resource_id, tenant_id')).toEqual([
+      {
+        resource_id: resourceId,
+        tenant_id: tenantId,
+      },
+    ])
+  })
+
+  it('skips a locked allocation and reclaims the next candidate after rollback', async () => {
+    const ids = [await seed(), await seed({ slot: 1 })].sort()
+    const blocker = await db.beginTransaction()
+    try {
+      await blocker.query({
+        text: `SELECT sl.slot_no FROM shard_slots sl
+          JOIN shard_reservation r USING (shard_id, slot_no)
+          WHERE r.id = $1 FOR UPDATE OF sl`,
+        values: [ids[0]],
+      })
+      expect(await runBatch()).toMatchObject({
+        scanned: 2,
+        skipped: 1,
+        reclaimed: 1,
+        reclaimedReservationIds: [ids[1]],
+      })
+      expect(await getReservations('id')).toEqual([{ id: ids[0] }])
+      expect(upstream.tableExists).toHaveBeenCalledOnce()
+    } finally {
+      await blocker.rollback()
+    }
+    expect(await runBatch()).toMatchObject({
+      scanned: 1,
+      skipped: 0,
+      reclaimed: 1,
+    })
+  })
+
+  it('skips a namespace-lock timeout and reclaims an unrelated namespace', async () => {
+    await seed()
+    const nextId = await seed({ slot: 1 })
+    const nextResource = `iceberg-table::${catalogId}::${randomUUID()}/next-table`
+    await pool.query('UPDATE shard_reservation SET resource_id = $1 WHERE id = $2', [
+      nextResource,
+      nextId,
+    ])
+    await pool.query(
+      'UPDATE shard_slots SET resource_id = $1 WHERE shard_id = $2 AND slot_no = 1',
+      [nextResource, shardId]
+    )
+    const blocker = await db.beginTransaction()
+    try {
+      await lockNamespace(blocker)
+      expect(await runBatch()).toMatchObject({
+        scanned: 2,
+        skipped: 1,
+        reclaimed: 1,
+        reclaimedReservationIds: [nextId],
+      })
+      expect(await getReservations('slot_no')).toEqual([{ slot_no: 0 }])
+      expect(upstream.tableExists).toHaveBeenCalledOnce()
+    } finally {
+      await blocker.rollback()
+    }
+  })
+
+  it('waits for concurrent namespace writes and preserves a recreated local table', async () => {
+    await seed()
+    const creator = await db.beginTransaction()
+    await lockNamespace(creator)
+    await insertLocal('table-0', creator)
+    const work = runBatch()
+    try {
+      await waitForAdvisoryLockWait()
+      await creator.commit()
+      expect(await work).toMatchObject({ localTable: 1, reclaimed: 0 })
+      expect(upstream.tableExists).not.toHaveBeenCalled()
+    } finally {
+      await creator.rollback()
+      await work.catch(() => {})
+    }
+  })
+
+  it('allows namespace writes during warehouse validation and rechecks local metadata', async () => {
+    await seed()
+    upstream.listNamespaces.mockImplementationOnce(async () => {
+      const creator = await db.beginTransaction()
+      try {
+        await creator.query("SET LOCAL lock_timeout = '100ms'")
+        await lockNamespace(creator)
+        await insertLocal('table-0', creator)
+        await creator.commit()
+      } catch (error) {
+        await creator.rollback()
+        throw error
+      }
+      return { namespaces: [] }
+    })
+
+    expect(await runBatch()).toMatchObject({
+      localTable: 1,
+      reclaimed: 0,
+    })
+    expect(upstream.tableExists).not.toHaveBeenCalled()
+  })
+
+  it('blocks concurrent creation while GET confirms upstream absence after HEAD 404', async () => {
+    await seed()
+    let checked!: () => void
+    const checking = new Promise<void>((resolve) => {
+      checked = resolve
+    })
+    let missingTable!: () => void
+    upstream.loadTable.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          checked()
+          missingTable = () => reject(missing)
+        })
+    )
+    const work = runBatch()
+    await checking
+    const creator = await db.beginTransaction()
+    const lock = lockNamespace(creator)
+    try {
+      await waitForAdvisoryLockWait()
+      missingTable()
+      expect(await work).toMatchObject({ reclaimed: 1 })
+      await lock
+      const shardCatalog = new ShardCatalog(new PgShardStoreFactory(creator))
+      const reservation = await shardCatalog.reserve({
+        kind: 'iceberg-table',
+        shardId: Number(shardId),
+        tenantId,
+        bucketName: catalogId,
+        logicalName: `${namespaceId}/table-0`,
+      })
+      expect(reservation.slotNo).toBe(0)
+    } finally {
+      missingTable()
+      await work.catch(() => {})
+      await lock.catch(() => {})
+      await creator.rollback()
+    }
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Iceberg shard slots are allocated by id but freed by name so leaks.

## What is the new behavior?

It's now always using id consistently.
Add admin triggered reclaim job that only does when slot identity matches tenant/resource, no local table metadata, warehouse is reachable, table is gone.
