### PR TITLE
feat: noncurrent lifecycle compilation, candidates and attempts

### DIFF
--- a/src/storage/database/lifecycle.test.ts
+++ b/src/storage/database/lifecycle.test.ts
@@ -1,0 +1,246 @@
+import { compileLifecycleEvaluationRules } from '../lifecycle/configuration'
+import {
+  buildEvaluateNoncurrentLifecyclePageStatement,
+  decodeCandidate,
+  decodeLifecycleCandidateIdentity,
+  mapLifecycleEvaluationPage,
+} from './lifecycle'
+
+describe('noncurrent lifecycle evaluation query', () => {
+  test.each([
+    {
+      label: 'BC timestamp near the PostgreSQL minimum',
+      timestamp: '-004713-11-26T00:00:00.000123Z',
+      expected: '4714-11-26T00:00:00.000123Z BC',
+    },
+    {
+      label: 'astronomical year zero',
+      timestamp: '0000-01-01T00:00:00.123456Z',
+      expected: '0001-01-01T00:00:00.123456Z BC',
+    },
+    {
+      label: 'expanded astronomical year zero',
+      timestamp: '+000000-01-01T00:00:00.123456Z',
+      expected: '0001-01-01T00:00:00.123456Z BC',
+    },
+    {
+      label: 'BC offset crossing into year zero',
+      timestamp: '-000001-12-31T23:59:59.123456-08:00',
+      expected: '0001-01-01T07:59:59.123456Z BC',
+    },
+    {
+      label: 'AD offset crossing into year zero',
+      timestamp: '0001-01-01T00:00:00.000123+01:00',
+      expected: '0001-12-31T23:00:00.000123Z BC',
+    },
+  ])('binds $label without losing fractional seconds', ({ timestamp, expected }) => {
+    const statement = buildEvaluateNoncurrentLifecyclePageStatement({
+      bucketId: 'bucket-a',
+      snapshotAt: timestamp,
+      cursor: { name: 'logs/a', archivedAt: timestamp },
+      pageSize: 1,
+      rules: [{ cutoffAt: timestamp }],
+    })
+
+    expect(statement.values).toEqual([
+      'bucket-a',
+      expected,
+      expected,
+      expected,
+      'logs/a',
+      1,
+      [expected],
+      [null],
+      1,
+    ])
+  })
+
+  test('binds an empty cutoff at the PostgreSQL timestamp minimum', () => {
+    const snapshotAt = new Date('2026-08-06T00:00:00.000Z')
+    const noncurrentDays =
+      (snapshotAt.getTime() - Date.parse('-004713-11-24T00:00:00.000Z')) / 86_400_000
+    const rules = compileLifecycleEvaluationRules(
+      {
+        rules: [
+          {
+            status: 'Enabled',
+            filter: {},
+            noncurrentVersionExpiration: { noncurrentDays },
+          },
+        ],
+      },
+      snapshotAt
+    )
+    const statement = buildEvaluateNoncurrentLifecyclePageStatement({
+      bucketId: 'bucket-a',
+      snapshotAt: snapshotAt.toISOString(),
+      pageSize: 1,
+      rules,
+    })
+
+    expect(statement.values?.[2]).toBe('-infinity')
+    expect(statement.values?.[4]).toEqual(['-infinity'])
+  })
+
+  test('builds a page variant without a cursor', () => {
+    const statement = buildEvaluateNoncurrentLifecyclePageStatement({
+      bucketId: 'bucket-a',
+      snapshotAt: '2026-08-15T00:00:00.000Z',
+      pageSize: 500,
+      rules: [
+        { cutoffAt: '2026-07-16T00:00:00.000Z' },
+        {
+          cutoffAt: '2026-08-08T00:00:00.000Z',
+          newerNoncurrentVersions: 3,
+        },
+      ],
+    })
+
+    expect(statement.text).toContain('AS MATERIALIZED')
+    expect(statement.text).toContain('evaluated.newer_count >= rules.newer_noncurrent_versions')
+    expect(statement.text).toContain('object_row.archived_at <')
+    expect(statement.text).not.toContain('object_row.metadata')
+    expect(statement.text).not.toContain('object_row.created_at')
+    expect(statement.text).not.toContain('object_row.id')
+    expect(statement.text).toMatch(
+      /ORDER BY\s+object_row\.archived_at,\s+object_row\.name COLLATE "C"/
+    )
+    expect(statement.values).toEqual([
+      'bucket-a',
+      '2026-08-15T00:00:00.000Z',
+      '2026-08-08T00:00:00.000Z',
+      500,
+      ['2026-07-16T00:00:00.000Z', '2026-08-08T00:00:00.000Z'],
+      [null, 3],
+      3,
+    ])
+  })
+
+  test('builds a continuation variant with the exact keyset tuple', () => {
+    const statement = buildEvaluateNoncurrentLifecyclePageStatement({
+      bucketId: 'bucket-a',
+      snapshotAt: '2026-08-15T00:00:00.000123Z',
+      cursor: {
+        name: 'logs/a',
+        archivedAt: '2026-08-01T00:00:00.000123Z',
+      },
+      pageSize: 20,
+      rules: [{ cutoffAt: '2026-08-08T00:00:00.000Z', newerNoncurrentVersions: 3 }],
+    })
+
+    expect(statement.text).toMatch(
+      /\(\s*object_row\.archived_at,\s*object_row\.name COLLATE "C"\s*\) > \(/
+    )
+    expect(statement.values).toEqual([
+      'bucket-a',
+      '2026-08-15T00:00:00.000123Z',
+      '2026-08-08T00:00:00.000Z',
+      '2026-08-01T00:00:00.000123Z',
+      'logs/a',
+      20,
+      ['2026-08-08T00:00:00.000Z'],
+      [3],
+      3,
+    ])
+  })
+
+  test('maps page progress independently from candidate selectivity', () => {
+    expect(
+      mapLifecycleEvaluationPage(
+        {
+          raw_rows_examined: 2,
+          candidates: [],
+          page_end: {
+            name: 'last',
+            archivedAt: '2026-08-01T00:00:00.000Z',
+          },
+        },
+        500
+      )
+    ).toEqual({
+      rawRowsExamined: 2,
+      candidates: [],
+      pageEnd: {
+        name: 'last',
+        archivedAt: '2026-08-01T00:00:00.000Z',
+      },
+      exhausted: true,
+    })
+  })
+
+  test.each([
+    null,
+    'version-a',
+  ])('maps the physical candidate identity with version %s', (version) => {
+    expect(
+      mapLifecycleEvaluationPage(
+        {
+          raw_rows_examined: 1,
+          candidates: [
+            {
+              name: 'history/object.txt',
+              version,
+              isDeleteMarker: false,
+            },
+          ],
+          page_end: {
+            name: 'history/object.txt',
+            archivedAt: '2026-08-01T00:00:00.000Z',
+          },
+        },
+        500
+      )
+    ).toMatchObject({
+      candidates: [{ name: 'history/object.txt', version, isDeleteMarker: false }],
+    })
+  })
+
+  test.each([0, 501])('rejects page size %s', (pageSize) => {
+    expect(() =>
+      buildEvaluateNoncurrentLifecyclePageStatement({
+        bucketId: 'bucket-a',
+        snapshotAt: '2026-08-15T00:00:00.000Z',
+        pageSize,
+        rules: [{ cutoffAt: '2026-08-01T00:00:00.000Z' }],
+      })
+    ).toThrow('between 1 and 500')
+  })
+})
+
+describe('lifecycle candidate decoding', () => {
+  const row = {
+    id: 'row-id',
+    bucketId: 'bucket-a',
+    name: 'history/object.txt',
+    version: null,
+    isVersioned: false,
+    isDeleteMarker: false,
+    metadata: { size: 12 },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    archivedAt: '2026-08-01T00:00:00.000123Z',
+  }
+
+  test('preserves a nullable physical version and microsecond archive ordering', () => {
+    expect(decodeCandidate(row)).toEqual(row)
+  })
+
+  test('accepts a delete marker with null metadata and a physical UUID', () => {
+    const marker = {
+      ...row,
+      version: '856d94e5-5241-42ae-9c0b-d06332a7ae15',
+      isVersioned: true,
+      isDeleteMarker: true,
+      metadata: null,
+    }
+    expect(decodeCandidate(marker)).toEqual(marker)
+  })
+
+  test.each([
+    undefined,
+    '',
+    1,
+  ])('rejects an omitted or malformed physical version %s', (version) => {
+    expect(() => decodeCandidate({ ...row, version })).toThrow('candidate.version')
+    expect(() => decodeLifecycleCandidateIdentity({ ...row, version })).toThrow('candidate.version')
+  })
+})

--- a/src/storage/database/lifecycle.ts
+++ b/src/storage/database/lifecycle.ts
@@ -1,0 +1,284 @@
+import type { DatabaseStatement } from '@internal/database'
+import type { QueryResultRow } from 'pg'
+import { lifecycleCutoffTime } from '../lifecycle/configuration'
+import {
+  type EvaluateNoncurrentLifecyclePageInput,
+  LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS,
+  LIFECYCLE_MAX_PAGE_SIZE,
+  type LifecycleCandidate,
+  type LifecycleCandidateIdentity,
+  type LifecycleEvaluationPage,
+  type NoncurrentLifecycleShardCursor,
+} from '../schemas/lifecycle'
+
+interface LifecycleEvaluationResultRow extends QueryResultRow {
+  raw_rows_examined: number
+  candidates: unknown
+  page_end: unknown | null
+}
+
+// Builds an oldest-first page up to the least restrictive rule cutoff. Cursor ordering
+// assumes distinct archive times per object key. Newer-version counts are bounded by
+// the largest retention count.
+export function buildEvaluateNoncurrentLifecyclePageStatement(
+  input: EvaluateNoncurrentLifecyclePageInput
+): DatabaseStatement {
+  validateEvaluationInput(input)
+
+  const values: unknown[] = [input.bucketId]
+  const parameter = (value: unknown) => {
+    values.push(value)
+    return `$${values.length}`
+  }
+
+  const snapshotParameter = parameter(timestampParameter(input.snapshotAt))
+  const latestCutoff = input.rules.reduce(
+    (latest, rule) =>
+      lifecycleCutoffTime(rule.cutoffAt) > lifecycleCutoffTime(latest) ? rule.cutoffAt : latest,
+    input.rules[0].cutoffAt
+  )
+  const latestCutoffParameter = parameter(timestampParameter(latestCutoff))
+  const conditions = [
+    'object_row.bucket_id = $1',
+    'object_row.archived_at IS NOT NULL',
+    `object_row.archived_at <= ${snapshotParameter}::timestamptz`,
+    `object_row.archived_at < ${latestCutoffParameter}::timestamptz`,
+  ]
+  if (input.cursor) {
+    const cursorArchivedAt = parameter(timestampParameter(input.cursor.archivedAt))
+    const cursorName = parameter(input.cursor.name)
+    conditions.push(`(
+      object_row.archived_at,
+      object_row.name COLLATE "C"
+    ) > (
+      ${cursorArchivedAt}::timestamptz,
+      ${cursorName}::text COLLATE "C"
+    )`)
+  }
+
+  const pageSizeParameter = parameter(input.pageSize)
+  const cutoffsParameter = parameter(input.rules.map((rule) => timestampParameter(rule.cutoffAt)))
+  const newerCountsParameter = parameter(
+    input.rules.map((rule) => rule.newerNoncurrentVersions ?? null)
+  )
+  const maximumNewerProbeParameter = parameter(
+    Math.max(1, ...input.rules.map((rule) => rule.newerNoncurrentVersions ?? 0))
+  )
+
+  return {
+    text: `
+      WITH rules(cutoff_at, newer_noncurrent_versions) AS MATERIALIZED (
+        SELECT *
+        FROM unnest(
+          ${cutoffsParameter}::timestamptz[],
+          ${newerCountsParameter}::integer[]
+        )
+      ),
+      raw_page AS MATERIALIZED (
+        SELECT
+          object_row.name,
+          object_row.version,
+          object_row.is_delete_marker,
+          object_row.archived_at
+        FROM storage.objects AS object_row
+        WHERE ${conditions.join('\n          AND ')}
+        ORDER BY object_row.archived_at, object_row.name COLLATE "C"
+        LIMIT ${pageSizeParameter}::integer
+      ),
+      evaluated AS MATERIALIZED (
+        SELECT raw_page.*, COALESCE(newer.newer_count, 0) AS newer_count
+        FROM raw_page
+        LEFT JOIN LATERAL (
+          SELECT count(*)::integer AS newer_count
+          FROM (
+            SELECT 1
+            FROM storage.objects AS newer_row
+            WHERE newer_row.bucket_id = $1
+              AND newer_row.name COLLATE "C" = raw_page.name COLLATE "C"
+              AND newer_row.archived_at IS NOT NULL
+              AND newer_row.archived_at <= ${snapshotParameter}::timestamptz
+              AND newer_row.archived_at > raw_page.archived_at
+            ORDER BY newer_row.archived_at
+            LIMIT ${maximumNewerProbeParameter}::integer
+          ) AS bounded_newer
+          WHERE EXISTS (
+            SELECT 1
+            FROM rules
+            WHERE rules.newer_noncurrent_versions IS NOT NULL
+              AND raw_page.archived_at < rules.cutoff_at
+          )
+        ) AS newer ON true
+      )
+      SELECT
+        (SELECT count(*)::integer FROM raw_page) AS raw_rows_examined,
+        COALESCE((
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'name', evaluated.name,
+              'version', evaluated.version,
+              'isDeleteMarker', evaluated.is_delete_marker
+            )
+            ORDER BY evaluated.archived_at, evaluated.name COLLATE "C"
+          )
+          FROM evaluated
+          WHERE EXISTS (
+            SELECT 1
+            FROM rules
+            WHERE evaluated.archived_at < rules.cutoff_at
+              AND (
+                rules.newer_noncurrent_versions IS NULL
+                OR evaluated.newer_count >= rules.newer_noncurrent_versions
+              )
+          )
+        ), '[]'::jsonb) AS candidates,
+        (
+          SELECT jsonb_build_object('archivedAt', raw_page.archived_at, 'name', raw_page.name)
+          FROM raw_page
+          ORDER BY raw_page.archived_at DESC, raw_page.name COLLATE "C" DESC
+          LIMIT 1
+        ) AS page_end
+    `,
+    values,
+  }
+}
+
+export function mapLifecycleEvaluationPage(
+  row: LifecycleEvaluationResultRow,
+  pageSize: number
+): LifecycleEvaluationPage {
+  const rawRowsExamined = Number(row.raw_rows_examined)
+  if (!Number.isSafeInteger(rawRowsExamined) || rawRowsExamined < 0 || rawRowsExamined > pageSize) {
+    throw new Error('Lifecycle evaluation returned an invalid raw row count')
+  }
+
+  if (!Array.isArray(row.candidates)) {
+    throw new Error('Lifecycle evaluation returned invalid candidates')
+  }
+  const candidates = row.candidates.map(decodeLifecycleCandidateIdentity)
+  if (candidates.length > rawRowsExamined) {
+    throw new Error('Lifecycle evaluation returned more candidates than raw rows')
+  }
+
+  const pageEnd = row.page_end === null ? undefined : decodeCursor(row.page_end)
+  if ((rawRowsExamined === 0) !== (pageEnd === undefined)) {
+    throw new Error('Lifecycle evaluation returned an invalid page end')
+  }
+
+  return {
+    rawRowsExamined,
+    candidates,
+    ...(pageEnd === undefined ? {} : { pageEnd }),
+    exhausted: rawRowsExamined < pageSize,
+  }
+}
+
+function timestampParameter(value: string): string {
+  if (value === '-infinity') return value
+  const date = new Date(value)
+  const year = date.getUTCFullYear()
+  if (year > 0) return value
+
+  // PostgreSQL uses 1 BC for astronomical year zero. Preserve fractional seconds
+  // from the input because Date truncates the microseconds used in cursor ordering.
+  const fraction = value.match(/\.\d+/)?.[0] ?? '.000'
+  const timestamp = date
+    .toISOString()
+    .replace(/^[+-]?\d+/, String(1 - year).padStart(4, '0'))
+    .replace(/\.\d+Z$/, `${fraction}Z`)
+  return `${timestamp} BC`
+}
+
+function validateEvaluationInput(input: EvaluateNoncurrentLifecyclePageInput) {
+  if (
+    !Number.isSafeInteger(input.pageSize) ||
+    input.pageSize < 1 ||
+    input.pageSize > LIFECYCLE_MAX_PAGE_SIZE
+  ) {
+    throw new Error(`Lifecycle page size must be between 1 and ${LIFECYCLE_MAX_PAGE_SIZE}`)
+  }
+  timestamp(input.snapshotAt, 'snapshotAt')
+  if (input.rules.length === 0) {
+    throw new Error('Lifecycle evaluation requires at least one enabled rule')
+  }
+  if (input.cursor) {
+    string(input.cursor.name, 'cursor.name')
+    timestamp(input.cursor.archivedAt, 'cursor.archivedAt')
+  }
+  for (const rule of input.rules) {
+    if (rule.cutoffAt !== '-infinity') timestamp(rule.cutoffAt, 'rule.cutoffAt')
+    if (
+      rule.newerNoncurrentVersions !== undefined &&
+      (!Number.isSafeInteger(rule.newerNoncurrentVersions) ||
+        rule.newerNoncurrentVersions < 1 ||
+        rule.newerNoncurrentVersions > LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS)
+    ) {
+      throw new Error(
+        `Lifecycle newer-version limit must be between 1 and ${LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS}`
+      )
+    }
+  }
+}
+
+export function decodeLifecycleCandidateIdentity(value: unknown): LifecycleCandidateIdentity {
+  const candidate = record(value, 'candidate')
+  return {
+    name: string(candidate.name, 'candidate.name'),
+    version: nullableString(candidate.version, 'candidate.version'),
+    isDeleteMarker: boolean(candidate.isDeleteMarker, 'candidate.isDeleteMarker'),
+  }
+}
+
+export function decodeCandidate(value: unknown): LifecycleCandidate {
+  const candidate = record(value, 'candidate')
+  return {
+    id: string(candidate.id, 'candidate.id'),
+    bucketId: string(candidate.bucketId, 'candidate.bucketId'),
+    name: string(candidate.name, 'candidate.name'),
+    version: nullableString(candidate.version, 'candidate.version'),
+    isVersioned: boolean(candidate.isVersioned, 'candidate.isVersioned'),
+    isDeleteMarker: boolean(candidate.isDeleteMarker, 'candidate.isDeleteMarker'),
+    metadata:
+      candidate.metadata === null
+        ? null
+        : (record(candidate.metadata, 'candidate.metadata') as Record<string, unknown>),
+    createdAt: timestamp(candidate.createdAt, 'candidate.createdAt'),
+    archivedAt: timestamp(candidate.archivedAt, 'candidate.archivedAt'),
+  }
+}
+
+function decodeCursor(value: unknown): NoncurrentLifecycleShardCursor {
+  const cursor = record(value, 'pageEnd')
+  return {
+    archivedAt: timestamp(cursor.archivedAt, 'pageEnd.archivedAt'),
+    name: string(cursor.name, 'pageEnd.name'),
+  }
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${label} must be a string`)
+  return value
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null ? null : string(value, label)
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${label} must be a boolean`)
+  return value
+}
+
+function timestamp(value: unknown, label: string): string {
+  const parsed = value instanceof Date ? value.toISOString() : string(value, label)
+  if (Number.isNaN(Date.parse(parsed))) throw new Error(`${label} must be an ISO timestamp`)
+  return parsed
+}
+
+export type { LifecycleEvaluationResultRow }

