### PR TITLE
fix: confirm backend object absence and preserve nullable version

### DIFF
--- a/src/storage/backend/adapter.test.ts
+++ b/src/storage/backend/adapter.test.ts
@@ -1,0 +1,79 @@
+import { ERRORS, StorageBackendError } from '@internal/errors'
+import { describe, expect, it } from 'vitest'
+import {
+  isMissingBackendObject,
+  SEPARATOR,
+  splitOptionalVersion,
+  withOptionalVersion,
+} from './adapter'
+
+describe('isMissingBackendObject', () => {
+  it('recognizes confirmed object absence and filesystem ENOENT', () => {
+    expect(isMissingBackendObject(Object.assign(new Error('missing'), { code: 'ENOENT' }))).toBe(
+      true
+    )
+    expect(
+      isMissingBackendObject(
+        StorageBackendError.fromError(
+          Object.assign(new Error('missing'), {
+            name: 'NoSuchKey',
+            $metadata: { httpStatusCode: 404 },
+          })
+        )
+      )
+    ).toBe(true)
+  })
+
+  it('does not infer backend absence from missing database metadata', () => {
+    expect(isMissingBackendObject(ERRORS.NoSuchKey('key'))).toBe(false)
+  })
+
+  it.each([
+    'NoSuchBucket',
+    'NotFound',
+    'AccessDenied',
+  ])('does not treat %s as proven object absence', (name) => {
+    const error = StorageBackendError.fromError(
+      Object.assign(new Error(name), {
+        name,
+        $metadata: { httpStatusCode: 404 },
+      })
+    )
+    expect(isMissingBackendObject(error)).toBe(false)
+  })
+
+  it('does not trust a NoSuchKey label without a matching 404 status', () => {
+    const error = StorageBackendError.fromError(
+      Object.assign(new Error('missing'), {
+        name: 'NoSuchKey',
+        $metadata: { httpStatusCode: 503 },
+      })
+    )
+    expect(isMissingBackendObject(error)).toBe(false)
+  })
+})
+
+describe('withOptionalVersion', () => {
+  it('keeps legacy and absent versions on the unsuffixed physical key', () => {
+    expect(withOptionalVersion('bucket/key')).toBe('bucket/key')
+    expect(withOptionalVersion('bucket/key', null)).toBe('bucket/key')
+  })
+
+  it('suffixes ordinary internal versions', () => {
+    expect(withOptionalVersion('bucket/key', 'version-id')).toBe(`bucket/key${SEPARATOR}version-id`)
+  })
+
+  it('splits a physical revision using the configured separator', () => {
+    expect(splitOptionalVersion(`bucket/key${SEPARATOR}version-id`)).toEqual({
+      key: 'bucket/key',
+      version: 'version-id',
+    })
+  })
+
+  it('treats a key without the configured separator as a legacy revision', () => {
+    expect(splitOptionalVersion('object')).toEqual({
+      key: 'object',
+      version: null,
+    })
+  })
+})

--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -1,3 +1,4 @@
+import { isS3Error, StorageBackendError } from '@internal/errors'
 import { Readable } from 'stream'
 import { getConfig } from '../../config'
 
@@ -48,6 +49,11 @@ export type CopyObjectOptions = {
   copyMetadata?: boolean
 }
 
