### PR TITLE
fix: report per-object backend deletion failures

### DIFF
--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -48,6 +48,17 @@ export type CopyObjectOptions = {
   copyMetadata?: boolean
 }
 
+export interface DeleteObjectDetailedResult {
+  key: string
+  // DELETED also covers an already-absent key. UNKNOWN may have been deleted.
+  outcome: 'DELETED' | 'FAILED' | 'UNKNOWN'
+  error?: {
+    code?: string
+    message?: string
+    httpStatusCode?: number
+  }
+}
+
 /**
  * A generic storage Adapter to interact with files
  */
@@ -152,6 +163,14 @@ export abstract class StorageBackendAdapter {
    */
   async deleteObjects(bucket: string, prefixes: string[]): Promise<void> {
     throw new Error('deleteObjects not implemented')
+  }
+
+  /** Returns one deletion outcome per requested key, in request order. */
+  async deleteObjectsDetailed(
+    bucket: string,
+    keys: string[]
+  ): Promise<DeleteObjectDetailedResult[]> {
+    throw new Error('deleteObjectsDetailed not implemented')
   }
 
   /**

--- a/src/storage/backend/file.test.ts
+++ b/src/storage/backend/file.test.ts
@@ -311,6 +311,141 @@ describe('FileBackend traversal protection', () => {
   })
 })
 
+describe('FileBackend bulk deletion outcomes', () => {
+  let tmpDir: string
+  let backend: FileBackend
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'storage-file-delete-'))
+    vi.stubEnv('STORAGE_FILE_BACKEND_PATH', tmpDir)
+    vi.stubEnv('FILE_STORAGE_BACKEND_PATH', tmpDir)
+    getConfig({ reload: true })
+    backend = new FileBackend()
+    await fsp.mkdir(path.join(tmpDir, 'bucket', 'folder'), { recursive: true })
+    await fsp.writeFile(path.join(tmpDir, 'bucket', 'folder', 'object'), 'data')
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    getConfig({ reload: true })
+    await removePath(tmpDir)
+  })
+
+  it('confirms deleted and absent keys while cleaning empty parents', async () => {
+    await expect(
+      backend.deleteObjectsDetailed('bucket', ['folder/missing', 'folder/object'])
+    ).resolves.toEqual([
+      { key: 'folder/missing', outcome: 'DELETED' },
+      { key: 'folder/object', outcome: 'DELETED' },
+    ])
+    await expect(fsp.access(path.join(tmpDir, 'bucket'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fsp.access(tmpDir)).resolves.toBeUndefined()
+    await expect(backend.deleteObjects('bucket', ['folder/object'])).resolves.toBeUndefined()
+  })
+
+  it('reports filesystem failures without hiding successful deletions', async () => {
+    await fsp.writeFile(path.join(tmpDir, 'bucket', 'blocked'), 'not a directory')
+
+    const results = await backend.deleteObjectsDetailed('bucket', [
+      'blocked/child',
+      'folder/object',
+    ])
+
+    expect(results).toEqual([
+      {
+        key: 'blocked/child',
+        outcome: 'UNKNOWN',
+        error: { code: 'ENOTDIR', message: expect.any(String) },
+      },
+      { key: 'folder/object', outcome: 'DELETED' },
+    ])
+    await expect(fsp.access(path.join(tmpDir, 'bucket', 'folder'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+    await expect(fsp.readFile(path.join(tmpDir, 'bucket', 'blocked'), 'utf8')).resolves.toBe(
+      'not a directory'
+    )
+  })
+
+  it('rethrows the original filesystem error from the existing wrapper', async () => {
+    await fsp.writeFile(path.join(tmpDir, 'bucket', 'blocked'), 'not a directory')
+    const filesystem = await import('@internal/fs')
+    const remove = filesystem.removePath
+    let originalError: unknown
+    const removePathSpy = vi.spyOn(filesystem, 'removePath').mockImplementation(async (...args) => {
+      try {
+        await remove(...args)
+      } catch (error) {
+        originalError = error
+        throw error
+      }
+    })
+
+    try {
+      const error = await backend.deleteObjects('bucket', ['folder/object', 'blocked/child']).then(
+        () => undefined,
+        (error: unknown) => error
+      )
+      expect(error).toBe(originalError)
+      expect(error).toMatchObject({
+        code: 'ENOTDIR',
+        errno: expect.any(Number),
+        syscall: expect.any(String),
+        path: path.join(tmpDir, 'bucket', 'blocked', 'child'),
+      })
+    } finally {
+      removePathSpy.mockRestore()
+    }
+    await expect(fsp.access(path.join(tmpDir, 'bucket', 'folder'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'keeps a recursive permission failure unknown after partially deleting a directory',
+    async () => {
+      const target = path.join(tmpDir, 'bucket', 'partial')
+      const locked = path.join(target, 'z-locked')
+      await fsp.mkdir(locked, { recursive: true })
+      await fsp.writeFile(path.join(target, 'a-removable'), 'deleted first')
+      await fsp.writeFile(path.join(locked, 'kept'), 'protected')
+      await fsp.chmod(locked, 0)
+      try {
+        await expect(backend.deleteObjectsDetailed('bucket', ['partial'])).resolves.toEqual([
+          {
+            key: 'partial',
+            outcome: 'UNKNOWN',
+            error: { code: 'EACCES', message: expect.any(String) },
+          },
+        ])
+        await vi.waitFor(async () => {
+          await expect(fsp.access(path.join(target, 'a-removable'))).rejects.toMatchObject({
+            code: 'ENOENT',
+          })
+        })
+      } finally {
+        await fsp.chmod(locked, 0o700)
+      }
+      expect(await fsp.readFile(path.join(locked, 'kept'), 'utf8')).toBe('protected')
+    }
+  )
+
+  it('validates all paths before deleting a mixed valid and invalid batch', async () => {
+    await expect(
+      backend.deleteObjectsDetailed('bucket', ['folder/object', '../../outside'])
+    ).rejects.toMatchObject({ code: 'InvalidKey' })
+    await expect(
+      fsp.readFile(path.join(tmpDir, 'bucket', 'folder', 'object'), 'utf8')
+    ).resolves.toBe('data')
+  })
+
+  it('returns an empty result without removing directories', async () => {
+    await expect(backend.deleteObjectsDetailed('bucket', [])).resolves.toEqual([])
+    await expect(backend.deleteObjects('bucket', [])).resolves.toBeUndefined()
+    await expect(fsp.access(path.join(tmpDir, 'bucket', 'folder'))).resolves.toBeUndefined()
+  })
+})
+
 describe('FileBackend empty directory cleanup', () => {
   let tmpDir: string
   let originalStoragePath: string | undefined

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -13,6 +13,7 @@ import { parseRangeHeader } from '../range'
 import {
   BrowserCacheHeaders,
   CopyObjectOptions,
+  DeleteObjectDetailedResult,
   ObjectMetadata,
   ObjectResponse,
   StorageBackendAdapter,
@@ -294,22 +295,39 @@ export class FileBackend implements StorageBackendAdapter {
    * @param prefixes
    */
   async deleteObjects(bucket: string, prefixes: string[]): Promise<void> {
-    const promises = prefixes.map((prefix) => {
-      return removePath(this.resolveSecurePath(`${bucket}/${prefix}`))
-    })
-    const results = await Promise.allSettled(promises)
+    const results = await this.deleteObjectPaths(bucket, prefixes)
+    const failure = results.find((result) => result.status === 'rejected')
+    if (failure?.status === 'rejected') throw failure.reason
+  }
 
-    // Collect unique parent directories for cleanup
-    const parentDirs = new Set<string>()
-
-    results.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        throw result.reason
-      } else {
-        // Add parent directory of successfully deleted file
-        const filePath = this.resolveSecurePath(`${bucket}/${prefixes[index]}`)
-        parentDirs.add(path.dirname(filePath))
+  async deleteObjectsDetailed(
+    bucket: string,
+    keys: string[]
+  ): Promise<DeleteObjectDetailedResult[]> {
+    const results = await this.deleteObjectPaths(bucket, keys)
+    return results.map((result, index): DeleteObjectDetailedResult => {
+      if (result.status === 'fulfilled') {
+        return { key: keys[index], outcome: 'DELETED' }
       }
+      // Recursive removal can reject after deleting part of a directory.
+      return {
+        key: keys[index],
+        outcome: 'UNKNOWN',
+        error: {
+          code: (result.reason as NodeJS.ErrnoException | undefined)?.code,
+          message: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        },
+      }
+    })
+  }
+
+  private async deleteObjectPaths(bucket: string, keys: string[]) {
+    const paths = keys.map((key) => this.resolveSecurePath(`${bucket}/${key}`))
+    const results = await Promise.allSettled(paths.map((filePath) => removePath(filePath)))
+
+    const parentDirs = new Set<string>()
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') parentDirs.add(path.dirname(paths[index]))
     })
 
     // Clean up empty directories