--- a/src/storage/lifecycle/configuration.test.ts
+++ b/src/storage/lifecycle/configuration.test.ts
@@ -1,6 +1,8 @@
 import {
+  compileLifecycleEvaluationRules,
   lifecycleConfigurationsEqual,
   lifecycleConfigurationToS3,
+  noncurrentCutoffAt,
   normalizeLifecycleConfiguration,
   normalizeS3LifecycleConfiguration,
 } from './configuration'
@@ -727,5 +729,217 @@ describe('lifecycle configuration', () => {
         message: 'Rule ID must be unique. Found same ID for more than one rule',
       })
     )
+  })
+})
+
+describe('noncurrent lifecycle time calculations', () => {
+  test.each([
+    {
+      label: 'omitted',
+      expiration: { noncurrentDays: 1 },
+      expected: { cutoffAt: '2026-08-05T00:00:00.000Z' },
+    },
+    {
+      label: 'minimum',
+      expiration: { noncurrentDays: 1, newerNoncurrentVersions: 1 },
+      expected: { cutoffAt: '2026-08-05T00:00:00.000Z', newerNoncurrentVersions: 1 },
+    },
+    {
+      label: 'maximum',
+      expiration: { noncurrentDays: 1, newerNoncurrentVersions: 100 },
+      expected: { cutoffAt: '2026-08-05T00:00:00.000Z', newerNoncurrentVersions: 100 },
+    },
+  ])('compiles rules with $label retention counts', ({ expiration, expected }) => {
+    expect(
+      compileLifecycleEvaluationRules(
+        {
+          rules: [{ status: 'Enabled', filter: {}, noncurrentVersionExpiration: expiration }],
+        },
+        new Date('2026-08-06T00:00:00Z')
+      )
+    ).toEqual([expected])
+  })
+
+  test.each([
+    0,
+    101,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects invalid retention count %s during compilation', (newerNoncurrentVersions) => {
+    expect(() =>
+      compileLifecycleEvaluationRules(
+        {
+          rules: [
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: { noncurrentDays: 1, newerNoncurrentVersions },
+            },
+          ],
+        },
+        new Date('2026-08-06T00:00:00Z')
+      )
+    ).toThrow('NewerNoncurrentVersions must be between 1 and 100')
+  })
+
+  test('rejects an invalid retention count before its rule is pruned', () => {
+    expect(() =>
+      compileLifecycleEvaluationRules(
+        {
+          rules: [101, 1].map((newerNoncurrentVersions) => ({
+            status: 'Enabled',
+            filter: {},
+            noncurrentVersionExpiration: { noncurrentDays: 1, newerNoncurrentVersions },
+          })),
+        },
+        new Date('2026-08-06T00:00:00Z')
+      )
+    ).toThrow('NewerNoncurrentVersions must be between 1 and 100')
+  })
+
+  test('uses the frozen UTC date and a strict cutoff', () => {
+    const snapshotAt = new Date('2026-08-06T17:42:01.000Z')
+    expect(noncurrentCutoffAt(snapshotAt, 30)).toBe('2026-07-07T00:00:00.000Z')
+    expect(
+      compileLifecycleEvaluationRules(
+        {
+          rules: [
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: {
+                noncurrentDays: 30,
+                newerNoncurrentVersions: 3,
+              },
+            },
+            {
+              status: 'Disabled',
+              filter: {},
+              noncurrentVersionExpiration: { noncurrentDays: 1 },
+            },
+          ],
+        },
+        snapshotAt
+      )
+    ).toEqual([
+      {
+        cutoffAt: '2026-07-07T00:00:00.000Z',
+        newerNoncurrentVersions: 3,
+      },
+    ])
+  })
+
+  test('prunes evaluation rules dominated under union semantics', () => {
+    const snapshotAt = new Date('2026-08-06T17:42:01.000Z')
+
+    expect(
+      compileLifecycleEvaluationRules(
+        {
+          rules: [
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: {
+                noncurrentDays: 30,
+                newerNoncurrentVersions: 3,
+              },
+            },
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: {
+                noncurrentDays: 10,
+                newerNoncurrentVersions: 2,
+              },
+            },
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: {
+                noncurrentDays: 5,
+                newerNoncurrentVersions: 5,
+              },
+            },
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: { noncurrentDays: 60 },
+            },
+            {
+              status: 'Enabled',
+              filter: {},
+              noncurrentVersionExpiration: {
+                noncurrentDays: 60,
+                newerNoncurrentVersions: 4,
+              },
+            },
+          ],
+        },
+        snapshotAt
+      )
+    ).toEqual([
+      {
+        cutoffAt: '2026-07-27T00:00:00.000Z',
+        newerNoncurrentVersions: 2,
+      },
+      {
+        cutoffAt: '2026-08-01T00:00:00.000Z',
+        newerNoncurrentVersions: 5,
+      },
+      { cutoffAt: '2026-06-07T00:00:00.000Z' },
+    ])
+  })
+
+  test('compiles the maximum supported day policy to an empty finite timestamp range', () => {
+    const snapshotAt = new Date('2026-08-06T17:42:01.000Z')
+    const configuration = normalizeLifecycleConfiguration({
+      rules: [
+        {
+          status: 'Enabled',
+          filter: {},
+          noncurrentVersionExpiration: {
+            noncurrentDays: 2147483647,
+          },
+        },
+      ],
+    })
+    expect(compileLifecycleEvaluationRules(configuration, snapshotAt)).toEqual([
+      { cutoffAt: '-infinity' },
+    ])
+    expect(noncurrentCutoffAt(new Date('-004713-11-26T00:00:00Z'), 1)).toBe(
+      '-004713-11-25T00:00:00.000Z'
+    )
+    expect(noncurrentCutoffAt(new Date('-004713-11-25T00:00:00Z'), 1)).toBe('-infinity')
+    expect(noncurrentCutoffAt(new Date('-004713-11-25T00:00:00Z'), 2)).toBe('-infinity')
+  })
+
+  test('a finite cutoff dominates an otherwise equivalent oversized-day rule', () => {
+    expect(
+      compileLifecycleEvaluationRules(
+        {
+          rules: [2147483647, 1].map((noncurrentDays) => ({
+            status: 'Enabled',
+            filter: {},
+            noncurrentVersionExpiration: { noncurrentDays },
+          })),
+        },
+        new Date('2026-08-06T00:00:00Z')
+      )
+    ).toEqual([{ cutoffAt: '2026-08-05T00:00:00.000Z' }])
+  })
+
+  test('does not follow a DST-observing local timezone', () => {
+    const previous = process.env.TZ
+    process.env.TZ = 'America/Los_Angeles'
+    try {
+      expect(noncurrentCutoffAt(new Date('2026-03-09T07:30:00.000Z'), 1)).toBe(
+        '2026-03-08T00:00:00.000Z'
+      )
+    } finally {
+      if (previous === undefined) delete process.env.TZ
+      else process.env.TZ = previous
+    }
   })
 })

