### PR TITLE
fix: preserve equals signs in OTLP metrics headers

### DIFF
--- a/src/internal/monitoring/otel-metrics.test.ts
+++ b/src/internal/monitoring/otel-metrics.test.ts
@@ -3,6 +3,7 @@ interface OTelGlobalState {
 }
 
 import fs from 'node:fs'
+import type { Metadata } from '@grpc/grpc-js'
 import { vi } from 'vitest'
 import { HTTP_SIZE_METRICS_AGGREGATION_CARDINALITY_LIMIT } from './metric-limits'
 
@@ -53,6 +54,8 @@ describe('otel metrics', () => {
   })
 
   test('still shuts down meter provider when unregister throws', async () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS =
+      'authorization=Basic dXNlcjpwYXNz==,x-api-key=metrics-token'
     const shutdown = vi.fn().mockResolvedValue(undefined)
     const unregisterError = new Error('metrics unregister failed')
     const unregisterMetricInstrumentations = vi.fn(() => {
@@ -75,7 +78,9 @@ describe('otel metrics', () => {
         getMetricsRequestHandler: vi.fn(),
       }
     })
-    const OTLPMetricExporter = vi.fn(function () {
+    let metricExporterOptions: { metadata: Metadata } | undefined
+    const OTLPMetricExporter = vi.fn(function (options: { metadata: Metadata }) {
+      metricExporterOptions = options
       return {}
     })
     const RuntimeNodeInstrumentation = vi.fn(function () {
@@ -155,6 +160,8 @@ describe('otel metrics', () => {
     expect(OTLPMetricExporter).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'http://metrics-collector:4317' })
     )
+    expect(metricExporterOptions?.metadata.get('authorization')).toEqual(['Basic dXNlcjpwYXNz=='])
+    expect(metricExporterOptions?.metadata.get('x-api-key')).toEqual(['metrics-token'])
     expect(unregisterMetricInstrumentations.mock.invocationCallOrder[0]).toBeLessThan(
       shutdown.mock.invocationCallOrder[0]
     )

--- a/src/internal/monitoring/otel-metrics.ts
+++ b/src/internal/monitoring/otel-metrics.ts
@@ -76,7 +76,17 @@ const exporterHeaders = headersEnv
   .filter(Boolean)
   .reduce(
     (all, header) => {
-      const [name, value] = header.split('=')
+      const separator = header.indexOf('=')
+      if (separator <= 0 || separator === header.length - 1) {
+        return all
+      }
+
+      const name = header.slice(0, separator).trim()
+      const value = header.slice(separator + 1).trim()
+      if (!name || !value) {
+        return all
+      }
+
       all[name] = value
       return all
     },


### PR DESCRIPTION
## Summary

Preserve complete OTLP metrics header values when they contain additional `=` characters.

Closes #1374.

## Problem

`OTEL_EXPORTER_OTLP_METRICS_HEADERS` was parsed with `header.split('=')` and array destructuring. Values such as padded Base64 credentials were therefore truncated after the first value segment:

```text
authorization=Basic dXNlcjpwYXNz==
```

became `Basic dXNlcjpwYXNz`.

## Change

- Split each entry at its first `=` separator, matching the existing trace-header parser.
- Preserve the remainder as the complete header value.
- Ignore malformed entries with a missing name or value.
- Add regression coverage at the `OTLPMetricExporter` metadata boundary.

## Validation

- `npm run test:unit -- --run src/internal/monitoring/otel-metrics.test.ts` — 6 passed
- `npm run build` — passed
- `npm run lint` — passed (Biome: 604 files; Prettier: all files matched)
- `git diff --check` — passed

The complete unit suite was also attempted in the fresh worktree, but repository-wide test setup requires environment configuration such as `PGRST_JWT_SECRET`; affected suites fail during config loading before running tests. The focused regression suite above is self-contained and passes.

## Compatibility

No configuration or API changes. Existing single-`=` headers retain their current behavior.