+export type HeadObjectOptions = {
+  /** Confirm ambiguous absence with an extra backend request. Defaults to false. */
+  confirmMissing?: boolean
+}
+
 export interface DeleteObjectDetailedResult {
   key: string
   // DELETED also covers an already-absent key. UNKNOWN may have been deleted.
@@ -90,7 +96,7 @@ export abstract class StorageBackendAdapter {
   async getObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     headers?: BrowserCacheHeaders,
     signal?: AbortSignal
   ): Promise<ObjectResponse> {
@@ -108,7 +114,7 @@ export abstract class StorageBackendAdapter {
   async uploadObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     body: NodeJS.ReadableStream,
     contentType: string,
     cacheControl: string,
@@ -124,7 +130,11 @@ export abstract class StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async deleteObject(bucket: string, key: string, version: string | undefined): Promise<void> {
+  async deleteObject(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<void> {
     throw new Error('deleteObject not implemented')
   }
 
@@ -141,9 +151,9 @@ export abstract class StorageBackendAdapter {
   async copyObject(
     bucket: string,
     source: string,
-    version: string | undefined,
+    version: string | null | undefined,
     destination: string,
-    destinationVersion: string | undefined,
+    destinationVersion: string | null | undefined,
     metadata?: { cacheControl?: string; mimetype?: string },
     conditions?: {
       ifMatch?: string
@@ -182,7 +192,8 @@ export abstract class StorageBackendAdapter {
   async headObject(
     bucket: string,
     key: string,
-    version: string | undefined
+    version: string | null | undefined,
+    options?: HeadObjectOptions
   ): Promise<ObjectMetadata> {
     throw new Error('headObject not implemented')
   }
@@ -193,14 +204,18 @@ export abstract class StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async privateAssetUrl(bucket: string, key: string, version: string | undefined): Promise<string> {
+  async privateAssetUrl(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<string> {
     throw new Error('privateAssetUrl not implemented')
   }
 
   async createMultiPartUpload(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     contentType: string,
     cacheControl: string,
     metadata?: Record<string, string>
@@ -242,7 +257,7 @@ export abstract class StorageBackendAdapter {
     bucketName: string,
     key: string,
     uploadId: string,
-    version?: string
+    version?: string | null
   ): Promise<void> {
     throw new Error('not implemented')
   }
@@ -254,7 +269,7 @@ export abstract class StorageBackendAdapter {
     UploadId: string,
     PartNumber: number,
     sourceKey: string,
-    sourceKeyVersion?: string,
+    sourceKeyVersion?: string | null,
     bytes?: { fromByte: number; toByte: number }
   ): Promise<{ eTag?: string; lastModified?: Date }> {
     throw new Error('not implemented')
@@ -271,6 +286,22 @@ export const PATH_SEPARATOR = '/'
 export const FILE_VERSION_SEPARATOR = '-$v-'
 export const SEPARATOR = tusUseFileVersionSeparator ? FILE_VERSION_SEPARATOR : PATH_SEPARATOR
 
-export function withOptionalVersion(key: string, version?: string): string {
+export function withOptionalVersion(key: string, version?: string | null): string {
   return version ? `${key}${SEPARATOR}${version}` : key
+}
+
+export function splitOptionalVersion(key: string): { key: string; version: string | null } {
+  const separatorIndex = key.lastIndexOf(SEPARATOR)
+  const version = separatorIndex < 0 ? '' : key.slice(separatorIndex + SEPARATOR.length)
+  if (version === '') return { key, version: null }
+
+  return { key: key.slice(0, separatorIndex), version }
+}
+
+export function isMissingBackendObject(error: unknown): boolean {
+  if (error instanceof StorageBackendError) {
+    const cause = error.getOriginalError()
+    return isS3Error(cause) && cause.name === 'NoSuchKey' && cause.$metadata.httpStatusCode === 404
+  }
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT'
 }

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -90,7 +90,7 @@ export class FileBackend implements StorageBackendAdapter {
   async getObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     headers?: BrowserCacheHeaders
   ): Promise<ObjectResponse> {
     // 'Range: bytes=#######-######
@@ -184,7 +184,7 @@ export class FileBackend implements StorageBackendAdapter {
   async uploadObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     body: NodeJS.ReadableStream,
     contentType: string,
     cacheControl: string,
@@ -222,7 +222,11 @@ export class FileBackend implements StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async deleteObject(bucket: string, key: string, version: string | undefined): Promise<void> {
+  async deleteObject(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<void> {
     try {
       const file = this.resolveSecurePath(withOptionalVersion(`${bucket}/${key}`, version))
       await removePath(file)
@@ -249,9 +253,9 @@ export class FileBackend implements StorageBackendAdapter {
   async copyObject(
     bucket: string,
     source: string,
-    version: string | undefined,
+    version: string | null | undefined,
     destination: string,
-    destinationVersion: string | undefined,
+    destinationVersion: string | null | undefined,
     metadata?: { cacheControl?: string; contentType?: string; mimetype?: string },
     _conditions?: {
       ifMatch?: string
@@ -351,7 +355,7 @@ export class FileBackend implements StorageBackendAdapter {
   async headObject(
     bucket: string,
     key: string,
-    version: string | undefined
+    version: string | null | undefined
   ): Promise<ObjectMetadata> {
     const file = this.resolveSecurePath(withOptionalVersion(`${bucket}/${key}`, version))
 
@@ -374,7 +378,7 @@ export class FileBackend implements StorageBackendAdapter {
   async createMultiPartUpload(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     contentType: string,
     cacheControl: string
   ): Promise<string | undefined> {
@@ -508,7 +512,7 @@ export class FileBackend implements StorageBackendAdapter {
     bucketName: string,
     key: string,
     uploadId: string,
-    version?: string
+    version?: string | null
   ): Promise<void> {
     const multiPartFolder = this.resolveSecurePath(path.join('multiparts', uploadId))
 
@@ -529,7 +533,7 @@ export class FileBackend implements StorageBackendAdapter {
     UploadId: string,
     PartNumber: number,
     sourceKey: string,
-    sourceVersion?: string,
+    sourceVersion?: string | null,
     rangeBytes?: { fromByte: number; toByte: number }
   ): Promise<{ eTag?: string; lastModified?: Date }> {
     const partFilePath = this.resolveSecurePath(
@@ -596,7 +600,11 @@ export class FileBackend implements StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async privateAssetUrl(bucket: string, key: string, version: string | undefined): Promise<string> {
+  async privateAssetUrl(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<string> {
     return 'local:///' + this.resolveSecurePath(withOptionalVersion(`${bucket}/${key}`, version))
   }
 

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import { ErrorCode, isStorageError } from '@internal/errors'
+import { ErrorCode, isStorageError, StorageBackendError } from '@internal/errors'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpRequest } from '@smithy/protocol-http'
 import { MAX_KEYS_PER_S3_DELETE } from '@storage/limits'
@@ -22,7 +22,7 @@ import { Readable } from 'stream'
 import { type Mock, vi } from 'vitest'
 import { getConfig } from '../../../config'
 import { setErrorHandler } from '../../../http/error-handler'
-import { withOptionalVersion } from '../adapter'
+import { type HeadObjectOptions, isMissingBackendObject, withOptionalVersion } from '../adapter'
 import { MAX_PUT_OBJECT_SIZE, S3Backend } from './adapter'
 
 const DEFAULT_S3_UPLOAD_PART_SIZE = 16 * 1024 * 1024
@@ -624,6 +624,152 @@ describe('S3Backend', () => {
     test('returns an empty result without issuing a request', async () => {
       await expect(createBackend().deleteObjectsDetailed('test-bucket', [])).resolves.toEqual([])
       expect(mockSend).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('headObject absence confirmation', () => {
+    function s3Error(name: string, status: number) {
+      return Object.assign(new Error(name), { name, $metadata: { httpStatusCode: status } })
+    }
+
+    async function failure(options?: HeadObjectOptions) {
+      return createBackend()
+        .headObject('test-bucket', 'legacy', null, options)
+        .then(
+          () => {
+            throw new Error('Expected the failed HEAD to remain an error')
+          },
+          (error: unknown) => {
+            if (!(error instanceof StorageBackendError)) throw error
+            return error
+          }
+        )
+    }
+
+    test.each([
+      ['not requested', undefined],
+      ['disabled', { confirmMissing: false }],
+    ] as const)('skips missing-object confirmation when %s', async (_label, options) => {
+      const headError = s3Error('NotFound', 404)
+      mockSend.mockRejectedValueOnce(headError)
+
+      const error = await failure(options)
+
+      expect(error.getOriginalError()).toBe(headError)
+      expect(error.httpStatusCode).toBe(404)
+      expect(isMissingBackendObject(error)).toBe(false)
+      expect(mockSend).toHaveBeenCalledExactlyOnceWith(expect.any(HeadObjectCommand))
+    })
+
+    test.each([
+      ['NoSuchKey', 404, true],
+      ['NoSuchBucket', 404, false],
+    ] as const)('requires an explicit missing key from GET: %s', async (name, status, absent) => {
+      const confirmationError = s3Error(name, status)
+      mockSend.mockRejectedValueOnce(s3Error('NotFound', 404))
+      mockSend.mockRejectedValueOnce(confirmationError)
+
+      const error = await failure({ confirmMissing: true })
+
+      expect(isMissingBackendObject(error)).toBe(absent)
+      expect(error).toMatchObject({ httpStatusCode: status })
+      expect(error.getOriginalError()).toBe(confirmationError)
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(mockSend.mock.calls[1][0]).toBeInstanceOf(GetObjectCommand)
+      expect(mockSend.mock.calls[1][0].input).toEqual({
+        Bucket: 'test-bucket',
+        Key: 'legacy',
+        Range: 'bytes=0-0',
+      })
+      expect(mockSend.mock.calls[1][1]).toEqual({ abortSignal: expect.any(AbortSignal) })
+    })
+
+    test.each([
+      ['NotFound', 404],
+      ['InvalidRange', 416],
+      ['AccessDenied', 403],
+      ['SlowDown', 503],
+      ['NoSuchKey', 503],
+      ['NoSuchBucket', 503],
+    ] as const)('preserves the original HEAD error when GET returns %s', async (name, status) => {
+      const headError = s3Error('NotFound', 404)
+      mockSend.mockRejectedValueOnce(headError)
+      mockSend.mockRejectedValueOnce(s3Error(name, status))
+
+      const error = await failure({ confirmMissing: true })
+
+      expect(error.getOriginalError()).toBe(headError)
+      expect(error.httpStatusCode).toBe(404)
+      expect(isMissingBackendObject(error)).toBe(false)
+      expect(mockSend).toHaveBeenCalledTimes(2)
+    })
+
+    test.each([
+      'NoSuchKey',
+      'NoSuchBucket',
+    ] as const)('keeps explicit HEAD %s errors without another request', async (name) => {
+      mockSend.mockRejectedValueOnce(s3Error(name, 404))
+
+      const error = await failure({ confirmMissing: true })
+
+      expect(isMissingBackendObject(error)).toBe(name === 'NoSuchKey')
+      expect(mockSend).toHaveBeenCalledTimes(1)
+    })
+
+    test.each([
+      Buffer.from('present'),
+      Buffer.alloc(0),
+    ])('preserves an object that appears after HEAD and disposes its GET body', async (bytes) => {
+      const body = Readable.from(bytes)
+      mockSend.mockRejectedValueOnce(s3Error('NotFound', 404))
+      mockSend.mockResolvedValueOnce({
+        $metadata: { httpStatusCode: bytes.length === 0 ? 200 : 206 },
+        Body: body,
+      })
+
+      const error = await failure({ confirmMissing: true })
+
+      expect(isMissingBackendObject(error)).toBe(false)
+      expect(body.destroyed).toBe(true)
+    })
+
+    test('cancels a web stream if a compatible client returns one', async () => {
+      const cancel = vi.fn()
+      const body = new ReadableStream({ cancel })
+      mockSend.mockRejectedValueOnce(s3Error('NotFound', 404))
+      mockSend.mockResolvedValueOnce({ $metadata: { httpStatusCode: 206 }, Body: body })
+
+      expect(isMissingBackendObject(await failure({ confirmMissing: true }))).toBe(false)
+      expect(cancel).toHaveBeenCalledOnce()
+    })
+
+    test('bounds an unresponsive GET and preserves ambiguous absence', async () => {
+      const createTimeout = AbortSignal.timeout.bind(AbortSignal)
+      const timeout = vi
+        .spyOn(AbortSignal, 'timeout')
+        .mockImplementationOnce(() => createTimeout(10))
+      try {
+        const headError = s3Error('NotFound', 404)
+        mockSend.mockRejectedValueOnce(headError)
+        mockSend.mockImplementationOnce(
+          (_command: GetObjectCommand, { abortSignal }: { abortSignal: AbortSignal }) =>
+            new Promise((_resolve, reject) => {
+              abortSignal.addEventListener('abort', () => reject(abortSignal.reason), {
+                once: true,
+              })
+            })
+        )
+
+        const error = await failure({ confirmMissing: true })
+
+        expect(timeout).toHaveBeenCalledWith(5000)
+        expect(mockSend.mock.calls[1][1].abortSignal.aborted).toBe(true)
+        expect(error.getOriginalError()).toBe(headError)
+        expect(error.httpStatusCode).toBe(404)
+        expect(isMissingBackendObject(error)).toBe(false)
+      } finally {
+        timeout.mockRestore()
+      }
     })
   })
 

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -20,7 +20,7 @@ import {
 } from '@aws-sdk/client-s3'
 import { Progress, Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import { ERRORS, StorageBackendError } from '@internal/errors'
+import { ERRORS, isS3Error, StorageBackendError } from '@internal/errors'
 import { createAgent, InstrumentedAgent } from '@internal/http'
 import { monitorStream } from '@internal/streams'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
@@ -31,6 +31,7 @@ import {
   BrowserCacheHeaders,
   CopyObjectOptions,
   DeleteObjectDetailedResult,
+  HeadObjectOptions,
   ObjectMetadata,
   ObjectResponse,
   StorageBackendAdapter,
@@ -49,6 +50,7 @@ const {
 } = getConfig()
 
 export const MAX_PUT_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 // 5GB
+const MISSING_OBJECT_CONFIRMATION_TIMEOUT_MS = 5000
 
 export interface S3ClientOptions {
   endpoint?: string
@@ -110,7 +112,7 @@ export class S3Backend implements StorageBackendAdapter {
   async getObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     headers?: BrowserCacheHeaders,
     signal?: AbortSignal
   ): Promise<ObjectResponse> {
@@ -159,7 +161,7 @@ export class S3Backend implements StorageBackendAdapter {
   async uploadObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     body: Readable,
     contentType: string,
     cacheControl: string,
@@ -200,7 +202,7 @@ export class S3Backend implements StorageBackendAdapter {
   protected async putObject(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     body: Readable,
     contentType: string,
     cacheControl: string,
@@ -245,7 +247,7 @@ export class S3Backend implements StorageBackendAdapter {
   protected async bufferedMultipartUpload(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     body: Readable,
     contentType: string,
     cacheControl: string,
@@ -323,7 +325,11 @@ export class S3Backend implements StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async deleteObject(bucket: string, key: string, version: string | undefined): Promise<void> {
+  async deleteObject(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<void> {
     const command = new DeleteObjectCommand({
       Bucket: bucket,
       Key: withOptionalVersion(key, version),
@@ -344,9 +350,9 @@ export class S3Backend implements StorageBackendAdapter {
   async copyObject(
     bucket: string,
     source: string,
-    version: string | undefined,
+    version: string | null | undefined,
     destination: string,
-    destinationVersion: string | undefined,
+    destinationVersion: string | null | undefined,
     metadata?: { cacheControl?: string; mimetype?: string },
     conditions?: {
       ifMatch?: string
@@ -535,7 +541,8 @@ export class S3Backend implements StorageBackendAdapter {
   async headObject(
     bucket: string,
     key: string,
-    version: string | undefined
+    version: string | null | undefined,
+    options?: HeadObjectOptions
   ): Promise<ObjectMetadata> {
     try {
       const command = new HeadObjectCommand({
@@ -553,7 +560,38 @@ export class S3Backend implements StorageBackendAdapter {
         size: data.ContentLength || 0,
       }
     } catch (e) {
+      if (
+        options?.confirmMissing &&
+        isS3Error(e) &&
+        e.$metadata.httpStatusCode === 404 &&
+        e.name !== 'NoSuchKey' &&
+        e.name !== 'NoSuchBucket'
+      ) {
+        // HEAD has no error body. A missing bucket and a missing object can both
+        // appear as NotFound, so destructive callers need GET's structured error.
+        await this.confirmMissingObject(bucket, withOptionalVersion(key, version))
+      }
       throw StorageBackendError.fromError(e)
+    }
+  }
+
+  private async confirmMissingObject(bucket: string, key: string): Promise<void> {
+    try {
+      const response = await this.client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: key, Range: 'bytes=0-0' }),
+        { abortSignal: AbortSignal.timeout(MISSING_OBJECT_CONFIRMATION_TIMEOUT_MS) }
+      )
+      if (response.Body instanceof Readable) response.Body.destroy()
+      else if (response.Body instanceof ReadableStream) await response.Body.cancel()
+    } catch (error) {
+      if (
+        isS3Error(error) &&
+        error.$metadata.httpStatusCode === 404 &&
+        (error.name === 'NoSuchKey' || error.name === 'NoSuchBucket')
+      ) {
+        throw StorageBackendError.fromError(error)
+      }
+      // Inconclusive confirmation leaves the original HEAD error intact.
     }
   }
 
@@ -592,7 +630,11 @@ export class S3Backend implements StorageBackendAdapter {
    * @param key
    * @param version
    */
-  async privateAssetUrl(bucket: string, key: string, version: string | undefined): Promise<string> {
+  async privateAssetUrl(
+    bucket: string,
+    key: string,
+    version: string | null | undefined
+  ): Promise<string> {
     const input: GetObjectCommandInput = {
       Bucket: bucket,
       Key: withOptionalVersion(key, version),
@@ -605,7 +647,7 @@ export class S3Backend implements StorageBackendAdapter {
   async createMultiPartUpload(
     bucketName: string,
     key: string,
-    version: string | undefined,
+    version: string | null | undefined,
     contentType: string,
     cacheControl: string,
     metadata?: Record<string, string>
@@ -727,7 +769,7 @@ export class S3Backend implements StorageBackendAdapter {
     bucketName: string,
     key: string,
     uploadId: string,
-    version?: string
+    version?: string | null
   ): Promise<void> {
     const abortUpload = new AbortMultipartUploadCommand({
       Bucket: bucketName,
@@ -744,7 +786,7 @@ export class S3Backend implements StorageBackendAdapter {
     UploadId: string,
     PartNumber: number,
     sourceKey: string,
-    sourceKeyVersion?: string,
+    sourceKeyVersion?: string | null,
     bytesRange?: { fromByte: number; toByte: number }
   ) {
     const uploadPartCopy = new UploadPartCopyCommand({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Version type is lying at the moment, it can be null.
S3 head is bodyless and ambiguous for missing.

## What is the new behavior?

Align type with runtime so that downstream can pass version directly.
Failing S3 head does a zero byte ranged get to resolve ambiguity.
Add utils for reverse version mapping.