### PR TITLE
fix: preserve caller scope through repeated service adapters

### DIFF
--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -257,7 +257,7 @@ export class StoragePgDB implements Database {
     return new StoragePgDB(this.connection.asSuperUser(), {
       ...this.options,
       tnx: this.options.tnx,
-      parentConnection: this.connection,
+      parentConnection: this.options.parentConnection ?? this.connection,
       parentTnx: this.options.tnx,
     })
   }

--- a/src/test/storage-pg-db.test.ts
+++ b/src/test/storage-pg-db.test.ts
@@ -355,6 +355,28 @@ describe('StoragePgDB bucket metadata', () => {
     ).resolves.toBeUndefined()
   })
 
+  it('keeps the caller scope when a service adapter is derived repeatedly', async () => {
+    await withAuthenticatedDb('storage-pg-db-repeated-super-user', async (authenticatedDb) => {
+      await authenticatedDb.withTransaction(async (tx) => {
+        const serviceDb = tx.asSuperUser().asSuperUser()
+
+        await expect(
+          runStorageQuery(serviceDb, 'RepeatedSuperUserRole', readCurrentRoleFromExecutor)
+        ).resolves.toBe(superUser.payload.role)
+        await expect(readCurrentRole(tx)).resolves.toBe('authenticated')
+
+        const failure = new Error('failed repeated super-user query')
+        await expect(
+          runStorageQuery(serviceDb, 'RepeatedSuperUserFailure', async (pg) => {
+            expect(await readCurrentRoleFromExecutor(pg)).toBe(superUser.payload.role)
+            throw failure
+          })
+        ).rejects.toBe(failure)
+        await expect(readCurrentRole(tx)).resolves.toBe('authenticated')
+      })
+    })
+  })
+
   it('restores parent transaction scope after failed super-user queries', async () => {
     await withAuthenticatedDb('storage-pg-db-authenticated-jwt', async (authenticatedDb) => {
       await authenticatedDb.withTransaction(async (tx) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A second `asSuperUser()` on an already-elevated adapter does not switch the session.

## What is the new behavior?

Repeated calls keep the original parent so the query runs as service and the caller role is restored afterward.