--- a/src/storage/lifecycle/configuration.ts
+++ b/src/storage/lifecycle/configuration.ts
@@ -6,6 +6,7 @@ import {
   LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS,
   LIFECYCLE_MAX_NONCURRENT_DAYS,
   LIFECYCLE_MAX_RULES,
+  type LifecycleEvaluationRule,
   type LifecycleRule,
 } from '../schemas/lifecycle'
 
@@ -108,6 +109,67 @@ export function lifecycleConfigurationToS3(
       })),
     },
   }
+}
+
+export function hasEnabledLifecycleRule(configuration: BucketLifecycleConfiguration): boolean {
+  return configuration.rules.some((rule) => rule.status === 'Enabled')
+}
+
+export function compileLifecycleEvaluationRules(
+  configuration: BucketLifecycleConfiguration,
+  snapshotAt: Date
+): LifecycleEvaluationRule[] {
+  assertValidDate(snapshotAt, 'snapshotAt')
+
+  const compiled = configuration.rules
+    .filter((rule) => rule.status === 'Enabled')
+    .map((rule) => {
+      const { noncurrentDays, newerNoncurrentVersions } = rule.noncurrentVersionExpiration
+      if (newerNoncurrentVersions !== undefined) {
+        assertIntegerInRange(
+          newerNoncurrentVersions,
+          1,
+          LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS,
+          'NewerNoncurrentVersions'
+        )
+      }
+      return {
+        cutoffAt: noncurrentCutoffAt(snapshotAt, noncurrentDays),
+        ...(newerNoncurrentVersions === undefined ? {} : { newerNoncurrentVersions }),
+      }
+    })
+
+  const cutoffTimes = compiled.map((rule) => lifecycleCutoffTime(rule.cutoffAt))
+  return compiled.filter((rule, index) => {
+    const count = rule.newerNoncurrentVersions ?? 0
+    return !compiled.some((candidate, candidateIndex) => {
+      if (candidateIndex === index) return false
+      const candidateCount = candidate.newerNoncurrentVersions ?? 0
+      const candidateTime = cutoffTimes[candidateIndex]
+      const ruleTime = cutoffTimes[index]
+      const candidateDominates = candidateTime >= ruleTime && candidateCount <= count
+      const strictlyDominates =
+        candidateTime > ruleTime || candidateCount < count || candidateIndex < index
+      return candidateDominates && strictlyDominates
+    })
+  })
+}
+
+export function noncurrentCutoffAt(snapshotAt: Date, noncurrentDays: number): string {
+  assertValidDate(snapshotAt, 'snapshotAt')
+  assertIntegerInRange(noncurrentDays, 1, Number.MAX_SAFE_INTEGER, 'NoncurrentDays')
+
+  const dayMs = 86_400_000
+  const cutoffDay = Math.floor(snapshotAt.getTime() / dayMs) - noncurrentDays
+  // PostgreSQL timestamps start at Julian day zero, 2,440,588 days before the Unix epoch.
+  // A strict cutoff at or before that boundary matches no finite timestamp.
+  // Represent it as an empty cutoff without serializing a BC Date.
+  if (cutoffDay <= -2_440_588) return '-infinity'
+  return new Date(cutoffDay * dayMs).toISOString()
+}
+
+export function lifecycleCutoffTime(value: string): number {
+  return value === '-infinity' ? Number.NEGATIVE_INFINITY : Date.parse(value)
 }
 
 export function lifecycleConfigurationsEqual(
@@ -348,6 +410,18 @@ function parseIntegerArgument(value: unknown, message: string): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function assertIntegerInRange(value: number, minimum: number, maximum: number, label: string) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw validationError(`${label} must be between ${minimum} and ${maximum}`)
+  }
+}
+
+function assertValidDate(value: Date, label: string) {
+  if (Number.isNaN(value.getTime())) {
+    throw validationError(`${label} must be a valid date`)
+  }
 }
 
 function requireRecord(value: unknown, message: string): Record<string, unknown> {

--- a/src/storage/lifecycle/continuation.test.ts
+++ b/src/storage/lifecycle/continuation.test.ts
@@ -1,0 +1,480 @@
+import { randomUUID } from 'node:crypto'
+import { withOptionalVersion } from '@storage/backend/adapter'
+import {
+  advanceLifecycleEvaluationPage,
+  armLifecycleAttempt,
+  commitLifecycleBatchResults,
+  completeLifecycleBatch,
+  createLifecycleContinuation,
+  decodeLifecycleContinuation,
+  filterStagedLifecycleBatch,
+  freezeLifecycleBatchVersion,
+  LifecycleContinuationDecodeError,
+  recordLifecycleArtifactOutcomes,
+  refreshStagedLifecycleBatchArtifacts,
+  stageLifecycleBatch,
+} from './continuation'
+
+function validContinuation() {
+  const generation = randomUUID()
+  return {
+    continuationVersion: 1,
+    runId: randomUUID(),
+    trigger: 'scheduled',
+    generation,
+    snapshotAt: '2026-08-06T00:00:00.000Z',
+    mode: 'DELETE',
+    topology: {
+      scanKind: 'NONCURRENT',
+      epoch: '1',
+      shardId: 0,
+      shardCount: 1,
+    },
+    pageEnd: {
+      name: 'logs/example.json',
+      archivedAt: '2026-08-05T12:00:00.000Z',
+    },
+    counters: {
+      versionsExamined: 1,
+      versionsEligible: 1,
+      objectVersionsDeleted: 0,
+      deleteMarkersDeleted: 0,
+      bytesDeleted: 0,
+      batchesCompleted: 0,
+    },
+    batch: {
+      versions: [
+        {
+          name: 'logs/example.json',
+          version: randomUUID(),
+          artifacts: [
+            { key: 'logs/example.json/version', outcome: 'UNRESOLVED' },
+            { key: 'logs/example.json/version.info', outcome: 'UNRESOLVED' },
+          ],
+        },
+      ],
+      inFlight: {
+        attemptId: randomUUID(),
+        authorizedGeneration: generation,
+        startedAt: '2026-08-06T00:01:00.000Z',
+      },
+    },
+  }
+}
+
+describe('decodeLifecycleContinuation', () => {
+  test('decodes a bounded v1 continuation', () => {
+    const input = validContinuation()
+    expect(decodeLifecycleContinuation(input)).toEqual(input)
+  })
+
+  test('rejects a resolved artifact with a missing companion', () => {
+    const input = validContinuation()
+    const artifacts = input.batch.versions[0].artifacts
+    artifacts[0].outcome = 'DELETED'
+    artifacts.pop()
+
+    expect(() => decodeLifecycleContinuation(input)).toThrow(
+      'batch.versions[0].artifacts must contain 0 or 2 entries'
+    )
+  })
+
+  test('round-trips an armed legacy physical version without replacing null with a sentinel', () => {
+    const input = validContinuation()
+    const legacy = freezeLifecycleBatchVersion({
+      name: 'logs/example.json',
+      version: null,
+      isDeleteMarker: false,
+    })
+    const journal = { ...input, batch: { ...input.batch, versions: [legacy] } }
+    expect(decodeLifecycleContinuation(JSON.parse(JSON.stringify(journal)))).toEqual(journal)
+    expect(legacy.artifacts).toEqual([
+      { key: 'logs/example.json', outcome: 'UNRESOLVED' },
+      { key: 'logs/example.json.info', outcome: 'UNRESOLVED' },
+    ])
+  })
+
+  test('rejects an omitted physical version selector in a durable batch', () => {
+    const input = validContinuation()
+    const { version: _version, ...entry } = input.batch.versions[0]
+    expect(() =>
+      decodeLifecycleContinuation({ ...input, batch: { ...input.batch, versions: [entry] } })
+    ).toThrow('batch.versions[0].version')
+  })
+
+  test.each([
+    2, 3,
+  ])('fails closed on unknown continuation version %s before reading the payload', (continuationVersion) => {
+    expect(() => decodeLifecycleContinuation({ continuationVersion })).toThrow(
+      `Unsupported lifecycle continuation version ${continuationVersion}`
+    )
+  })
+
+  test.each([
+    [
+      'invalid UUID',
+      (value: ReturnType<typeof validContinuation>) => {
+        value.runId = 'not-a-uuid' as ReturnType<typeof validContinuation>['runId']
+      },
+    ],
+    [
+      'batch without page end',
+      (value: ReturnType<typeof validContinuation>) => {
+        delete (value as { pageEnd?: unknown }).pageEnd
+      },
+    ],
+    [
+      'unknown artifact outcome',
+      (value: ReturnType<typeof validContinuation>) => {
+        value.batch.versions[0].artifacts[0].outcome = 'MAYBE'
+      },
+    ],
+  ])('rejects %s', (_name, mutate) => {
+    const value = validContinuation()
+    mutate(value)
+    expect(() => decodeLifecycleContinuation(value)).toThrow(LifecycleContinuationDecodeError)
+  })
+
+  test('bounds the durable logical-version batch', () => {
+    const value = validContinuation()
+    value.batch.versions = Array.from({ length: 501 }, () => value.batch.versions[0])
+    expect(() => decodeLifecycleContinuation(value)).toThrow('at most 500 entries')
+  })
+})
+
+describe('lifecycle continuation transitions', () => {
+  test('rejects empty staging and advances pages without eligible candidates', () => {
+    const initial = createLifecycleContinuation({
+      runId: randomUUID(),
+      trigger: 'scheduled',
+      generation: randomUUID(),
+      snapshotAt: '2026-08-15T00:00:00.000Z',
+      mode: 'DELETE',
+      topology: {
+        scanKind: 'NONCURRENT',
+        epoch: '1',
+        shardId: 0,
+        shardCount: 1,
+      },
+    })
+    const page = {
+      rawRowsExamined: 1,
+      candidates: [],
+      pageEnd: { name: 'logs/example.json', archivedAt: '2026-08-02T00:00:00.000Z' },
+      exhausted: false,
+    }
+
+    expect(() =>
+      stageLifecycleBatch(initial, {
+        pageEnd: page.pageEnd,
+        rawRowsExamined: page.rawRowsExamined,
+        versions: [],
+      })
+    ).toThrow('Lifecycle batch cannot be empty')
+
+    expect(advanceLifecycleEvaluationPage(initial, page)).toEqual({
+      ...initial,
+      cursor: page.pageEnd,
+      counters: { ...initial.counters, versionsExamined: 1 },
+    })
+  })
+
+  test('keeps null and literal null-string identities separate through filtering and recovery', () => {
+    const initial = validContinuation()
+    const legacy = freezeLifecycleBatchVersion({
+      name: 'logs/example.json',
+      version: null,
+      isDeleteMarker: false,
+    })
+    const named = freezeLifecycleBatchVersion({
+      name: legacy.name,
+      version: 'null',
+      isDeleteMarker: false,
+    })
+    const staged = decodeLifecycleContinuation({
+      ...initial,
+      counters: { ...initial.counters, versionsExamined: 2, versionsEligible: 2 },
+      batch: { versions: [legacy, named] },
+    })
+
+    expect(filterStagedLifecycleBatch(staged, [legacy]).batch?.versions).toEqual([legacy])
+    expect(filterStagedLifecycleBatch(staged, [named]).batch?.versions).toEqual([named])
+
+    const armed = armLifecycleAttempt(staged, initial.batch.inFlight)
+    const recorded = recordLifecycleArtifactOutcomes(
+      armed,
+      new Map(named.artifacts.map(({ key }) => [key, { outcome: 'ABSENT' as const }]))
+    )
+    const recovered = commitLifecycleBatchResults(recorded, [legacy], {
+      objectVersions: 1,
+      deleteMarkers: 0,
+      bytes: 12,
+    })
+    expect(recovered.batch).toEqual({ versions: [legacy], inFlight: initial.batch.inFlight })
+    expect(recovered.cursor).toBeUndefined()
+  })
+
+  test('freezes exact physical keys using the backend locator helper', () => {
+    const physicalKey = withOptionalVersion('logs/example.json', 'version-a')
+    expect(
+      freezeLifecycleBatchVersion({
+        name: 'logs/example.json',
+        version: 'version-a',
+        isDeleteMarker: false,
+      })
+    ).toEqual({
+      name: 'logs/example.json',
+      version: 'version-a',
+      artifacts: [
+        { key: physicalKey, outcome: 'UNRESOLVED' },
+        { key: `${physicalKey}.info`, outcome: 'UNRESOLVED' },
+      ],
+    })
+
+    expect(
+      freezeLifecycleBatchVersion({
+        name: 'deleted',
+        version: randomUUID(),
+        isDeleteMarker: true,
+      }).artifacts
+    ).toEqual([])
+  })
+
+  test('requires an armed attempt to complete a delete-marker batch', () => {
+    const initial = validContinuation()
+    const marker = freezeLifecycleBatchVersion({
+      name: initial.pageEnd.name,
+      version: randomUUID(),
+      isDeleteMarker: true,
+    })
+    const staged = decodeLifecycleContinuation({
+      ...initial,
+      batch: { versions: [marker] },
+    })
+
+    expect(() => completeLifecycleBatch(staged)).toThrow('must be armed before completing')
+
+    const armed = armLifecycleAttempt(staged, initial.batch.inFlight)
+    const completed = completeLifecycleBatch(armed, {
+      objectVersions: 0,
+      deleteMarkers: 1,
+      bytes: 0,
+    })
+    expect(completed.cursor).toEqual(staged.pageEnd)
+    expect(completed.batch).toBeUndefined()
+    expect(completed.counters).toEqual({
+      ...staged.counters,
+      deleteMarkersDeleted: 1,
+      batchesCompleted: 1,
+    })
+
+    const filtered = filterStagedLifecycleBatch(staged, [])
+    expect(filtered.cursor).toEqual(staged.pageEnd)
+    expect(filtered.batch).toBeUndefined()
+    expect(filtered.counters).toEqual({ ...staged.counters, batchesCompleted: 1 })
+  })
+
+  test('keeps one stable attempt as compensation authority across generation replacement', () => {
+    const generation = randomUUID()
+    const initial = createLifecycleContinuation({
+      runId: randomUUID(),
+      trigger: 'scheduled',
+      generation,
+      snapshotAt: '2026-08-15T00:00:00.000Z',
+      mode: 'DELETE',
+      topology: {
+        scanKind: 'NONCURRENT',
+        epoch: '1',
+        shardId: 0,
+        shardCount: 1,
+      },
+    })
+    const candidate = freezeLifecycleBatchVersion({
+      name: 'logs/example.json',
+      version: randomUUID(),
+      isDeleteMarker: false,
+    })
+    const staged = stageLifecycleBatch(initial, {
+      pageEnd: { name: candidate.name, archivedAt: '2026-08-02T00:00:00.000Z' },
+      rawRowsExamined: 1,
+      versions: [candidate],
+    })
+    const attempt = {
+      attemptId: randomUUID(),
+      authorizedGeneration: generation,
+      startedAt: '2026-08-15T00:01:00.000Z',
+    }
+    const armed = armLifecycleAttempt(staged, attempt)
+
+    expect(armLifecycleAttempt(armed, attempt)).toBe(armed)
+    expect(() => completeLifecycleBatch(armed)).toThrow('artifact compensation')
+
+    const partiallyResolved = recordLifecycleArtifactOutcomes(
+      armed,
+      new Map([[candidate.artifacts[0].key, { outcome: 'DELETED' }]])
+    )
+    expect(partiallyResolved.batch?.inFlight).toEqual(attempt)
+    expect(() => completeLifecycleBatch(partiallyResolved)).toThrow('artifact compensation')
+
+    const resolved = recordLifecycleArtifactOutcomes(
+      partiallyResolved,
+      new Map([[candidate.artifacts[1].key, { outcome: 'ABSENT' }]])
+    )
+    expect(completeLifecycleBatch(resolved)).toMatchObject({
+      cursor: staged.pageEnd,
+      counters: { versionsExamined: 1, versionsEligible: 1, batchesCompleted: 1 },
+    })
+  })
+
+  test('refreshes the exact artifact set from the locked row shape before arming', () => {
+    const generation = randomUUID()
+    const version = randomUUID()
+    const staged = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'scheduled',
+        generation,
+        snapshotAt: '2026-08-15T00:00:00.000Z',
+        mode: 'DELETE',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        pageEnd: {
+          name: 'deleted',
+          archivedAt: '2026-08-02T00:00:00.000Z',
+        },
+        rawRowsExamined: 1,
+        versions: [
+          {
+            name: 'deleted',
+            version,
+            artifacts: [
+              { key: 'stale-artifact', outcome: 'UNRESOLVED' },
+              { key: 'stale-artifact.info', outcome: 'UNRESOLVED' },
+            ],
+          },
+        ],
+      }
+    )
+
+    expect(
+      refreshStagedLifecycleBatchArtifacts(staged, [
+        { name: 'deleted', version, isDeleteMarker: true },
+      ]).batch?.versions
+    ).toEqual([{ name: 'deleted', version, artifacts: [] }])
+  })
+
+  test('rejects attempt replacement and cursor advancement with unresolved artifacts', () => {
+    const continuation = decodeLifecycleContinuation(validContinuation())
+    expect(() =>
+      armLifecycleAttempt(continuation, {
+        attemptId: randomUUID(),
+        authorizedGeneration: continuation.generation,
+        startedAt: '2026-08-15T00:01:00.000Z',
+      })
+    ).toThrow('different armed attempt')
+    expect(() => completeLifecycleBatch(continuation)).toThrow('artifact compensation')
+  })
+
+  test('retains partial artifact success and records completed-version counters immediately', () => {
+    const continuation = decodeLifecycleContinuation(validContinuation())
+    const version = continuation.batch!.versions[0]
+    const partial = recordLifecycleArtifactOutcomes(
+      continuation,
+      new Map([
+        [version.artifacts[0].key, { outcome: 'DELETED' as const }],
+        [version.artifacts[1].key, { outcome: 'FAILED' as const, error: 'retry me' }],
+      ])
+    )
+
+    expect(() => completeLifecycleBatch(partial)).toThrow('artifact compensation')
+    expect(
+      commitLifecycleBatchResults(partial, [version], {
+        objectVersions: 2,
+        deleteMarkers: 1,
+        bytes: 30,
+      })
+    ).toMatchObject({
+      batch: {
+        inFlight: partial.batch!.inFlight,
+        versions: [
+          {
+            name: version.name,
+            version: version.version,
+            artifacts: [
+              expect.objectContaining({ outcome: 'DELETED' }),
+              expect.objectContaining({ outcome: 'FAILED' }),
+            ],
+          },
+        ],
+      },
+      counters: {
+        objectVersionsDeleted: 2,
+        deleteMarkersDeleted: 1,
+        bytesDeleted: 30,
+        batchesCompleted: 0,
+      },
+    })
+  })
+
+  test.each([
+    ['UNRESOLVED', 'UNRESOLVED'],
+    ['DELETED', 'UNRESOLVED'],
+    ['DELETED', 'FAILED'],
+    ['ABSENT', 'FAILED'],
+  ])('rejects dropping %s/%s artifacts while retaining another version', (main, sidecar) => {
+    const input = validContinuation()
+    const retained = input.batch.versions[0]
+    input.counters.versionsExamined = 2
+    input.counters.versionsEligible = 2
+    input.batch.versions.push({
+      name: 'logs/other.json',
+      version: randomUUID(),
+      artifacts: [
+        { key: 'logs/other.json/version', outcome: main },
+        { key: 'logs/other.json/version.info', outcome: sidecar },
+      ],
+    })
+    const continuation = decodeLifecycleContinuation(input)
+
+    expect(() =>
+      commitLifecycleBatchResults(continuation, [retained], {
+        objectVersions: 1,
+        deleteMarkers: 0,
+        bytes: 12,
+      })
+    ).toThrow('artifact compensation')
+    expect(continuation).toEqual(input)
+  })
+
+  test('drains definitive all-failed versions and can filter an unarmed staged batch', () => {
+    const armed = decodeLifecycleContinuation(validContinuation())
+    const failed = recordLifecycleArtifactOutcomes(
+      armed,
+      new Map(
+        armed.batch!.versions[0].artifacts.map((artifact) => [
+          artifact.key,
+          { outcome: 'FAILED' as const, error: 'not deleted' },
+        ])
+      )
+    )
+    expect(completeLifecycleBatch(failed)).toMatchObject({
+      cursor: armed.pageEnd,
+      counters: { batchesCompleted: 1 },
+    })
+
+    const staged = decodeLifecycleContinuation({
+      ...validContinuation(),
+      batch: { versions: armed.batch!.versions },
+    })
+    expect(filterStagedLifecycleBatch(staged, [])).toMatchObject({
+      cursor: staged.pageEnd,
+      counters: { batchesCompleted: 1 },
+    })
+  })
+})