@@ -320,6 +338,8 @@ export class FileBackend implements StorageBackendAdapter {
         // Ignore cleanup errors to not affect the main deletion operation
       }
     }
+
+    return results
   }
 
   /**

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -4,6 +4,7 @@ import {
   AbortMultipartUploadCommand,
   CopyObjectCommand,
   DeleteObjectsCommand,
+  DeleteObjectsCommandOutput,
   GetObjectCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
@@ -16,9 +17,11 @@ import { ErrorCode, isStorageError } from '@internal/errors'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpRequest } from '@smithy/protocol-http'
 import { MAX_KEYS_PER_S3_DELETE } from '@storage/limits'
+import Fastify from 'fastify'
 import { Readable } from 'stream'
 import { type Mock, vi } from 'vitest'
 import { getConfig } from '../../../config'
+import { setErrorHandler } from '../../../http/error-handler'
 import { withOptionalVersion } from '../adapter'
 import { MAX_PUT_OBJECT_SIZE, S3Backend } from './adapter'
 
@@ -341,10 +344,11 @@ describe('S3Backend', () => {
 
   describe('deleteObjects', () => {
     test('chunks DeleteObjectsCommand payloads to the S3 key limit', async () => {
-      mockSend.mockResolvedValue({
-        $metadata: {
-          httpStatusCode: 200,
-        },
+      mockSend.mockImplementation((command: DeleteObjectsCommand) => {
+        return Promise.resolve({
+          $metadata: { httpStatusCode: 200 },
+          Deleted: command.input.Delete?.Objects,
+        })
       })
 
       const backend = createBackend()
@@ -358,6 +362,7 @@ describe('S3Backend', () => {
         Bucket: 'test-bucket',
         Delete: {
           Objects: keys.slice(0, MAX_KEYS_PER_S3_DELETE).map((Key) => ({ Key })),
+          Quiet: false,
         },
       })
       expect(mockSend.mock.calls[1][0]).toBeInstanceOf(DeleteObjectsCommand)
@@ -370,8 +375,8 @@ describe('S3Backend', () => {
     })
 
     test('sends DeleteObjectsCommand chunks concurrently', async () => {
-      const firstDelete = Promise.withResolvers<{ $metadata: { httpStatusCode: number } }>()
-      const secondDelete = Promise.withResolvers<{ $metadata: { httpStatusCode: number } }>()
+      const firstDelete = Promise.withResolvers<DeleteObjectsCommandOutput>()
+      const secondDelete = Promise.withResolvers<DeleteObjectsCommandOutput>()
       mockSend.mockImplementationOnce(() => firstDelete.promise)
       mockSend.mockImplementationOnce(() => secondDelete.promise)
 
@@ -386,14 +391,239 @@ describe('S3Backend', () => {
         $metadata: {
           httpStatusCode: 200,
         },
+        Deleted: keys.slice(0, MAX_KEYS_PER_S3_DELETE).map((Key) => ({ Key })),
       })
       secondDelete.resolve({
         $metadata: {
           httpStatusCode: 200,
         },
+        Deleted: [{ Key: keys[MAX_KEYS_PER_S3_DELETE] }],
       })
 
       await expect(deletePromise).resolves.toBeUndefined()
+    })
+
+    test.each([
+      'AccessDenied',
+      'InternalError',
+    ])('preserves request-level success when S3 returns a per-key %s', async (code) => {
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 200 },
+        Deleted: [{ Key: 'deleted' }],
+        Errors: [{ Key: 'failed', Code: code, Message: 'deletion failed' }],
+      })
+
+      await expect(
+        createBackend().deleteObjects('test-bucket', ['deleted', 'failed'])
+      ).resolves.toBeUndefined()
+    })
+
+    test('preserves request-level success when S3 omits a key acknowledgment', async () => {
+      mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } })
+
+      await expect(
+        createBackend().deleteObjects('test-bucket', ['omitted'])
+      ).resolves.toBeUndefined()
+    })
+
+    test('rejects a failed chunk after every chunk has settled', async () => {
+      const completedChunk = Promise.withResolvers<DeleteObjectsCommandOutput>()
+      mockSend.mockRejectedValueOnce(new Error('connection reset'))
+      mockSend.mockReturnValueOnce(completedChunk.promise)
+      const keys = Array.from({ length: MAX_KEYS_PER_S3_DELETE + 1 }, (_, index) => `key-${index}`)
+
+      const deleting = createBackend().deleteObjects('test-bucket', keys)
+      const rejected = expect(deleting).rejects.toThrow('connection reset')
+      const completed = vi.fn()
+      const completion = deleting.then(completed, completed)
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect(completed).not.toHaveBeenCalled()
+      completedChunk.resolve({
+        $metadata: { httpStatusCode: 200 },
+        Deleted: [{ Key: keys[MAX_KEYS_PER_S3_DELETE] }],
+      })
+      await rejected
+      await completion
+    })
+
+    test('reports a rejected request even when an earlier chunk has per-key errors', async () => {
+      const keys = Array.from({ length: MAX_KEYS_PER_S3_DELETE + 1 }, (_, index) => `key-${index}`)
+      const upstreamError = new Error('connection reset')
+      mockSend.mockResolvedValueOnce({
+        $metadata: { httpStatusCode: 200 },
+        Errors: [{ Key: keys[0], Code: 'AccessDenied', Message: 'deletion denied' }],
+      })
+      mockSend.mockRejectedValueOnce(upstreamError)
+
+      await expect(createBackend().deleteObjects('test-bucket', keys)).rejects.toMatchObject({
+        code: ErrorCode.InternalError,
+        httpStatusCode: 500,
+        error: 'Error',
+        message: 'connection reset',
+        originalError: upstreamError,
+      })
+    })
+
+    test('preserves the S3 error code and HTTP status for rejected requests', async () => {
+      const upstreamError = Object.assign(new Error('upstream unavailable'), {
+        name: 'ServiceUnavailable',
+        $metadata: { httpStatusCode: 503 },
+      })
+      mockSend.mockRejectedValue(upstreamError)
+
+      await expect(createBackend().deleteObjects('test-bucket', ['key'])).rejects.toMatchObject({
+        code: ErrorCode.S3Error,
+        httpStatusCode: 503,
+        message: 'ServiceUnavailable',
+        error: 'upstream unavailable',
+        originalError: upstreamError,
+      })
+      await expect(createBackend().deleteObjectsDetailed('test-bucket', ['key'])).resolves.toEqual([
+        {
+          key: 'key',
+          outcome: 'UNKNOWN',
+          error: { code: ErrorCode.S3Error, message: 'ServiceUnavailable', httpStatusCode: 503 },
+        },
+      ])
+    })
+
+    test.each([
+      {
+        upstreamError: Object.assign(new Error('upstream unavailable'), {
+          name: 'ServiceUnavailable',
+          $metadata: { httpStatusCode: 503 },
+        }),
+        body: {
+          code: ErrorCode.S3Error,
+          error: 'upstream unavailable',
+          message: 'ServiceUnavailable',
+        },
+      },
+      {
+        upstreamError: new Error('connection reset'),
+        body: {
+          code: ErrorCode.InternalError,
+          error: 'Error',
+          message: 'connection reset',
+        },
+      },
+    ])('preserves the REST error fields for $body.code', async ({ upstreamError, body }) => {
+      mockSend.mockRejectedValue(upstreamError)
+      const backend = createBackend()
+      const app = Fastify()
+      setErrorHandler(app)
+      app.delete('/objects', async () => {
+        await backend.deleteObjects('test-bucket', ['key'])
+      })
+
+      try {
+        const response = await app.inject({ method: 'DELETE', url: '/objects' })
+        expect(response.json()).toMatchObject(body)
+      } finally {
+        await app.close()
+      }
+    })
+
+    test('does not issue requests for an empty key list', async () => {
+      await expect(createBackend().deleteObjects('test-bucket', [])).resolves.toBeUndefined()
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteObjectsDetailed', () => {
+    test('returns ordered results for mixed, duplicate, and unacknowledged keys', async () => {
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 200 },
+        Deleted: [{ Key: 'deleted' }, { Key: 'conflicted' }, { Key: 'unrequested' }, {}],
+        Errors: [{ Key: 'conflicted', Code: 'AccessDenied', Message: 'denied' }, {}],
+      })
+
+      await expect(
+        createBackend().deleteObjectsDetailed('test-bucket', [
+          'conflicted',
+          'deleted',
+          'omitted',
+          'deleted',
+        ])
+      ).resolves.toEqual([
+        {
+          key: 'conflicted',
+          outcome: 'UNKNOWN',
+          error: {
+            message: 'S3 delete response contained conflicting results for this requested key',
+          },
+        },
+        { key: 'deleted', outcome: 'DELETED' },
+        {
+          key: 'omitted',
+          outcome: 'UNKNOWN',
+          error: { message: 'S3 delete response did not contain this requested key' },
+        },
+        { key: 'deleted', outcome: 'DELETED' },
+      ])
+    })
+
+    test('normalizes repeated success acknowledgments for a single requested key', async () => {
+      mockSend.mockResolvedValue({
+        $metadata: { httpStatusCode: 200 },
+        Deleted: [{ Key: 'deleted' }, { Key: 'deleted' }],
+      })
+
+      await expect(
+        createBackend().deleteObjectsDetailed('test-bucket', ['deleted'])
+      ).resolves.toEqual([{ key: 'deleted', outcome: 'DELETED' }])
+    })
+
+    test('preserves per-key results across successful and rejected chunks', async () => {
+      const firstChunk = Promise.withResolvers<DeleteObjectsCommandOutput>()
+      const lastChunk = Promise.withResolvers<DeleteObjectsCommandOutput>()
+      mockSend.mockReturnValueOnce(firstChunk.promise)
+      mockSend.mockRejectedValueOnce(new Error('connection reset'))
+      mockSend.mockReturnValueOnce(lastChunk.promise)
+      const keys = Array.from(
+        { length: MAX_KEYS_PER_S3_DELETE * 2 + 1 },
+        (_, index) => `key-${index}`
+      )
+
+      const deleting = createBackend().deleteObjectsDetailed('test-bucket', keys)
+      expect(mockSend).toHaveBeenCalledTimes(3)
+      lastChunk.resolve({
+        $metadata: { httpStatusCode: 200 },
+        Errors: [{ Key: keys.at(-1), Code: 'AccessDenied', Message: 'denied' }],
+      })
+      firstChunk.resolve({
+        $metadata: { httpStatusCode: 200 },
+        Deleted: keys.slice(0, MAX_KEYS_PER_S3_DELETE).map((Key) => ({ Key })),
+      })
+
+      const results = await deleting
+      expect(results).toHaveLength(keys.length)
+      expect(results.map(({ key }) => key)).toEqual(keys)
+      expect(results.slice(0, MAX_KEYS_PER_S3_DELETE)).toEqual(
+        keys.slice(0, MAX_KEYS_PER_S3_DELETE).map((key) => ({ key, outcome: 'DELETED' }))
+      )
+      expect(results.slice(MAX_KEYS_PER_S3_DELETE, -1)).toEqual(
+        keys.slice(MAX_KEYS_PER_S3_DELETE, -1).map((key) => ({
+          key,
+          outcome: 'UNKNOWN',
+          error: {
+            code: ErrorCode.InternalError,
+            message: 'connection reset',
+            httpStatusCode: 500,
+          },
+        }))
+      )
+      expect(results.at(-1)).toEqual({
+        key: keys.at(-1),
+        outcome: 'FAILED',
+        error: { code: 'AccessDenied', message: 'denied' },
+      })
+    })
+
+    test('returns an empty result without issuing a request', async () => {
+      await expect(createBackend().deleteObjectsDetailed('test-bucket', [])).resolves.toEqual([])
+      expect(mockSend).not.toHaveBeenCalled()
     })
   })
 

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -6,6 +6,7 @@ import {
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
+  DeleteObjectsCommandOutput,
   GetObjectCommand,
   GetObjectCommandInput,
   HeadObjectCommand,
@@ -29,6 +30,7 @@ import { getConfig } from '../../../config'
 import {
   BrowserCacheHeaders,
   CopyObjectOptions,
+  DeleteObjectDetailedResult,
   ObjectMetadata,
   ObjectResponse,
   StorageBackendAdapter,
@@ -437,33 +439,91 @@ export class S3Backend implements StorageBackendAdapter {
    */
   async deleteObjects(bucket: string, prefixes: string[]): Promise<void> {
     try {
-      const deleteRequests: Promise<unknown>[] = []
-
-      for (let i = 0; i < prefixes.length; i += MAX_KEYS_PER_S3_DELETE) {
-        const s3Prefixes = prefixes.slice(i, i + MAX_KEYS_PER_S3_DELETE).map((ele) => {
-          return { Key: ele }
-        })
-
-        const command = new DeleteObjectsCommand({
-          Bucket: bucket,
-          Delete: {
-            Objects: s3Prefixes,
-          },
-        })
-        deleteRequests.push(this.client.send(command))
-      }
-
-      const results = await Promise.allSettled(deleteRequests)
-      const rejected = results.find((result): result is PromiseRejectedResult => {
-        return result.status === 'rejected'
-      })
-
-      if (rejected) {
-        throw rejected.reason
-      }
-    } catch (e) {
-      throw StorageBackendError.fromError(e)
+      const batches = await this.deleteObjectBatches(bucket, prefixes)
+      const failure = batches.find(({ result }) => result.status === 'rejected')
+      if (failure?.result.status === 'rejected') throw failure.result.reason
+    } catch (error) {
+      throw StorageBackendError.fromError(error)
     }
+  }
+
+  async deleteObjectsDetailed(
+    bucket: string,
+    keys: string[]
+  ): Promise<DeleteObjectDetailedResult[]> {
+    const batches = await this.deleteObjectBatches(bucket, keys)
+    return batches.flatMap(({ keys: requested, result }) => {
+      if (result.status === 'rejected') {
+        const error = StorageBackendError.fromError(result.reason)
+        return requested.map((key) => ({
+          key,
+          outcome: 'UNKNOWN' as const,
+          error: {
+            code: error.code,
+            message: error.message,
+            httpStatusCode: error.httpStatusCode,
+          },
+        }))
+      }
+
+      const deleted = new Set(
+        (result.value.Deleted ?? []).flatMap((entry) =>
+          typeof entry.Key === 'string' ? [entry.Key] : []
+        )
+      )
+      const errors = new Map(
+        (result.value.Errors ?? []).flatMap((entry) =>
+          typeof entry.Key === 'string' ? [[entry.Key, entry] as const] : []
+        )
+      )
+      return requested.map((key): DeleteObjectDetailedResult => {
+        const error = errors.get(key)
+        if (error && deleted.has(key)) {
+          return {
+            key,
+            outcome: 'UNKNOWN',
+            error: {
+              message: 'S3 delete response contained conflicting results for this requested key',
+            },
+          }
+        }
+        if (error) {
+          return {
+            key,
+            outcome: 'FAILED',
+            error: { code: error.Code, message: error.Message },
+          }
+        }
+        if (deleted.has(key)) return { key, outcome: 'DELETED' }
+        return {
+          key,
+          outcome: 'UNKNOWN',
+          error: { message: 'S3 delete response did not contain this requested key' },
+        }
+      })
+    })
+  }
+
+  private async deleteObjectBatches(bucket: string, keys: string[]) {
+    const requests: Array<{
+      keys: string[]
+      request: Promise<DeleteObjectsCommandOutput>
+    }> = []
+    for (let index = 0; index < keys.length; index += MAX_KEYS_PER_S3_DELETE) {
+      const chunk = keys.slice(index, index + MAX_KEYS_PER_S3_DELETE)
+      requests.push({
+        keys: chunk,
+        request: this.client.send(
+          new DeleteObjectsCommand({
+            Bucket: bucket,
+            Delete: { Objects: chunk.map((key) => ({ Key: key })), Quiet: false },
+          })
+        ),
+      })
+    }
+
+    const results = await Promise.allSettled(requests.map(({ request }) => request))
+    return results.map((result, index) => ({ keys: requests[index].keys, result }))
   }
 
   /**

--- a/src/test/object-delete-transactions.test.ts
+++ b/src/test/object-delete-transactions.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from 'node:crypto'
+import { DeleteObjectsCommand } from '@aws-sdk/client-s3'
+import { S3Backend } from '@storage/backend/s3/adapter'
+import { ObjectAdminDeleteAllBefore, ObjectRemoved } from '@storage/events'
+import { Storage } from '@storage/storage'
+import Fastify from 'fastify'
+import { getConfig } from '../config'
+import { setErrorHandler } from '../http/error-handler'
+import deleteObjectsRoute from '../http/routes/object/deleteObjects'
+import { authSchema } from '../http/schemas/auth'
+import { errorSchema } from '../http/schemas/error'
+import { useStorage } from './utils/storage'
+
+describe('Bulk delete backend compatibility', () => {
+  const store = useStorage()
+  const { tenantId } = getConfig()
+  const names = ['deleted.txt', 'failed.txt']
+  let bucketId: string
+  let backend: S3Backend
+  let storage: Storage
+  let keys: string[]
+  let blobs: Set<string>
+  let failureCode: string | undefined
+
+  beforeEach(async () => {
+    bucketId = `delete-compat-${randomUUID()}`
+    failureCode = 'AccessDenied'
+    backend = new S3Backend({ region: 'us-east-1', endpoint: 'http://127.0.0.1:1' })
+    storage = new Storage(backend, store.database, store.storage.location)
+    await store.database.createBucket({ id: bucketId, name: bucketId, public: false })
+    keys = []
+    for (const name of names) {
+      const version = randomUUID()
+      await store.database.createObject({ bucket_id: bucketId, name, version, metadata: {} })
+      keys.push(storage.location.getKeyLocation({ tenantId, bucketId, objectName: name, version }))
+    }
+    blobs = new Set(keys)
+    vi.spyOn(ObjectRemoved, 'sendWebhook').mockResolvedValue(undefined)
+    vi.spyOn(backend.client, 'send').mockImplementation(async (command) => {
+      if (!(command instanceof DeleteObjectsCommand)) throw new Error('Unexpected S3 command')
+      const deleted = []
+      const errors = []
+      for (const { Key } of command.input.Delete?.Objects ?? []) {
+        if (Key === keys[1]) {
+          if (failureCode) errors.push({ Key, Code: failureCode, Message: 'deletion failed' })
+        } else if (Key !== undefined) {
+          blobs.delete(Key)
+          deleted.push({ Key })
+        }
+      }
+      return { $metadata: { httpStatusCode: 200 }, Deleted: deleted, Errors: errors }
+    })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await store.database.deleteObjects(bucketId, names, 'name')
+    await store.database.deleteBucket(bucketId)
+    backend.close()
+  })
+
+  it.each([
+    { label: 'AccessDenied', code: 'AccessDenied' },
+    { label: 'InternalError', code: 'InternalError' },
+    { label: 'no key acknowledgment', code: undefined },
+  ])('keeps REST metadata deletion committed for a successful S3 response with $label', async ({
+    code,
+  }) => {
+    failureCode = code
+    const app = Fastify()
+    app.addSchema(authSchema)
+    app.addSchema(errorSchema)
+    setErrorHandler(app)
+    app.addHook('onRequest', async (request) => {
+      request.storage = storage
+      request.tenantId = tenantId
+    })
+    await app.register(deleteObjectsRoute, { prefix: '/object' })
+
+    try {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/object/${bucketId}`,
+        headers: { authorization: 'Bearer test' },
+        payload: { prefixes: names },
+      })
+
+      expect.soft(response.statusCode).toBe(200)
+      expect
+        .soft(response.json())
+        .toEqual(expect.arrayContaining(names.map((name) => expect.objectContaining({ name }))))
+      expect.soft([...blobs]).toEqual([keys[1]])
+      expect(await store.database.listObjects(bucketId, 'name', 10)).toEqual([])
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('keeps background deletion metadata committed after a per-key S3 failure', async () => {
+    class DeleteWorker extends ObjectAdminDeleteAllBefore {
+      protected static override getOrCreateStorageBackend() {
+        return backend
+      }
+    }
+
+    const error = await DeleteWorker.handle({
+      id: randomUUID(),
+      name: ObjectAdminDeleteAllBefore.queueName,
+      expireInSeconds: 30,
+      data: {
+        tenant: { ref: tenantId, host: 'localhost' },
+        bucketId,
+        before: new Date(Date.now() + 60_000).toISOString(),
+      },
+    }).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+
+    expect.soft(error).toBeUndefined()
+    expect.soft([...blobs]).toEqual([keys[1]])
+    expect(await store.database.listObjects(bucketId, 'name', 10)).toEqual([])
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Bulk delete only threw on a failed S3/file request and ignored per-key results, so an HTTP 200 with mixed errors still counted as full success. 

## What is the new behavior?

Keep the same contract for bulk delete but add detailed version to report each key as DELETED, FAILED or UNKNOWN.