--- a/src/storage/lifecycle/continuation.ts
+++ b/src/storage/lifecycle/continuation.ts
@@ -1,0 +1,530 @@
+import { withOptionalVersion } from '../backend/adapter'
+import {
+  LIFECYCLE_CONTINUATION_VERSION,
+  LIFECYCLE_MAX_PAGE_SIZE,
+  type LifecycleArtifact,
+  type LifecycleBatchVersion,
+  type LifecycleCandidateIdentity,
+  type LifecycleContinuation,
+  type LifecycleContinuationBatch,
+  type LifecycleEvaluationPage,
+  type LifecycleExecutionMode,
+  type LifecycleInFlightAttempt,
+  type LifecycleRunCounters,
+  type LifecycleShardTopology,
+  type LifecycleTrigger,
+  type NoncurrentLifecycleShardCursor,
+} from '../schemas/lifecycle'
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const BIGINT = /^-?\d+$/
+const MIN_SIGNED_BIGINT = -(1n << 63n)
+const MAX_SIGNED_BIGINT = (1n << 63n) - 1n
+
+interface LifecycleDeletionCounts {
+  objectVersions: number
+  deleteMarkers: number
+  bytes: number
+}
+
+export class LifecycleContinuationDecodeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LifecycleContinuationDecodeError'
+  }
+}
+
+export function createLifecycleContinuation(input: {
+  runId: string
+  trigger: LifecycleTrigger
+  generation: string
+  snapshotAt: string
+  mode: LifecycleExecutionMode
+  topology: LifecycleShardTopology
+}): LifecycleContinuation {
+  return decodeLifecycleContinuation({
+    continuationVersion: LIFECYCLE_CONTINUATION_VERSION,
+    ...input,
+    counters: {
+      versionsExamined: 0,
+      versionsEligible: 0,
+      objectVersionsDeleted: 0,
+      deleteMarkersDeleted: 0,
+      bytesDeleted: 0,
+      batchesCompleted: 0,
+    },
+  })
+}
+
+export function freezeLifecycleBatchVersion(
+  candidate: LifecycleCandidateIdentity
+): LifecycleBatchVersion {
+  const physicalKey = withOptionalVersion(candidate.name, candidate.version ?? undefined)
+  return {
+    name: candidate.name,
+    version: candidate.version,
+    artifacts: candidate.isDeleteMarker
+      ? []
+      : [
+          { key: physicalKey, outcome: 'UNRESOLVED' },
+          { key: `${physicalKey}.info`, outcome: 'UNRESOLVED' },
+        ],
+  }
+}
+
+export function stageLifecycleBatch(
+  continuation: LifecycleContinuation,
+  input: {
+    pageEnd: NoncurrentLifecycleShardCursor
+    rawRowsExamined: number
+    versions: LifecycleBatchVersion[]
+  }
+): LifecycleContinuation {
+  if (continuation.batch !== undefined) {
+    throw new Error('Lifecycle continuation already has a staged batch')
+  }
+  if (input.versions.length === 0) {
+    throw new Error('Lifecycle batch cannot be empty')
+  }
+  if (
+    !Number.isSafeInteger(input.rawRowsExamined) ||
+    input.rawRowsExamined < input.versions.length ||
+    input.rawRowsExamined > LIFECYCLE_MAX_PAGE_SIZE
+  ) {
+    throw new Error('Lifecycle batch does not fit its raw page')
+  }
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    pageEnd: input.pageEnd,
+    counters: {
+      ...continuation.counters,
+      versionsExamined: continuation.counters.versionsExamined + input.rawRowsExamined,
+      versionsEligible: continuation.counters.versionsEligible + input.versions.length,
+    },
+    batch: { versions: input.versions },
+  })
+}
+
+export function advanceLifecycleEvaluationPage(
+  continuation: LifecycleContinuation,
+  page: LifecycleEvaluationPage
+): LifecycleContinuation {
+  if (continuation.batch !== undefined) {
+    throw new Error('Lifecycle continuation already has a staged batch')
+  }
+  if (page.rawRowsExamined > 0 && page.pageEnd === undefined) {
+    throw new Error('A non-empty lifecycle page requires pageEnd')
+  }
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    ...(page.pageEnd === undefined ? {} : { cursor: page.pageEnd }),
+    counters: {
+      ...continuation.counters,
+      versionsExamined: continuation.counters.versionsExamined + page.rawRowsExamined,
+      versionsEligible: continuation.counters.versionsEligible + page.candidates.length,
+    },
+  })
+}
+
+export function armLifecycleAttempt(
+  continuation: LifecycleContinuation,
+  attempt: LifecycleInFlightAttempt
+): LifecycleContinuation {
+  if (!continuation.batch || continuation.batch.versions.length === 0) {
+    throw new Error('Lifecycle continuation has no batch to arm')
+  }
+  if (continuation.batch.inFlight) {
+    if (
+      continuation.batch.inFlight.attemptId === attempt.attemptId &&
+      continuation.batch.inFlight.authorizedGeneration === attempt.authorizedGeneration
+    ) {
+      return continuation
+    }
+    throw new Error('Lifecycle batch already has a different armed attempt')
+  }
+  if (attempt.authorizedGeneration !== continuation.generation) {
+    throw new Error('Lifecycle attempt generation does not match the staged policy')
+  }
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    batch: { ...continuation.batch, inFlight: attempt },
+  })
+}
+
+export function recordLifecycleArtifactOutcomes(
+  continuation: LifecycleContinuation,
+  outcomes: ReadonlyMap<string, Pick<LifecycleArtifact, 'outcome' | 'error'>>
+): LifecycleContinuation {
+  if (!continuation.batch?.inFlight) {
+    throw new Error('Lifecycle batch must be armed before recording artifact outcomes')
+  }
+
+  const knownKeys = new Set(
+    continuation.batch.versions.flatMap((version) =>
+      version.artifacts.map((artifact) => artifact.key)
+    )
+  )
+  for (const key of outcomes.keys()) {
+    if (!knownKeys.has(key)) throw new Error(`Lifecycle outcome references unknown artifact ${key}`)
+  }
+
+  const versions = continuation.batch.versions.map((version) => ({
+    ...version,
+    artifacts: version.artifacts.map((artifact) => {
+      const outcome = outcomes.get(artifact.key)
+      return outcome ? { key: artifact.key, ...outcome } : artifact
+    }),
+  }))
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    batch: { versions, inFlight: continuation.batch.inFlight },
+  })
+}
+
+export function filterStagedLifecycleBatch(
+  continuation: LifecycleContinuation,
+  retainedVersions: ReadonlyArray<Pick<LifecycleBatchVersion, 'name' | 'version'>>
+): LifecycleContinuation {
+  if (!continuation.batch || continuation.batch.inFlight) {
+    throw new Error('Lifecycle batch must be staged and unarmed before filtering')
+  }
+
+  const versions = selectRetainedVersions(continuation.batch.versions, retainedVersions)
+  if (versions.length === continuation.batch.versions.length) return continuation
+  if (versions.length === 0) return advanceLifecycleBatch(continuation)
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    batch: { versions },
+  })
+}
+
+export function refreshStagedLifecycleBatchArtifacts(
+  continuation: LifecycleContinuation,
+  candidates: ReadonlyArray<LifecycleCandidateIdentity>
+): LifecycleContinuation {
+  if (!continuation.batch || continuation.batch.inFlight) {
+    throw new Error('Lifecycle batch must be staged and unarmed before refreshing artifacts')
+  }
+  if (candidates.length !== continuation.batch.versions.length) {
+    throw new Error('Lifecycle artifact refresh must cover the current batch')
+  }
+
+  const currentVersions = continuation.batch.versions
+  const versions = candidates.map((candidate, index) => {
+    const current = currentVersions[index]
+    if (current.name !== candidate.name || current.version !== candidate.version) {
+      throw new Error('Lifecycle artifact refresh identities must preserve batch order')
+    }
+    return freezeLifecycleBatchVersion(candidate)
+  })
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    batch: { versions },
+  })
+}
+
+export function commitLifecycleBatchResults(
+  continuation: LifecycleContinuation,
+  retainedVersions: ReadonlyArray<Pick<LifecycleBatchVersion, 'name' | 'version'>>,
+  deleted: LifecycleDeletionCounts
+): LifecycleContinuation {
+  if (!continuation.batch?.inFlight) {
+    throw new Error('Lifecycle batch must be armed before committing results')
+  }
+
+  const versions = selectRetainedVersions(continuation.batch.versions, retainedVersions)
+  if (versions.length === 0) return completeLifecycleBatch(continuation, deleted)
+
+  const retained = new Set(versions)
+  if (
+    continuation.batch.versions.some(
+      (version) => !retained.has(version) && lifecycleVersionNeedsCompensation(version)
+    )
+  ) {
+    throw new Error('Lifecycle batch still requires artifact compensation')
+  }
+
+  return decodeLifecycleContinuation({
+    ...continuation,
+    counters: addDeletionCounters(continuation.counters, deleted),
+    batch: { versions, inFlight: continuation.batch.inFlight },
+  })
+}
+
+export function completeLifecycleBatch(
+  continuation: LifecycleContinuation,
+  deleted: LifecycleDeletionCounts = { objectVersions: 0, deleteMarkers: 0, bytes: 0 }
+): LifecycleContinuation {
+  if (!continuation.batch || !continuation.pageEnd) {
+    throw new Error('Lifecycle continuation has no batch to complete')
+  }
+  if (!continuation.batch.inFlight) {
+    throw new Error('Lifecycle batch must be armed before completing')
+  }
+  if (continuation.batch.versions.some(lifecycleVersionNeedsCompensation)) {
+    throw new Error('Lifecycle batch still requires artifact compensation')
+  }
+
+  return advanceLifecycleBatch(continuation, deleted)
+}
+
+function advanceLifecycleBatch(
+  continuation: LifecycleContinuation,
+  deleted: LifecycleDeletionCounts = { objectVersions: 0, deleteMarkers: 0, bytes: 0 }
+): LifecycleContinuation {
+  if (!continuation.batch || !continuation.pageEnd) {
+    throw new Error('Lifecycle continuation has no batch to advance')
+  }
+
+  const { batch: _batch, pageEnd: _pageEnd, ...rest } = continuation
+  return decodeLifecycleContinuation({
+    ...rest,
+    cursor: continuation.pageEnd,
+    counters: {
+      ...addDeletionCounters(continuation.counters, deleted),
+      batchesCompleted: continuation.counters.batchesCompleted + 1,
+    },
+  })
+}
+
+export function lifecycleVersionNeedsCompensation(version: LifecycleBatchVersion): boolean {
+  const outcomes = new Set(version.artifacts.map((artifact) => artifact.outcome))
+  return (
+    outcomes.has('UNRESOLVED') ||
+    (outcomes.has('FAILED') && (outcomes.has('DELETED') || outcomes.has('ABSENT')))
+  )
+}
+
+function selectRetainedVersions(
+  currentVersions: LifecycleBatchVersion[],
+  retainedVersions: ReadonlyArray<Pick<LifecycleBatchVersion, 'name' | 'version'>>
+): LifecycleBatchVersion[] {
+  const identities = new Set(
+    retainedVersions.map((version) => lifecycleVersionIdentity(version.name, version.version))
+  )
+  if (identities.size !== retainedVersions.length) {
+    throw new Error('Lifecycle retained version identities must be unique')
+  }
+
+  const versions = currentVersions.filter((version) =>
+    identities.has(lifecycleVersionIdentity(version.name, version.version))
+  )
+  if (versions.length !== retainedVersions.length) {
+    throw new Error('Lifecycle retained versions must belong to the current batch')
+  }
+  return versions
+}
+
+export function lifecycleVersionIdentity(name: string, version: string | null): string {
+  return JSON.stringify([name, version])
+}
+
+function addDeletionCounters(
+  counters: LifecycleRunCounters,
+  deleted: LifecycleDeletionCounts
+): LifecycleRunCounters {
+  return {
+    ...counters,
+    objectVersionsDeleted: counters.objectVersionsDeleted + deleted.objectVersions,
+    deleteMarkersDeleted: counters.deleteMarkersDeleted + deleted.deleteMarkers,
+    bytesDeleted: counters.bytesDeleted + deleted.bytes,
+  }
+}
+
+export function decodeLifecycleContinuation(value: unknown): LifecycleContinuation {
+  const continuation = record(value, 'continuation')
+  const continuationVersion = continuation.continuationVersion
+  if (continuationVersion !== LIFECYCLE_CONTINUATION_VERSION) {
+    throw decodeError(`Unsupported lifecycle continuation version ${String(continuationVersion)}`)
+  }
+
+  const decoded: LifecycleContinuation = {
+    continuationVersion: LIFECYCLE_CONTINUATION_VERSION,
+    runId: uuid(continuation.runId, 'runId'),
+    trigger: oneOf(
+      continuation.trigger,
+      ['scheduled', 'configuration_change', 'manual', 'recovery'] as const,
+      'trigger'
+    ),
+    generation: uuid(continuation.generation, 'generation'),
+    snapshotAt: timestamp(continuation.snapshotAt, 'snapshotAt'),
+    mode: oneOf(continuation.mode, ['EVALUATE', 'DELETE'] as const, 'mode'),
+    topology: decodeTopology(continuation.topology),
+    counters: decodeCounters(continuation.counters),
+  }
+
+  if (continuation.cursor !== undefined)
+    decoded.cursor = decodeCursor(continuation.cursor, 'cursor')
+  if (continuation.pageEnd !== undefined) {
+    decoded.pageEnd = decodeCursor(continuation.pageEnd, 'pageEnd')
+  }
+  if (continuation.batch !== undefined) decoded.batch = decodeBatch(continuation.batch)
+
+  if (decoded.batch?.versions.length && decoded.pageEnd === undefined) {
+    throw decodeError('A lifecycle continuation batch requires pageEnd')
+  }
+
+  return decoded
+}
+
+function decodeTopology(value: unknown): LifecycleShardTopology {
+  const topology = record(value, 'topology')
+  const shardCount = safeInteger(topology.shardCount, 'topology.shardCount', 1, 1024)
+  const shardId = safeInteger(topology.shardId, 'topology.shardId', 0, shardCount - 1)
+
+  return {
+    scanKind: oneOf(topology.scanKind, ['NONCURRENT', 'CURRENT'] as const, 'topology.scanKind'),
+    epoch: positiveBigint(topology.epoch, 'topology.epoch'),
+    shardId,
+    shardCount,
+  }
+}
+
+function decodeCursor(value: unknown, label: string): NoncurrentLifecycleShardCursor {
+  const cursor = record(value, label)
+  return {
+    archivedAt: timestamp(cursor.archivedAt, `${label}.archivedAt`),
+    name: string(cursor.name, `${label}.name`),
+  }
+}
+
+function decodeCounters(value: unknown): LifecycleRunCounters {
+  const counters = record(value, 'counters')
+  return {
+    versionsExamined: nonnegativeInteger(counters.versionsExamined, 'counters.versionsExamined'),
+    versionsEligible: nonnegativeInteger(counters.versionsEligible, 'counters.versionsEligible'),
+    objectVersionsDeleted: nonnegativeInteger(
+      counters.objectVersionsDeleted,
+      'counters.objectVersionsDeleted'
+    ),
+    deleteMarkersDeleted: nonnegativeInteger(
+      counters.deleteMarkersDeleted,
+      'counters.deleteMarkersDeleted'
+    ),
+    bytesDeleted: nonnegativeInteger(counters.bytesDeleted, 'counters.bytesDeleted'),
+    batchesCompleted: nonnegativeInteger(counters.batchesCompleted, 'counters.batchesCompleted'),
+  }
+}
+
+function decodeBatch(value: unknown): LifecycleContinuationBatch {
+  const batch = record(value, 'batch')
+  if (!Array.isArray(batch.versions) || batch.versions.length > LIFECYCLE_MAX_PAGE_SIZE) {
+    throw decodeError(`batch.versions must contain at most ${LIFECYCLE_MAX_PAGE_SIZE} entries`)
+  }
+
+  const versions = batch.versions.map((entry, index): LifecycleBatchVersion => {
+    const version = record(entry, `batch.versions[${index}]`)
+    if (
+      !Array.isArray(version.artifacts) ||
+      (version.artifacts.length !== 0 && version.artifacts.length !== 2)
+    ) {
+      throw decodeError(`batch.versions[${index}].artifacts must contain 0 or 2 entries`)
+    }
+    return {
+      name: string(version.name, `batch.versions[${index}].name`),
+      version:
+        version.version === null
+          ? null
+          : string(version.version, `batch.versions[${index}].version`),
+      artifacts: version.artifacts.map((artifact, artifactIndex) =>
+        decodeArtifact(artifact, `batch.versions[${index}].artifacts[${artifactIndex}]`)
+      ),
+    }
+  })
+
+  const decoded: LifecycleContinuationBatch = { versions }
+  if (batch.inFlight !== undefined) decoded.inFlight = decodeAttempt(batch.inFlight)
+  return decoded
+}
+
+function decodeArtifact(value: unknown, label: string): LifecycleArtifact {
+  const artifact = record(value, label)
+  const decoded: LifecycleArtifact = {
+    key: string(artifact.key, `${label}.key`),
+    outcome: oneOf(
+      artifact.outcome,
+      ['UNRESOLVED', 'DELETED', 'ABSENT', 'FAILED'] as const,
+      `${label}.outcome`
+    ),
+  }
+  if (artifact.error !== undefined) decoded.error = string(artifact.error, `${label}.error`)
+  return decoded
+}
+
+function decodeAttempt(value: unknown): LifecycleInFlightAttempt {
+  const attempt = record(value, 'batch.inFlight')
+  return {
+    attemptId: uuid(attempt.attemptId, 'batch.inFlight.attemptId'),
+    authorizedGeneration: uuid(attempt.authorizedGeneration, 'batch.inFlight.authorizedGeneration'),
+    startedAt: timestamp(attempt.startedAt, 'batch.inFlight.startedAt'),
+  }
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw decodeError(`${label} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0)
+    throw decodeError(`${label} must be a string`)
+  return value
+}
+
+function uuid(value: unknown, label: string): string {
+  const parsed = string(value, label)
+  if (!UUID.test(parsed)) throw decodeError(`${label} must be a UUID`)
+  return parsed
+}
+
+function timestamp(value: unknown, label: string): string {
+  const parsed = string(value, label)
+  if (Number.isNaN(Date.parse(parsed))) throw decodeError(`${label} must be an ISO timestamp`)
+  return parsed
+}
+
+function signedBigint(value: unknown, label: string): string {
+  const parsed = string(value, label)
+  if (!BIGINT.test(parsed)) throw decodeError(`${label} must be a bigint decimal string`)
+  const bigint = BigInt(parsed)
+  if (bigint < MIN_SIGNED_BIGINT || bigint > MAX_SIGNED_BIGINT) {
+    throw decodeError(`${label} is outside the signed bigint range`)
+  }
+  return parsed
+}
+
+function positiveBigint(value: unknown, label: string): string {
+  const parsed = signedBigint(value, label)
+  if (BigInt(parsed) < 1n) throw decodeError(`${label} must be positive`)
+  return parsed
+}
+
+function nonnegativeInteger(value: unknown, label: string): number {
+  return safeInteger(value, label, 0, Number.MAX_SAFE_INTEGER)
+}
+
+function safeInteger(value: unknown, label: string, minimum: number, maximum: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    throw decodeError(`${label} must be an integer between ${minimum} and ${maximum}`)
+  }
+  return value as number
+}
+
+function oneOf<T extends readonly string[]>(value: unknown, values: T, label: string): T[number] {
+  if (typeof value !== 'string' || !values.includes(value)) {
+    throw decodeError(`${label} must be one of ${values.join(', ')}`)
+  }
+  return value as T[number]
+}
+
+function decodeError(message: string) {
+  return new LifecycleContinuationDecodeError(message)
+}

--- a/src/storage/lifecycle/index.ts
+++ b/src/storage/lifecycle/index.ts
@@ -1,2 +1,3 @@
 export * from './configuration'
+export * from './continuation'
 export * from './guards'

--- a/src/storage/schemas/lifecycle.ts
+++ b/src/storage/schemas/lifecycle.ts
@@ -65,6 +65,114 @@ export interface BucketLifecycleConfiguration {
   rules: LifecycleRule[]
 }
 
+export interface LifecycleEvaluationRule {
+  cutoffAt: string
+  newerNoncurrentVersions?: number
+}
+
+export const LIFECYCLE_MAX_PAGE_SIZE = 500
+
+export interface NoncurrentLifecycleShardCursor {
+  archivedAt: string
+  name: string
+}
+
+export interface LifecycleCandidate {
+  id: string
+  bucketId: string
+  name: string
+  version: string | null
+  isVersioned: boolean
+  isDeleteMarker: boolean
+  metadata: Record<string, unknown> | null
+  createdAt: string
+  archivedAt: string
+}
+
+export interface LifecycleCandidateIdentity {
+  name: string
+  version: string | null
+  isDeleteMarker: boolean
+}
+
+export interface LifecycleEvaluationPage {
+  rawRowsExamined: number
+  candidates: LifecycleCandidateIdentity[]
+  pageEnd?: NoncurrentLifecycleShardCursor
+  exhausted: boolean
+}
+
+export interface EvaluateNoncurrentLifecyclePageInput {
+  bucketId: string
+  snapshotAt: string
+  cursor?: NoncurrentLifecycleShardCursor
+  rules: LifecycleEvaluationRule[]
+  pageSize: number
+}
+
+export const LIFECYCLE_CONTINUATION_VERSION = 1 as const
+
+export type LifecycleExecutionMode = 'EVALUATE' | 'DELETE'
+
+export type LifecycleScanKind = 'NONCURRENT' | 'CURRENT'
+
+export type LifecycleTrigger = 'scheduled' | 'configuration_change' | 'manual' | 'recovery'
+
+export interface LifecycleShardTopology {
+  scanKind: LifecycleScanKind
+  epoch: string
+  shardId: number
+  shardCount: number
+}
+
+export interface LifecycleRunCounters {
+  versionsExamined: number
+  versionsEligible: number
+  objectVersionsDeleted: number
+  deleteMarkersDeleted: number
+  bytesDeleted: number
+  batchesCompleted: number
+}
+
+export type LifecycleArtifactOutcome = 'UNRESOLVED' | 'DELETED' | 'ABSENT' | 'FAILED'
+
+export interface LifecycleArtifact {
+  key: string
+  outcome: LifecycleArtifactOutcome
+  error?: string
+}
+
+export interface LifecycleBatchVersion {
+  name: string
+  version: string | null
+  artifacts: LifecycleArtifact[]
+}
+
+export interface LifecycleInFlightAttempt {
+  attemptId: string
+  authorizedGeneration: string
+  startedAt: string
+}
+
+export interface LifecycleContinuationBatch {
+  versions: LifecycleBatchVersion[]
+  inFlight?: LifecycleInFlightAttempt
+}
+
+export interface LifecycleContinuation {
+  continuationVersion: typeof LIFECYCLE_CONTINUATION_VERSION
+  runId: string
+  trigger: LifecycleTrigger
+  generation: string
+  snapshotAt: string
+  mode: LifecycleExecutionMode
+  topology: LifecycleShardTopology
+  cursor?: NoncurrentLifecycleShardCursor
+  pageEnd?: NoncurrentLifecycleShardCursor
+  counters: LifecycleRunCounters
+  batch?: LifecycleContinuationBatch
+}
+
 export type LifecycleBucket = Pick<Bucket, 'id' | 'name' | 'type'> & {
   lifecycle_configuration: BucketLifecycleConfiguration | null
   lifecycle_configuration_generation: string | null


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the new behavior?

* compile enabled noncurrent-expiration rules against a frozen UTC snapshot into cutoffs and drop dominated rules.
* build the bounded candidate query (archived time, C-collated name, snapshot bound, retention count) and journal for continuation of unfinished deletes.
