### PR TITLE
feat: add noncurrent lifecycle engine

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -92,14 +92,16 @@ S3_PROTOCOL_ACCESS_KEY_SECRET=67d161a7a8a46a24a17a75b26e7724f11d56b8d49a119227c6
 #######################################
 STORAGE_BACKEND=s3
 
-# Enable the REST and S3 bucket lifecycle configuration APIs.
-STORAGE_LIFECYCLE_ENABLED=false
+# Enable versioning and lifecycle. S3 lifecycle deletion requires compatible versioning writers.
+STORAGE_VERSIONING_ENABLED=false
+STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS=5000
 
 #######################################
 # S3 Backend
 #######################################
 STORAGE_S3_BUCKET=supa-storage-bucket
 STORAGE_S3_MAX_SOCKETS=200
+STORAGE_S3_CLIENT_TIMEOUT=5000
 STORAGE_S3_ENDPOINT=http://127.0.0.1:9000
 STORAGE_S3_FORCE_PATH_STYLE=true
 STORAGE_S3_REGION=us-east-1

--- a/migrations/multitenant/0030-object-versioning-feature.sql
+++ b/migrations/multitenant/0030-object-versioning-feature.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS feature_object_versioning boolean NOT NULL DEFAULT false;

--- a/migrations/multitenant/0031-lifecycle-tenants.sql
+++ b/migrations/multitenant/0031-lifecycle-tenants.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS lifecycle_tenants (
+    tenant_id text PRIMARY KEY
+      REFERENCES tenants(id)
+      ON DELETE CASCADE,
+
+    next_dispatch_at timestamptz NOT NULL DEFAULT now(),
+
+    claim_id uuid,
+    claim_until timestamptz,
+
+    last_dispatched_at timestamptz,
+    last_completed_at timestamptz,
+    last_success_at timestamptz,
+
+    failure_count integer NOT NULL DEFAULT 0,
+    last_error jsonb,
+
+    CONSTRAINT lifecycle_tenants_failure_count_check
+      CHECK (failure_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS lifecycle_tenants_due_idx
+ON lifecycle_tenants (
+    next_dispatch_at,
+    tenant_id
+);
+
+CREATE INDEX IF NOT EXISTS lifecycle_tenants_expired_claim_idx
+ON lifecycle_tenants (
+    claim_until,
+    tenant_id
+)
+WHERE claim_until IS NOT NULL;

--- a/migrations/tenant/0070-noncurrent-lifecycle.sql
+++ b/migrations/tenant/0070-noncurrent-lifecycle.sql
@@ -1,0 +1,249 @@
+-- Add lifecycle execution controls and durable shard state to the versioning schema.
+
+ALTER TABLE storage.buckets
+  ADD COLUMN IF NOT EXISTS lifecycle_shard_epoch bigint NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS lifecycle_shard_count integer NOT NULL DEFAULT 1;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_lifecycle_shard_epoch_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_lifecycle_shard_epoch_check
+      CHECK (lifecycle_shard_epoch >= 1) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_lifecycle_shard_count_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_lifecycle_shard_count_check
+      CHECK (lifecycle_shard_count BETWEEN 1 AND 1024) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'storage.buckets'::regclass
+      AND conname = 'buckets_lifecycle_standard_only_check'
+  ) THEN
+    ALTER TABLE storage.buckets
+    ADD CONSTRAINT buckets_lifecycle_standard_only_check CHECK (
+      type = 'STANDARD'
+      OR (
+        lifecycle_shard_epoch = 1
+        AND lifecycle_shard_count = 1
+      )
+    ) NOT VALID;
+  END IF;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS storage.bucket_lifecycle_states (
+    bucket_id text NOT NULL,
+    scan_kind text NOT NULL DEFAULT 'NONCURRENT',
+    shard_id integer NOT NULL,
+    shard_epoch bigint NOT NULL,
+    shard_count integer NOT NULL,
+    configuration_generation uuid NOT NULL,
+    next_run_at timestamptz,
+    claim_id uuid,
+    claim_until timestamptz,
+    continuation jsonb,
+    last_started_at timestamptz,
+    last_completed_at timestamptz,
+    last_success_at timestamptz,
+    last_result jsonb,
+    failure_count integer NOT NULL DEFAULT 0,
+    last_error jsonb,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (bucket_id, scan_kind, shard_id),
+
+    CONSTRAINT bucket_lifecycle_states_bucket_id_fkey
+      FOREIGN KEY (bucket_id)
+      REFERENCES storage.buckets(id)
+      ON DELETE RESTRICT,
+
+    CONSTRAINT bucket_lifecycle_scan_kind_check
+      CHECK (scan_kind IN ('NONCURRENT', 'CURRENT')),
+
+    CONSTRAINT bucket_lifecycle_shard_shape_check
+      CHECK (
+        shard_epoch >= 1
+        AND shard_count BETWEEN 1 AND 1024
+        AND shard_id >= 0
+        AND shard_id < shard_count
+      ),
+
+    CONSTRAINT bucket_lifecycle_failure_count_check
+      CHECK (failure_count >= 0),
+
+    CONSTRAINT bucket_lifecycle_continuation_object_check
+      CHECK (
+        continuation IS NULL
+        OR jsonb_typeof(continuation) = 'object'
+      ),
+
+    CONSTRAINT bucket_lifecycle_recovery_due_check
+      CHECK (
+        next_run_at IS NOT NULL
+        OR NOT jsonb_path_exists(
+          COALESCE(continuation, '{}'::jsonb),
+          '$.batch.inFlight'
+        )
+      ),
+
+    CONSTRAINT bucket_lifecycle_last_result_object_check
+      CHECK (
+        last_result IS NULL
+        OR jsonb_typeof(last_result) = 'object'
+      )
+);
+
+CREATE INDEX IF NOT EXISTS bucket_lifecycle_states_due_idx
+ON storage.bucket_lifecycle_states (
+    next_run_at,
+    bucket_id,
+    scan_kind,
+    shard_id
+)
+WHERE next_run_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS bucket_lifecycle_states_expired_claim_idx
+ON storage.bucket_lifecycle_states (
+    claim_until,
+    bucket_id,
+    scan_kind,
+    shard_id
+)
+WHERE claim_until IS NOT NULL;
+
+ALTER TABLE storage.bucket_lifecycle_states ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    anon_role text = COALESCE(current_setting('storage.anon_role', true), 'anon');
+    authenticated_role text = COALESCE(current_setting('storage.authenticated_role', true), 'authenticated');
+    service_role text = COALESCE(current_setting('storage.service_role', true), 'service_role');
+    super_user text = COALESCE(current_setting('storage.super_user', true), 'postgres');
+    role_name text;
+BEGIN
+    REVOKE ALL ON TABLE storage.bucket_lifecycle_states FROM PUBLIC;
+
+    FOREACH role_name IN ARRAY ARRAY[anon_role, authenticated_role]
+    LOOP
+      IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = role_name) THEN
+        EXECUTE format('REVOKE ALL ON TABLE storage.bucket_lifecycle_states FROM %I', role_name);
+      END IF;
+    END LOOP;
+
+    FOREACH role_name IN ARRAY ARRAY['postgres', super_user, service_role]
+    LOOP
+      IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = role_name) THEN
+        EXECUTE format('GRANT ALL ON TABLE storage.bucket_lifecycle_states TO %I', role_name);
+      END IF;
+    END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION storage.protect_bucket_control_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    service_role text = TG_ARGV[0];
+    configuration_changed boolean;
+    topology_changed boolean;
+    changed_group_count integer;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+      IF NEW.lifecycle_shard_epoch IS DISTINCT FROM 1::bigint
+         OR NEW.lifecycle_shard_count IS DISTINCT FROM 1 THEN
+        RAISE EXCEPTION 'bucket control columns must use their protected defaults on insert'
+          USING ERRCODE = '42501';
+      END IF;
+
+      IF (NEW.lifecycle_configuration IS NOT NULL OR NEW.lifecycle_configuration_generation IS NOT NULL)
+         AND NOT pg_has_role(current_user, service_role, 'MEMBER') THEN
+        RAISE EXCEPTION 'only members of the configured storage service role may insert lifecycle policy state'
+          USING ERRCODE = '42501',
+                HINT = format('Insert with both lifecycle columns NULL and configure lifecycle through the Storage API afterward, or insert as a member of %I.', service_role);
+      END IF;
+      RETURN NEW;
+    END IF;
+
+    configuration_changed =
+      OLD.lifecycle_configuration IS DISTINCT FROM NEW.lifecycle_configuration
+      OR OLD.lifecycle_configuration_generation IS DISTINCT FROM NEW.lifecycle_configuration_generation;
+    topology_changed =
+      OLD.lifecycle_shard_epoch IS DISTINCT FROM NEW.lifecycle_shard_epoch
+      OR OLD.lifecycle_shard_count IS DISTINCT FROM NEW.lifecycle_shard_count;
+
+    changed_group_count =
+      configuration_changed::integer
+      + topology_changed::integer;
+
+    IF changed_group_count = 0 THEN
+      RETURN NEW;
+    END IF;
+
+    IF NEW.type IS DISTINCT FROM 'STANDARD' THEN
+      RAISE EXCEPTION 'bucket lifecycle controls require a Standard bucket'
+        USING ERRCODE = '0A000';
+    END IF;
+
+    IF changed_group_count > 1 THEN
+      RAISE EXCEPTION 'bucket control groups must be changed by separate operations'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF topology_changed THEN
+      RAISE EXCEPTION 'lifecycle shard topology changes are not supported in v1'
+        USING ERRCODE = '0A000';
+    END IF;
+
+    IF configuration_changed THEN
+      IF NEW.lifecycle_configuration IS NULL
+         AND NEW.lifecycle_configuration_generation IS NULL THEN
+        RETURN NEW;
+      END IF;
+
+      IF NEW.lifecycle_configuration IS NULL
+         OR NEW.lifecycle_configuration_generation IS NULL
+         OR OLD.lifecycle_configuration IS NOT DISTINCT FROM NEW.lifecycle_configuration
+         OR OLD.lifecycle_configuration_generation IS NOT DISTINCT FROM NEW.lifecycle_configuration_generation THEN
+        RAISE EXCEPTION 'a changed lifecycle policy requires a new non-null generation'
+          USING ERRCODE = '22023';
+      END IF;
+
+      -- The control-plane AFTER trigger enforces service-role writes after caller RLS.
+      RETURN NEW;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DO $$
+DECLARE
+    service_role text = COALESCE(current_setting('storage.service_role', true), 'service_role');
+BEGIN
+    DROP TRIGGER IF EXISTS protect_bucket_control_insert ON storage.buckets;
+    EXECUTE format(
+      'CREATE TRIGGER protect_bucket_control_insert BEFORE INSERT ON storage.buckets FOR EACH ROW EXECUTE FUNCTION storage.protect_bucket_control_columns(%L)',
+      service_role
+    );
+
+    DROP TRIGGER IF EXISTS protect_bucket_control_update ON storage.buckets;
+    EXECUTE format(
+      'CREATE TRIGGER protect_bucket_control_update BEFORE UPDATE OF lifecycle_configuration, lifecycle_configuration_generation, lifecycle_shard_epoch, lifecycle_shard_count ON storage.buckets FOR EACH ROW EXECUTE FUNCTION storage.protect_bucket_control_columns(%L)',
+      service_role
+    );
+END;
+$$;

--- a/migrations/tenant/0071-validate-bucket-lifecycle-execution-constraints.sql
+++ b/migrations/tenant/0071-validate-bucket-lifecycle-execution-constraints.sql
@@ -1,0 +1,8 @@
+ALTER TABLE storage.buckets
+VALIDATE CONSTRAINT buckets_lifecycle_shard_epoch_check;
+
+ALTER TABLE storage.buckets
+VALIDATE CONSTRAINT buckets_lifecycle_shard_count_check;
+
+ALTER TABLE storage.buckets
+VALIDATE CONSTRAINT buckets_lifecycle_standard_only_check;

--- a/migrations/tenant/0072-noncurrent-lifecycle-archived-order-index.sql
+++ b/migrations/tenant/0072-noncurrent-lifecycle-archived-order-index.sql
@@ -1,0 +1,6 @@
+-- postgres-migrations disable-transaction
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS objects_archived_order_uq
+ON storage.objects (bucket_id, name COLLATE "C", archived_at)
+INCLUDE (version, is_delete_marker)
+WHERE archived_at IS NOT NULL;

--- a/migrations/tenant/0073-noncurrent-lifecycle-archived-due-index.sql
+++ b/migrations/tenant/0073-noncurrent-lifecycle-archived-due-index.sql
@@ -1,0 +1,10 @@
+-- postgres-migrations disable-transaction
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS objects_archived_due_idx
+ON storage.objects (
+    bucket_id,
+    archived_at,
+    name COLLATE "C"
+)
+INCLUDE (version, is_delete_marker)
+WHERE archived_at IS NOT NULL;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,8 +9,24 @@ const CONFIG_ENV_KEYS = [
   'DATABASE_HEALTHCHECK_UNSCOPED',
   'OTEL_EXPORTER_OTLP_ENDPOINT',
   'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
+  'STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS',
+  'STORAGE_LIFECYCLE_PAGE_SIZE',
+  'STORAGE_LIFECYCLE_JOB_BUDGET_MS',
+  'STORAGE_LIFECYCLE_CLAIM_LEASE_MS',
+  'STORAGE_LIFECYCLE_RECOVERY_GRACE_MS',
+  'STORAGE_LIFECYCLE_FAIRNESS_DELAY_MS',
+  'STORAGE_LIFECYCLE_EVALUATION_INTERVAL_MS',
+  'STORAGE_LIFECYCLE_SCHEDULER_CRON',
+  'STORAGE_LIFECYCLE_TENANT_CONCURRENCY',
+  'STORAGE_LIFECYCLE_SHARD_CONCURRENCY',
+  'STORAGE_LIFECYCLE_DISPATCH_LIMIT',
+  'STORAGE_LIFECYCLE_CONFIG_TRANSACTION_TIMEOUT_MS',
+  'STORAGE_S3_CLIENT_TIMEOUT',
+  'STORAGE_BACKEND',
+  'DATABASE_MULTITENANT_QUERY_TIMEOUT',
+  'DATABASE_STATEMENT_TIMEOUT',
   'REQUEST_HARD_LIMITS_ENABLED',
-  'STORAGE_LIFECYCLE_ENABLED',
+  'STORAGE_VERSIONING_ENABLED',
   'STORAGE_S3_REQUEST_CHECKSUM_CALCULATION',
   'STORAGE_S3_RESPONSE_CHECKSUM_VALIDATION',
   'GLOBAL_S3_BUCKET',
@@ -36,6 +52,8 @@ const CONFIG_ENV_KEYS = [
   'PROFILING_MAX_CAPTURES_PER_HOUR',
   'AUTH_URL_SIGNING_JWK_TYPE',
   'AUTH_JWT_ALGORITHM',
+  'AUTH_JWT_SECRET',
+  'DATABASE_URL',
 ] as const
 
 type ConfigEnvKey = (typeof CONFIG_ENV_KEYS)[number]
@@ -84,15 +102,70 @@ describe('tenant pool cache config parsing', () => {
     expect(config.tenantPoolCacheMaxEntries).toBe(16_384)
     expect(config.databasePoolDrainTimeout).toBe(30_000)
     expect(config.requestHardLimitsEnabled).toBe(false)
-    expect(config.storageLifecycleEnabled).toBe(false)
+    expect(config.versioningEnabled).toBe(false)
+    expect(config.storageLifecycleObjectLockTimeoutMs).toBe(5000)
+    expect(config.storageLifecyclePageSize).toBe(500)
+    expect(config.storageLifecycleJobBudgetMs).toBe(20_000)
+    expect(config.storageLifecycleClaimLeaseMs).toBe(120_000)
+    expect(config.storageLifecycleRecoveryGraceMs).toBe(30_000)
+    expect(config.storageLifecycleFairnessDelayMs).toBe(5000)
+    expect(config.storageLifecycleEvaluationIntervalMs).toBe(86_400_000)
+    expect(config.storageLifecycleConfigurationTransactionTimeoutMs).toBe(30_000)
   })
 
-  test('requires explicit opt-in for lifecycle configuration routes', async () => {
-    setConfigEnv({ STORAGE_LIFECYCLE_ENABLED: 'true' })
+  test('requires explicit opt-in for lifecycle execution', async () => {
+    setConfigEnv({
+      STORAGE_VERSIONING_ENABLED: 'true',
+      STORAGE_BACKEND: 's3',
+      STORAGE_S3_CLIENT_TIMEOUT: '60000',
+      STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS: '2500',
+      STORAGE_LIFECYCLE_PAGE_SIZE: '750',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.versioningEnabled).toBe(true)
+    expect(config.storageLifecycleObjectLockTimeoutMs).toBe(2500)
+    expect(config.storageLifecyclePageSize).toBe(500)
+  })
+
+  test('enables multitenant lifecycle APIs with the shared versioning flag', async () => {
+    setConfigEnv({
+      STORAGE_VERSIONING_ENABLED: 'true',
+      STORAGE_BACKEND: 's3',
+      STORAGE_S3_CLIENT_TIMEOUT: '5000',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.isMultitenant).toBe(true)
+    expect(config.versioningEnabled).toBe(true)
+  })
+
+  test('allows the shared versioning flag on the file backend', async () => {
+    setConfigEnv({
+      STORAGE_VERSIONING_ENABLED: 'true',
+      STORAGE_BACKEND: 'file',
+    })
+
+    const { getConfig } = await import('./config')
+    const config = getConfig({ reload: true })
+
+    expect(config.versioningEnabled).toBe(true)
+    expect(config.storageBackendType).toBe('file')
+  })
+
+  test('allows unbounded database statements while multitenant lifecycle is disabled', async () => {
+    setConfigEnv({
+      STORAGE_VERSIONING_ENABLED: 'false',
+      DATABASE_STATEMENT_TIMEOUT: '0',
+    })
 
     const { getConfig } = await import('./config')
 
-    expect(getConfig({ reload: true }).storageLifecycleEnabled).toBe(true)
+    expect(getConfig({ reload: true }).databaseStatementTimeout).toBe(0)
   })
 
   test('uses the general OTLP endpoint as the metrics endpoint fallback', async () => {
@@ -117,6 +190,114 @@ describe('tenant pool cache config parsing', () => {
     const config = getConfig({ reload: true })
 
     expect(config.otlpMetricsEndpoint).toBe('http://metrics-collector:4317')
+  })
+
+  test.each([
+    [
+      'unbounded destructive S3 request',
+      {
+        STORAGE_BACKEND: 's3',
+        STORAGE_VERSIONING_ENABLED: 'true',
+        STORAGE_S3_CLIENT_TIMEOUT: '0',
+      },
+      'Destructive lifecycle on S3 requires a positive STORAGE_S3_CLIENT_TIMEOUT',
+    ],
+    [
+      'malformed destructive S3 timeout',
+      {
+        STORAGE_BACKEND: 's3',
+        STORAGE_VERSIONING_ENABLED: 'true',
+        STORAGE_S3_CLIENT_TIMEOUT: 'not-a-number',
+      },
+      'Destructive lifecycle on S3 requires a positive STORAGE_S3_CLIENT_TIMEOUT',
+    ],
+    [
+      'destructive S3 request outliving its claim lease',
+      {
+        STORAGE_BACKEND: 's3',
+        STORAGE_VERSIONING_ENABLED: 'true',
+        STORAGE_S3_CLIENT_TIMEOUT: '60000',
+        STORAGE_LIFECYCLE_CLAIM_LEASE_MS: '80000',
+        STORAGE_LIFECYCLE_RECOVERY_GRACE_MS: '30000',
+      },
+      'Destructive lifecycle on S3 requires a positive STORAGE_S3_CLIENT_TIMEOUT',
+    ],
+    [
+      'lifecycle job budget outliving its claim',
+      {
+        STORAGE_LIFECYCLE_JOB_BUDGET_MS: '120000',
+        STORAGE_LIFECYCLE_CLAIM_LEASE_MS: '120000',
+      },
+      'STORAGE_LIFECYCLE_JOB_BUDGET_MS must be shorter than STORAGE_LIFECYCLE_CLAIM_LEASE_MS',
+    ],
+    [
+      'unbounded tenant lifecycle configuration statement',
+      {
+        STORAGE_VERSIONING_ENABLED: 'true',
+        STORAGE_BACKEND: 's3',
+        STORAGE_S3_CLIENT_TIMEOUT: '5000',
+        DATABASE_STATEMENT_TIMEOUT: '0',
+      },
+      'DATABASE_STATEMENT_TIMEOUT must be positive',
+    ],
+  ])('rejects %s at startup', async (_label, env, message) => {
+    setConfigEnv(env)
+
+    const { getConfig } = await import('./config')
+
+    expect(() => getConfig({ reload: true })).toThrow(message)
+    expect(() => getConfig()).toThrow(message)
+  })
+
+  test('retains the valid cached configuration after a rejected reload', async () => {
+    setConfigEnv({})
+    const { getConfig } = await import('./config')
+    const valid = getConfig({ reload: true })
+    process.env.STORAGE_LIFECYCLE_JOB_BUDGET_MS = '120000'
+
+    expect(() => getConfig({ reload: true })).toThrow('must be shorter')
+    expect(getConfig()).toBe(valid)
+  })
+
+  test.each([
+    '2147483648',
+    '9007199254740992',
+  ])('bounds configuration timers: %s', async (value) => {
+    setConfigEnv({ STORAGE_LIFECYCLE_CONFIG_TRANSACTION_TIMEOUT_MS: value })
+    const { getConfig } = await import('./config')
+
+    expect(getConfig({ reload: true }).storageLifecycleConfigurationTransactionTimeoutMs).toBe(
+      30_000
+    )
+  })
+
+  test.each([
+    ['2147483647', 2147483647],
+    ['2147483648', 5000],
+    ['9007199254740991', 5000],
+  ])('bounds the PostgreSQL lifecycle lock timeout %s', async (value, expected) => {
+    setConfigEnv({ STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS: value })
+    const { getConfig } = await import('./config')
+    expect(getConfig({ reload: true }).storageLifecycleObjectLockTimeoutMs).toBe(expected)
+  })
+
+  test('rejects unsafe lifecycle integers before constructing an executor', async () => {
+    setConfigEnv({
+      STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS: '9007199254740992',
+      STORAGE_LIFECYCLE_CLAIM_LEASE_MS: '9007199254740992',
+      STORAGE_LIFECYCLE_RECOVERY_GRACE_MS: '9007199254740992',
+      STORAGE_LIFECYCLE_FAIRNESS_DELAY_MS: '9007199254740992',
+      STORAGE_LIFECYCLE_EVALUATION_INTERVAL_MS: '9007199254740992',
+    })
+    const { getConfig } = await import('./config')
+
+    expect(getConfig({ reload: true })).toMatchObject({
+      storageLifecycleObjectLockTimeoutMs: 5000,
+      storageLifecycleClaimLeaseMs: 120_000,
+      storageLifecycleRecoveryGraceMs: 30_000,
+      storageLifecycleFairnessDelayMs: 5000,
+      storageLifecycleEvaluationIntervalMs: 86_400_000,
+    })
   })
 
   test('freezes JWT JWKS configuration and its keys', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,15 @@ type StorageConfigType = {
   storageS3ForcePathStyle?: boolean
   storageS3Region: string
   storageS3ClientTimeout: number
-  storageLifecycleEnabled: boolean
+  versioningEnabled: boolean
+  storageLifecycleObjectLockTimeoutMs: number
+  storageLifecyclePageSize: number
+  storageLifecycleJobBudgetMs: number
+  storageLifecycleClaimLeaseMs: number
+  storageLifecycleRecoveryGraceMs: number
+  storageLifecycleFairnessDelayMs: number
+  storageLifecycleEvaluationIntervalMs: number
+  storageLifecycleConfigurationTransactionTimeoutMs: number
   isMultitenant: boolean
   jwtSecret: string
   jwtAlgorithm: JwtAlgorithm
@@ -334,7 +342,7 @@ function getOptionalIfMultitenantConfigFromEnv(key: string, fallback?: string): 
     : getConfigFromEnv(key, fallback)
 }
 
-let config: StorageConfigType | undefined
+let cachedConfig: StorageConfigType | undefined
 let envPaths = ['.env']
 
 export function setEnvPaths(paths: string[]) {
@@ -345,18 +353,18 @@ export function mergeConfig(newConfig: Partial<StorageConfigType>) {
   if (newConfig.jwtJWKS) {
     freezeJwksConfig(newConfig.jwtJWKS)
   }
-  config = { ...config, ...(newConfig as Required<StorageConfigType>) }
+  cachedConfig = { ...cachedConfig, ...(newConfig as Required<StorageConfigType>) }
 }
 
 export function getConfig(options?: { reload?: boolean }): StorageConfigType {
-  if (config && !options?.reload) {
-    return config
+  if (cachedConfig && !options?.reload) {
+    return cachedConfig
   }
 
   envPaths.map((envPath) => dotenv.config({ path: envPath, override: false }))
 
   const isMultitenant = getOptionalConfigFromEnv('MULTI_TENANT', 'IS_MULTITENANT') === 'true'
-  config = {
+  const config = {
     serviceName: getOptionalConfigFromEnv('SERVICE_NAME') || 'storage_api',
     numWorkers: envNumber(getOptionalConfigFromEnv('WORKERS_NUM'), 1),
     isProduction: process.env.NODE_ENV === 'production',
@@ -465,7 +473,41 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     // Storage
     storageBackendType: getOptionalConfigFromEnv('STORAGE_BACKEND') as StorageBackendType,
     emptyBucketMax: parseInt(getOptionalConfigFromEnv('STORAGE_EMPTY_BUCKET_MAX') || '200000', 10),
-    storageLifecycleEnabled: getOptionalConfigFromEnv('STORAGE_LIFECYCLE_ENABLED') === 'true',
+    versioningEnabled: getOptionalConfigFromEnv('STORAGE_VERSIONING_ENABLED') === 'true',
+    storageLifecycleObjectLockTimeoutMs: envBoundedPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_OBJECT_LOCK_TIMEOUT_MS'),
+      5000,
+      MAX_TIMER_DELAY_MS
+    ),
+    storageLifecyclePageSize: Math.min(
+      envPositiveInteger(getOptionalConfigFromEnv('STORAGE_LIFECYCLE_PAGE_SIZE'), 500),
+      500
+    ),
+    storageLifecycleJobBudgetMs: envPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_JOB_BUDGET_MS'),
+      20_000
+    ),
+    storageLifecycleClaimLeaseMs: envPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_CLAIM_LEASE_MS'),
+      120_000
+    ),
+    storageLifecycleRecoveryGraceMs: envPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_RECOVERY_GRACE_MS'),
+      30_000
+    ),
+    storageLifecycleFairnessDelayMs: envPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_FAIRNESS_DELAY_MS'),
+      5000
+    ),
+    storageLifecycleEvaluationIntervalMs: envPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_EVALUATION_INTERVAL_MS'),
+      24 * 60 * 60 * 1000
+    ),
+    storageLifecycleConfigurationTransactionTimeoutMs: envBoundedPositiveInteger(
+      getOptionalConfigFromEnv('STORAGE_LIFECYCLE_CONFIG_TRANSACTION_TIMEOUT_MS'),
+      30_000,
+      MAX_TIMER_DELAY_MS
+    ),
 
     // Storage - File
     storageFilePath: getOptionalConfigFromEnv(
@@ -813,6 +855,35 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     )
   }
 
+  if (
+    config.versioningEnabled &&
+    config.storageBackendType === 's3' &&
+    (!Number.isFinite(config.storageS3ClientTimeout) ||
+      config.storageS3ClientTimeout <= 0 ||
+      config.storageLifecycleClaimLeaseMs <=
+        config.storageS3ClientTimeout + config.storageLifecycleRecoveryGraceMs)
+  ) {
+    throw new Error(
+      'Destructive lifecycle on S3 requires a positive STORAGE_S3_CLIENT_TIMEOUT and a claim lease longer than that timeout plus recovery grace'
+    )
+  }
+
+  if (config.storageLifecycleJobBudgetMs >= config.storageLifecycleClaimLeaseMs) {
+    throw new Error(
+      'STORAGE_LIFECYCLE_JOB_BUDGET_MS must be shorter than STORAGE_LIFECYCLE_CLAIM_LEASE_MS'
+    )
+  }
+
+  if (
+    config.versioningEnabled &&
+    config.isMultitenant &&
+    (!Number.isSafeInteger(config.databaseStatementTimeout) || config.databaseStatementTimeout <= 0)
+  ) {
+    throw new Error(
+      'DATABASE_STATEMENT_TIMEOUT must be positive for multitenant lifecycle configuration'
+    )
+  }
+
   const serviceKey = getOptionalConfigFromEnv('SERVICE_KEY') || ''
   if (!config.isMultitenant && !serviceKey) {
     config.serviceKeyAsync = new SignJWT({ role: config.dbServiceRole })
@@ -845,6 +916,7 @@ export function getConfig(options?: { reload?: boolean }): StorageConfigType {
     }
   }
 
+  cachedConfig = config
   return config
 }
 
@@ -862,7 +934,7 @@ function envNumber(value: string | undefined, defaultValue?: number): number | u
 function envPositiveInteger(value: string | undefined, defaultValue: number): number {
   const parsed = envNumber(value, defaultValue)
 
-  return parsed && parsed > 0 ? parsed : defaultValue
+  return parsed && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : defaultValue
 }
 
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1

--- a/src/http/routes/admin/tenants.ts
+++ b/src/http/routes/admin/tenants.ts
@@ -68,6 +68,12 @@ const patchSchema = {
               enabled: { type: 'boolean' },
             },
           },
+          objectVersioning: {
+            type: 'object',
+            properties: {
+              enabled: { type: 'boolean' },
+            },
+          },
           icebergCatalog: {
             type: 'object',
             properties: {
@@ -125,6 +131,7 @@ interface tenantDBInterface {
   file_size_limit?: number
   delete_objects_limit?: number | null
   feature_s3_protocol?: boolean
+  feature_object_versioning?: boolean
   feature_purge_cache?: boolean
   feature_image_transformation?: boolean
   feature_iceberg_catalog?: boolean
@@ -282,6 +289,7 @@ export default async function routes(fastify: FastifyInstance) {
         feature_purge_cache,
         feature_image_transformation,
         feature_s3_protocol,
+        feature_object_versioning,
         feature_iceberg_catalog,
         feature_iceberg_catalog_max_catalogs,
         feature_iceberg_catalog_max_namespaces,
@@ -329,6 +337,9 @@ export default async function routes(fastify: FastifyInstance) {
           s3Protocol: {
             enabled: feature_s3_protocol,
           },
+          objectVersioning: {
+            enabled: feature_object_versioning,
+          },
           icebergCatalog: {
             enabled: feature_iceberg_catalog,
             maxNamespaces: feature_iceberg_catalog_max_namespaces,
@@ -367,6 +378,7 @@ export default async function routes(fastify: FastifyInstance) {
         service_key,
         feature_purge_cache,
         feature_s3_protocol,
+        feature_object_versioning,
         feature_image_transformation,
         feature_iceberg_catalog,
         feature_iceberg_catalog_max_catalogs,
@@ -420,6 +432,9 @@ export default async function routes(fastify: FastifyInstance) {
           },
           s3Protocol: {
             enabled: feature_s3_protocol,
+          },
+          objectVersioning: {
+            enabled: feature_object_versioning,
           },
           icebergCatalog: {
             enabled: feature_iceberg_catalog,
@@ -477,6 +492,7 @@ export default async function routes(fastify: FastifyInstance) {
         feature_image_transformation: features?.imageTransformation?.enabled ?? false,
         feature_purge_cache: features?.purgeCache?.enabled ?? false,
         feature_s3_protocol: features?.s3Protocol?.enabled ?? true,
+        feature_object_versioning: features?.objectVersioning?.enabled ?? false,
         feature_iceberg_catalog: features?.icebergCatalog?.enabled ?? false,
         feature_iceberg_catalog_max_catalogs: features?.icebergCatalog?.maxCatalogs,
         feature_iceberg_catalog_max_namespaces: features?.icebergCatalog?.maxNamespaces,
@@ -549,6 +565,7 @@ export default async function routes(fastify: FastifyInstance) {
         feature_image_transformation: features?.imageTransformation?.enabled,
         feature_purge_cache: features?.purgeCache?.enabled,
         feature_s3_protocol: features?.s3Protocol?.enabled,
+        feature_object_versioning: features?.objectVersioning?.enabled,
         feature_iceberg_catalog: features?.icebergCatalog?.enabled,
         feature_iceberg_catalog_max_catalogs: features?.icebergCatalog?.maxCatalogs,
         feature_iceberg_catalog_max_namespaces: features?.icebergCatalog?.maxNamespaces,
@@ -641,6 +658,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       if (typeof features?.s3Protocol?.enabled !== 'undefined') {
         tenantInfo.feature_s3_protocol = features?.s3Protocol?.enabled
+      }
+
+      if (typeof features?.objectVersioning?.enabled !== 'undefined') {
+        tenantInfo.feature_object_versioning = features.objectVersioning.enabled
       }
 
       if (databasePoolUrl !== undefined) {

--- a/src/http/routes/bucket/lifecycle-disabled.test.ts
+++ b/src/http/routes/bucket/lifecycle-disabled.test.ts
@@ -14,7 +14,7 @@ describe('REST bucket lifecycle feature flag', () => {
       ...config,
       getConfig: () => ({
         ...configured,
-        storageLifecycleEnabled: false,
+        versioningEnabled: false,
       }),
     }))
 

--- a/src/http/routes/bucket/lifecycle.test.ts
+++ b/src/http/routes/bucket/lifecycle.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../../config', async (importOriginal) => {
     ...config,
     getConfig: () => ({
       ...configured,
-      storageLifecycleEnabled: true,
+      versioningEnabled: true,
     }),
   }
 })

--- a/src/http/routes/s3/router.test.ts
+++ b/src/http/routes/s3/router.test.ts
@@ -400,7 +400,7 @@ describe('S3 route handler matching', () => {
         getConfig: (getConfigOptions?: Parameters<typeof actual.getConfig>[0]) => ({
           ...actual.getConfig(getConfigOptions),
           s3ProtocolEnabled: true,
-          storageLifecycleEnabled: true,
+          versioningEnabled: true,
           tracingEnabled: options.tracingEnabled ?? false,
         }),
       }

--- a/src/internal/database/connection.ts
+++ b/src/internal/database/connection.ts
@@ -44,7 +44,7 @@ export interface DatabaseTransactionalExecutor extends DatabaseExecutor {
 export interface TenantConnection extends DatabaseTransactionalExecutor {
   readonly role: string
   dispose(): void
-  setAbortSignal(signal: AbortSignal): void
+  setAbortSignal(signal: AbortSignal | undefined): void
   getAbortSignal(): AbortSignal | undefined
   asSuperUser(): TenantConnection
   transaction(options?: TransactionOptions): Promise<DatabaseTransaction>

--- a/src/internal/database/index.ts
+++ b/src/internal/database/index.ts
@@ -1,5 +1,6 @@
 export * from './client'
 export * from './connection'
+export * from './lifecycle-tenant-store'
 export * from './migration-admin-store-pg'
 export * from './multitenant-pg'
 export * from './pg-connection'

--- a/src/internal/database/lifecycle-tenant-store.test.ts
+++ b/src/internal/database/lifecycle-tenant-store.test.ts
@@ -1,0 +1,71 @@
+import type { DatabaseTransactionalExecutor } from './connection'
+import { LifecycleTenantStorePg } from './lifecycle-tenant-store'
+
+function fixture(rows: Record<string, unknown>[] = [], rowCount = rows.length) {
+  const database = {
+    query: vi.fn().mockResolvedValue({ rows, rowCount }),
+    beginTransaction: vi.fn(),
+  } as unknown as DatabaseTransactionalExecutor
+  return { database, store: new LifecycleTenantStorePg(database) }
+}
+
+describe('LifecycleTenantStorePg', () => {
+  test('wake preserves an earlier dispatch hint with a database-clock timestamp', async () => {
+    const { database, store } = fixture()
+    const signal = new AbortController().signal
+    await store.wakeTenant('tenant-a', signal)
+
+    expect(database.query).toHaveBeenCalledWith(
+      {
+        text: expect.stringMatching(/VALUES \([\s\S]*clock_timestamp\(\)[\s\S]*ON CONFLICT/),
+        values: ['tenant-a'],
+      },
+      { signal }
+    )
+    expect((vi.mocked(database.query).mock.calls[0]?.[0] as { text: string }).text).not.toContain(
+      'updated_at'
+    )
+  })
+
+  test('claims consume the due hint', async () => {
+    const { database, store } = fixture([
+      {
+        tenant_id: 'tenant-a',
+        claim_id: '49f3e225-7455-4b2e-bf49-2ca7abc80b49',
+      },
+    ])
+
+    await expect(store.claimDueTenants(10, 60_000)).resolves.toEqual([
+      {
+        tenantId: 'tenant-a',
+        claimId: '49f3e225-7455-4b2e-bf49-2ca7abc80b49',
+      },
+    ])
+
+    const statement = vi.mocked(database.query).mock.calls[0]?.[0]
+    expect(statement).toMatchObject({
+      text: expect.stringContaining("next_dispatch_at = 'infinity'::timestamptz"),
+      values: [10, 60_000],
+    })
+    expect((statement as { text: string }).text).not.toContain('updated_at')
+  })
+
+  test('completion and failure preserve earlier concurrent wakes with LEAST', async () => {
+    const { database, store } = fixture([], 1)
+    const claimId = '49f3e225-7455-4b2e-bf49-2ca7abc80b49'
+
+    await expect(
+      store.completeTenantDispatch('tenant-a', claimId, '2026-08-16T00:00:00.000Z')
+    ).resolves.toBe(true)
+    await expect(
+      store.failTenantDispatch('tenant-a', claimId, {
+        code: 'timeout',
+      })
+    ).resolves.toBe(true)
+
+    for (const [statement] of vi.mocked(database.query).mock.calls) {
+      expect(statement).toMatchObject({ text: expect.stringContaining('LEAST(next_dispatch_at') })
+      expect((statement as { text: string }).text).not.toContain('updated_at')
+    }
+  })
+})

--- a/src/internal/database/lifecycle-tenant-store.ts
+++ b/src/internal/database/lifecycle-tenant-store.ts
@@ -1,0 +1,138 @@
+import type { DatabaseExecutor } from './connection'
+
+export interface LifecycleTenantClaim {
+  tenantId: string
+  claimId: string
+}
+
+interface LifecycleTenantClaimRow {
+  tenant_id: string
+  claim_id: string
+}
+
+export class LifecycleTenantStorePg {
+  constructor(private readonly database: DatabaseExecutor) {}
+
+  async wakeTenant(tenantId: string, signal?: AbortSignal): Promise<void> {
+    await this.database.query(
+      {
+        text: `
+        INSERT INTO lifecycle_tenants (
+          tenant_id,
+          next_dispatch_at
+        ) VALUES (
+          $1,
+          clock_timestamp()
+        )
+        ON CONFLICT (tenant_id) DO UPDATE
+        SET next_dispatch_at = LEAST(
+              lifecycle_tenants.next_dispatch_at,
+              EXCLUDED.next_dispatch_at
+            )
+      `,
+        values: [tenantId],
+      },
+      { signal }
+    )
+  }
+
+  async claimDueTenants(limit: number, leaseMs: number): Promise<LifecycleTenantClaim[]> {
+    assertPositiveInteger(limit, 'Lifecycle tenant claim limit')
+    assertPositiveInteger(leaseMs, 'Lifecycle tenant claim lease')
+
+    const result = await this.database.query<LifecycleTenantClaimRow>({
+      text: `
+        WITH due AS MATERIALIZED (
+          SELECT tenant_id
+          FROM lifecycle_tenants
+          WHERE (
+              next_dispatch_at <= clock_timestamp()
+              OR claim_until < clock_timestamp()
+            )
+            AND (claim_until IS NULL OR claim_until < clock_timestamp())
+          ORDER BY
+            CASE
+              WHEN claim_until < clock_timestamp() THEN claim_until
+              ELSE next_dispatch_at
+            END,
+            tenant_id
+          FOR UPDATE SKIP LOCKED
+          LIMIT $1
+        )
+        UPDATE lifecycle_tenants AS target
+        SET claim_id = gen_random_uuid(),
+            claim_until = clock_timestamp() + $2::bigint * interval '1 millisecond',
+            next_dispatch_at = 'infinity'::timestamptz,
+            last_dispatched_at = clock_timestamp()
+        FROM due
+        WHERE target.tenant_id = due.tenant_id
+        RETURNING
+          target.tenant_id,
+          target.claim_id
+      `,
+      values: [limit, leaseMs],
+    })
+
+    return result.rows.map((row) => ({
+      tenantId: row.tenant_id,
+      claimId: row.claim_id,
+    }))
+  }
+
+  async completeTenantDispatch(
+    tenantId: string,
+    claimId: string,
+    computedNextDispatchAt: string
+  ): Promise<boolean> {
+    assertTimestamp(computedNextDispatchAt, 'computedNextDispatchAt')
+    const result = await this.database.query({
+      text: `
+        UPDATE lifecycle_tenants
+        SET next_dispatch_at = LEAST(next_dispatch_at, $3::timestamptz),
+            claim_id = NULL,
+            claim_until = NULL,
+            last_completed_at = clock_timestamp(),
+            last_success_at = clock_timestamp(),
+            failure_count = 0,
+            last_error = NULL
+        WHERE tenant_id = $1
+          AND claim_id = $2::uuid
+      `,
+      values: [tenantId, claimId, computedNextDispatchAt],
+    })
+    return result.rowCount === 1
+  }
+
+  async failTenantDispatch(
+    tenantId: string,
+    claimId: string,
+    error: Record<string, unknown>
+  ): Promise<boolean> {
+    const result = await this.database.query({
+      text: `
+        UPDATE lifecycle_tenants
+        SET next_dispatch_at = LEAST(next_dispatch_at,
+              clock_timestamp() + LEAST(21600, 300 * power(2, LEAST(failure_count, 7)))
+                * interval '1 second'
+            ),
+            claim_id = NULL,
+            claim_until = NULL,
+            last_completed_at = clock_timestamp(),
+            failure_count = failure_count + 1,
+            last_error = $3::jsonb
+        WHERE tenant_id = $1
+          AND claim_id = $2::uuid
+      `,
+      values: [tenantId, claimId, JSON.stringify(error)],
+    })
+    return result.rowCount === 1
+  }
+}
+
+function assertPositiveInteger(value: number, label: string) {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${label} must be positive`)
+}
+
+function assertTimestamp(value: string, label: string) {
+  if (Number.isNaN(Date.parse(value))) throw new Error(`${label} must be a timestamp`)
+}

--- a/src/internal/database/migrations/concurrent-index-guard.test.ts
+++ b/src/internal/database/migrations/concurrent-index-guard.test.ts
@@ -235,6 +235,6 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_test ON storage.objects (nam
       await expect(repairInvalidConcurrentIndexes(client, migration)).resolves.toBeDefined()
     }
 
-    expect(query).toHaveBeenCalledTimes(8)
+    expect(query).toHaveBeenCalledTimes(10)
   })
 })

--- a/src/internal/database/migrations/types.test.ts
+++ b/src/internal/database/migrations/types.test.ts
@@ -8,12 +8,42 @@ describe('DBMigration', () => {
     expect(Object.entries(DBMigration)).toEqual(migrations.map(({ id, name }) => [name, id]))
   })
 
-  it('stages validation of the lifecycle bucket checks', async () => {
+  it('adds the shared versioning feature before the lifecycle registry', async () => {
+    const migrations = await loadMigrationFiles('./migrations/multitenant')
+
+    expect(migrations.filter(({ id }) => id >= 30).map(({ id, name }) => [id, name])).toEqual([
+      [30, 'object-versioning-feature'],
+      [31, 'lifecycle-tenants'],
+    ])
+  })
+
+  it.each([
+    {
+      migrationName: 'bucket-lifecycle-configuration',
+      validationName: 'validate-bucket-lifecycle-constraints',
+      constraints: [
+        'buckets_lifecycle_configuration_pair_check',
+        'buckets_lifecycle_configuration_shape_check',
+        'buckets_lifecycle_configuration_standard_only_check',
+      ],
+    },
+    {
+      migrationName: 'noncurrent-lifecycle',
+      validationName: 'validate-bucket-lifecycle-execution-constraints',
+      constraints: [
+        'buckets_lifecycle_shard_epoch_check',
+        'buckets_lifecycle_shard_count_check',
+        'buckets_lifecycle_standard_only_check',
+      ],
+    },
+  ])('stages validation of $migrationName bucket checks', async ({
+    migrationName,
+    validationName,
+    constraints,
+  }) => {
     const migrations = await loadMigrationFiles('./migrations/tenant')
-    const migration = migrations.find(({ name }) => name === 'bucket-lifecycle-configuration')
-    const validation = migrations.find(
-      ({ name }) => name === 'validate-bucket-lifecycle-constraints'
-    )
+    const migration = migrations.find(({ name }) => name === migrationName)
+    const validation = migrations.find(({ name }) => name === validationName)
 
     expect(migration).toBeDefined()
     expect(validation).toBeDefined()
@@ -21,12 +51,9 @@ describe('DBMigration', () => {
       throw new Error('Lifecycle migrations were not loaded')
     }
 
-    expect(migration.sql.match(/\bNOT VALID;/g)).toHaveLength(3)
-    for (const constraint of [
-      'buckets_lifecycle_configuration_pair_check',
-      'buckets_lifecycle_configuration_shape_check',
-      'buckets_lifecycle_configuration_standard_only_check',
-    ]) {
+    expect(validation.id).toBeGreaterThan(migration.id)
+    expect(migration.sql.match(/\bNOT VALID;/g)).toHaveLength(constraints.length)
+    for (const constraint of constraints) {
       expect(migration.sql).not.toContain(`VALIDATE CONSTRAINT ${constraint}`)
       expect(validation.sql).toContain(`VALIDATE CONSTRAINT ${constraint};`)
     }

--- a/src/internal/database/migrations/types.ts
+++ b/src/internal/database/migrations/types.ts
@@ -69,4 +69,8 @@ export const DBMigration = {
   'objects-null-version-index': 67,
   'bucket-lifecycle-configuration': 68,
   'validate-bucket-lifecycle-constraints': 69,
+  'noncurrent-lifecycle': 70,
+  'validate-bucket-lifecycle-execution-constraints': 71,
+  'noncurrent-lifecycle-archived-order-index': 72,
+  'noncurrent-lifecycle-archived-due-index': 73,
 } as const

--- a/src/internal/database/pg-connection.ts
+++ b/src/internal/database/pg-connection.ts
@@ -681,7 +681,7 @@ export class PgTenantConnection implements TenantConnection {
     this.poolLease.release()
   }
 
-  setAbortSignal(signal: AbortSignal) {
+  setAbortSignal(signal: AbortSignal | undefined) {
     this.abortSignal = signal
   }
 

--- a/src/internal/database/tenant-store-pg.ts
+++ b/src/internal/database/tenant-store-pg.ts
@@ -23,6 +23,7 @@ export interface TenantConfigRow {
   file_size_limit?: number
   delete_objects_limit?: number | null
   feature_s3_protocol?: boolean
+  feature_object_versioning?: boolean
   feature_purge_cache?: boolean
   feature_image_transformation?: boolean
   feature_iceberg_catalog?: boolean
@@ -55,6 +56,7 @@ const tenantWritableColumns = [
   'file_size_limit',
   'delete_objects_limit',
   'feature_s3_protocol',
+  'feature_object_versioning',
   'feature_purge_cache',
   'feature_image_transformation',
   'feature_iceberg_catalog',

--- a/src/internal/database/tenant.ts
+++ b/src/internal/database/tenant.ts
@@ -68,6 +68,9 @@ export interface Features {
   s3Protocol: {
     enabled: boolean
   }
+  objectVersioning: {
+    enabled: boolean
+  }
   purgeCache: {
     enabled: boolean
   }
@@ -211,6 +214,7 @@ export async function getTenantConfig(
         feature_purge_cache,
         feature_image_transformation,
         feature_s3_protocol,
+        feature_object_versioning,
         feature_iceberg_catalog,
         feature_iceberg_catalog_max_catalogs,
         feature_iceberg_catalog_max_namespaces,
@@ -255,6 +259,9 @@ export async function getTenantConfig(
           },
           s3Protocol: {
             enabled: Boolean(feature_s3_protocol),
+          },
+          objectVersioning: {
+            enabled: Boolean(feature_object_versioning),
           },
           purgeCache: {
             enabled: Boolean(feature_purge_cache),

--- a/src/internal/monitoring/metrics.ts
+++ b/src/internal/monitoring/metrics.ts
@@ -496,6 +496,28 @@ export const queueJobError = registerMetric('queue_job_error', 'updowncounter', 
 )
 
 // ============================================================================
+// Object lifecycle metrics. Attribute sets are deliberately closed and never
+// contain tenant, bucket, object, rule, run, claim, or attempt identifiers.
+// ============================================================================
+export const lifecycleVersionsExamined = registerMetric(
+  'storage_lifecycle_versions_examined_total',
+  'counter',
+  () =>
+    meter.createCounter('storage_lifecycle_versions_examined_total', {
+      description: 'Total historical versions examined by lifecycle evaluation',
+    })
+)
+
+export const lifecycleVersionsEligible = registerMetric(
+  'storage_lifecycle_versions_eligible_total',
+  'counter',
+  () =>
+    meter.createCounter('storage_lifecycle_versions_eligible_total', {
+      description: 'Total historical versions eligible for lifecycle expiration',
+    })
+)
+
+// ============================================================================
 // S3 Metrics
 // ============================================================================
 export const s3UploadPart = registerMetric('s3_upload_part_seconds', 'histogram', () =>

--- a/src/storage/backend/adapter.ts
+++ b/src/storage/backend/adapter.ts
@@ -52,6 +52,8 @@ export type CopyObjectOptions = {
 export type HeadObjectOptions = {
   /** Confirm ambiguous absence with an extra backend request. Defaults to false. */
   confirmMissing?: boolean
+  /** Cancels both HEAD and any absence-confirmation request. */
+  signal?: AbortSignal
 }
 
 export interface DeleteObjectDetailedResult {

--- a/src/storage/backend/s3/adapter.test.ts
+++ b/src/storage/backend/s3/adapter.test.ts
@@ -646,6 +646,26 @@ describe('S3Backend', () => {
         )
     }
 
+    test('propagates caller cancellation through HEAD and absence confirmation', async () => {
+      const controller = new AbortController()
+      const headError = s3Error('NotFound', 404)
+      mockSend.mockRejectedValueOnce(headError)
+      mockSend.mockImplementationOnce(async (_command, options) => {
+        controller.abort()
+        expect(options.abortSignal.aborted).toBe(true)
+        throw controller.signal.reason
+      })
+
+      const error = await failure({ confirmMissing: true, signal: controller.signal })
+
+      expect(mockSend).toHaveBeenNthCalledWith(1, expect.any(HeadObjectCommand), {
+        abortSignal: controller.signal,
+      })
+      expect(mockSend.mock.calls[1][1].abortSignal.aborted).toBe(true)
+      expect(error.getOriginalError()).toBe(headError)
+      expect(isMissingBackendObject(error)).toBe(false)
+    })
+
     test.each([
       ['not requested', undefined],
       ['disabled', { confirmMissing: false }],

--- a/src/storage/backend/s3/adapter.ts
+++ b/src/storage/backend/s3/adapter.ts
@@ -549,7 +549,9 @@ export class S3Backend implements StorageBackendAdapter {
         Bucket: bucket,
         Key: withOptionalVersion(key, version),
       })
-      const data = await this.client.send(command)
+      const data = options?.signal
+        ? await this.client.send(command, { abortSignal: options.signal })
+        : await this.client.send(command)
       return {
         cacheControl: data.CacheControl || 'no-cache',
         mimetype: data.ContentType || 'application/octet-stream',
@@ -569,17 +571,22 @@ export class S3Backend implements StorageBackendAdapter {
       ) {
         // HEAD has no error body. A missing bucket and a missing object can both
         // appear as NotFound, so destructive callers need GET's structured error.
-        await this.confirmMissingObject(bucket, withOptionalVersion(key, version))
+        await this.confirmMissingObject(bucket, withOptionalVersion(key, version), options.signal)
       }
       throw StorageBackendError.fromError(e)
     }
   }
 
-  private async confirmMissingObject(bucket: string, key: string): Promise<void> {
+  private async confirmMissingObject(
+    bucket: string,
+    key: string,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const deadline = AbortSignal.timeout(MISSING_OBJECT_CONFIRMATION_TIMEOUT_MS)
     try {
       const response = await this.client.send(
         new GetObjectCommand({ Bucket: bucket, Key: key, Range: 'bytes=0-0' }),
-        { abortSignal: AbortSignal.timeout(MISSING_OBJECT_CONFIRMATION_TIMEOUT_MS) }
+        { abortSignal: signal ? AbortSignal.any([signal, deadline]) : deadline }
       )
       if (response.Body instanceof Readable) response.Body.destroy()
       else if (response.Body instanceof ReadableStream) await response.Body.cancel()

--- a/src/storage/database/adapter.ts
+++ b/src/storage/database/adapter.ts
@@ -4,8 +4,18 @@ import { ObjectMetadata } from '../backend'
 import {
   Bucket,
   BucketLifecycleConfiguration,
+  EvaluateNoncurrentLifecyclePageInput,
   IcebergCatalog,
+  LifecycleArmAttemptInput,
   LifecycleBucket,
+  LifecycleCommitAttemptInput,
+  LifecycleContinuation,
+  LifecycleEvaluationPage,
+  LifecycleReleaseClaimInput,
+  LifecycleShardClaimIdentity,
+  LifecycleShardClaimInput,
+  LifecycleShardCoordinate,
+  LifecycleShardState,
   Obj,
   S3MultipartUpload,
   S3PartUpload,
@@ -77,7 +87,7 @@ export interface Database {
 
   withTransaction<T>(
     fn: (db: Database) => Promise<T>,
-    transactionOptions?: TransactionOptions
+    transactionOptions?: TransactionOptions & { deadlineSignal?: AbortSignal }
   ): Promise<T>
 
   testPermission<T>(fn: (db: Database) => T | Promise<T>): Promise<Awaited<T>>
@@ -105,6 +115,60 @@ export interface Database {
   ): Promise<LifecycleBucket>
 
   deleteLifecycleConfiguration(bucketId: string): Promise<LifecycleBucket>
+
+  createNoncurrentLifecycleState(
+    bucketId: string,
+    configurationGeneration: string,
+    nextRunAt: string | null
+  ): Promise<LifecycleShardState | undefined>
+
+  listDueLifecycleShards(limit: number): Promise<LifecycleShardCoordinate[]>
+
+  findNextLifecycleDispatchAt(): Promise<string | null>
+
+  wakeLifecycleShards(bucketId: string): Promise<LifecycleShardCoordinate[]>
+
+  claimLifecycleShard(input: LifecycleShardClaimInput): Promise<LifecycleShardState | undefined>
+
+  revalidateLifecycleShardClaim(
+    input: LifecycleShardClaimIdentity
+  ): Promise<LifecycleShardState | undefined>
+
+  evaluateNoncurrentLifecyclePage(
+    input: EvaluateNoncurrentLifecyclePageInput
+  ): Promise<LifecycleEvaluationPage>
+
+  saveLifecycleContinuation(
+    input: LifecycleShardClaimIdentity,
+    continuation: LifecycleContinuation
+  ): Promise<boolean>
+
+  armLifecycleAttempt(input: LifecycleArmAttemptInput): Promise<LifecycleShardState | undefined>
+
+  revalidateLifecycleRecoveryAttempt(
+    input: LifecycleShardClaimIdentity,
+    attemptId: string,
+    leaseMs: number
+  ): Promise<LifecycleShardState | undefined>
+
+  commitLifecycleAttempt(
+    input: LifecycleCommitAttemptInput
+  ): Promise<LifecycleShardState | undefined>
+
+  releaseLifecycleShardClaim(input: LifecycleReleaseClaimInput): Promise<boolean>
+
+  completeLifecycleShardRun(
+    input: LifecycleShardClaimIdentity,
+    lastResult: Record<string, unknown>,
+    nextRunAt: string
+  ): Promise<boolean>
+
+  prepareLifecycleStateForBucketDelete(bucketId: string): Promise<number>
+
+  findLifecycleObjectVersions(
+    bucketId: string,
+    objects: Array<{ name: string; version: string | null }>
+  ): Promise<LifecycleObjectRow[]>
 
   countObjectsInBucket(bucketId: string, limit?: number): Promise<number>
 
@@ -255,4 +319,16 @@ export interface Database {
   ): Promise<ScannerS3Key[]>
   findS3KeysInTempTable(tableName: string, keys: string[]): Promise<Pick<ScannerS3Key, 'key'>[]>
   insertS3KeysIntoTempTable(tableName: string, keys: ScannerS3Key[]): Promise<void>
+}
+
+export interface LifecycleObjectRow {
+  id: string
+  bucket_id: string
+  name: string
+  version: string | null
+  is_versioned: boolean
+  is_delete_marker: boolean
+  metadata: Record<string, unknown> | null
+  created_at: string | Date
+  archived_at: string | Date | null
 }

--- a/src/storage/database/pg.test.ts
+++ b/src/storage/database/pg.test.ts
@@ -277,6 +277,9 @@ describe('StoragePgDB lifecycle mutation permissions', () => {
       id: 'bucket',
       name: 'bucket',
       type: 'STANDARD',
+      versioning_status: 'DISABLED',
+      lifecycle_shard_epoch: 1,
+      lifecycle_shard_count: 1,
       lifecycle_configuration: lifecycleConfiguration,
       lifecycle_configuration_generation: lifecycleConfiguration === null ? null : 'generation',
     }

--- a/src/storage/database/pg.ts
+++ b/src/storage/database/pg.ts
@@ -13,16 +13,34 @@ import { ERRORS, ErrorCode, isStorageError, StorageBackendError } from '@interna
 import { hashStringToInt } from '@internal/hashing'
 import { logger, logSchema } from '@internal/monitoring'
 import { dbQueryPerformance } from '@internal/monitoring/metrics'
-import { ObjectMetadata } from '@storage/backend'
-import { assertLifecycleSchemaReady, lifecycleConfigurationsEqual } from '@storage/lifecycle'
+import { ObjectMetadata, withOptionalVersion } from '@storage/backend'
+import {
+  assertLifecycleSchemaReady,
+  commitLifecycleBatchResults,
+  compileLifecycleEvaluationRules,
+  decodeLifecycleContinuation,
+  hasEnabledLifecycleRule,
+  lifecycleConfigurationsEqual,
+  lifecycleVersionNeedsCompensation,
+} from '@storage/lifecycle'
 import { DatabaseError, QueryResultRow } from 'pg'
 import { DatabaseEngine, getConfig } from '../../config'
 import { isUuid } from '../limits'
 import {
   Bucket,
   BucketLifecycleConfiguration,
+  EvaluateNoncurrentLifecyclePageInput,
   IcebergCatalog,
+  LifecycleArmAttemptInput,
   LifecycleBucket,
+  LifecycleCommitAttemptInput,
+  LifecycleContinuation,
+  LifecycleEvaluationPage,
+  LifecycleReleaseClaimInput,
+  LifecycleShardClaimIdentity,
+  LifecycleShardClaimInput,
+  LifecycleShardCoordinate,
+  LifecycleShardState,
   Obj,
   S3MultipartUpload,
   S3PartUpload,
@@ -31,12 +49,18 @@ import {
   Database,
   FindBucketFilters,
   FindObjectFilters,
+  LifecycleObjectRow,
   ListBucketOptions,
   ScannerS3Key,
   SearchObjectOption,
 } from './adapter'
 import { SelectColumnPolicy, selectColumns } from './columns'
 import { DBError, mapPgTransactionAbortedError, PgErrorContext } from './errors'
+import {
+  buildEvaluateNoncurrentLifecyclePageStatement,
+  type LifecycleEvaluationResultRow,
+  mapLifecycleEvaluationPage,
+} from './lifecycle'
 
 const { databaseEngine, databaseStatementTimeout, isMultitenant, databaseHealthcheckUnscoped } =
   getConfig()
@@ -71,13 +95,33 @@ const HEALTHCHECK_SQL = 'SELECT id from storage.buckets limit 1'
 const HEALTHCHECK_QUERY_OPTIONS: UnscopedQueryOptions = Object.freeze({
   timeoutMs: databaseStatementTimeout,
 })
+const LIFECYCLE_CONFIGURATION_COLUMNS =
+  'id,name,type,lifecycle_configuration,lifecycle_configuration_generation'
+
 const LIFECYCLE_BUCKET_COLUMNS = [
   'id',
   'name',
   'type',
+  'versioning_status',
   'lifecycle_configuration',
   'lifecycle_configuration_generation',
+  'lifecycle_shard_epoch',
+  'lifecycle_shard_count',
 ].join(',')
+
+interface LifecycleShardStateRow extends QueryResultRow {
+  bucket_id: string
+  scan_kind: 'NONCURRENT' | 'CURRENT'
+  shard_id: number
+  shard_epoch: string
+  shard_count: number
+  configuration_generation: string
+  next_run_at: Date | string | null
+  claim_id: string | null
+  claim_until: Date | string | null
+  continuation: unknown | null
+  failure_count: number
+}
 async function executeQuery<T extends QueryResultRow = QueryResultRow>(
   db: DatabaseExecutor,
   statement: string | DatabaseStatement,
@@ -164,10 +208,12 @@ export class StoragePgDB implements Database {
 
   async withTransaction<T>(
     fn: (db: StoragePgDB) => Promise<T>,
-    opts?: TransactionOptions
+    opts?: TransactionOptions & { deadlineSignal?: AbortSignal }
   ): Promise<T> {
+    const { deadlineSignal, ...transactionOptions } = opts ?? {}
     const parentTnx = this.options.tnx
-    const tnx = parentTnx ?? (await this.connection.transaction(opts))
+    const tnx =
+      parentTnx ?? (await this.connection.transaction(opts ? transactionOptions : undefined))
     const savepoint = parentTnx ? nextSavepointName() : undefined
     let savepointEstablished = false
 
@@ -185,6 +231,7 @@ export class StoragePgDB implements Database {
       })
 
       const result = await fn(storageWithTnx)
+      deadlineSignal?.throwIfAborted()
 
       if (savepoint) {
         if (
@@ -513,9 +560,13 @@ export class StoragePgDB implements Database {
   async findLifecycleBucket(bucketId: string): Promise<LifecycleBucket> {
     await assertLifecycleSchemaReady(this, bucketId)
 
-    const bucket = await this.findBucketById(bucketId, LIFECYCLE_BUCKET_COLUMNS)
+    const columns = (await this.hasMigration('noncurrent-lifecycle'))
+      ? LIFECYCLE_BUCKET_COLUMNS
+      : LIFECYCLE_CONFIGURATION_COLUMNS
+    const bucket = await this.findBucketById(bucketId, columns)
     assertStandardLifecycleBucket(bucket)
-    return bucket as LifecycleBucket
+
+    return mapLifecycleBucket(bucket as LifecycleBucket)
   }
 
   async putLifecycleConfiguration(
@@ -533,7 +584,7 @@ export class StoragePgDB implements Database {
                   SET lifecycle_configuration = $2::jsonb,
                       lifecycle_configuration_generation = $3::uuid
                   WHERE id = $1
-                  RETURNING ${selectColumns(LIFECYCLE_BUCKET_COLUMNS)}
+                  RETURNING ${selectColumns(LIFECYCLE_CONFIGURATION_COLUMNS)}
                 `,
         values: [
           bucketId,
@@ -555,7 +606,7 @@ export class StoragePgDB implements Database {
                   SET lifecycle_configuration = NULL,
                       lifecycle_configuration_generation = NULL
                   WHERE id = $1
-                  RETURNING ${selectColumns(LIFECYCLE_BUCKET_COLUMNS)}
+                  RETURNING ${selectColumns(LIFECYCLE_CONFIGURATION_COLUMNS)}
                 `,
         values: [bucketId],
       }),
@@ -2074,9 +2125,12 @@ export class StoragePgDB implements Database {
     assertStandardLifecycleBucket(visible)
 
     const serviceDatabase = this.asSuperUser()
-    const locked = (await serviceDatabase.findBucketById(bucketId, LIFECYCLE_BUCKET_COLUMNS, {
-      forUpdate: true,
-    })) as LifecycleBucket
+    const supportsLifecycleExecution = await serviceDatabase.hasMigration('noncurrent-lifecycle')
+    const locked = supportsLifecycleExecution
+      ? await serviceDatabase.lockLifecycleControlBucket(bucketId)
+      : ((await serviceDatabase.findBucketById(bucketId, LIFECYCLE_CONFIGURATION_COLUMNS, {
+          forUpdate: true,
+        })) as LifecycleBucket)
     const unchanged = options.unchanged(locked)
     // Equivalent PUTs, including reorders, retain the stored order and generation. Probe the exact
     // row we would persist, including the same generated UUID for changed PUTs.
@@ -2084,6 +2138,9 @@ export class StoragePgDB implements Database {
     await this.testLifecycleWritePermission(statement)
 
     if (unchanged) {
+      if (supportsLifecycleExecution) {
+        await serviceDatabase.reconcileLifecycleConfiguration(locked, false)
+      }
       return locked
     }
 
@@ -2093,6 +2150,11 @@ export class StoragePgDB implements Database {
 
     const bucket = result.rows[0]
     if (!bucket) throw ERRORS.NoSuchBucket(bucketId)
+    if (supportsLifecycleExecution) {
+      const executionBucket = mapLifecycleBucket({ ...locked, ...bucket })
+      await serviceDatabase.reconcileLifecycleConfiguration(executionBucket, true)
+      return executionBucket
+    }
     return bucket
   }
 
@@ -2142,6 +2204,958 @@ export class StoragePgDB implements Database {
         throw error
       }
     }
+  }
+
+  async findLifecycleObjectVersions(
+    bucketId: string,
+    objects: Array<{ name: string; version: string | null }>
+  ): Promise<LifecycleObjectRow[]> {
+    if (objects.length === 0) return []
+
+    const result = await this.runQuery('FindLifecycleObjectVersions', (db, signal) =>
+      this.query<LifecycleObjectRow>(
+        db,
+        {
+          text: `SELECT id, bucket_id, name, version, is_versioned, is_delete_marker,
+                        metadata, created_at, archived_at
+                 FROM storage.objects
+                 WHERE bucket_id = $1
+                   AND EXISTS (
+                     SELECT 1 FROM unnest($2::text[], $3::text[]) AS target(name, version)
+                     WHERE storage.objects.name COLLATE "C" = target.name COLLATE "C"
+                       AND storage.objects.version IS NOT DISTINCT FROM target.version
+                   )`,
+          values: [
+            bucketId,
+            objects.map((object) => object.name),
+            objects.map((object) => object.version),
+          ],
+        },
+        signal
+      )
+    )
+
+    return result.rows
+  }
+
+  private async lockLifecycleObjects(bucketId: string, names: string[]): Promise<void> {
+    if (!this.options.tnx) {
+      throw ERRORS.InvalidRequest('Lifecycle object locks require a transaction')
+    }
+
+    const lockKeys = [...new Set(names.map((name) => hashStringToInt(`${bucketId}/${name}`)))].sort(
+      (left, right) => left - right
+    )
+
+    await this.runQuery('LockLifecycleObjects', async (db, signal) => {
+      try {
+        await db.query(
+          {
+            text: `SELECT set_config('lock_timeout', $1, true)`,
+            values: [`${getConfig().storageLifecycleObjectLockTimeoutMs}ms`],
+          },
+          { signal }
+        )
+        await db.query(
+          {
+            text: `SELECT pg_advisory_xact_lock(lock_key)
+                   FROM unnest($1::bigint[]) AS requested(lock_key) ORDER BY lock_key`,
+            values: [lockKeys],
+          },
+          { signal }
+        )
+        // Match the writer lock order. Read the bucket in a new statement after
+        // waiting for object locks so later lifecycle checks use a fresh snapshot.
+        const bucket = await db.query<{ id: string }>(
+          {
+            text: `SELECT id FROM storage.buckets WHERE id = $1 FOR SHARE`,
+            values: [bucketId],
+          },
+          { signal }
+        )
+        if (!bucket.rows[0]) throw ERRORS.NoSuchBucket(bucketId)
+      } catch (error) {
+        if (isPgLockTimeoutError(error)) throw ERRORS.LockTimeout(error)
+        throw mapPgError(error, 'Acquire lifecycle object locks')
+      }
+    })
+  }
+
+  async createNoncurrentLifecycleState(
+    bucketId: string,
+    configurationGeneration: string,
+    nextRunAt: string | null
+  ): Promise<LifecycleShardState | undefined> {
+    const result = await this.runQuery('CreateNoncurrentLifecycleState', async (db, signal) => {
+      return this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            INSERT INTO storage.bucket_lifecycle_states (
+              bucket_id,
+              scan_kind,
+              shard_id,
+              shard_epoch,
+              shard_count,
+              configuration_generation,
+              next_run_at
+            )
+            SELECT
+              bucket.id,
+              'NONCURRENT',
+              0,
+              bucket.lifecycle_shard_epoch,
+              bucket.lifecycle_shard_count,
+              bucket.lifecycle_configuration_generation,
+              $3::timestamptz
+            FROM storage.buckets AS bucket
+            WHERE bucket.id = $1
+              AND bucket.type = 'STANDARD'
+              AND bucket.lifecycle_configuration_generation = $2::uuid
+              AND bucket.lifecycle_shard_epoch = 1
+              AND bucket.lifecycle_shard_count = 1
+            ON CONFLICT (bucket_id, scan_kind, shard_id) DO NOTHING
+            RETURNING *,
+              shard_epoch::text AS shard_epoch
+          `,
+          values: [bucketId, configurationGeneration, nextRunAt],
+        },
+        signal
+      )
+    })
+
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async listDueLifecycleShards(limit: number): Promise<LifecycleShardCoordinate[]> {
+    assertPositiveSafeInteger(limit, 'Lifecycle shard query limit')
+    const result = await this.runQuery('ListDueLifecycleShards', async (db, signal) => {
+      return this.query<{
+        bucket_id: string
+        scan_kind: 'NONCURRENT' | 'CURRENT'
+        shard_epoch: string
+        shard_id: number
+      }>(
+        db,
+        {
+          text: `
+            SELECT
+              state.bucket_id,
+              state.scan_kind,
+              state.shard_epoch::text,
+              state.shard_id
+            FROM storage.bucket_lifecycle_states AS state
+            JOIN storage.buckets AS bucket
+              ON bucket.id = state.bucket_id
+             AND bucket.type = 'STANDARD'
+             AND bucket.lifecycle_shard_epoch = state.shard_epoch
+             AND bucket.lifecycle_shard_count = state.shard_count
+            WHERE state.next_run_at <= clock_timestamp()
+              AND (state.claim_until IS NULL OR state.claim_until < clock_timestamp())
+            ORDER BY state.next_run_at, state.bucket_id, state.scan_kind, state.shard_id
+            LIMIT $1
+          `,
+          values: [limit],
+        },
+        signal
+      )
+    })
+
+    return result.rows.map((row) => ({
+      bucketId: row.bucket_id,
+      scanKind: row.scan_kind,
+      shardEpoch: row.shard_epoch,
+      shardId: row.shard_id,
+    }))
+  }
+
+  async findNextLifecycleDispatchAt(): Promise<string | null> {
+    const result = await this.runQuery('FindNextLifecycleDispatchAt', async (db, signal) => {
+      return this.query<{ next_dispatch_at: string | null }>(
+        db,
+        {
+          text: `
+            SELECT MIN(state.next_run_at)::text AS next_dispatch_at
+            FROM storage.bucket_lifecycle_states AS state
+            JOIN storage.buckets AS bucket
+              ON bucket.id = state.bucket_id
+             AND bucket.type = 'STANDARD'
+             AND bucket.lifecycle_shard_epoch = state.shard_epoch
+             AND bucket.lifecycle_shard_count = state.shard_count
+            WHERE state.next_run_at IS NOT NULL
+          `,
+        },
+        signal
+      )
+    })
+
+    return result.rows[0]?.next_dispatch_at ?? null
+  }
+
+  async wakeLifecycleShards(bucketId: string): Promise<LifecycleShardCoordinate[]> {
+    const result = await this.runQuery('WakeLifecycleShards', async (db, signal) => {
+      return this.query<{
+        bucket_id: string
+        scan_kind: 'NONCURRENT' | 'CURRENT'
+        shard_epoch: string
+        shard_id: number
+      }>(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states AS state
+            SET next_run_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            FROM storage.buckets AS bucket
+            WHERE state.bucket_id = $1
+              AND bucket.id = state.bucket_id
+              AND bucket.type = 'STANDARD'
+              AND bucket.versioning_status <> 'DISABLED'
+              AND bucket.lifecycle_configuration_generation IS NOT NULL
+              AND bucket.lifecycle_shard_epoch = state.shard_epoch
+              AND bucket.lifecycle_shard_count = state.shard_count
+            RETURNING
+              state.bucket_id,
+              state.scan_kind,
+              state.shard_epoch::text,
+              state.shard_id
+          `,
+          values: [bucketId],
+        },
+        signal
+      )
+    })
+
+    return result.rows.map((row) => ({
+      bucketId: row.bucket_id,
+      scanKind: row.scan_kind,
+      shardEpoch: row.shard_epoch,
+      shardId: row.shard_id,
+    }))
+  }
+
+  async claimLifecycleShard(
+    input: LifecycleShardClaimInput
+  ): Promise<LifecycleShardState | undefined> {
+    assertPositiveSafeInteger(input.leaseMs, 'Lifecycle shard lease')
+    const result = await this.runQuery('ClaimLifecycleShard', async (db, signal) => {
+      return this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states AS state
+            SET claim_id = $5::uuid,
+                claim_until = clock_timestamp() + $6::bigint * interval '1 millisecond',
+                last_started_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            FROM storage.buckets AS bucket
+            WHERE state.bucket_id = $1
+              AND state.scan_kind = $2
+              AND state.shard_id = $3
+              AND state.shard_epoch = $4::bigint
+              AND state.next_run_at <= clock_timestamp()
+              AND (state.claim_until IS NULL OR state.claim_until < clock_timestamp())
+              AND bucket.id = state.bucket_id
+              AND bucket.type = 'STANDARD'
+              AND bucket.lifecycle_shard_epoch = state.shard_epoch
+              AND bucket.lifecycle_shard_count = state.shard_count
+            RETURNING state.*,
+              state.shard_epoch::text AS shard_epoch
+          `,
+          values: [
+            input.bucketId,
+            input.scanKind,
+            input.shardId,
+            input.shardEpoch,
+            input.claimId,
+            input.leaseMs,
+          ],
+        },
+        signal
+      )
+    })
+
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async revalidateLifecycleShardClaim(
+    input: LifecycleShardClaimIdentity
+  ): Promise<LifecycleShardState | undefined> {
+    const result = await this.runQuery('RevalidateLifecycleShardClaim', async (db, signal) => {
+      return this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            SELECT state.*,
+                   state.shard_epoch::text AS shard_epoch
+            FROM storage.bucket_lifecycle_states AS state
+            JOIN storage.buckets AS bucket
+              ON bucket.id = state.bucket_id
+             AND bucket.type = 'STANDARD'
+             AND bucket.lifecycle_shard_epoch = state.shard_epoch
+             AND bucket.lifecycle_shard_count = state.shard_count
+            WHERE state.bucket_id = $1
+              AND state.scan_kind = $2
+              AND state.shard_id = $3
+              AND state.shard_epoch = $4::bigint
+              AND state.claim_id = $5::uuid
+              AND state.claim_until > clock_timestamp()
+          `,
+          values: [input.bucketId, input.scanKind, input.shardId, input.shardEpoch, input.claimId],
+        },
+        signal
+      )
+    })
+
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async evaluateNoncurrentLifecyclePage(
+    input: EvaluateNoncurrentLifecyclePageInput
+  ): Promise<LifecycleEvaluationPage> {
+    const statement = buildEvaluateNoncurrentLifecyclePageStatement(input)
+    const result = await this.runQuery('EvaluateNoncurrentLifecyclePage', (db, signal) =>
+      this.query<LifecycleEvaluationResultRow>(db, statement, signal)
+    )
+
+    const row = result.rows[0]
+    if (!row) throw ERRORS.InternalError(undefined, 'Lifecycle evaluation returned no result')
+    return mapLifecycleEvaluationPage(row, input.pageSize)
+  }
+
+  async saveLifecycleContinuation(
+    input: LifecycleShardClaimIdentity,
+    continuation: LifecycleContinuation
+  ): Promise<boolean> {
+    const decoded = decodeLifecycleContinuation(continuation)
+    const result = await this.runQuery('SaveLifecycleContinuation', (db, signal) =>
+      this.query(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states
+            SET continuation = $6::jsonb,
+                updated_at = clock_timestamp()
+            WHERE bucket_id = $1
+              AND scan_kind = $2
+              AND shard_id = $3
+              AND shard_epoch = $4::bigint
+              AND claim_id = $5::uuid
+              AND claim_until > clock_timestamp()
+          `,
+          values: [...lifecycleClaimIdentityValues(input), JSON.stringify(decoded)],
+        },
+        signal
+      )
+    )
+    return result.rowCount === 1
+  }
+
+  async armLifecycleAttempt(
+    input: LifecycleArmAttemptInput
+  ): Promise<LifecycleShardState | undefined> {
+    if (!this.options.tnx) {
+      return this.withTransaction((db) => db.armLifecycleAttempt(input))
+    }
+    assertPositiveSafeInteger(input.leaseMs, 'Lifecycle attempt lease')
+    const continuation = decodeLifecycleContinuation(input.continuation)
+    const batch = continuation.batch
+    if (!batch?.inFlight || batch.versions.length === 0) {
+      throw ERRORS.InvalidParameter('lifecycle attempt continuation')
+    }
+    for (const version of batch.versions) {
+      const physicalKey = withOptionalVersion(version.name, version.version)
+      const expectedArtifactKeys =
+        version.artifacts.length === 0 ? [] : [physicalKey, `${physicalKey}.info`]
+      if (
+        version.artifacts.length !== expectedArtifactKeys.length ||
+        version.artifacts.some(
+          (artifact, index) =>
+            artifact.key !== expectedArtifactKeys[index] ||
+            artifact.outcome !== 'UNRESOLVED' ||
+            artifact.error !== undefined
+        )
+      ) {
+        throw ERRORS.InvalidParameter('lifecycle attempt artifacts')
+      }
+    }
+
+    const serviceDatabase = this.asSuperUser()
+    await serviceDatabase.lockLifecycleObjects(
+      input.bucketId,
+      batch.versions.map((version) => version.name)
+    )
+    const bucket = await serviceDatabase.findLifecycleBucket(input.bucketId)
+    const rules =
+      bucket.lifecycle_configuration === null
+        ? []
+        : compileLifecycleEvaluationRules(
+            bucket.lifecycle_configuration,
+            new Date(continuation.snapshotAt)
+          )
+
+    // Recheck the exact archived rows and policy under the writer locks before
+    // durably authorizing backend deletion. Upload-session fencing is deferred.
+    const result = await this.runQuery('ArmLifecycleAttempt', (db, signal) =>
+      this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            WITH targets AS MATERIALIZED (
+              SELECT *
+              FROM unnest($9::text[], $10::text[], $11::boolean[])
+                AS target(name, version, is_delete_marker)
+            ),
+            rules(cutoff_at, newer_noncurrent_versions) AS MATERIALIZED (
+              SELECT * FROM unnest($12::timestamptz[], $13::integer[])
+            ),
+            eligible_targets AS MATERIALIZED (
+              SELECT count(*)::integer AS eligible_count
+              FROM targets AS target
+              JOIN storage.objects AS object_row
+                ON object_row.bucket_id = $1
+               AND object_row.name COLLATE "C" = target.name
+               AND object_row.version IS NOT DISTINCT FROM target.version
+              WHERE object_row.archived_at IS NOT NULL
+                AND object_row.is_delete_marker = target.is_delete_marker
+                AND object_row.archived_at <= $14::timestamptz
+                AND EXISTS (
+                  SELECT 1 FROM rules
+                  WHERE object_row.archived_at < rules.cutoff_at
+                    AND (rules.newer_noncurrent_versions IS NULL OR (
+                      SELECT count(*) FROM (
+                        SELECT 1 FROM storage.objects AS newer
+                        WHERE newer.bucket_id = object_row.bucket_id
+                          AND newer.name COLLATE "C" = object_row.name COLLATE "C"
+                          AND newer.archived_at > object_row.archived_at
+                          AND newer.archived_at <= $14::timestamptz
+                        ORDER BY newer.archived_at LIMIT $15::integer
+                      ) AS bounded_newer
+                    ) >= rules.newer_noncurrent_versions)
+                )
+
+            )
+            UPDATE storage.bucket_lifecycle_states AS state
+            SET continuation = CASE WHEN eligible_targets.eligible_count = cardinality($9::text[])
+                                        THEN $8::jsonb ELSE NULL END,
+                claim_id = CASE WHEN eligible_targets.eligible_count = cardinality($9::text[])
+                                THEN state.claim_id ELSE NULL END,
+                claim_until = CASE WHEN eligible_targets.eligible_count = cardinality($9::text[])
+                                   THEN clock_timestamp() + $7::bigint * interval '1 millisecond'
+                                   ELSE NULL END,
+                next_run_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            FROM storage.buckets AS bucket, eligible_targets
+            WHERE state.bucket_id = $1
+              AND state.scan_kind = $2
+              AND state.shard_id = $3
+              AND state.shard_epoch = $4::bigint
+              AND state.claim_id = $5::uuid
+              AND state.claim_until > clock_timestamp()
+              AND state.configuration_generation = $6::uuid
+              AND bucket.id = state.bucket_id
+              AND bucket.type = 'STANDARD'
+              AND bucket.versioning_status <> 'DISABLED'
+              AND bucket.lifecycle_configuration_generation = $6::uuid
+              AND bucket.lifecycle_shard_epoch = state.shard_epoch
+              AND bucket.lifecycle_shard_count = state.shard_count
+              AND state.continuation #> '{batch,inFlight}' IS NULL
+            RETURNING state.*,
+              state.shard_epoch::text AS shard_epoch
+          `,
+          values: [
+            ...lifecycleClaimIdentityValues(input),
+            input.configurationGeneration,
+            input.leaseMs,
+            JSON.stringify(continuation),
+            batch.versions.map((version) => version.name),
+            batch.versions.map((version) => version.version),
+            batch.versions.map((version) => version.artifacts.length === 0),
+            rules.map((rule) =>
+              rule.cutoffAt === '-infinity' ? '-infinity' : new Date(rule.cutoffAt)
+            ),
+            rules.map((rule) => rule.newerNoncurrentVersions ?? null),
+            new Date(continuation.snapshotAt),
+            Math.max(1, ...rules.map((rule) => rule.newerNoncurrentVersions ?? 0)),
+          ],
+        },
+        signal
+      )
+    )
+
+    return result.rows[0]?.claim_id ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async revalidateLifecycleRecoveryAttempt(
+    input: LifecycleShardClaimIdentity,
+    attemptId: string,
+    leaseMs: number
+  ): Promise<LifecycleShardState | undefined> {
+    assertPositiveSafeInteger(leaseMs, 'Lifecycle recovery lease')
+    const result = await this.runQuery('RevalidateLifecycleRecoveryAttempt', (db, signal) =>
+      this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states AS state
+            SET claim_until = clock_timestamp() + $7::bigint * interval '1 millisecond',
+                next_run_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            FROM storage.buckets AS bucket
+            WHERE state.bucket_id = $1
+              AND state.scan_kind = $2
+              AND state.shard_id = $3
+              AND state.shard_epoch = $4::bigint
+              AND state.claim_id = $5::uuid
+              AND state.claim_until > clock_timestamp()
+              AND state.continuation #>> '{batch,inFlight,attemptId}' = $6
+              AND bucket.id = state.bucket_id
+              AND bucket.type = 'STANDARD'
+              AND bucket.lifecycle_shard_epoch = state.shard_epoch
+              AND bucket.lifecycle_shard_count = state.shard_count
+            RETURNING state.*,
+              state.shard_epoch::text AS shard_epoch
+          `,
+          values: [...lifecycleClaimIdentityValues(input), attemptId, leaseMs],
+        },
+        signal
+      )
+    )
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async commitLifecycleAttempt(
+    input: LifecycleCommitAttemptInput
+  ): Promise<LifecycleShardState | undefined> {
+    if (!this.options.tnx) {
+      return this.withTransaction((database) => database.commitLifecycleAttempt(input))
+    }
+
+    const continuation = decodeLifecycleContinuation(input.continuation)
+    if (continuation.batch?.inFlight?.attemptId !== input.attemptId) {
+      throw ERRORS.InvalidParameter('lifecycle attempt identity')
+    }
+
+    const successfulVersions = continuation.batch.versions.filter((version) =>
+      version.artifacts.every(
+        (artifact) => artifact.outcome === 'DELETED' || artifact.outcome === 'ABSENT'
+      )
+    )
+    const serviceDatabase = this.asSuperUser()
+    await serviceDatabase.lockLifecycleObjects(
+      input.bucketId,
+      successfulVersions.map((version) => version.name)
+    )
+
+    const state = await serviceDatabase.revalidateLifecycleAttemptForCommit(input)
+    if (!state) return undefined
+    if (!state.continuation || !sameFrozenLifecycleBatch(state.continuation, continuation)) {
+      throw ERRORS.InvalidRequest('Lifecycle attempt artifact set changed before completion')
+    }
+
+    const deletedRows = await serviceDatabase.deleteLifecycleMetadataRows(
+      input.bucketId,
+      successfulVersions
+    )
+    if (deletedRows.length > 0) await serviceDatabase.invalidateLifecycleDecisions(input.bucketId)
+    const deletionCounters = lifecycleDeletionCounters(deletedRows, {
+      tenantId: this.tenantId,
+      bucketId: input.bucketId,
+    })
+    const retainedVersions = continuation.batch.versions.filter(lifecycleVersionNeedsCompensation)
+    const persisted = commitLifecycleBatchResults(continuation, retainedVersions, deletionCounters)
+
+    const result = await serviceDatabase.runQuery('CommitLifecycleAttemptState', (db, signal) =>
+      serviceDatabase.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states
+            SET continuation = $7::jsonb,
+                next_run_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            WHERE bucket_id = $1
+              AND scan_kind = $2
+              AND shard_id = $3
+              AND shard_epoch = $4::bigint
+              AND claim_id = $5::uuid
+              AND continuation #>> '{batch,inFlight,attemptId}' = $6
+            RETURNING *,
+              shard_epoch::text AS shard_epoch
+          `,
+          values: [
+            ...lifecycleClaimIdentityValues(input),
+            input.attemptId,
+            JSON.stringify(persisted),
+          ],
+        },
+        signal
+      )
+    )
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  async releaseLifecycleShardClaim(input: LifecycleReleaseClaimInput): Promise<boolean> {
+    const continuation =
+      input.continuation == null
+        ? input.continuation
+        : decodeLifecycleContinuation(input.continuation)
+    if ((continuation === undefined || continuation?.batch?.inFlight) && input.nextRunAt === null) {
+      throw ERRORS.InvalidParameter('lifecycle recovery schedule')
+    }
+    const result = await this.runQuery('ReleaseLifecycleShardClaim', (db, signal) =>
+      this.query(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states
+            SET continuation = CASE WHEN $9::boolean THEN $6::jsonb ELSE continuation END,
+                next_run_at = $7::timestamptz,
+                claim_id = NULL,
+                claim_until = NULL,
+                last_completed_at = clock_timestamp(),
+                failure_count = CASE WHEN $8::jsonb IS NULL THEN failure_count ELSE failure_count + 1 END,
+                last_error = COALESCE($8::jsonb, last_error),
+                updated_at = clock_timestamp()
+            WHERE bucket_id = $1
+              AND scan_kind = $2
+              AND shard_id = $3
+              AND shard_epoch = $4::bigint
+              AND claim_id = $5::uuid
+          `,
+          values: [
+            ...lifecycleClaimIdentityValues(input),
+            continuation == null ? null : JSON.stringify(continuation),
+            input.nextRunAt,
+            input.error === undefined ? null : JSON.stringify(input.error),
+            continuation !== undefined,
+          ],
+        },
+        signal
+      )
+    )
+    return result.rowCount === 1
+  }
+
+  async completeLifecycleShardRun(
+    input: LifecycleShardClaimIdentity,
+    lastResult: Record<string, unknown>,
+    nextRunAt: string
+  ): Promise<boolean> {
+    if (Number.isNaN(Date.parse(nextRunAt))) throw ERRORS.InvalidParameter('next lifecycle run')
+    const result = await this.runQuery('CompleteLifecycleShardRun', (db, signal) =>
+      this.query(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states
+            SET continuation = NULL,
+                next_run_at = $6::timestamptz,
+                claim_id = NULL,
+                claim_until = NULL,
+                last_completed_at = clock_timestamp(),
+                last_success_at = clock_timestamp(),
+                last_result = $7::jsonb,
+                failure_count = 0,
+                last_error = NULL,
+                updated_at = clock_timestamp()
+            WHERE bucket_id = $1
+              AND scan_kind = $2
+              AND shard_id = $3
+              AND shard_epoch = $4::bigint
+              AND claim_id = $5::uuid
+          `,
+          values: [...lifecycleClaimIdentityValues(input), nextRunAt, JSON.stringify(lastResult)],
+        },
+        signal
+      )
+    )
+    return result.rowCount === 1
+  }
+
+  async prepareLifecycleStateForBucketDelete(bucketId: string): Promise<number> {
+    if (!this.options.tnx) {
+      throw ERRORS.InternalError(
+        undefined,
+        'Lifecycle state cleanup must run inside the bucket-delete transaction'
+      )
+    }
+
+    const result = await this.runQuery(
+      'PrepareLifecycleStateForBucketDelete',
+      async (db, signal) => {
+        const bucket = await this.query<{ id: string }>(
+          db,
+          {
+            text: `SELECT id FROM storage.buckets WHERE id = $1 FOR UPDATE`,
+            values: [bucketId],
+          },
+          signal
+        )
+        if (!bucket.rows[0]) throw ERRORS.NoSuchBucket(bucketId)
+
+        const locked = await this.query<{ continuation: unknown | null }>(
+          db,
+          {
+            text: `
+            SELECT continuation
+            FROM storage.bucket_lifecycle_states
+            WHERE bucket_id = $1
+            FOR UPDATE
+          `,
+            values: [bucketId],
+          },
+          signal
+        )
+        for (const row of locked.rows) {
+          if (row.continuation === null) continue
+          let continuation: LifecycleContinuation
+          try {
+            continuation = decodeLifecycleContinuation(row.continuation)
+          } catch (error) {
+            throw ERRORS.ResourceReferenced(
+              `Bucket ${bucketId} has lifecycle state that this service cannot safely remove`,
+              error as Error
+            )
+          }
+          if (continuation.batch?.inFlight) {
+            throw ERRORS.ResourceReferenced(
+              `Bucket ${bucketId} has lifecycle recovery work in flight`
+            )
+          }
+        }
+
+        return this.query(
+          db,
+          {
+            text: `DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = $1`,
+            values: [bucketId],
+          },
+          signal
+        )
+      }
+    )
+
+    return result.rowCount || 0
+  }
+
+  private async reconcileLifecycleConfiguration(bucket: LifecycleBucket, changed: boolean) {
+    if (bucket.lifecycle_configuration === null) {
+      await this.reconcileLifecycleStateAfterConfigurationDelete(bucket.id)
+    } else {
+      await this.reconcileLifecycleStateAfterConfigurationChange(
+        bucket,
+        bucket.lifecycle_configuration,
+        changed
+      )
+    }
+  }
+
+  private async lockLifecycleControlBucket(bucketId: string): Promise<LifecycleBucket> {
+    const bucket = await this.findBucketById(bucketId, LIFECYCLE_BUCKET_COLUMNS, {
+      forUpdate: true,
+    })
+    return mapLifecycleBucket(bucket)
+  }
+
+  private async reconcileLifecycleStateAfterConfigurationChange(
+    bucket: LifecycleBucket,
+    configuration: BucketLifecycleConfiguration,
+    changed: boolean
+  ): Promise<void> {
+    const generation = bucket.lifecycle_configuration_generation
+    if (!generation) {
+      throw ERRORS.InternalError(undefined, 'Lifecycle configuration generation is missing')
+    }
+
+    const active = bucket.versioning_status !== 'DISABLED' && hasEnabledLifecycleRule(configuration)
+    await this.runQuery('ReconcileLifecycleStateAfterConfigurationChange', (db, signal) =>
+      this.query(
+        db,
+        {
+          text: `
+            INSERT INTO storage.bucket_lifecycle_states (
+              bucket_id,
+              scan_kind,
+              shard_id,
+              shard_epoch,
+              shard_count,
+              configuration_generation,
+              next_run_at
+            ) VALUES (
+              $1,
+              'NONCURRENT',
+              0,
+              $2::bigint,
+              $3,
+              $4::uuid,
+              CASE WHEN $5::boolean THEN clock_timestamp() ELSE NULL END
+            )
+            ON CONFLICT (bucket_id, scan_kind, shard_id) ${
+              changed
+                ? `DO UPDATE SET
+                    shard_epoch = EXCLUDED.shard_epoch,
+                    shard_count = EXCLUDED.shard_count,
+                    configuration_generation = EXCLUDED.configuration_generation,
+                    next_run_at = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN clock_timestamp()
+                      WHEN $5::boolean
+                        THEN clock_timestamp()
+                      ELSE NULL
+                    END,
+                    claim_id = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN bucket_lifecycle_states.claim_id
+                      ELSE NULL
+                    END,
+                    claim_until = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN bucket_lifecycle_states.claim_until
+                      ELSE NULL
+                    END,
+                    continuation = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN bucket_lifecycle_states.continuation
+                      ELSE NULL
+                    END,
+                    failure_count = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN bucket_lifecycle_states.failure_count
+                      ELSE 0
+                    END,
+                    last_error = CASE
+                      WHEN bucket_lifecycle_states.continuation #> '{batch,inFlight}' IS NOT NULL
+                        THEN bucket_lifecycle_states.last_error
+                      ELSE NULL
+                    END,
+                    updated_at = clock_timestamp()`
+                : 'DO NOTHING'
+            }
+          `,
+          values: [
+            bucket.id,
+            bucket.lifecycle_shard_epoch,
+            bucket.lifecycle_shard_count,
+            generation,
+            active,
+          ],
+        },
+        signal
+      )
+    )
+  }
+
+  private async reconcileLifecycleStateAfterConfigurationDelete(bucketId: string): Promise<void> {
+    await this.runQuery('ReconcileLifecycleStateAfterConfigurationDelete', async (db, signal) => {
+      await this.query(
+        db,
+        {
+          text: `
+            UPDATE storage.bucket_lifecycle_states
+            SET next_run_at = clock_timestamp(),
+                updated_at = clock_timestamp()
+            WHERE bucket_id = $1
+              AND continuation #> '{batch,inFlight}' IS NOT NULL
+          `,
+          values: [bucketId],
+        },
+        signal
+      )
+      await this.query(
+        db,
+        {
+          text: `
+            DELETE FROM storage.bucket_lifecycle_states
+            WHERE bucket_id = $1
+              AND continuation #> '{batch,inFlight}' IS NULL
+          `,
+          values: [bucketId],
+        },
+        signal
+      )
+    })
+  }
+
+  private async revalidateLifecycleAttemptForCommit(
+    input: LifecycleCommitAttemptInput
+  ): Promise<LifecycleShardState | undefined> {
+    const result = await this.runQuery('RevalidateLifecycleAttemptForCommit', (db, signal) =>
+      this.query<LifecycleShardStateRow>(
+        db,
+        {
+          text: `
+            SELECT state.*,
+              state.shard_epoch::text AS shard_epoch
+            FROM storage.bucket_lifecycle_states AS state
+            JOIN storage.buckets AS bucket
+              ON bucket.id = state.bucket_id
+             AND bucket.type = 'STANDARD'
+             AND bucket.lifecycle_shard_epoch = state.shard_epoch
+             AND bucket.lifecycle_shard_count = state.shard_count
+            WHERE state.bucket_id = $1
+              AND state.scan_kind = $2
+              AND state.shard_id = $3
+              AND state.shard_epoch = $4::bigint
+              AND state.claim_id = $5::uuid
+              AND state.claim_until > clock_timestamp()
+              AND state.continuation #>> '{batch,inFlight,attemptId}' = $6
+            FOR UPDATE OF state
+          `,
+          values: [...lifecycleClaimIdentityValues(input), input.attemptId],
+        },
+        signal
+      )
+    )
+    return result.rows[0] ? mapLifecycleShardState(result.rows[0]) : undefined
+  }
+
+  private async deleteLifecycleMetadataRows(
+    bucketId: string,
+    versions: Array<{ name: string; version: string | null }>
+  ): Promise<LifecycleDeletedObjectRow[]> {
+    if (versions.length === 0) return []
+    const result = await this.runQuery('DeleteLifecycleMetadataRows', (db, signal) =>
+      this.query<LifecycleDeletedObjectRow>(
+        db,
+        {
+          text: `
+            DELETE FROM storage.objects AS object_row
+            USING unnest($2::text[], $3::text[]) AS target(name, version)
+            WHERE object_row.bucket_id = $1
+              AND object_row.name COLLATE "C" = target.name
+              AND object_row.version IS NOT DISTINCT FROM target.version
+              AND object_row.archived_at IS NOT NULL
+            RETURNING object_row.is_delete_marker, object_row.metadata
+          `,
+          values: [
+            bucketId,
+            versions.map((version) => version.name),
+            versions.map((version) => version.version),
+          ],
+        },
+        signal
+      )
+    )
+    return result.rows
+  }
+
+  private async invalidateLifecycleDecisions(bucketId: string): Promise<void> {
+    if (!(await this.hasMigration('noncurrent-lifecycle'))) return
+    await this.asSuperUser().runQuery('InvalidateLifecycleDecisions', (db, signal) =>
+      this.query(
+        db,
+        {
+          text: `UPDATE storage.bucket_lifecycle_states
+               SET continuation = NULL, claim_id = NULL, claim_until = NULL,
+                   next_run_at = clock_timestamp(), updated_at = clock_timestamp()
+               WHERE bucket_id = $1 AND scan_kind = 'NONCURRENT'
+                 AND continuation #> '{batch,inFlight}' IS NULL`,
+          values: [bucketId],
+        },
+        signal
+      )
+    )
   }
 }
 
@@ -2331,3 +3345,120 @@ async function rollbackSavepoint(tnx: DatabaseTransaction, savepoint: string): P
   await tnx.query(`ROLLBACK TO SAVEPOINT ${savepoint}`)
   await tnx.query(`RELEASE SAVEPOINT ${savepoint}`)
 }
+
+function mapLifecycleShardState(row: LifecycleShardStateRow): LifecycleShardState {
+  return {
+    bucketId: row.bucket_id,
+    scanKind: row.scan_kind,
+    shardId: row.shard_id,
+    shardEpoch: String(row.shard_epoch),
+    shardCount: row.shard_count,
+    configurationGeneration: row.configuration_generation,
+    nextRunAt: nullableTimestamp(row.next_run_at),
+    claimId: row.claim_id,
+    claimUntil: nullableTimestamp(row.claim_until),
+    continuation: row.continuation === null ? null : decodeLifecycleContinuation(row.continuation),
+    failureCount: row.failure_count,
+  }
+}
+
+function mapLifecycleBucket(bucket: Bucket | LifecycleBucket): LifecycleBucket {
+  const lifecycleBucket = bucket as LifecycleBucket
+  return {
+    ...lifecycleBucket,
+    versioning_status: lifecycleBucket.versioning_status ?? 'DISABLED',
+    lifecycle_configuration: lifecycleBucket.lifecycle_configuration ?? null,
+    lifecycle_configuration_generation: lifecycleBucket.lifecycle_configuration_generation ?? null,
+    lifecycle_shard_epoch: Number(lifecycleBucket.lifecycle_shard_epoch ?? 1),
+    lifecycle_shard_count: Number(lifecycleBucket.lifecycle_shard_count ?? 1),
+  }
+}
+
+function lifecycleClaimIdentityValues(input: LifecycleShardClaimIdentity): unknown[] {
+  return [input.bucketId, input.scanKind, input.shardId, input.shardEpoch, input.claimId]
+}
+
+function sameFrozenLifecycleBatch(
+  persisted: LifecycleContinuation,
+  proposed: LifecycleContinuation
+): boolean {
+  const persistedBatch = persisted.batch
+  const proposedBatch = proposed.batch
+  if (
+    !persistedBatch?.inFlight ||
+    !proposedBatch?.inFlight ||
+    persistedBatch.inFlight.attemptId !== proposedBatch.inFlight.attemptId ||
+    persistedBatch.versions.length !== proposedBatch.versions.length
+  ) {
+    return false
+  }
+
+  return persistedBatch.versions.every((version, index) => {
+    const other = proposedBatch.versions[index]
+    return (
+      version.name === other.name &&
+      version.version === other.version &&
+      version.artifacts.length === other.artifacts.length &&
+      version.artifacts.every((artifact, artifactIndex) => {
+        return artifact.key === other.artifacts[artifactIndex].key
+      })
+    )
+  })
+}
+
+function lifecycleDeletionCounters(
+  rows: LifecycleDeletedObjectRow[],
+  context: { tenantId: string; bucketId: string }
+): {
+  objectVersions: number
+  deleteMarkers: number
+  bytes: number
+} {
+  let objectVersions = 0
+  let deleteMarkers = 0
+  let bytes = 0
+  let invalidSizeCount = 0
+  for (const row of rows) {
+    if (row.is_delete_marker) {
+      deleteMarkers++
+      continue
+    }
+    objectVersions++
+    const metadata = row.metadata
+    const rawSize = metadata && typeof metadata === 'object' ? metadata.size : undefined
+    const size =
+      typeof rawSize === 'number' || (typeof rawSize === 'string' && rawSize.trim() !== '')
+        ? Number(rawSize)
+        : NaN
+    if (!Number.isSafeInteger(size) || size < 0) {
+      invalidSizeCount++
+      continue
+    }
+    bytes += size
+    if (!Number.isSafeInteger(bytes)) {
+      throw ERRORS.InternalError(undefined, 'Lifecycle deleted-byte counter overflowed')
+    }
+  }
+  if (invalidSizeCount > 0) {
+    logSchema.warning(logger, '[Lifecycle] Missing or invalid object sizes counted as zero bytes', {
+      type: 'event',
+      tenantId: context.tenantId,
+      project: context.tenantId,
+      metadata: JSON.stringify({ bucketId: context.bucketId, invalidSizeCount }),
+    })
+  }
+  return { objectVersions, deleteMarkers, bytes }
+}
+
+function nullableTimestamp(value: Date | string | null): string | null {
+  if (value === null) return null
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function assertPositiveSafeInteger(value: number, label: string) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw ERRORS.InvalidParameter(label)
+  }
+}
+
+type LifecycleDeletedObjectRow = Pick<LifecycleObjectRow, 'is_delete_marker' | 'metadata'>

--- a/src/storage/lifecycle/continuation.test.ts
+++ b/src/storage/lifecycle/continuation.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { withOptionalVersion } from '@storage/backend/adapter'
 import {
-  advanceLifecycleEvaluationPage,
+  advanceEmptyLifecyclePage,
   armLifecycleAttempt,
   commitLifecycleBatchResults,
   completeLifecycleBatch,
@@ -23,7 +23,6 @@ function validContinuation() {
     trigger: 'scheduled',
     generation,
     snapshotAt: '2026-08-06T00:00:00.000Z',
-    mode: 'DELETE',
     topology: {
       scanKind: 'NONCURRENT',
       epoch: '1',
@@ -149,7 +148,6 @@ describe('lifecycle continuation transitions', () => {
       trigger: 'scheduled',
       generation: randomUUID(),
       snapshotAt: '2026-08-15T00:00:00.000Z',
-      mode: 'DELETE',
       topology: {
         scanKind: 'NONCURRENT',
         epoch: '1',
@@ -172,11 +170,24 @@ describe('lifecycle continuation transitions', () => {
       })
     ).toThrow('Lifecycle batch cannot be empty')
 
-    expect(advanceLifecycleEvaluationPage(initial, page)).toEqual({
+    expect(advanceEmptyLifecyclePage(initial, page)).toEqual({
       ...initial,
       cursor: page.pageEnd,
       counters: { ...initial.counters, versionsExamined: 1 },
     })
+
+    expect(() =>
+      advanceEmptyLifecyclePage(initial, {
+        ...page,
+        candidates: [
+          {
+            name: page.pageEnd.name,
+            version: randomUUID(),
+            isDeleteMarker: false,
+          },
+        ],
+      })
+    ).toThrow('Lifecycle pages with eligible candidates must be staged before advancing')
   })
 
   test('keeps null and literal null-string identities separate through filtering and recovery', () => {
@@ -281,7 +292,6 @@ describe('lifecycle continuation transitions', () => {
       trigger: 'scheduled',
       generation,
       snapshotAt: '2026-08-15T00:00:00.000Z',
-      mode: 'DELETE',
       topology: {
         scanKind: 'NONCURRENT',
         epoch: '1',
@@ -335,7 +345,6 @@ describe('lifecycle continuation transitions', () => {
         trigger: 'scheduled',
         generation,
         snapshotAt: '2026-08-15T00:00:00.000Z',
-        mode: 'DELETE',
         topology: {
           scanKind: 'NONCURRENT',
           epoch: '1',

--- a/src/storage/lifecycle/continuation.ts
+++ b/src/storage/lifecycle/continuation.ts
@@ -8,7 +8,6 @@ import {
   type LifecycleContinuation,
   type LifecycleContinuationBatch,
   type LifecycleEvaluationPage,
-  type LifecycleExecutionMode,
   type LifecycleInFlightAttempt,
   type LifecycleRunCounters,
   type LifecycleShardTopology,
@@ -39,7 +38,6 @@ export function createLifecycleContinuation(input: {
   trigger: LifecycleTrigger
   generation: string
   snapshotAt: string
-  mode: LifecycleExecutionMode
   topology: LifecycleShardTopology
 }): LifecycleContinuation {
   return decodeLifecycleContinuation({
@@ -106,12 +104,15 @@ export function stageLifecycleBatch(
   })
 }
 
-export function advanceLifecycleEvaluationPage(
+export function advanceEmptyLifecyclePage(
   continuation: LifecycleContinuation,
   page: LifecycleEvaluationPage
 ): LifecycleContinuation {
   if (continuation.batch !== undefined) {
     throw new Error('Lifecycle continuation already has a staged batch')
+  }
+  if (page.candidates.length !== 0) {
+    throw new Error('Lifecycle pages with eligible candidates must be staged before advancing')
   }
   if (page.rawRowsExamined > 0 && page.pageEnd === undefined) {
     throw new Error('A non-empty lifecycle page requires pageEnd')
@@ -123,7 +124,6 @@ export function advanceLifecycleEvaluationPage(
     counters: {
       ...continuation.counters,
       versionsExamined: continuation.counters.versionsExamined + page.rawRowsExamined,
-      versionsEligible: continuation.counters.versionsEligible + page.candidates.length,
     },
   })
 }
@@ -354,7 +354,6 @@ export function decodeLifecycleContinuation(value: unknown): LifecycleContinuati
     ),
     generation: uuid(continuation.generation, 'generation'),
     snapshotAt: timestamp(continuation.snapshotAt, 'snapshotAt'),
-    mode: oneOf(continuation.mode, ['EVALUATE', 'DELETE'] as const, 'mode'),
     topology: decodeTopology(continuation.topology),
     counters: decodeCounters(continuation.counters),
   }

--- a/src/storage/lifecycle/control-plane.ts
+++ b/src/storage/lifecycle/control-plane.ts
@@ -1,0 +1,54 @@
+import { LifecycleTenantStorePg, multitenantPgExecutor, tenantHasFeature } from '@internal/database'
+import { ERRORS } from '@internal/errors'
+import { logger, logSchema } from '@internal/monitoring'
+import { getConfig } from '../../config'
+import type { Database } from '../database'
+import { assertLifecycleApiEnabled } from './guards'
+
+export async function assertTenantLifecycleApiEnabled(bucketId: string, tenantId: string) {
+  assertLifecycleApiEnabled(bucketId)
+  if (!(await tenantHasFeature(tenantId, 'objectVersioning'))) {
+    throw ERRORS.FeatureNotEnabled(bucketId, 'object lifecycle for this tenant')
+  }
+}
+
+export async function withLifecycleConfigurationTransaction<T>(
+  database: Database,
+  tenantId: string,
+  mutation: (database: Database) => Promise<T>
+): Promise<T> {
+  const config = getConfig()
+  const deadlineSignal = AbortSignal.timeout(
+    config.storageLifecycleConfigurationTransactionTimeoutMs
+  )
+  const requestSignal = database.connection.getAbortSignal()
+  const tenantStore = config.isMultitenant
+    ? new LifecycleTenantStorePg(multitenantPgExecutor)
+    : undefined
+  const operationSignal = requestSignal
+    ? AbortSignal.any([requestSignal, deadlineSignal])
+    : deadlineSignal
+  database.connection.setAbortSignal(operationSignal)
+
+  try {
+    operationSignal.throwIfAborted()
+    await tenantStore?.wakeTenant(tenantId, operationSignal)
+    operationSignal.throwIfAborted()
+    const result = await database.withTransaction(mutation, { deadlineSignal: operationSignal })
+    try {
+      // The dispatcher may have consumed the first wake before this commit.
+      // Give committed work its own wake budget, independent of request cancellation.
+      await tenantStore?.wakeTenant(tenantId, AbortSignal.timeout(5000))
+    } catch (error) {
+      logSchema.warning(logger, '[Lifecycle] Failed to wake lifecycle tenant after commit', {
+        type: 'event',
+        tenantId,
+        project: tenantId,
+        error,
+      })
+    }
+    return result
+  } finally {
+    database.connection.setAbortSignal(requestSignal)
+  }
+}

--- a/src/storage/lifecycle/executor.test.ts
+++ b/src/storage/lifecycle/executor.test.ts
@@ -1,0 +1,1116 @@
+import { randomUUID } from 'node:crypto'
+import { logSchema } from '@internal/monitoring'
+import type { Database } from '../database'
+import type {
+  LifecycleCandidate,
+  LifecycleCommitAttemptInput,
+  LifecycleContinuation,
+  LifecycleShardState,
+} from '../schemas'
+import type { Storage } from '../storage'
+import {
+  commitLifecycleBatchResults,
+  createLifecycleContinuation,
+  freezeLifecycleBatchVersion,
+  lifecycleVersionNeedsCompensation,
+  stageLifecycleBatch,
+} from './continuation'
+import { NoncurrentLifecycleExecutor } from './executor'
+
+const now = new Date('2026-08-15T00:00:00.000Z')
+
+function configuration(generation: string) {
+  return {
+    id: 'bucket',
+    name: 'bucket',
+    type: 'STANDARD' as const,
+    versioning_status: 'ENABLED' as const,
+    lifecycle_configuration_generation: generation,
+    lifecycle_configuration: {
+      rules: [
+        {
+          status: 'Enabled' as const,
+          filter: {},
+          noncurrentVersionExpiration: { noncurrentDays: 1 },
+        },
+      ],
+    },
+    lifecycle_shard_epoch: 1,
+    lifecycle_shard_count: 1,
+  }
+}
+
+function candidate(generation: string): LifecycleCandidate {
+  return {
+    id: randomUUID(),
+    bucketId: 'bucket',
+    name: 'folder/object.txt',
+    version: randomUUID(),
+    isVersioned: true,
+    isDeleteMarker: false,
+    metadata: {
+      size: 12,
+      generation,
+    },
+    createdAt: '2026-07-01T00:00:01.000Z',
+    archivedAt: '2026-07-02T00:00:00.000Z',
+  }
+}
+
+function state(
+  generation: string,
+  continuation: LifecycleContinuation | null = null
+): LifecycleShardState {
+  return {
+    bucketId: 'bucket',
+    scanKind: 'NONCURRENT',
+    shardId: 0,
+    shardEpoch: '1',
+    shardCount: 1,
+    configurationGeneration: generation,
+    nextRunAt: now.toISOString(),
+    claimId: randomUUID(),
+    claimUntil: new Date(now.getTime() + 120_000).toISOString(),
+    continuation,
+    failureCount: 0,
+  }
+}
+
+function createHarness(input: {
+  continuation?: LifecycleContinuation
+  deleteOutcome?: 'DELETED' | 'FAILED' | 'UNKNOWN'
+  deleteOutcomesByCall?: Array<Array<'DELETED' | 'FAILED' | 'UNKNOWN'>>
+  headMissing?: boolean
+  deleteEnabled?: boolean
+}) {
+  const generation = input.continuation?.generation ?? randomUUID()
+  let persisted = input.continuation ?? null
+  const claimed = state(generation, persisted)
+  const pageCandidate = candidate(generation)
+  const calls: string[] = []
+  const database = {
+    tenantId: 'tenant',
+    asSuperUser: vi.fn(() => database),
+    claimLifecycleShard: vi
+      .fn()
+      .mockImplementation(() => ({ ...claimed, continuation: persisted })),
+    findLifecycleBucket: vi.fn().mockResolvedValue(configuration(generation)),
+    saveLifecycleContinuation: vi.fn().mockImplementation((_identity, continuation) => {
+      persisted = continuation
+      calls.push(continuation.batch ? 'stage' : 'save')
+      return true
+    }),
+    evaluateNoncurrentLifecyclePage: vi.fn().mockResolvedValue({
+      rawRowsExamined: 1,
+      candidates: [pageCandidate],
+      pageEnd: {
+        name: pageCandidate.name,
+        archivedAt: pageCandidate.archivedAt,
+      },
+      exhausted: true,
+    }),
+    findLifecycleObjectVersions: vi
+      .fn()
+      .mockImplementation(
+        (_bucketId: string, versions: Array<{ name: string; version: string | null }>) =>
+          versions.map((version) => ({
+            id: pageCandidate.id,
+            bucket_id: pageCandidate.bucketId,
+            name: version.name,
+            version: version.version,
+            is_versioned: pageCandidate.isVersioned,
+            is_delete_marker: pageCandidate.isDeleteMarker,
+            metadata: pageCandidate.metadata,
+            created_at: new Date(pageCandidate.createdAt),
+            archived_at: new Date(pageCandidate.archivedAt),
+          }))
+      ),
+    armLifecycleAttempt: vi.fn().mockImplementation((attempt) => {
+      persisted = attempt.continuation
+      calls.push('arm')
+      return { ...claimed, continuation: persisted }
+    }),
+    revalidateLifecycleShardClaim: vi.fn().mockImplementation(() => ({
+      ...claimed,
+      continuation: persisted,
+      configurationGeneration: generation,
+    })),
+    commitLifecycleAttempt: vi.fn().mockImplementation((attempt: LifecycleCommitAttemptInput) => {
+      const versions = attempt.continuation.batch!.versions
+      const successful = versions.filter((version) =>
+        version.artifacts.every(
+          (artifact) => artifact.outcome === 'DELETED' || artifact.outcome === 'ABSENT'
+        )
+      )
+      const retained = versions.filter(lifecycleVersionNeedsCompensation)
+      persisted = commitLifecycleBatchResults(attempt.continuation, retained, {
+        objectVersions: successful.length,
+        deleteMarkers: 0,
+        bytes: successful.length * 12,
+      })
+      calls.push('commit')
+      return { ...claimed, continuation: persisted }
+    }),
+    revalidateLifecycleRecoveryAttempt: vi.fn().mockImplementation(() => ({
+      ...claimed,
+      continuation: persisted,
+    })),
+    releaseLifecycleShardClaim: vi.fn().mockImplementation((input) => {
+      if (input.error) claimed.failureCount++
+      return true
+    }),
+    completeLifecycleShardRun: vi.fn().mockImplementation(() => {
+      calls.push('complete')
+      return true
+    }),
+  }
+  let deleteCall = 0
+  const backend = {
+    deleteObjectsDetailed: vi.fn().mockImplementation((_bucket: string, keys: string[]) => {
+      calls.push('delete')
+      const configuredOutcomes = input.deleteOutcomesByCall?.[deleteCall++]
+      return keys.map((key, index) => {
+        const outcome = configuredOutcomes?.[index] ?? input.deleteOutcome ?? 'DELETED'
+        return {
+          key,
+          outcome,
+          ...(outcome === 'DELETED' ? {} : { error: { message: outcome.toLowerCase() } }),
+        }
+      })
+    }),
+    headObject: input.headMissing
+      ? vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+      : vi.fn().mockResolvedValue({ size: 12 }),
+  }
+  const storage = {
+    backend,
+    db: database as unknown as Database,
+    location: {
+      getRootLocation: () => 'root',
+      getKeyLocation: ({ tenantId, bucketId, objectName }: Record<string, string>) =>
+        `${tenantId}/${bucketId}/${objectName}`,
+    },
+  } as unknown as Storage
+  const executor = new NoncurrentLifecycleExecutor(storage, {
+    now: () => now,
+    deleteEnabled: input.deleteEnabled ?? true,
+    pageSize: 500,
+    jobBudgetMs: 20_000,
+    claimLeaseMs: 120_000,
+    recoveryGraceMs: 1,
+    fairnessDelayMs: 1000,
+    evaluationIntervalMs: 86_400_000,
+  })
+  return {
+    backend,
+    calls,
+    database,
+    executor,
+    generation,
+    pageCandidate,
+    storage,
+    getPersisted: () => persisted,
+  }
+}
+
+const coordinate = {
+  bucketId: 'bucket',
+  scanKind: 'NONCURRENT' as const,
+  shardEpoch: '1',
+  shardId: 0,
+}
+
+test('releases a claim whose persisted continuation cannot be decoded', async () => {
+  const harness = createHarness({})
+  const failure = new Error('Unsupported lifecycle continuation version')
+  harness.database.claimLifecycleShard.mockRejectedValueOnce(failure)
+
+  await expect(harness.executor.run(coordinate, { tenantVersioningEnabled: true })).rejects.toBe(
+    failure
+  )
+  expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...coordinate,
+      claimId: expect.any(String),
+      nextRunAt: expect.any(String),
+      error: expect.any(Object),
+    })
+  )
+  expect(harness.database.releaseLifecycleShardClaim.mock.calls[0][0]).not.toHaveProperty(
+    'continuation'
+  )
+})
+
+test('preserves the original failure when releasing its claim also fails', async () => {
+  const harness = createHarness({})
+  const failure = new Error('invalid continuation')
+  const releaseFailure = new Error('database offline')
+  harness.database.claimLifecycleShard.mockRejectedValueOnce(failure)
+  harness.database.releaseLifecycleShardClaim.mockRejectedValueOnce(releaseFailure)
+  const warning = vi.spyOn(logSchema, 'warning').mockImplementation(() => {})
+  try {
+    await expect(harness.executor.run(coordinate, { tenantVersioningEnabled: true })).rejects.toBe(
+      failure
+    )
+    expect(warning).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('release lifecycle claim'),
+      expect.objectContaining({ error: releaseFailure, tenantId: 'tenant' })
+    )
+  } finally {
+    warning.mockRestore()
+  }
+})
+
+test.each([
+  true,
+  false,
+])('recovers a large journal with deletion enabled=%s', async (deleteEnabled) => {
+  const generation = randomUUID()
+  const candidates = Array.from({ length: 500 }, (_, index) => ({
+    ...candidate(generation),
+    name: `object-${index}`,
+  }))
+  const initial = stageLifecycleBatch(
+    createLifecycleContinuation({
+      runId: randomUUID(),
+      trigger: 'recovery',
+      generation,
+      snapshotAt: '2026-08-01T00:00:00.000Z',
+      topology: { scanKind: 'NONCURRENT', epoch: '1', shardId: 0, shardCount: 1 },
+    }),
+    {
+      rawRowsExamined: candidates.length,
+      pageEnd: { name: candidates.at(-1)!.name, archivedAt: candidates.at(-1)!.archivedAt },
+      versions: candidates.map(freezeLifecycleBatchVersion),
+    }
+  )
+  initial.batch!.inFlight = {
+    attemptId: randomUUID(),
+    authorizedGeneration: generation,
+    startedAt: '2026-08-01T00:00:00.000Z',
+  }
+  const harness = createHarness({ continuation: initial })
+  let elapsed = 0
+  let leaseUntil = 120_000
+  let inspected = 0
+  const inspectedKeys = new Set<string>()
+  harness.backend.headObject.mockImplementation(async (_bucket, key) => {
+    inspectedKeys.add(key)
+    if (++inspected % 8 === 0) elapsed += 5000
+    if (!deleteEnabled) throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    return { size: 12 }
+  })
+  const commit = harness.database.commitLifecycleAttempt.getMockImplementation()!
+  harness.database.commitLifecycleAttempt.mockImplementation((input) =>
+    elapsed >= leaseUntil ? undefined : commit(input)
+  )
+  const renew = harness.database.revalidateLifecycleRecoveryAttempt.getMockImplementation()!
+  harness.database.revalidateLifecycleRecoveryAttempt.mockImplementation((...args) => {
+    if (elapsed >= leaseUntil) return undefined
+    leaseUntil = elapsed + 120_000
+    return renew(...args)
+  })
+  harness.database.evaluateNoncurrentLifecyclePage.mockResolvedValue({
+    rawRowsExamined: 0,
+    candidates: [],
+    exhausted: true,
+  })
+  const executor = new NoncurrentLifecycleExecutor(harness.storage, {
+    now: () => new Date(now.getTime() + elapsed),
+    deleteEnabled,
+    jobBudgetMs: 20_000,
+    claimLeaseMs: 120_000,
+    recoveryGraceMs: 1,
+  })
+
+  await expect(executor.run(coordinate, { tenantVersioningEnabled: true })).resolves.toMatchObject({
+    status: deleteEnabled ? 'COMPLETED' : 'PAUSED',
+  })
+  if (deleteEnabled) {
+    expect(harness.backend.headObject).not.toHaveBeenCalled()
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledOnce()
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledOnce()
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledWith(
+      'root',
+      initial.batch!.versions.flatMap((version) =>
+        version.artifacts.map((artifact) => `tenant/bucket/${artifact.key}`)
+      )
+    )
+    expect(harness.database.commitLifecycleAttempt).toHaveBeenCalledOnce()
+    expect(
+      harness.database.revalidateLifecycleRecoveryAttempt.mock.invocationCallOrder[0]
+    ).toBeLessThan(harness.backend.deleteObjectsDetailed.mock.invocationCallOrder[0])
+    expect(harness.getPersisted()?.batch).toBeUndefined()
+    expect(harness.getPersisted()?.counters.objectVersionsDeleted).toBe(500)
+    expect(harness.getPersisted()?.counters.bytesDeleted).toBe(6000)
+  } else {
+    expect(inspected).toBe(32)
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledTimes(4)
+    expect(harness.database.commitLifecycleAttempt).toHaveBeenCalledTimes(4)
+    expect(harness.getPersisted()?.counters.objectVersionsDeleted).toBe(16)
+    await expect(
+      executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PAUSED' })
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    expect(harness.getPersisted()?.counters.objectVersionsDeleted).toBe(32)
+    expect(harness.getPersisted()?.batch?.versions).toHaveLength(468)
+    expect(inspected).toBe(64)
+    expect(inspectedKeys.size).toBe(64)
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledTimes(8)
+    expect(harness.database.commitLifecycleAttempt).toHaveBeenCalledTimes(8)
+  }
+})
+
+describe('NoncurrentLifecycleExecutor', () => {
+  test.each([
+    { versioningEnabled: false, backend: 's3', canDelete: false },
+    { versioningEnabled: true, backend: 's3', canDelete: true },
+    { versioningEnabled: true, backend: 'file', canDelete: false },
+  ])('derives deletion from versioning=$versioningEnabled on $backend', async (options) => {
+    vi.resetModules()
+    vi.stubEnv('STORAGE_VERSIONING_ENABLED', String(options.versioningEnabled))
+    vi.stubEnv('STORAGE_BACKEND', options.backend)
+    vi.stubEnv('STORAGE_S3_CLIENT_TIMEOUT', '5000')
+
+    try {
+      const { NoncurrentLifecycleExecutor: ConfiguredExecutor } = await import('./executor')
+      const harness = createHarness({})
+      const executor = new ConfiguredExecutor(harness.storage, { now: () => now })
+
+      await expect(
+        executor.run(coordinate, { tenantVersioningEnabled: true })
+      ).resolves.toMatchObject({
+        status: options.canDelete ? 'COMPLETED' : 'PAUSED',
+      })
+      expect(harness.database.evaluateNoncurrentLifecyclePage).toHaveBeenCalledTimes(
+        options.canDelete ? 1 : 0
+      )
+      expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledTimes(options.canDelete ? 1 : 0)
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
+  })
+
+  test('rejects a job budget that can outlive its shard claim', () => {
+    const storage = {
+      db: { asSuperUser: () => ({}) },
+    } as unknown as Storage
+
+    expect(
+      () =>
+        new NoncurrentLifecycleExecutor(storage, {
+          jobBudgetMs: 120_000,
+          claimLeaseMs: 120_000,
+        })
+    ).toThrow('Lifecycle executor job budget must be shorter than its claim lease')
+  })
+
+  describe.each([
+    { gate: 'fleet', deleteEnabled: false, tenantVersioningEnabled: true },
+    { gate: 'tenant', deleteEnabled: true, tenantVersioningEnabled: false },
+  ])('with the $gate deletion gate closed', ({ deleteEnabled, tenantVersioningEnabled }) => {
+    it.each([
+      'fresh',
+      'cursor',
+      'staged',
+    ] as const)('pauses a %s run without scanning or changing its journal', async (progress) => {
+      let continuation: LifecycleContinuation | undefined
+      if (progress !== 'fresh') {
+        const generation = randomUUID()
+        const row = candidate(generation)
+        continuation = createLifecycleContinuation({
+          runId: randomUUID(),
+          trigger: 'scheduled',
+          generation,
+          snapshotAt: now.toISOString(),
+          topology: { scanKind: 'NONCURRENT', epoch: '1', shardId: 0, shardCount: 1 },
+        })
+        if (progress === 'staged') {
+          continuation = stageLifecycleBatch(continuation, {
+            rawRowsExamined: 1,
+            pageEnd: { name: row.name, archivedAt: row.archivedAt },
+            versions: [freezeLifecycleBatchVersion(row)],
+          })
+        } else {
+          continuation.cursor = { name: row.name, archivedAt: row.archivedAt }
+        }
+      }
+      const harness = createHarness({ deleteEnabled, continuation })
+
+      await expect(harness.executor.run(coordinate, { tenantVersioningEnabled })).resolves.toEqual({
+        status: 'PAUSED',
+        runId: continuation?.runId,
+      })
+
+      expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+        expect.objectContaining({
+          continuation: continuation ?? null,
+          nextRunAt: new Date(now.getTime() + 1000).toISOString(),
+        })
+      )
+      expect(harness.database.findLifecycleBucket).not.toHaveBeenCalled()
+      expect(harness.database.saveLifecycleContinuation).not.toHaveBeenCalled()
+      expect(harness.database.evaluateNoncurrentLifecyclePage).not.toHaveBeenCalled()
+      expect(harness.database.findLifecycleObjectVersions).not.toHaveBeenCalled()
+      expect(harness.database.armLifecycleAttempt).not.toHaveBeenCalled()
+      expect(harness.database.completeLifecycleShardRun).not.toHaveBeenCalled()
+      expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    })
+  })
+
+  it('persists an attempt before deleting exact data and info artifacts', async () => {
+    const harness = createHarness({ deleteOutcome: 'DELETED' })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+
+    expect(harness.calls.indexOf('arm')).toBeLessThan(harness.calls.indexOf('delete'))
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledWith('root', [
+      `tenant/bucket/${harness.pageCandidate.name}/${harness.pageCandidate.version}`,
+      `tenant/bucket/${harness.pageCandidate.name}/${harness.pageCandidate.version}.info`,
+    ])
+    expect(harness.calls).toContain('commit')
+  })
+
+  it('resumes an unarmed staged batch from raw PostgreSQL timestamp values', async () => {
+    const generation = randomUUID()
+    const stagedCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: stagedCandidate.name,
+          archivedAt: stagedCandidate.archivedAt,
+        },
+        versions: [freezeLifecycleBatchVersion(stagedCandidate)],
+      }
+    )
+    const harness = createHarness({ continuation: initial })
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+
+    expect(harness.database.findLifecycleObjectVersions).toHaveBeenCalledWith('bucket', [
+      { name: stagedCandidate.name, version: stagedCandidate.version },
+    ])
+    expect(harness.calls.indexOf('arm')).toBeLessThan(harness.calls.indexOf('delete'))
+    expect(harness.backend.deleteObjectsDetailed.mock.calls[0]?.[1]).toEqual([
+      `tenant/bucket/${stagedCandidate.name}/${stagedCandidate.version}`,
+      `tenant/bucket/${stagedCandidate.name}/${stagedCandidate.version}.info`,
+    ])
+  })
+
+  it('drops a disappeared staged row and advances instead of wedging the shard', async () => {
+    const generation = randomUUID()
+    const stagedCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: stagedCandidate.name,
+          archivedAt: stagedCandidate.archivedAt,
+        },
+        versions: [freezeLifecycleBatchVersion(stagedCandidate)],
+      }
+    )
+    const harness = createHarness({ continuation: initial })
+    harness.database.findLifecycleObjectVersions.mockResolvedValue([])
+    harness.database.evaluateNoncurrentLifecyclePage.mockResolvedValue({
+      rawRowsExamined: 0,
+      candidates: [],
+      exhausted: true,
+    })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+
+    expect(harness.database.armLifecycleAttempt).not.toHaveBeenCalled()
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    const filtered = harness.database.saveLifecycleContinuation.mock.calls[0][1]
+    expect(filtered.batch).toBeUndefined()
+    expect(filtered).toMatchObject({
+      cursor: initial.pageEnd,
+      counters: { batchesCompleted: 1 },
+    })
+  })
+
+  it('reports LOST_CLAIM when an arm rejection cannot revalidate the claim', async () => {
+    const generation = randomUUID()
+    const stagedCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: stagedCandidate.name,
+          archivedAt: stagedCandidate.archivedAt,
+        },
+        versions: [freezeLifecycleBatchVersion(stagedCandidate)],
+      }
+    )
+    const harness = createHarness({ continuation: initial })
+    harness.database.armLifecycleAttempt.mockResolvedValueOnce(undefined)
+    harness.database.revalidateLifecycleShardClaim.mockResolvedValueOnce(undefined)
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'LOST_CLAIM' })
+    expect(harness.database.armLifecycleAttempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('pauses when an arm rejection revalidates a claim whose policy changed', async () => {
+    const generation = randomUUID()
+    const stagedCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: stagedCandidate.name,
+          archivedAt: stagedCandidate.archivedAt,
+        },
+        versions: [freezeLifecycleBatchVersion(stagedCandidate)],
+      }
+    )
+    const harness = createHarness({ continuation: initial })
+    harness.database.armLifecycleAttempt.mockResolvedValueOnce(undefined)
+    harness.database.revalidateLifecycleShardClaim.mockResolvedValueOnce(
+      state(randomUUID(), initial)
+    )
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PAUSED' })
+    expect(harness.database.armLifecycleAttempt).toHaveBeenCalledTimes(1)
+    expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ nextRunAt: expect.any(String) })
+    )
+  })
+
+  it('throws a fenced failure when an arm rejection leaves the claim unchanged', async () => {
+    const generation = randomUUID()
+    const stagedCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: stagedCandidate.name,
+          archivedAt: stagedCandidate.archivedAt,
+        },
+        versions: [freezeLifecycleBatchVersion(stagedCandidate)],
+      }
+    )
+    const harness = createHarness({ continuation: initial })
+    harness.database.armLifecycleAttempt.mockResolvedValueOnce(undefined)
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).rejects.toThrow('Lifecycle arm fence rejected')
+    expect(harness.database.findLifecycleObjectVersions).toHaveBeenCalledOnce()
+    expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ nextRunAt: expect.any(String), error: expect.any(Object) })
+    )
+  })
+
+  it.each([
+    true,
+    false,
+  ])('expires rule-eligible history without an upload-age delay with is_versioned=%s', async (isVersioned) => {
+    const harness = createHarness({})
+    harness.pageCandidate.isVersioned = isVersioned
+    harness.pageCandidate.metadata = { size: 12 }
+    harness.pageCandidate.createdAt = new Date(
+      now.getTime() - 3 * 24 * 60 * 60 * 1000
+    ).toISOString()
+    harness.pageCandidate.archivedAt = new Date(
+      now.getTime() - 2 * 24 * 60 * 60 * 1000
+    ).toISOString()
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledOnce()
+    expect(harness.database.armLifecycleAttempt).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    null,
+    {},
+    { size: null },
+    { size: -1 },
+    { size: 1.5 },
+    { size: 'invalid' },
+  ])('does not let malformed size metadata %j block expiration', async (metadata) => {
+    const harness = createHarness({})
+    harness.pageCandidate.metadata = metadata
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledOnce()
+    expect(harness.database.armLifecycleAttempt).toHaveBeenCalledOnce()
+  })
+
+  it('arms a delete marker with null metadata and no backend artifacts', async () => {
+    const harness = createHarness({})
+    harness.pageCandidate.isDeleteMarker = true
+    harness.pageCandidate.metadata = null
+    harness.pageCandidate.createdAt = now.toISOString()
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.database.armLifecycleAttempt).toHaveBeenCalledOnce()
+    expect(
+      harness.database.armLifecycleAttempt.mock.calls[0][0].continuation.batch.versions
+    ).toEqual([
+      { name: harness.pageCandidate.name, version: harness.pageCandidate.version, artifacts: [] },
+    ])
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    null,
+    '856d94e5-5241-42ae-9c0b-d06332a7ae15',
+  ])('deletes exactly the physical version %s for an unversioned data row', async (version) => {
+    const harness = createHarness({})
+    harness.pageCandidate.version = version
+    harness.pageCandidate.isVersioned = false
+    const name = harness.pageCandidate.name
+    const key = version === null ? name : `${name}/${version}`
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.database.findLifecycleObjectVersions).toHaveBeenCalledWith(coordinate.bucketId, [
+      { name, version },
+    ])
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledWith('root', [
+      `tenant/bucket/${key}`,
+      `tenant/bucket/${key}.info`,
+    ])
+  })
+
+  it('rejects a reloaded row whose physical version was omitted', async () => {
+    const harness = createHarness({})
+    harness.database.findLifecycleObjectVersions.mockImplementationOnce(() => [
+      {
+        id: harness.pageCandidate.id,
+        name: harness.pageCandidate.name,
+        archived_at: new Date(harness.pageCandidate.archivedAt),
+      },
+    ])
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).rejects.toThrow('A staged lifecycle candidate has no physical version identity')
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    expect(harness.database.armLifecycleAttempt).not.toHaveBeenCalled()
+  })
+
+  it('expires both older and younger eligible rows from the same page', async () => {
+    const harness = createHarness({})
+    const safe = harness.pageCandidate
+    const young = {
+      ...candidate(harness.generation),
+      name: 'folder/young.txt',
+      createdAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      archivedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      metadata: {
+        size: 12,
+      },
+    }
+    harness.database.evaluateNoncurrentLifecyclePage.mockResolvedValue({
+      rawRowsExamined: 2,
+      candidates: [safe, young],
+      pageEnd: {
+        name: young.name,
+        archivedAt: young.archivedAt,
+      },
+      exhausted: true,
+    })
+    harness.database.findLifecycleObjectVersions.mockImplementation(
+      (_bucketId: string, versions: Array<{ name: string; version: string | null }>) =>
+        versions.map((version) => {
+          const value = version.name === young.name ? young : safe
+          return {
+            id: value.id,
+            bucket_id: value.bucketId,
+            name: version.name,
+            version: version.version,
+            is_versioned: value.isVersioned,
+            is_delete_marker: value.isDeleteMarker,
+            metadata: value.metadata,
+            created_at: new Date(value.createdAt),
+            archived_at: new Date(value.archivedAt),
+          }
+        })
+    )
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+
+    expect(
+      harness.database.armLifecycleAttempt.mock.calls[0][0].continuation.batch.versions
+    ).toEqual([
+      expect.objectContaining({ name: safe.name, version: safe.version }),
+      expect.objectContaining({ name: young.name, version: young.version }),
+    ])
+    expect(harness.backend.deleteObjectsDetailed).toHaveBeenCalledWith(
+      'root',
+      expect.arrayContaining([
+        `tenant/bucket/${safe.name}/${safe.version}`,
+        `tenant/bucket/${safe.name}/${safe.version}.info`,
+      ])
+    )
+    expect(harness.backend.deleteObjectsDetailed.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([expect.stringContaining(young.name)])
+    )
+  })
+
+  it('treats a definitive per-key failure as resolved without deleting metadata', async () => {
+    const harness = createHarness({ deleteOutcome: 'FAILED' })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+
+    const committed = harness.database.commitLifecycleAttempt.mock.calls[0][0]
+    expect(committed.continuation.batch.versions[0].artifacts).toEqual([
+      expect.objectContaining({ outcome: 'FAILED' }),
+      expect.objectContaining({ outcome: 'FAILED' }),
+    ])
+  })
+
+  it('keeps partial per-version deletion in-flight and retries the failed artifact', async () => {
+    const harness = createHarness({
+      deleteOutcomesByCall: [['DELETED', 'FAILED'], ['DELETED']],
+    })
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PARTIAL' })
+    expect(harness.getPersisted()).toMatchObject({
+      batch: {
+        inFlight: expect.any(Object),
+        versions: [
+          {
+            artifacts: [
+              expect.objectContaining({ outcome: 'DELETED' }),
+              expect.objectContaining({ outcome: 'FAILED' }),
+            ],
+          },
+        ],
+      },
+    })
+
+    harness.getPersisted()!.batch!.inFlight!.startedAt = '2026-08-14T00:00:00.000Z'
+    harness.database.evaluateNoncurrentLifecyclePage.mockResolvedValue({
+      rawRowsExamined: 0,
+      candidates: [],
+      exhausted: true,
+    })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.backend.deleteObjectsDetailed.mock.calls[1][1]).toEqual([
+      `tenant/bucket/${harness.pageCandidate.name}/${harness.pageCandidate.version}.info`,
+    ])
+    expect(harness.backend.headObject).not.toHaveBeenCalled()
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledOnce()
+    expect(harness.database.commitLifecycleAttempt).toHaveBeenCalledTimes(2)
+  })
+
+  it('backs off repeated incomplete deletion and records the backend failure', async () => {
+    const harness = createHarness({
+      deleteOutcomesByCall: [['DELETED', 'FAILED'], ['FAILED']],
+    })
+    for (const delayMinutes of [5, 10]) {
+      await expect(
+        harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+      ).resolves.toMatchObject({ status: 'PARTIAL' })
+      expect(harness.database.releaseLifecycleShardClaim).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          continuation: harness.getPersisted(),
+          nextRunAt: new Date(now.getTime() + delayMinutes * 60_000).toISOString(),
+          error: expect.objectContaining({ message: 'failed', pendingArtifacts: 1 }),
+        })
+      )
+      harness.getPersisted()!.batch!.inFlight!.startedAt = '2026-08-14T00:00:00.000Z'
+    }
+    expect(harness.backend.deleteObjectsDetailed.mock.calls[1][1]).toEqual([
+      `tenant/bucket/${harness.pageCandidate.name}/${harness.pageCandidate.version}.info`,
+    ])
+  })
+
+  it.each([
+    { waitForGrace: true, status: 'PAUSED' },
+    { waitForGrace: false, status: 'LOST_CLAIM' },
+  ])('does no recovery I/O when an open gate still yields $status', async ({
+    waitForGrace,
+    status,
+  }) => {
+    const harness = createHarness({ deleteOutcome: 'UNKNOWN' })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PARTIAL' })
+    const continuation = harness.getPersisted()!
+    if (!waitForGrace) {
+      continuation.batch!.inFlight!.startedAt = '2026-08-14T00:00:00.000Z'
+      harness.database.revalidateLifecycleRecoveryAttempt.mockResolvedValueOnce(undefined)
+    }
+    harness.backend.deleteObjectsDetailed.mockClear()
+    harness.database.commitLifecycleAttempt.mockClear()
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status })
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledTimes(
+      waitForGrace ? 0 : 1
+    )
+    expect(harness.backend.headObject).not.toHaveBeenCalled()
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    expect(harness.database.commitLifecycleAttempt).not.toHaveBeenCalled()
+    expect(harness.getPersisted()).toBe(continuation)
+  })
+
+  it('recovers partial legacy deletion using the durable null identity and unsuffixed sidecar', async () => {
+    const harness = createHarness({
+      deleteOutcomesByCall: [['DELETED', 'FAILED'], ['DELETED']],
+    })
+    harness.pageCandidate.version = null
+    harness.pageCandidate.isVersioned = false
+    const name = harness.pageCandidate.name
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PARTIAL' })
+    expect(harness.getPersisted()?.batch?.versions).toEqual([
+      {
+        name,
+        version: null,
+        artifacts: [
+          { key: name, outcome: 'DELETED' },
+          { key: `${name}.info`, outcome: 'FAILED', error: 'failed' },
+        ],
+      },
+    ])
+
+    harness.getPersisted()!.batch!.inFlight!.startedAt = '2026-08-14T00:00:00.000Z'
+    harness.database.evaluateNoncurrentLifecyclePage.mockResolvedValue({
+      rawRowsExamined: 0,
+      candidates: [],
+      exhausted: true,
+    })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(harness.backend.deleteObjectsDetailed.mock.calls[1][1]).toEqual([
+      `tenant/bucket/${name}.info`,
+    ])
+    expect(harness.getPersisted()?.batch).toBeUndefined()
+  })
+
+  it('keeps an unknown backend outcome in-flight and leaves the shard due', async () => {
+    const harness = createHarness({ deleteOutcome: 'UNKNOWN' })
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled: true })
+    ).resolves.toMatchObject({ status: 'PARTIAL' })
+
+    expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        continuation: expect.objectContaining({
+          batch: expect.objectContaining({ inFlight: expect.any(Object) }),
+        }),
+        nextRunAt: expect.any(String),
+      })
+    )
+    expect(harness.database.completeLifecycleShardRun).not.toHaveBeenCalled()
+  })
+
+  it('preserves committed recovery progress when the commit acknowledgement is lost', async () => {
+    const harness = createHarness({})
+    const commit = harness.database.commitLifecycleAttempt.getMockImplementation()!
+    const failure = new Error('connection lost after COMMIT')
+    harness.database.commitLifecycleAttempt.mockImplementationOnce(async (input) => {
+      commit(input)
+      throw failure
+    })
+    harness.database.releaseLifecycleShardClaim.mockImplementation(async (input) => {
+      if (input.continuation !== undefined) {
+        await harness.database.saveLifecycleContinuation(input, input.continuation)
+      }
+      return true
+    })
+
+    await expect(harness.executor.run(coordinate, { tenantVersioningEnabled: true })).rejects.toBe(
+      failure
+    )
+
+    expect(harness.getPersisted()).toMatchObject({
+      counters: { objectVersionsDeleted: 1, bytesDeleted: 12, batchesCompleted: 1 },
+    })
+    expect(harness.getPersisted()!.batch).toBeUndefined()
+    expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextRunAt: expect.any(String),
+        error: { message: failure.message, name: 'Error' },
+      })
+    )
+  })
+
+  it.each([
+    { deleteEnabled: false, tenantVersioningEnabled: true, headMissing: false },
+    { deleteEnabled: false, tenantVersioningEnabled: true, headMissing: true },
+    { deleteEnabled: true, tenantVersioningEnabled: false, headMissing: false },
+    { deleteEnabled: true, tenantVersioningEnabled: false, headMissing: true },
+  ])('reconciles an armed journal without redriving deletion: %o', async ({
+    deleteEnabled,
+    tenantVersioningEnabled,
+    headMissing,
+  }) => {
+    const generation = randomUUID()
+    const pageCandidate = candidate(generation)
+    const initial = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'recovery',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        rawRowsExamined: 1,
+        pageEnd: {
+          name: pageCandidate.name,
+          archivedAt: pageCandidate.archivedAt,
+        },
+        versions: [
+          {
+            name: pageCandidate.name,
+            version: pageCandidate.version,
+            artifacts: [
+              { key: `${pageCandidate.name}/${pageCandidate.version}`, outcome: 'UNRESOLVED' },
+              { key: `${pageCandidate.name}/${pageCandidate.version}.info`, outcome: 'UNRESOLVED' },
+            ],
+          },
+        ],
+      }
+    )
+    initial.batch!.inFlight = {
+      attemptId: randomUUID(),
+      authorizedGeneration: generation,
+      startedAt: '2026-08-01T00:00:00.000Z',
+    }
+    const harness = createHarness({ continuation: initial, deleteEnabled, headMissing })
+
+    await expect(
+      harness.executor.run(coordinate, { tenantVersioningEnabled })
+    ).resolves.toMatchObject({
+      status: 'PAUSED',
+    })
+    expect(harness.backend.headObject).toHaveBeenCalledTimes(2)
+    for (const suffix of ['', '.info']) {
+      expect(harness.backend.headObject).toHaveBeenCalledWith(
+        'root',
+        `tenant/bucket/${pageCandidate.name}/${pageCandidate.version}${suffix}`,
+        undefined,
+        { confirmMissing: true, signal: expect.any(AbortSignal) }
+      )
+    }
+    expect(harness.backend.deleteObjectsDetailed).not.toHaveBeenCalled()
+    expect(harness.database.evaluateNoncurrentLifecyclePage).not.toHaveBeenCalled()
+    expect(harness.database.armLifecycleAttempt).not.toHaveBeenCalled()
+    expect(harness.database.revalidateLifecycleRecoveryAttempt).toHaveBeenCalledOnce()
+    expect(harness.database.completeLifecycleShardRun).not.toHaveBeenCalled()
+    expect(harness.database.releaseLifecycleShardClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        continuation: harness.getPersisted(),
+        nextRunAt: expect.any(String),
+      })
+    )
+    if (headMissing) {
+      expect(harness.getPersisted()?.batch).toBeUndefined()
+      expect(harness.getPersisted()?.counters.objectVersionsDeleted).toBe(1)
+    } else {
+      expect(harness.getPersisted()?.batch?.inFlight).toEqual(initial.batch!.inFlight)
+    }
+    expect(harness.database.commitLifecycleAttempt.mock.calls[0][0].continuation).toMatchObject({
+      batch: {
+        versions: [
+          {
+            artifacts: [
+              expect.objectContaining({ outcome: headMissing ? 'ABSENT' : 'UNRESOLVED' }),
+              expect.objectContaining({ outcome: headMissing ? 'ABSENT' : 'UNRESOLVED' }),
+            ],
+          },
+        ],
+      },
+    })
+  })
+})

--- a/src/storage/lifecycle/executor.ts
+++ b/src/storage/lifecycle/executor.ts
@@ -1,0 +1,649 @@
+import { randomUUID } from 'node:crypto'
+import { hashStringToInt } from '@internal/hashing'
+import { logger, logSchema } from '@internal/monitoring'
+import { lifecycleVersionsEligible, lifecycleVersionsExamined } from '@internal/monitoring/metrics'
+import { getConfig } from '../../config'
+import { type DeleteObjectDetailedResult, isMissingBackendObject } from '../backend'
+import type { Database } from '../database'
+import { decodeCandidate } from '../database/lifecycle'
+import type {
+  LifecycleArtifact,
+  LifecycleBatchVersion,
+  LifecycleCandidate,
+  LifecycleContinuation,
+  LifecycleShardCoordinate,
+  LifecycleShardState,
+} from '../schemas'
+import type { Storage } from '../storage'
+import { compileLifecycleEvaluationRules } from './configuration'
+import {
+  advanceEmptyLifecyclePage,
+  armLifecycleAttempt,
+  createLifecycleContinuation,
+  filterStagedLifecycleBatch,
+  freezeLifecycleBatchVersion,
+  lifecycleVersionIdentity,
+  recordLifecycleArtifactOutcomes,
+  refreshStagedLifecycleBatchArtifacts,
+  stageLifecycleBatch,
+} from './continuation'
+
+const configured = getConfig()
+const RECOVERY_HEAD_CONCURRENCY = 8
+
+export interface LifecycleExecutorOptions {
+  pageSize: number
+  jobBudgetMs: number
+  claimLeaseMs: number
+  recoveryGraceMs: number
+  fairnessDelayMs: number
+  evaluationIntervalMs: number
+  deleteEnabled: boolean
+  now: () => Date
+}
+
+export interface LifecycleShardRunOptions {
+  /** The tenant's objectVersioning feature; false permits only armed recovery. */
+  tenantVersioningEnabled: boolean
+}
+
+export interface LifecycleShardRunResult {
+  status: 'NOT_CLAIMED' | 'COMPLETED' | 'PARTIAL' | 'PAUSED' | 'LOST_CLAIM'
+  runId?: string
+}
+
+type ClaimIdentity = LifecycleShardCoordinate & { claimId: string }
+type StepResult = { continuation: LifecycleContinuation; result?: LifecycleShardRunResult }
+
+const defaultOptions: LifecycleExecutorOptions = {
+  pageSize: configured.storageLifecyclePageSize,
+  jobBudgetMs: configured.storageLifecycleJobBudgetMs,
+  claimLeaseMs: configured.storageLifecycleClaimLeaseMs,
+  recoveryGraceMs: configured.storageLifecycleRecoveryGraceMs,
+  fairnessDelayMs: configured.storageLifecycleFairnessDelayMs,
+  evaluationIntervalMs: configured.storageLifecycleEvaluationIntervalMs,
+  // Lifecycle deletion is S3-only during staging; versioning also supports file storage.
+  deleteEnabled: configured.versioningEnabled && configured.storageBackendType === 's3',
+  now: () => new Date(),
+}
+
+export class NoncurrentLifecycleExecutor {
+  private readonly database: Database
+  private readonly options: LifecycleExecutorOptions
+
+  constructor(
+    private readonly storage: Storage,
+    options: Partial<LifecycleExecutorOptions> = {}
+  ) {
+    this.database = storage.db.asSuperUser()
+    this.options = { ...defaultOptions, ...options }
+    validateExecutorOptions(this.options)
+  }
+
+  async run(
+    coordinate: LifecycleShardCoordinate,
+    runOptions: LifecycleShardRunOptions
+  ): Promise<LifecycleShardRunResult> {
+    if (coordinate.scanKind !== 'NONCURRENT') {
+      throw new Error(`Unsupported lifecycle scan kind ${coordinate.scanKind}`)
+    }
+
+    const identity = { ...coordinate, claimId: randomUUID() }
+    let claimed: LifecycleShardState | undefined
+    try {
+      // The claim can commit before its persisted continuation fails decoding.
+      claimed = await this.database.claimLifecycleShard({
+        ...identity,
+        leaseMs: this.options.claimLeaseMs,
+      })
+      if (!claimed) return { status: 'NOT_CLAIMED' }
+      return await this.runClaimedShard(claimed, identity, runOptions)
+    } catch (error) {
+      try {
+        await this.database.releaseLifecycleShardClaim({
+          ...identity,
+          // A failed acknowledgement may follow a committed journal update.
+          // Preserve the database continuation when releasing after an error.
+          nextRunAt: retryAt(this.options.now(), claimed?.failureCount ?? 0),
+          error: lifecycleErrorSummary(error),
+        })
+      } catch (releaseError) {
+        logSchema.warning(logger, '[Lifecycle] Failed to release lifecycle claim', {
+          type: 'event',
+          tenantId: this.database.tenantId,
+          project: this.database.tenantId,
+          error: releaseError,
+          metadata: JSON.stringify(identity),
+        })
+      }
+      throw error
+    }
+  }
+
+  private async runClaimedShard(
+    claimed: LifecycleShardState,
+    identity: ClaimIdentity,
+    runOptions: LifecycleShardRunOptions
+  ): Promise<LifecycleShardRunResult> {
+    const startedAt = this.options.now().getTime()
+    let continuation = claimed.continuation
+    if (continuation?.batch?.inFlight) {
+      const recovery = await this.recoverAttempt(identity, continuation, runOptions)
+      if (recovery.result) return recovery.result
+      continuation = recovery.continuation
+    }
+
+    if (!this.options.deleteEnabled || !runOptions.tenantVersioningEnabled) {
+      await this.releaseAfterDelay(identity, continuation, this.options.fairnessDelayMs)
+      return { status: 'PAUSED', runId: continuation?.runId }
+    }
+
+    const bucket = await this.database.findLifecycleBucket(claimed.bucketId)
+    if (!bucket.lifecycle_configuration || !bucket.lifecycle_configuration_generation) {
+      await this.database.releaseLifecycleShardClaim({
+        ...identity,
+        continuation: null,
+        nextRunAt: null,
+      })
+      return { status: 'PAUSED', runId: continuation?.runId }
+    }
+
+    if (continuation?.generation !== bucket.lifecycle_configuration_generation) {
+      continuation = null
+    }
+
+    if (!continuation) {
+      continuation = createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'scheduled',
+        generation: bucket.lifecycle_configuration_generation,
+        snapshotAt: this.options.now().toISOString(),
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: claimed.shardEpoch,
+          shardId: claimed.shardId,
+          shardCount: claimed.shardCount,
+        },
+      })
+      if (!(await this.database.saveLifecycleContinuation(identity, continuation))) {
+        return { status: 'LOST_CLAIM', runId: continuation.runId }
+      }
+    }
+
+    const rules = compileLifecycleEvaluationRules(
+      bucket.lifecycle_configuration,
+      new Date(continuation.snapshotAt)
+    )
+    if (rules.length === 0) {
+      await this.database.releaseLifecycleShardClaim({
+        ...identity,
+        continuation: null,
+        nextRunAt: null,
+      })
+      return { status: 'PAUSED', runId: continuation.runId }
+    }
+
+    while (this.options.now().getTime() - startedAt < this.options.jobBudgetMs) {
+      if (continuation.batch) {
+        const resumed = await this.processStagedBatch(identity, claimed, continuation, runOptions)
+        if (resumed.result) return resumed.result
+        continuation = resumed.continuation
+        continue
+      }
+
+      const page = await this.database.evaluateNoncurrentLifecyclePage({
+        bucketId: claimed.bucketId,
+        snapshotAt: continuation.snapshotAt,
+        cursor: continuation.cursor,
+        rules,
+        pageSize: this.options.pageSize,
+      })
+      const metricAttributes = { scan_kind: 'NONCURRENT' }
+      lifecycleVersionsExamined.add(page.rawRowsExamined, metricAttributes)
+      lifecycleVersionsEligible.add(page.candidates.length, metricAttributes)
+
+      if (page.candidates.length === 0) {
+        continuation = advanceEmptyLifecyclePage(continuation, page)
+        if (!(await this.database.saveLifecycleContinuation(identity, continuation))) {
+          return { status: 'LOST_CLAIM', runId: continuation.runId }
+        }
+      } else {
+        continuation = stageLifecycleBatch(continuation, {
+          pageEnd: page.pageEnd!,
+          rawRowsExamined: page.rawRowsExamined,
+          versions: page.candidates.map(freezeLifecycleBatchVersion),
+        })
+        if (!(await this.database.saveLifecycleContinuation(identity, continuation))) {
+          return { status: 'LOST_CLAIM', runId: continuation.runId }
+        }
+        const processed = await this.processStagedBatch(identity, claimed, continuation, runOptions)
+        if (processed.result) return processed.result
+        continuation = processed.continuation
+      }
+
+      if (page.exhausted && !continuation.batch) {
+        const completed = await this.completeRun(identity, continuation)
+        if (!completed) return { status: 'LOST_CLAIM', runId: continuation.runId }
+        return { status: 'COMPLETED', runId: continuation.runId }
+      }
+    }
+
+    await this.releaseAfterDelay(identity, continuation, this.options.fairnessDelayMs)
+    return { status: 'PARTIAL', runId: continuation.runId }
+  }
+
+  private async processStagedBatch(
+    identity: ClaimIdentity,
+    claimed: LifecycleShardState,
+    continuation: LifecycleContinuation,
+    runOptions: LifecycleShardRunOptions
+  ): Promise<StepResult> {
+    if (!continuation.batch) throw new Error('Lifecycle batch is missing')
+    if (continuation.batch.inFlight) {
+      return this.recoverAttempt(identity, continuation, runOptions)
+    }
+    if (
+      continuation.generation !== claimed.configurationGeneration ||
+      !this.options.deleteEnabled ||
+      !runOptions.tenantVersioningEnabled
+    ) {
+      return this.pause(identity, continuation)
+    }
+
+    const ready = await this.reloadStagedCandidates(identity.bucketId, continuation.batch.versions)
+    if (ready.length !== continuation.batch.versions.length) {
+      continuation = filterStagedLifecycleBatch(continuation, ready)
+      if (!(await this.database.saveLifecycleContinuation(identity, continuation))) {
+        return { continuation, result: { status: 'LOST_CLAIM', runId: continuation.runId } }
+      }
+      if (!continuation.batch) return { continuation }
+    }
+
+    const armed = armLifecycleAttempt(refreshStagedLifecycleBatchArtifacts(continuation, ready), {
+      attemptId: randomUUID(),
+      authorizedGeneration: continuation.generation,
+      startedAt: this.options.now().toISOString(),
+    })
+    const state = await this.database.armLifecycleAttempt({
+      ...identity,
+      configurationGeneration: continuation.generation,
+      leaseMs: this.options.claimLeaseMs,
+      continuation: armed,
+    })
+    if (!state) return this.resolveArmRejection(identity, continuation)
+    return this.sendAttempt(identity, armed)
+  }
+
+  // The arm SQL clears the claim and continuation when a staged row loses eligibility.
+  // Otherwise distinguish a changed policy from an unexpected rejection.
+  private async resolveArmRejection(
+    identity: ClaimIdentity,
+    continuation: LifecycleContinuation
+  ): Promise<StepResult> {
+    const current = await this.database.revalidateLifecycleShardClaim(identity)
+    if (!current) {
+      return { continuation, result: { status: 'LOST_CLAIM', runId: continuation.runId } }
+    }
+    if (current.configurationGeneration !== continuation.generation) {
+      return this.pause(identity, continuation)
+    }
+
+    throw new Error('Lifecycle arm fence rejected a staged batch with an unchanged claim')
+  }
+
+  private async recoverAttempt(
+    identity: ClaimIdentity,
+    continuation: LifecycleContinuation,
+    runOptions: LifecycleShardRunOptions
+  ): Promise<StepResult> {
+    const attempt = continuation.batch?.inFlight
+    if (!attempt) return { continuation }
+    const recoverAt = new Date(attempt.startedAt).getTime() + this.options.recoveryGraceMs
+    if (this.options.now().getTime() < recoverAt) {
+      await this.database.releaseLifecycleShardClaim({
+        ...identity,
+        continuation,
+        nextRunAt: new Date(recoverAt).toISOString(),
+      })
+      return { continuation, result: { status: 'PAUSED', runId: continuation.runId } }
+    }
+
+    const canRedrive = this.options.deleteEnabled && runOptions.tenantVersioningEnabled
+    if (canRedrive) {
+      // The armed journal authorizes an idempotent retry of every pending artifact.
+      const state = await this.database.revalidateLifecycleRecoveryAttempt(
+        identity,
+        attempt.attemptId,
+        this.options.claimLeaseMs
+      )
+      if (!state) {
+        return { continuation, result: { status: 'LOST_CLAIM', runId: continuation.runId } }
+      }
+      return this.sendAttempt(identity, state.continuation!)
+    }
+
+    const startedAt = this.options.now().getTime()
+    const unresolved = continuation.batch!.versions.flatMap((version) =>
+      version.artifacts.filter((artifact) => artifact.outcome === 'UNRESOLVED')
+    )
+    let persisted = continuation
+    // Save confirmed absence between bounded waves. The explicit deadline also
+    // bounds backend retries and the GET used to confirm ambiguous HEAD responses.
+    for (
+      let offset = 0;
+      offset < unresolved.length || offset === 0;
+      offset += RECOVERY_HEAD_CONCURRENCY
+    ) {
+      const current = await this.database.revalidateLifecycleRecoveryAttempt(
+        identity,
+        attempt.attemptId,
+        this.options.claimLeaseMs
+      )
+      if (!current) {
+        return { continuation: persisted, result: { status: 'LOST_CLAIM', runId: persisted.runId } }
+      }
+      const inspected = await this.inspectUnresolvedArtifacts(
+        identity.bucketId,
+        current.continuation!,
+        unresolved.slice(offset, offset + RECOVERY_HEAD_CONCURRENCY),
+        Math.max(
+          1,
+          Math.min(
+            this.options.jobBudgetMs - (this.options.now().getTime() - startedAt),
+            Math.floor(this.options.claimLeaseMs / 2),
+            2 ** 31 - 1
+          )
+        )
+      )
+      const state = await this.database.commitLifecycleAttempt({
+        ...identity,
+        attemptId: attempt.attemptId,
+        continuation: inspected,
+      })
+      if (!state) {
+        return { continuation: persisted, result: { status: 'LOST_CLAIM', runId: persisted.runId } }
+      }
+      persisted = state.continuation!
+      if (!persisted.batch?.inFlight) return { continuation: persisted }
+      if (this.options.now().getTime() - startedAt >= this.options.jobBudgetMs) break
+    }
+
+    return this.pause(identity, persisted)
+  }
+
+  private async sendAttempt(
+    identity: ClaimIdentity,
+    continuation: LifecycleContinuation
+  ): Promise<StepResult> {
+    const batch = continuation.batch
+    const attempt = batch?.inFlight
+    if (!attempt) throw new Error('Lifecycle attempt is not armed')
+    const pending = batch.versions.flatMap((version) =>
+      version.artifacts.filter(
+        (artifact) => artifact.outcome === 'UNRESOLVED' || artifact.outcome === 'FAILED'
+      )
+    )
+    const physicalKeys = pending.map((artifact) =>
+      this.physicalKey(identity.bucketId, artifact.key)
+    )
+    const results =
+      physicalKeys.length === 0
+        ? []
+        : await this.storage.backend.deleteObjectsDetailed(
+            this.storage.location.getRootLocation(),
+            physicalKeys
+          )
+    const outcomes = correlateDeleteResults(pending, physicalKeys, results)
+    const recorded = recordLifecycleArtifactOutcomes(continuation, outcomes)
+    const state = await this.database.commitLifecycleAttempt({
+      ...identity,
+      attemptId: attempt.attemptId,
+      continuation: recorded,
+    })
+    if (!state) {
+      return { continuation, result: { status: 'LOST_CLAIM', runId: continuation.runId } }
+    }
+    const persisted = state.continuation!
+    if (persisted.batch?.inFlight) {
+      const pending = persisted.batch.versions.flatMap((version) =>
+        version.artifacts.filter(
+          (artifact) => artifact.outcome === 'UNRESOLVED' || artifact.outcome === 'FAILED'
+        )
+      )
+      await this.database.releaseLifecycleShardClaim({
+        ...identity,
+        continuation: persisted,
+        nextRunAt: retryAt(this.options.now(), state.failureCount),
+        error: {
+          name: 'LifecycleDeletionIncomplete',
+          message:
+            pending.find((artifact) => artifact.error)?.error?.slice(0, 1000) ??
+            'Lifecycle deletion remains incomplete',
+          pendingArtifacts: pending.length,
+        },
+      })
+      return { continuation: persisted, result: { status: 'PARTIAL', runId: persisted.runId } }
+    }
+    return { continuation: persisted }
+  }
+
+  private async inspectUnresolvedArtifacts(
+    bucketId: string,
+    continuation: LifecycleContinuation,
+    unresolved: LifecycleArtifact[],
+    budgetMs: number
+  ): Promise<LifecycleContinuation> {
+    if (unresolved.length === 0) return continuation
+
+    const signal = AbortSignal.timeout(budgetMs)
+    const outcomes = new Map<string, { outcome: 'ABSENT' | 'UNRESOLVED'; error?: string }>()
+    await Promise.all(
+      unresolved.map(async (artifact) => {
+        try {
+          await this.storage.backend.headObject(
+            this.storage.location.getRootLocation(),
+            this.physicalKey(bucketId, artifact.key),
+            undefined,
+            { confirmMissing: true, signal }
+          )
+        } catch (error) {
+          outcomes.set(
+            artifact.key,
+            isMissingBackendObject(error)
+              ? { outcome: 'ABSENT' }
+              : {
+                  outcome: 'UNRESOLVED',
+                  error: error instanceof Error ? error.message : String(error),
+                }
+          )
+        }
+      })
+    )
+    return outcomes.size === 0
+      ? continuation
+      : recordLifecycleArtifactOutcomes(continuation, outcomes)
+  }
+
+  private async reloadStagedCandidates(
+    bucketId: string,
+    versions: LifecycleBatchVersion[]
+  ): Promise<LifecycleCandidate[]> {
+    const rows = await this.database.findLifecycleObjectVersions(
+      bucketId,
+      versions.map(({ name, version }) => ({ name, version }))
+    )
+    const byIdentity = new Map(
+      rows.map((row) => {
+        if (row.version === undefined) {
+          throw new Error('A staged lifecycle candidate has no physical version identity')
+        }
+        return [lifecycleVersionIdentity(row.name, row.version), row]
+      })
+    )
+    return versions.flatMap((version) => {
+      const row = byIdentity.get(lifecycleVersionIdentity(version.name, version.version))
+      if (!row || row.archived_at === null) return []
+      try {
+        return [
+          decodeCandidate({
+            id: row.id,
+            bucketId: row.bucket_id,
+            name: row.name,
+            version: row.version,
+            isVersioned: row.is_versioned,
+            isDeleteMarker: row.is_delete_marker,
+            metadata: row.metadata ?? null,
+            createdAt: row.created_at,
+            archivedAt: row.archived_at,
+          }),
+        ]
+      } catch {
+        throw new Error('A staged lifecycle candidate no longer exists or is malformed')
+      }
+    })
+  }
+
+  private async pause(
+    identity: ClaimIdentity,
+    continuation: LifecycleContinuation
+  ): Promise<StepResult> {
+    await this.releaseAfterDelay(identity, continuation, this.options.fairnessDelayMs)
+    return { continuation, result: { status: 'PAUSED', runId: continuation.runId } }
+  }
+
+  private releaseAfterDelay(
+    identity: ClaimIdentity,
+    continuation: LifecycleContinuation | null,
+    delayMs: number
+  ): Promise<boolean> {
+    return this.database.releaseLifecycleShardClaim({
+      ...identity,
+      continuation,
+      nextRunAt: new Date(this.options.now().getTime() + delayMs).toISOString(),
+    })
+  }
+
+  private physicalKey(bucketId: string, artifactKey: string): string {
+    return this.storage.location.getKeyLocation({
+      tenantId: this.database.tenantId,
+      bucketId,
+      objectName: artifactKey,
+    })
+  }
+
+  private completeRun(identity: ClaimIdentity, continuation: LifecycleContinuation) {
+    return this.database.completeLifecycleShardRun(
+      identity,
+      {
+        runId: continuation.runId,
+        generation: continuation.generation,
+        snapshotAt: continuation.snapshotAt,
+        counters: continuation.counters,
+        completedAt: this.options.now().toISOString(),
+      },
+      nextEvaluationAt(
+        this.options.now(),
+        this.options.evaluationIntervalMs,
+        this.database.tenantId,
+        identity
+      )
+    )
+  }
+}
+
+function correlateDeleteResults(
+  artifacts: Array<{ key: string }>,
+  physicalKeys: string[],
+  results: DeleteObjectDetailedResult[]
+): Map<string, { outcome: 'DELETED' | 'FAILED' | 'UNRESOLVED'; error?: string }> {
+  const byKey = new Map<string, DeleteObjectDetailedResult[]>()
+  for (const result of results) {
+    const entries = byKey.get(result.key) ?? []
+    entries.push(result)
+    byKey.set(result.key, entries)
+  }
+
+  const outcomes = new Map<
+    string,
+    { outcome: 'DELETED' | 'FAILED' | 'UNRESOLVED'; error?: string }
+  >()
+  artifacts.forEach((artifact, index) => {
+    const physicalKey = physicalKeys[index]
+    const matching = byKey.get(physicalKey) ?? []
+    const result = matching.shift()
+    if (matching.length === 0) byKey.delete(physicalKey)
+    if (!result) {
+      outcomes.set(artifact.key, {
+        outcome: 'UNRESOLVED',
+        error: 'Backend delete response omitted this artifact',
+      })
+      return
+    }
+    outcomes.set(artifact.key, {
+      outcome:
+        result.outcome === 'DELETED'
+          ? 'DELETED'
+          : result.outcome === 'FAILED'
+            ? 'FAILED'
+            : 'UNRESOLVED',
+      ...(result.error?.message === undefined ? {} : { error: result.error.message }),
+    })
+  })
+
+  if (byKey.size > 0) {
+    for (const artifact of artifacts) {
+      const current = outcomes.get(artifact.key)
+      if (current?.outcome === 'DELETED') {
+        outcomes.set(artifact.key, {
+          outcome: 'UNRESOLVED',
+          error: 'Backend delete response contained unexpected or duplicate results',
+        })
+      }
+    }
+  }
+  return outcomes
+}
+
+function validateExecutorOptions(options: LifecycleExecutorOptions) {
+  const positive = [
+    options.pageSize,
+    options.jobBudgetMs,
+    options.claimLeaseMs,
+    options.recoveryGraceMs,
+    options.fairnessDelayMs,
+    options.evaluationIntervalMs,
+  ]
+  if (positive.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    throw new Error('Lifecycle executor limits must be positive integers')
+  }
+  if (options.pageSize > 500) throw new Error('Lifecycle executor page size cannot exceed 500')
+  if (options.jobBudgetMs >= options.claimLeaseMs) {
+    throw new Error('Lifecycle executor job budget must be shorter than its claim lease')
+  }
+}
+
+function lifecycleErrorSummary(error: unknown): Record<string, unknown> {
+  return {
+    name: error instanceof Error ? error.name : 'Error',
+    message: error instanceof Error ? error.message.slice(0, 1000) : String(error).slice(0, 1000),
+  }
+}
+
+function retryAt(now: Date, failureCount: number): string {
+  const delay = Math.min(6 * 60 * 60 * 1000, 5 * 60 * 1000 * 2 ** Math.min(failureCount, 10))
+  return new Date(now.getTime() + delay).toISOString()
+}
+
+function nextEvaluationAt(
+  now: Date,
+  intervalMs: number,
+  tenantId: string,
+  coordinate: LifecycleShardCoordinate
+): string {
+  const jitterWindow = Math.max(1, Math.floor(intervalMs / 10))
+  const hash = hashStringToInt(
+    `${tenantId}/${coordinate.bucketId}/${coordinate.scanKind}/${coordinate.shardEpoch}/${coordinate.shardId}`
+  )
+  const jitter = Math.abs(hash) % jitterWindow
+  return new Date(now.getTime() + intervalMs + jitter).toISOString()
+}

--- a/src/storage/lifecycle/guards.test.ts
+++ b/src/storage/lifecycle/guards.test.ts
@@ -10,7 +10,9 @@ afterEach(() => {
 it('applies config reloads to lifecycle access without reloading the guard module', async () => {
   const database = { hasMigration: vi.fn().mockResolvedValue(true) }
 
-  vi.stubEnv('STORAGE_LIFECYCLE_ENABLED', 'false')
+  vi.stubEnv('STORAGE_BACKEND', 's3')
+  vi.stubEnv('STORAGE_S3_CLIENT_TIMEOUT', '5000')
+  vi.stubEnv('STORAGE_VERSIONING_ENABLED', 'false')
   getConfig({ reload: true })
   expect(() => assertLifecycleApiEnabled('avatars')).toThrow()
   await expect(assertLifecycleWriteReady(database, 'avatars')).rejects.toMatchObject({
@@ -18,14 +20,14 @@ it('applies config reloads to lifecycle access without reloading the guard modul
   })
   expect(database.hasMigration).not.toHaveBeenCalled()
 
-  vi.stubEnv('STORAGE_LIFECYCLE_ENABLED', 'true')
+  vi.stubEnv('STORAGE_VERSIONING_ENABLED', 'true')
   getConfig({ reload: true })
   expect(() => assertLifecycleApiEnabled('avatars')).not.toThrow()
   await expect(assertLifecycleWriteReady(database, 'avatars')).resolves.toBeUndefined()
   expect(database.hasMigration).toHaveBeenCalledWith('bucket-lifecycle-configuration')
 
   database.hasMigration.mockClear()
-  vi.stubEnv('STORAGE_LIFECYCLE_ENABLED', 'false')
+  vi.stubEnv('STORAGE_VERSIONING_ENABLED', 'false')
   getConfig({ reload: true })
   expect(() => assertLifecycleApiEnabled('avatars')).toThrow()
   await expect(assertLifecycleWriteReady(database, 'avatars')).rejects.toMatchObject({

--- a/src/storage/lifecycle/guards.ts
+++ b/src/storage/lifecycle/guards.ts
@@ -3,7 +3,7 @@ import { getConfig } from '../../config'
 import type { Database } from '../database'
 
 export function assertLifecycleApiEnabled(bucketId: string): void {
-  if (!getConfig().storageLifecycleEnabled) {
+  if (!getConfig().versioningEnabled) {
     throw ERRORS.FeatureNotEnabled(bucketId, 'object lifecycles')
   }
 }

--- a/src/storage/lifecycle/index.ts
+++ b/src/storage/lifecycle/index.ts
@@ -1,3 +1,4 @@
 export * from './configuration'
 export * from './continuation'
+export * from './executor'
 export * from './guards'

--- a/src/storage/protocols/s3/s3-handler-lifecycle.test.ts
+++ b/src/storage/protocols/s3/s3-handler-lifecycle.test.ts
@@ -1,29 +1,43 @@
 import { ErrorCode } from '@internal/errors'
 import * as config from '../../../config'
-import { Storage } from '../../storage'
+
+const tenantHasFeature = vi.hoisted(() => vi.fn())
 
 describe('S3ProtocolHandler lifecycle configuration', () => {
   let Handler: typeof import('./s3-handler').S3ProtocolHandler
-  let storageLifecycleEnabled = true
+  let Storage: typeof import('../../storage').Storage
+  let versioningEnabled = true
 
   beforeAll(async () => {
     const configured = config.getConfig()
     vi.resetModules()
+    vi.doMock('@internal/database', async () => ({
+      ...(await vi.importActual<typeof import('@internal/database')>('@internal/database')),
+      tenantHasFeature,
+    }))
     vi.doMock('../../../config', () => ({
       ...config,
       getConfig: () => ({
         ...configured,
-        storageLifecycleEnabled,
+        versioningEnabled,
+        isMultitenant: false,
+        storageVersioningLockTimeoutMs: 3210,
       }),
     }))
     Handler = (await import('./s3-handler')).S3ProtocolHandler
+    Storage = (await import('../../storage')).Storage
+  })
+
+  beforeEach(() => {
+    tenantHasFeature.mockReset().mockResolvedValue(true)
   })
 
   afterEach(() => {
-    storageLifecycleEnabled = true
+    versioningEnabled = true
   })
 
   afterAll(() => {
+    vi.doUnmock('@internal/database')
     vi.doUnmock('../../../config')
     vi.resetModules()
   })
@@ -37,13 +51,27 @@ describe('S3ProtocolHandler lifecycle configuration', () => {
       lifecycle_configuration_generation: null,
       ...bucketOverrides,
     }
-    const db = {
+    const transactionDatabase = {
       deleteLifecycleConfiguration: vi.fn().mockResolvedValue(bucket),
+      updateBucket: vi.fn().mockResolvedValue({ previous: { public: false } }),
+      findBucketById: vi.fn().mockResolvedValue(bucket),
       findLifecycleBucket: vi.fn().mockResolvedValue(bucket),
       hasMigration: vi.fn().mockResolvedValue(true),
       putLifecycleConfiguration: vi.fn().mockResolvedValue(bucket),
     }
 
+    const db = {
+      ...transactionDatabase,
+      tenantId: 'tenant-id',
+      tenant: () => ({ ref: 'tenant-id', host: '' }),
+      connection: {
+        getAbortSignal: vi.fn().mockReturnValue(undefined),
+        setAbortSignal: vi.fn(),
+      },
+      withTransaction: vi.fn((fn: (database: typeof transactionDatabase) => unknown) =>
+        fn(transactionDatabase)
+      ),
+    }
     return {
       db,
       handler: new Handler(
@@ -150,16 +178,17 @@ describe('S3ProtocolHandler lifecycle configuration', () => {
     expect(db.putLifecycleConfiguration).not.toHaveBeenCalled()
   })
 
-  it('deletes lifecycle configuration idempotently through the database contract', async () => {
+  it('allows DELETE recovery before the legacy bucket/name index is removed', async () => {
     const { db, handler } = createHandler()
+    db.hasMigration.mockImplementation(async (name) => name === 'bucket-lifecycle-configuration')
 
     await expect(handler.deleteBucketLifecycle('bucket')).resolves.toEqual({ statusCode: 204 })
     expect(db.deleteLifecycleConfiguration).toHaveBeenCalledWith('bucket')
-    expect(db.hasMigration).not.toHaveBeenCalled()
+    expect(db.hasMigration).toHaveBeenCalledWith('bucket-lifecycle-configuration')
   })
 
   it('rejects every lifecycle operation when the feature flag is disabled', async () => {
-    storageLifecycleEnabled = false
+    versioningEnabled = false
     const { db, handler } = createHandler()
 
     await expect(handler.getBucketLifecycle('bucket')).rejects.toMatchObject({

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -101,7 +101,7 @@ export class S3ProtocolHandler {
   }
 
   async deleteBucketLifecycle(bucketId: string) {
-    assertLifecycleApiEnabled(bucketId)
+    await assertLifecycleWriteReady(this.storage.db, bucketId)
     await this.storage.deleteBucketLifecycle(bucketId)
     return { statusCode: 204 }
   }

--- a/src/storage/schemas/bucket.ts
+++ b/src/storage/schemas/bucket.ts
@@ -31,7 +31,15 @@ export const bucketSchema = {
   ],
 } as const
 
-export type Bucket = FromSchema<typeof bucketSchema>
+export type BucketVersioningStatus = 'DISABLED' | 'ENABLED' | 'SUSPENDED'
+
+export type Bucket = FromSchema<typeof bucketSchema> & {
+  versioning_status?: BucketVersioningStatus
+  lifecycle_configuration?: Record<string, unknown> | null
+  lifecycle_configuration_generation?: string | null
+  lifecycle_shard_epoch?: number
+  lifecycle_shard_count?: number
+}
 export type IcebergCatalog = Pick<Bucket, 'id' | 'name' | 'created_at' | 'updated_at'> & {
   deleted_at: Date | null
 }

--- a/src/storage/schemas/lifecycle.ts
+++ b/src/storage/schemas/lifecycle.ts
@@ -1,8 +1,10 @@
-import type { Bucket } from './bucket'
+import type { Bucket, BucketVersioningStatus } from './bucket'
 
+export const LIFECYCLE_CONTINUATION_VERSION = 1 as const
 export const LIFECYCLE_MAX_RULES = 1000
 export const LIFECYCLE_MAX_NONCURRENT_DAYS = 2147483647
 export const LIFECYCLE_MAX_NEWER_NONCURRENT_VERSIONS = 100
+export const LIFECYCLE_MAX_PAGE_SIZE = 500
 
 // Keep additional fields visible to the semantic validator instead of allowing
 // Fastify to strip them before we can return a useful unsupported-field error.
@@ -46,6 +48,9 @@ export const bucketLifecycleConfigurationSchema = {
   required: ['rules'],
 } as const
 
+export type LifecycleScanKind = 'NONCURRENT' | 'CURRENT'
+export type LifecycleTrigger = 'scheduled' | 'configuration_change' | 'manual' | 'recovery'
+
 export interface NoncurrentVersionExpiration {
   noncurrentDays: number
   newerNoncurrentVersions?: number
@@ -65,64 +70,23 @@ export interface BucketLifecycleConfiguration {
   rules: LifecycleRule[]
 }
 
-export interface LifecycleEvaluationRule {
-  cutoffAt: string
-  newerNoncurrentVersions?: number
-}
-
-export const LIFECYCLE_MAX_PAGE_SIZE = 500
-
-export interface NoncurrentLifecycleShardCursor {
-  archivedAt: string
-  name: string
-}
-
-export interface LifecycleCandidate {
-  id: string
+export interface LifecycleShardCoordinate {
   bucketId: string
-  name: string
-  version: string | null
-  isVersioned: boolean
-  isDeleteMarker: boolean
-  metadata: Record<string, unknown> | null
-  createdAt: string
-  archivedAt: string
+  scanKind: LifecycleScanKind
+  shardEpoch: string
+  shardId: number
 }
-
-export interface LifecycleCandidateIdentity {
-  name: string
-  version: string | null
-  isDeleteMarker: boolean
-}
-
-export interface LifecycleEvaluationPage {
-  rawRowsExamined: number
-  candidates: LifecycleCandidateIdentity[]
-  pageEnd?: NoncurrentLifecycleShardCursor
-  exhausted: boolean
-}
-
-export interface EvaluateNoncurrentLifecyclePageInput {
-  bucketId: string
-  snapshotAt: string
-  cursor?: NoncurrentLifecycleShardCursor
-  rules: LifecycleEvaluationRule[]
-  pageSize: number
-}
-
-export const LIFECYCLE_CONTINUATION_VERSION = 1 as const
-
-export type LifecycleExecutionMode = 'EVALUATE' | 'DELETE'
-
-export type LifecycleScanKind = 'NONCURRENT' | 'CURRENT'
-
-export type LifecycleTrigger = 'scheduled' | 'configuration_change' | 'manual' | 'recovery'
 
 export interface LifecycleShardTopology {
   scanKind: LifecycleScanKind
   epoch: string
   shardId: number
   shardCount: number
+}
+
+export interface NoncurrentLifecycleShardCursor {
+  archivedAt: string
+  name: string
 }
 
 export interface LifecycleRunCounters {
@@ -165,7 +129,6 @@ export interface LifecycleContinuation {
   trigger: LifecycleTrigger
   generation: string
   snapshotAt: string
-  mode: LifecycleExecutionMode
   topology: LifecycleShardTopology
   cursor?: NoncurrentLifecycleShardCursor
   pageEnd?: NoncurrentLifecycleShardCursor
@@ -173,7 +136,89 @@ export interface LifecycleContinuation {
   batch?: LifecycleContinuationBatch
 }
 
+export interface LifecycleEvaluationRule {
+  cutoffAt: string
+  newerNoncurrentVersions?: number
+}
+
+export interface LifecycleCandidate {
+  id: string
+  bucketId: string
+  name: string
+  version: string | null
+  isVersioned: boolean
+  isDeleteMarker: boolean
+  metadata: Record<string, unknown> | null
+  createdAt: string
+  archivedAt: string
+}
+
+export interface LifecycleCandidateIdentity {
+  name: string
+  version: string | null
+  isDeleteMarker: boolean
+}
+
+export interface LifecycleEvaluationPage {
+  rawRowsExamined: number
+  candidates: LifecycleCandidateIdentity[]
+  pageEnd?: NoncurrentLifecycleShardCursor
+  exhausted: boolean
+}
+
+export interface EvaluateNoncurrentLifecyclePageInput {
+  bucketId: string
+  snapshotAt: string
+  cursor?: NoncurrentLifecycleShardCursor
+  rules: LifecycleEvaluationRule[]
+  pageSize: number
+}
+
+export interface LifecycleShardClaimIdentity extends LifecycleShardCoordinate {
+  claimId: string
+}
+
+export interface LifecycleShardClaimInput extends LifecycleShardClaimIdentity {
+  leaseMs: number
+}
+
+export interface LifecycleArmAttemptInput extends LifecycleShardClaimIdentity {
+  configurationGeneration: string
+  leaseMs: number
+  continuation: LifecycleContinuation
+}
+
+export interface LifecycleCommitAttemptInput extends LifecycleShardClaimIdentity {
+  attemptId: string
+  continuation: LifecycleContinuation
+}
+
+export interface LifecycleReleaseClaimInput extends LifecycleShardClaimIdentity {
+  /** Omit after an ambiguous write to preserve the durable journal. */
+  continuation?: LifecycleContinuation | null
+  nextRunAt: string | null
+  error?: Record<string, unknown>
+}
+
+export interface LifecycleShardState {
+  bucketId: string
+  scanKind: LifecycleScanKind
+  shardId: number
+  shardEpoch: string
+  shardCount: number
+  configurationGeneration: string
+  nextRunAt: string | null
+  claimId: string | null
+  claimUntil: string | null
+  continuation: LifecycleContinuation | null
+  failureCount: number
+}
+
 export type LifecycleBucket = Pick<Bucket, 'id' | 'name' | 'type'> & {
+  type: 'STANDARD' | 'ANALYTICS'
+  versioning_status: BucketVersioningStatus
   lifecycle_configuration: BucketLifecycleConfiguration | null
   lifecycle_configuration_generation: string | null
+  lifecycle_shard_epoch: number
+  lifecycle_shard_count: number
 }

--- a/src/storage/storage-lifecycle.test.ts
+++ b/src/storage/storage-lifecycle.test.ts
@@ -1,0 +1,239 @@
+import * as tenants from '@internal/database'
+import { logSchema } from '@internal/monitoring'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as config from '../config'
+import type { Database } from './database'
+import type { BucketLifecycleConfiguration } from './schemas'
+import { Storage } from './storage'
+
+const policy: BucketLifecycleConfiguration = {
+  rules: [{ status: 'Enabled', filter: {}, noncurrentVersionExpiration: { noncurrentDays: 1 } }],
+}
+
+function fixture() {
+  const requestController = new AbortController()
+  const requestSignal = requestController.signal
+  const transaction = {
+    putLifecycleConfiguration: vi.fn().mockResolvedValue({ lifecycle_configuration: policy }),
+    deleteLifecycleConfiguration: vi.fn(),
+    updateBucket: vi.fn().mockResolvedValue({ previous: { public: false } }),
+  }
+  const database = {
+    tenantId: 'tenant-a',
+    tenant: () => ({ ref: 'tenant-a', host: '' }),
+    findBucketById: vi.fn().mockResolvedValue({ id: 'bucket', type: 'STANDARD' }),
+    hasMigration: vi.fn().mockResolvedValue(true),
+    updateBucket: vi.fn().mockResolvedValue({ previous: { public: false } }),
+    connection: {
+      getAbortSignal: () => requestSignal,
+      setAbortSignal: vi.fn(),
+    },
+    findLifecycleBucket: vi.fn().mockResolvedValue({ lifecycle_configuration: policy }),
+    withTransaction: vi.fn((callback: (db: Database) => unknown) =>
+      callback(transaction as unknown as Database)
+    ),
+  }
+  return {
+    database,
+    transaction,
+    requestController,
+    requestSignal,
+    storage: new Storage({} as never, database as unknown as Database, {} as never),
+  }
+}
+
+describe('Storage lifecycle coordination', () => {
+  beforeEach(() => {
+    vi.spyOn(config, 'getConfig').mockReturnValue({
+      ...config.getConfig(),
+      versioningEnabled: true,
+      isMultitenant: true,
+    })
+    vi.spyOn(tenants, 'tenantHasFeature').mockResolvedValue(true)
+    vi.spyOn(tenants.LifecycleTenantStorePg.prototype, 'wakeTenant').mockResolvedValue()
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each([
+    'get',
+    'put',
+    'delete',
+  ] as const)('gates REST %s by the tenant feature', async (method) => {
+    vi.mocked(tenants.tenantHasFeature).mockResolvedValue(false)
+    const { storage, database } = fixture()
+    const operation =
+      method === 'get'
+        ? storage.getBucketLifecycle('bucket')
+        : method === 'put'
+          ? storage.putBucketLifecycle('bucket', policy)
+          : storage.deleteBucketLifecycle('bucket')
+
+    await expect(operation).rejects.toMatchObject({ code: 'FeatureNotEnabled' })
+    expect(tenants.tenantHasFeature).toHaveBeenCalledWith('tenant-a', 'objectVersioning')
+    expect(database.findLifecycleBucket).not.toHaveBeenCalled()
+    expect(database.withTransaction).not.toHaveBeenCalled()
+    expect(tenants.LifecycleTenantStorePg.prototype.wakeTenant).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'put',
+    'delete',
+  ] as const)('wakes before and after REST %s commits, with separate deadlines', async (method) => {
+    const { storage, database, transaction, requestSignal } = fixture()
+    const events: string[] = []
+    const wake = vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant)
+    wake.mockImplementation(async () => {
+      events.push('wake')
+    })
+    database.withTransaction.mockImplementation(async (callback) => {
+      const result = await callback(transaction as unknown as Database)
+      events.push('commit')
+      return result
+    })
+
+    if (method === 'put') {
+      await expect(storage.putBucketLifecycle('bucket', policy)).resolves.toEqual(policy)
+      expect(transaction.putLifecycleConfiguration).toHaveBeenCalledWith('bucket', policy)
+    } else {
+      await storage.deleteBucketLifecycle('bucket')
+      expect(transaction.deleteLifecycleConfiguration).toHaveBeenCalledWith('bucket')
+    }
+
+    const operationSignal = database.connection.setAbortSignal.mock.calls[0][0]
+    expect(events).toEqual(['wake', 'commit', 'wake'])
+    expect(wake).toHaveBeenCalledTimes(2)
+    expect(wake).toHaveBeenNthCalledWith(1, 'tenant-a', operationSignal)
+    const postCommitSignal = wake.mock.calls[1][1]
+    expect(postCommitSignal).toBeInstanceOf(AbortSignal)
+    expect(postCommitSignal).not.toBe(operationSignal)
+    expect(postCommitSignal).not.toBe(requestSignal)
+    expect(operationSignal).toBeInstanceOf(AbortSignal)
+    expect(operationSignal).not.toBe(requestSignal)
+    expect(database.withTransaction).toHaveBeenCalledWith(expect.any(Function), {
+      deadlineSignal: operationSignal,
+    })
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+
+  it.each([
+    'request cancellation',
+    'transaction deadline',
+  ])('still wakes committed work after %s', async (cause) => {
+    const transactionDeadline = new AbortController()
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValueOnce(transactionDeadline.signal)
+    const { storage, database, transaction, requestController, requestSignal } = fixture()
+    database.withTransaction.mockImplementation(async (callback) => {
+      const result = await callback(transaction as unknown as Database)
+      if (cause === 'request cancellation') requestController.abort()
+      else transactionDeadline.abort()
+      return result
+    })
+    let committedWake = false
+    vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant)
+      .mockResolvedValueOnce()
+      .mockImplementationOnce(async (_tenantId, signal) => {
+        signal!.throwIfAborted()
+        committedWake = true
+      })
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).resolves.toEqual(policy)
+    expect(committedWake).toBe(true)
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+
+  it('bounds the independent wake without failing the committed mutation', async () => {
+    const transactionDeadline = new AbortController()
+    const wakeDeadline = new AbortController()
+    const timeout = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(transactionDeadline.signal)
+      .mockReturnValueOnce(wakeDeadline.signal)
+    const { storage, database, requestSignal } = fixture()
+    const failure = new Error('post-commit wake deadline')
+    const warning = vi.spyOn(logSchema, 'warning').mockImplementation(() => {})
+    vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant)
+      .mockResolvedValueOnce()
+      .mockImplementationOnce((_tenantId, signal) => {
+        const pending = new Promise<void>((_resolve, reject) => {
+          signal!.addEventListener('abort', () => reject(signal!.reason), { once: true })
+        })
+        wakeDeadline.abort(failure)
+        return pending
+      })
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).resolves.toEqual(policy)
+    expect(timeout).toHaveBeenLastCalledWith(5000)
+    expect(warning).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('wake lifecycle tenant after commit'),
+      expect.objectContaining({ error: failure, tenantId: 'tenant-a' })
+    )
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+
+  it('preserves the committed mutation when its second wake fails', async () => {
+    const { storage, database, requestSignal } = fixture()
+    const failure = new Error('central registry unavailable')
+    const wake = vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant)
+    wake.mockResolvedValueOnce().mockRejectedValueOnce(failure)
+    const warning = vi.spyOn(logSchema, 'warning').mockImplementation(() => {})
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).resolves.toEqual(policy)
+    expect(wake).toHaveBeenCalledTimes(2)
+    expect(database.withTransaction).toHaveBeenCalledOnce()
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+    expect(warning).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('wake lifecycle tenant after commit'),
+      expect.objectContaining({ error: failure, tenantId: 'tenant-a' })
+    )
+  })
+
+  it('does not send the second wake after a failed transaction', async () => {
+    const { storage, database, requestSignal } = fixture()
+    const failure = new Error('transaction rolled back')
+    database.withTransaction.mockRejectedValueOnce(failure)
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).rejects.toBe(failure)
+    expect(tenants.LifecycleTenantStorePg.prototype.wakeTenant).toHaveBeenCalledOnce()
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+
+  it('does not enter the tenant transaction when the deadline expires during pre-wake', async () => {
+    const controller = new AbortController()
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+    const { storage, database, requestSignal } = fixture()
+    vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant).mockImplementation(async () => {
+      controller.abort(new Error('configuration deadline'))
+    })
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).rejects.toThrow(
+      'configuration deadline'
+    )
+    expect(database.withTransaction).not.toHaveBeenCalled()
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+
+  it('cancels a pending central wake when the configuration deadline expires', async () => {
+    const controller = new AbortController()
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+    const { storage, database, requestSignal } = fixture()
+    vi.mocked(tenants.LifecycleTenantStorePg.prototype.wakeTenant).mockImplementation(
+      async (_tenantId, signal) => {
+        expect(signal).toBeInstanceOf(AbortSignal)
+        const pending = new Promise<void>((_resolve, reject) => {
+          signal!.addEventListener('abort', () => reject(signal!.reason), { once: true })
+        })
+        controller.abort(new Error('configuration deadline'))
+        return pending
+      }
+    )
+
+    await expect(storage.putBucketLifecycle('bucket', policy)).rejects.toThrow(
+      'configuration deadline'
+    )
+    expect(database.withTransaction).not.toHaveBeenCalled()
+    expect(database.connection.setAbortSignal).toHaveBeenLastCalledWith(requestSignal)
+  })
+})

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -9,6 +9,10 @@ import { StorageBackendAdapter } from './backend'
 import { Database, FindBucketFilters, ListBucketOptions } from './database'
 import { ObjectAdminDeleteAllBefore } from './events'
 import {
+  assertTenantLifecycleApiEnabled,
+  withLifecycleConfigurationTransaction,
+} from './lifecycle/control-plane'
+import {
   BucketType,
   getFileSizeLimit,
   mustBeNotReservedBucketName,
@@ -85,17 +89,26 @@ export class Storage {
   }
 
   async getBucketLifecycle(bucketId: string) {
+    await assertTenantLifecycleApiEnabled(bucketId, this.db.tenant().ref)
     const bucket = await this.db.findLifecycleBucket(bucketId)
     return bucket.lifecycle_configuration
   }
 
   async putBucketLifecycle(id: string, config: BucketLifecycleConfiguration) {
-    const bucket = await this.db.putLifecycleConfiguration(id, config)
+    const tenantId = this.db.tenant().ref
+    await assertTenantLifecycleApiEnabled(id, tenantId)
+    const bucket = await withLifecycleConfigurationTransaction(this.db, tenantId, (database) =>
+      database.putLifecycleConfiguration(id, config)
+    )
     return bucket.lifecycle_configuration
   }
 
   async deleteBucketLifecycle(bucketId: string) {
-    await this.db.deleteLifecycleConfiguration(bucketId)
+    const tenantId = this.db.tenant().ref
+    await assertTenantLifecycleApiEnabled(bucketId, tenantId)
+    await withLifecycleConfigurationTransaction(this.db, tenantId, (database) =>
+      database.deleteLifecycleConfiguration(bucketId)
+    )
   }
 
   /**
@@ -269,6 +282,10 @@ export class Storage {
 
       if (countObjects && countObjects > 0) {
         throw ERRORS.BucketNotEmpty(id)
+      }
+
+      if (await db.hasMigration('noncurrent-lifecycle')) {
+        await db.asSuperUser().prepareLifecycleStateForBucketDelete(id)
       }
 
       const deleted = await db.deleteBucket(id)

--- a/src/test/bucket-lifecycle-configuration.test.ts
+++ b/src/test/bucket-lifecycle-configuration.test.ts
@@ -36,6 +36,9 @@ describe('bucket lifecycle configuration persistence', () => {
   afterEach(async () => {
     await withDeleteEnabled(helper.database.connection, async (transaction) => {
       await transaction.query('DELETE FROM storage.objects WHERE bucket_id = $1', [bucketId])
+      await transaction.query('DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = $1', [
+        bucketId,
+      ])
       await transaction.query('DELETE FROM storage.buckets WHERE id = $1', [bucketId])
     })
   })

--- a/src/test/bucket-lifecycle-rest.test.ts
+++ b/src/test/bucket-lifecycle-rest.test.ts
@@ -15,12 +15,15 @@ describe('REST bucket lifecycle configuration', () => {
   let authorizationKey: string
   let jwtSecret: string
   let s3Client: S3Client
-  let previousLifecycleEnabled: string | undefined
+  let previousVersioningEnabled: string | undefined
+  let previousS3ClientTimeout: string | undefined
   const bucketIds = new Set<string>()
 
   beforeAll(async () => {
-    previousLifecycleEnabled = process.env.STORAGE_LIFECYCLE_ENABLED
-    process.env.STORAGE_LIFECYCLE_ENABLED = 'true'
+    previousVersioningEnabled = process.env.STORAGE_VERSIONING_ENABLED
+    process.env.STORAGE_VERSIONING_ENABLED = 'true'
+    previousS3ClientTimeout = process.env.STORAGE_S3_CLIENT_TIMEOUT
+    process.env.STORAGE_S3_CLIENT_TIMEOUT = '5000'
 
     vi.resetModules()
     const configModule = await import('../config')
@@ -71,7 +74,12 @@ describe('REST bucket lifecycle configuration', () => {
   afterEach(async () => {
     for (const bucketId of bucketIds) {
       const bucket = await adminDb.findBucketById(bucketId, 'id', { dontErrorOnEmpty: true })
-      if (bucket) await adminDb.deleteBucket(bucketId)
+      if (bucket) {
+        await adminDb.withTransaction(async (database) => {
+          await database.asSuperUser().prepareLifecycleStateForBucketDelete(bucketId)
+          await database.deleteBucket(bucketId)
+        })
+      }
     }
     bucketIds.clear()
   })
@@ -84,10 +92,15 @@ describe('REST bucket lifecycle configuration', () => {
       try {
         adminDb?.destroyConnection()
       } finally {
-        if (previousLifecycleEnabled === undefined) {
-          delete process.env.STORAGE_LIFECYCLE_ENABLED
+        if (previousVersioningEnabled === undefined) {
+          delete process.env.STORAGE_VERSIONING_ENABLED
         } else {
-          process.env.STORAGE_LIFECYCLE_ENABLED = previousLifecycleEnabled
+          process.env.STORAGE_VERSIONING_ENABLED = previousVersioningEnabled
+        }
+        if (previousS3ClientTimeout === undefined) {
+          delete process.env.STORAGE_S3_CLIENT_TIMEOUT
+        } else {
+          process.env.STORAGE_S3_CLIENT_TIMEOUT = previousS3ClientTimeout
         }
       }
     }

--- a/src/test/bucket-lifecycle.test.ts
+++ b/src/test/bucket-lifecycle.test.ts
@@ -1,0 +1,509 @@
+import { randomUUID } from 'node:crypto'
+import {
+  armLifecycleAttempt,
+  createLifecycleContinuation,
+  freezeLifecycleBatchVersion,
+  normalizeLifecycleConfiguration,
+  recordLifecycleArtifactOutcomes,
+  stageLifecycleBatch,
+} from '@storage/lifecycle'
+import { useLifecycleVersioningFixtures } from './utils/lifecycle-versioning'
+import { useStorage, withDeleteEnabled } from './utils/storage'
+
+describe('bucket lifecycle controls', () => {
+  const helper = useStorage()
+  const fixtures = useLifecycleVersioningFixtures()
+  let bucketId: string
+
+  beforeEach(async () => {
+    bucketId = fixtures.trackBucket(`bucket-lifecycle-${randomUUID()}`)
+    await helper.database.createBucket({ id: bucketId, name: bucketId })
+  })
+
+  afterEach(async () => {
+    await withDeleteEnabled(helper.database.connection, async (transaction) => {
+      await transaction.query('DELETE FROM storage.objects WHERE bucket_id = $1', [bucketId])
+      await transaction.query('DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = $1', [
+        bucketId,
+      ])
+      await transaction.query('DELETE FROM storage.buckets WHERE id = $1', [bucketId])
+    })
+  })
+
+  const configuration = {
+    rules: [
+      {
+        id: 'expire-history',
+        status: 'Enabled' as const,
+        filter: {},
+        noncurrentVersionExpiration: {
+          noncurrentDays: 30,
+          newerNoncurrentVersions: 2,
+        },
+      },
+    ],
+  }
+
+  it('preserves generation and continuation for a canonically unchanged PUT', async () => {
+    const first = await helper.database.putLifecycleConfiguration(bucketId, configuration)
+    expect(first.lifecycle_configuration_generation).toMatch(/^[0-9a-f]{8}-[0-9a-f-]{27}$/i)
+
+    const marker = { preserved: true }
+    await helper.database.connection.query(
+      `UPDATE storage.bucket_lifecycle_states
+       SET continuation = $2::jsonb,
+           next_run_at = '2030-01-01T00:00:00Z',
+           failure_count = 3
+       WHERE bucket_id = $1`,
+      [bucketId, JSON.stringify(marker)]
+    )
+
+    const retry = await helper.database.putLifecycleConfiguration(bucketId, {
+      rules: configuration.rules.map((rule) => ({ ...rule, filter: {} })),
+    })
+    expect(retry.lifecycle_configuration_generation).toBe(first.lifecycle_configuration_generation)
+
+    const state = await helper.database.connection.query<{
+      continuation: unknown
+      next_run_at: Date
+      failure_count: number
+    }>(
+      `SELECT continuation, next_run_at, failure_count
+       FROM storage.bucket_lifecycle_states WHERE bucket_id = $1`,
+      [bucketId]
+    )
+    expect(state.rows[0]).toMatchObject({ continuation: marker, failure_count: 3 })
+    expect(state.rows[0].next_run_at.toISOString()).toBe('2030-01-01T00:00:00.000Z')
+  })
+
+  it('preserves generation when an ID-less configuration is retried', async () => {
+    const idlessConfiguration = normalizeLifecycleConfiguration({
+      rules: [
+        {
+          status: 'Enabled' as const,
+          filter: {},
+          noncurrentVersionExpiration: { noncurrentDays: 30 },
+        },
+      ],
+    })
+
+    const first = await helper.database.putLifecycleConfiguration(bucketId, idlessConfiguration)
+    const retry = await helper.database.putLifecycleConfiguration(bucketId, {
+      rules: idlessConfiguration.rules.map((rule) => ({ ...rule, filter: {} })),
+    })
+
+    expect(first.lifecycle_configuration?.rules[0].id).toMatch(/^rule-[0-9a-f]{64}$/)
+    expect(retry.lifecycle_configuration_generation).toBe(first.lifecycle_configuration_generation)
+    expect(retry.lifecycle_configuration?.rules[0].id).toBe(
+      first.lifecycle_configuration?.rules[0].id
+    )
+  })
+
+  it('treats rule order as irrelevant to configuration generation', async () => {
+    const rules = [
+      configuration.rules[0],
+      {
+        id: 'expire-sooner',
+        status: 'Enabled' as const,
+        filter: {},
+        noncurrentVersionExpiration: { noncurrentDays: 7 },
+      },
+    ]
+    const first = await helper.database.putLifecycleConfiguration(bucketId, { rules })
+    const marker = { preservedAcrossReorder: true }
+    await helper.database.connection.query(
+      `UPDATE storage.bucket_lifecycle_states
+       SET continuation = $2::jsonb
+       WHERE bucket_id = $1`,
+      [bucketId, JSON.stringify(marker)]
+    )
+
+    const reordered = await helper.database.putLifecycleConfiguration(bucketId, {
+      rules: [...rules].reverse(),
+    })
+
+    expect(reordered.lifecycle_configuration_generation).toBe(
+      first.lifecycle_configuration_generation
+    )
+    expect(reordered.lifecycle_configuration?.rules.map((rule) => rule.id)).toEqual([
+      'expire-history',
+      'expire-sooner',
+    ])
+    const state = await helper.database.connection.query<{ continuation: unknown }>(
+      `SELECT continuation
+       FROM storage.bucket_lifecycle_states
+       WHERE bucket_id = $1`,
+      [bucketId]
+    )
+    expect(state.rows[0].continuation).toEqual(marker)
+  })
+
+  it('keeps disabled state dormant until explicitly woken after fixture activation', async () => {
+    const configured = await helper.database.putLifecycleConfiguration(bucketId, configuration)
+    const dormant = await helper.database.connection.query<{ next_run_at: Date | null }>(
+      'SELECT next_run_at FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(dormant.rows[0].next_run_at).toBeNull()
+    await expect(helper.database.findNextLifecycleDispatchAt()).resolves.toBeNull()
+
+    await fixtures.setStatus(bucketId, 'ENABLED')
+    await expect(helper.database.wakeLifecycleShards(bucketId)).resolves.toEqual([
+      { bucketId, scanKind: 'NONCURRENT', shardEpoch: '1', shardId: 0 },
+    ])
+    const enabled = await helper.database.findLifecycleBucket(bucketId)
+    expect(enabled).toMatchObject({ versioning_status: 'ENABLED' })
+    expect(enabled.lifecycle_configuration_generation).toBe(
+      configured.lifecycle_configuration_generation
+    )
+
+    const due = await helper.database.connection.query<{ next_run_at: Date | null }>(
+      'SELECT next_run_at FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(due.rows[0].next_run_at).toBeInstanceOf(Date)
+    await expect(helper.database.findNextLifecycleDispatchAt()).resolves.toEqual(expect.any(String))
+
+    await helper.database.wakeLifecycleShards(bucketId)
+    const retry = await helper.database.findLifecycleBucket(bucketId)
+    expect(retry).toMatchObject({
+      versioning_status: 'ENABLED',
+      lifecycle_configuration_generation: enabled.lifecycle_configuration_generation,
+    })
+  })
+
+  it.each([
+    'DISABLED',
+    'ENABLED',
+    'SUSPENDED',
+  ] as const)('deletes lifecycle state with an empty %s bucket', async (status) => {
+    await fixtures.setStatus(bucketId, status)
+    await helper.database.putLifecycleConfiguration(bucketId, configuration)
+
+    await expect(helper.storage.deleteBucket(bucketId)).resolves.toBe(1)
+    await expect(
+      helper.database.connection.query(
+        'SELECT 1 FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+        [bucketId]
+      )
+    ).resolves.toMatchObject({ rowCount: 0 })
+    await expect(
+      helper.database.connection.query('SELECT 1 FROM storage.buckets WHERE id = $1', [bucketId])
+    ).resolves.toMatchObject({ rowCount: 0 })
+  })
+
+  it('requires lifecycle state cleanup to stay inside the bucket-delete transaction', async () => {
+    await expect(
+      helper.database.asSuperUser().prepareLifecycleStateForBucketDelete(bucketId)
+    ).rejects.toMatchObject({ code: 'InternalError' })
+  })
+
+  it('preserves unknown lifecycle state when deleting an unversioned bucket', async () => {
+    await helper.database.putLifecycleConfiguration(bucketId, configuration)
+    await helper.database.connection.query(
+      `UPDATE storage.bucket_lifecycle_states
+       SET continuation = '{"continuationVersion":999}'::jsonb
+       WHERE bucket_id = $1`,
+      [bucketId]
+    )
+
+    await expect(helper.storage.deleteBucket(bucketId)).rejects.toMatchObject({
+      code: 'ResourceReferenced',
+    })
+    await expect(
+      helper.database.connection.query(
+        'SELECT 1 FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+        [bucketId]
+      )
+    ).resolves.toMatchObject({ rowCount: 1 })
+    await expect(
+      helper.database.connection.query('SELECT 1 FROM storage.buckets WHERE id = $1', [bucketId])
+    ).resolves.toMatchObject({ rowCount: 1 })
+  })
+
+  it('retains an armed attempt when the lifecycle configuration is deleted', async () => {
+    const configured = await helper.database.putLifecycleConfiguration(bucketId, configuration)
+    const generation = configured.lifecycle_configuration_generation!
+    const now = new Date().toISOString()
+    const continuation = armLifecycleAttempt(
+      stageLifecycleBatch(
+        createLifecycleContinuation({
+          runId: randomUUID(),
+          trigger: 'configuration_change',
+          generation,
+          snapshotAt: now,
+          topology: {
+            scanKind: 'NONCURRENT',
+            epoch: '1',
+            shardId: 0,
+            shardCount: 1,
+          },
+        }),
+        {
+          pageEnd: { name: 'object', archivedAt: now },
+          rawRowsExamined: 1,
+          versions: [
+            {
+              name: 'object',
+              version: randomUUID(),
+              artifacts: [
+                { key: 'object/version', outcome: 'UNRESOLVED' },
+                { key: 'object/version.info', outcome: 'UNRESOLVED' },
+              ],
+            },
+          ],
+        }
+      ),
+      { attemptId: randomUUID(), authorizedGeneration: generation, startedAt: now }
+    )
+    await helper.database.connection.query(
+      `UPDATE storage.bucket_lifecycle_states
+       SET continuation = $2::jsonb, next_run_at = clock_timestamp()
+       WHERE bucket_id = $1`,
+      [bucketId, JSON.stringify(continuation)]
+    )
+
+    const deleted = await helper.database.deleteLifecycleConfiguration(bucketId)
+    expect(deleted).toMatchObject({ lifecycle_configuration: null })
+
+    const state = await helper.database.connection.query<{
+      continuation: unknown
+      next_run_at: Date | null
+    }>(
+      'SELECT continuation, next_run_at FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(state.rows[0].continuation).toEqual(continuation)
+    expect(state.rows[0].next_run_at).toBeInstanceOf(Date)
+
+    const retry = await helper.database.deleteLifecycleConfiguration(bucketId)
+    expect(retry.lifecycle_configuration).toBeNull()
+    expect(
+      await helper.database.connection.query(
+        'SELECT 1 FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+        [bucketId]
+      )
+    ).toMatchObject({ rowCount: 1 })
+  })
+
+  it('rejects lifecycle controls for a resolved analytics bucket', async () => {
+    await helper.database.connection.query(
+      `UPDATE storage.buckets SET type = 'ANALYTICS' WHERE id = $1`,
+      [bucketId]
+    )
+
+    await expect(
+      helper.database.putLifecycleConfiguration(bucketId, configuration)
+    ).rejects.toMatchObject({
+      code: 'InvalidRequest',
+      httpStatusCode: 400,
+    })
+  })
+
+  it('commits partial artifact outcomes before advancing archived metadata', async () => {
+    const configured = await helper.database.putLifecycleConfiguration(bucketId, {
+      rules: [{ ...configuration.rules[0], noncurrentVersionExpiration: { noncurrentDays: 1 } }],
+    })
+    await fixtures.setStatus(bucketId, 'ENABLED')
+    await helper.database.wakeLifecycleShards(bucketId)
+    const generation = configured.lifecycle_configuration_generation!
+    const name = 'history/expired.txt'
+    const version = randomUUID()
+    const completedName = 'history/completed.txt'
+    const completedVersion = randomUUID()
+    const transaction = await helper.database.connection.transaction()
+    try {
+      await helper.database.connection.setScope(transaction)
+
+      await transaction.query(
+        `INSERT INTO storage.objects (
+           id, bucket_id, name, version, metadata, created_at, updated_at,
+           archived_at, is_versioned, is_delete_marker
+         ) VALUES (
+           $1, $2, $3, $4, $5::jsonb, $6, $6, $7, true, false
+         )`,
+        [
+          randomUUID(),
+          bucketId,
+          name,
+          version,
+          JSON.stringify({ size: 42 }),
+          '2026-07-01T00:00:01.000Z',
+          '2026-07-02T00:00:00.000Z',
+        ]
+      )
+      await transaction.query(
+        `INSERT INTO storage.objects (
+           id, bucket_id, name, version, metadata, created_at, updated_at,
+           archived_at, is_versioned, is_delete_marker
+         ) VALUES (
+           $1, $2, $3, $4, $5::jsonb, $6, $6, $7, true, false
+         )`,
+        [
+          randomUUID(),
+          bucketId,
+          completedName,
+          completedVersion,
+          JSON.stringify({ size: 8 }),
+          '2026-07-01T00:00:01.000Z',
+          '2026-07-02T00:00:00.000Z',
+        ]
+      )
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+
+    const claimId = randomUUID()
+    const claimed = await helper.database.claimLifecycleShard({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardId: 0,
+      shardEpoch: '1',
+      claimId,
+      leaseMs: 120_000,
+    })
+    expect(claimed).toMatchObject({ claimId })
+    const candidate = {
+      id: randomUUID(),
+      bucketId,
+      name,
+      version,
+      isVersioned: true,
+      isDeleteMarker: false,
+      metadata: { size: 42 },
+      createdAt: '2026-07-01T00:00:01.000Z',
+      archivedAt: '2026-07-02T00:00:00.000Z',
+    }
+    const completedCandidate = {
+      ...candidate,
+      id: randomUUID(),
+      name: completedName,
+      version: completedVersion,
+      metadata: { size: 8 },
+    }
+    const staged = stageLifecycleBatch(
+      createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'manual',
+        generation,
+        snapshotAt: '2026-08-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      }),
+      {
+        pageEnd: {
+          name: completedName,
+          archivedAt: completedCandidate.archivedAt,
+        },
+        rawRowsExamined: 2,
+        versions: [
+          freezeLifecycleBatchVersion(candidate),
+          freezeLifecycleBatchVersion(completedCandidate),
+        ],
+      }
+    )
+    expect(
+      await helper.database.saveLifecycleContinuation(
+        { bucketId, scanKind: 'NONCURRENT', shardId: 0, shardEpoch: '1', claimId },
+        staged
+      )
+    ).toBe(true)
+    const armed = armLifecycleAttempt(staged, {
+      attemptId: randomUUID(),
+      authorizedGeneration: generation,
+      startedAt: new Date().toISOString(),
+    })
+    const armedState = await helper.database.armLifecycleAttempt({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardId: 0,
+      shardEpoch: '1',
+      claimId,
+      configurationGeneration: generation,
+      leaseMs: 120_000,
+      continuation: armed,
+    })
+    expect(armedState?.continuation).toMatchObject({
+      batch: { inFlight: { attemptId: armed.batch!.inFlight!.attemptId } },
+    })
+
+    const partiallyRecorded = recordLifecycleArtifactOutcomes(
+      armed,
+      new Map<string, { outcome: 'DELETED' | 'FAILED'; error?: string }>([
+        [armed.batch!.versions[0].artifacts[0].key, { outcome: 'DELETED' as const }],
+        [
+          armed.batch!.versions[0].artifacts[1].key,
+          { outcome: 'FAILED' as const, error: 'retryable backend failure' },
+        ],
+        ...armed.batch!.versions[1].artifacts.map(
+          (artifact) => [artifact.key, { outcome: 'DELETED' as const }] as const
+        ),
+      ])
+    )
+    const partial = await helper.database.commitLifecycleAttempt({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardId: 0,
+      shardEpoch: '1',
+      claimId,
+      attemptId: armed.batch!.inFlight!.attemptId,
+      continuation: partiallyRecorded,
+    })
+    expect(partial?.continuation).toMatchObject({
+      batch: {
+        inFlight: { attemptId: armed.batch!.inFlight!.attemptId },
+        versions: [
+          {
+            artifacts: [
+              expect.objectContaining({ outcome: 'DELETED' }),
+              expect.objectContaining({ outcome: 'FAILED' }),
+            ],
+          },
+        ],
+      },
+      counters: { objectVersionsDeleted: 1, bytesDeleted: 8, batchesCompleted: 0 },
+    })
+    expect(
+      await helper.database.connection.query(
+        'SELECT 1 FROM storage.objects WHERE bucket_id = $1 AND name = $2 AND version = $3',
+        [bucketId, name, version]
+      )
+    ).toMatchObject({ rowCount: 1 })
+    expect(
+      await helper.database.connection.query(
+        'SELECT 1 FROM storage.objects WHERE bucket_id = $1 AND name = $2 AND version = $3',
+        [bucketId, completedName, completedVersion]
+      )
+    ).toMatchObject({ rowCount: 0 })
+
+    const recorded = recordLifecycleArtifactOutcomes(
+      partial!.continuation!,
+      new Map([[armed.batch!.versions[0].artifacts[1].key, { outcome: 'DELETED' as const }]])
+    )
+    const committed = await helper.database.commitLifecycleAttempt({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardId: 0,
+      shardEpoch: '1',
+      claimId,
+      attemptId: armed.batch!.inFlight!.attemptId,
+      continuation: recorded,
+    })
+    expect(committed?.continuation).toMatchObject({
+      cursor: { name: completedName, archivedAt: candidate.archivedAt },
+      counters: { objectVersionsDeleted: 2, bytesDeleted: 50, batchesCompleted: 1 },
+    })
+    expect(
+      await helper.database.connection.query(
+        'SELECT 1 FROM storage.objects WHERE bucket_id = $1 AND name = $2 AND version = $3',
+        [bucketId, name, version]
+      )
+    ).toMatchObject({ rowCount: 0 })
+  })
+})

--- a/src/test/lifecycle-tenant-store.test.ts
+++ b/src/test/lifecycle-tenant-store.test.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'node:crypto'
+import {
+  closeMultitenantPg,
+  type DatabaseTransaction,
+  LifecycleTenantStorePg,
+  multitenantPgExecutor,
+} from '@internal/database'
+import { PgPoolExecutor } from '@internal/database/pg-connection'
+import { Pool } from 'pg'
+import { getConfig } from '../config'
+
+describe('lifecycle tenant retry scheduling', () => {
+  let transaction: DatabaseTransaction | undefined
+  let store: LifecycleTenantStorePg
+  const claimId = '49f3e225-7455-4b2e-bf49-2ca7abc80b49'
+
+  beforeEach(async () => {
+    transaction = await multitenantPgExecutor.beginTransaction()
+    await transaction.query(`
+      CREATE TEMP TABLE lifecycle_tenants (
+        tenant_id text PRIMARY KEY,
+        next_dispatch_at timestamptz NOT NULL,
+        claim_id uuid,
+        claim_until timestamptz,
+        last_dispatched_at timestamptz,
+        last_completed_at timestamptz,
+        last_success_at timestamptz,
+        failure_count integer NOT NULL DEFAULT 0,
+        last_error jsonb
+      ) ON COMMIT DROP
+    `)
+    store = new LifecycleTenantStorePg(transaction)
+  })
+
+  afterEach(async () => {
+    await transaction?.rollback()
+    transaction = undefined
+  })
+
+  afterAll(() => closeMultitenantPg())
+
+  it.each([
+    [0, 300],
+    [1, 600],
+    [6, 19200],
+    [7, 21600],
+    [100, 21600],
+  ])('backs off %i prior failures by %i seconds', async (failureCount, delaySeconds) => {
+    await transaction!.query({
+      text: `INSERT INTO lifecycle_tenants (tenant_id, next_dispatch_at, claim_id, failure_count)
+        VALUES ('tenant-a', 'infinity', $1, $2)`,
+      values: [claimId, failureCount],
+    })
+
+    await expect(store.failTenantDispatch('tenant-a', claimId, { code: 'offline' })).resolves.toBe(
+      true
+    )
+
+    const result = await transaction!.query(`
+      SELECT extract(epoch FROM next_dispatch_at - last_completed_at)::float8 AS delay,
+        failure_count, claim_id, last_error
+      FROM lifecycle_tenants
+    `)
+    expect(result.rows[0]).toMatchObject({
+      failure_count: failureCount + 1,
+      claim_id: null,
+      last_error: { code: 'offline' },
+    })
+    expect(result.rows[0].delay).toBeCloseTo(delaySeconds, 1)
+  })
+
+  it('preserves a concurrent wake and ignores a stale claim', async () => {
+    await transaction!.query({
+      text: `INSERT INTO lifecycle_tenants (tenant_id, next_dispatch_at, claim_id, failure_count)
+        VALUES ('tenant-a', '2026-01-01T00:00:00Z', $1, 4)`,
+      values: [claimId],
+    })
+    await expect(store.failTenantDispatch('tenant-a', claimId, { code: 'offline' })).resolves.toBe(
+      true
+    )
+    await expect(store.failTenantDispatch('tenant-a', claimId, { code: 'stale' })).resolves.toBe(
+      false
+    )
+    const result = await transaction!.query(`SELECT * FROM lifecycle_tenants`)
+    expect(result.rows[0]).toMatchObject({
+      next_dispatch_at: new Date('2026-01-01T00:00:00Z'),
+      failure_count: 5,
+      last_error: { code: 'offline' },
+    })
+  })
+
+  it('preserves a second wake when a dispatcher consumed the pre-commit wake', async () => {
+    await store.wakeTenant('tenant-a')
+    const [claim] = await store.claimDueTenants(1, 60_000)
+    expect(claim.tenantId).toBe('tenant-a')
+
+    await store.wakeTenant('tenant-a')
+    await expect(
+      store.completeTenantDispatch('tenant-a', claim.claimId, '2099-01-01T00:00:00Z')
+    ).resolves.toBe(true)
+
+    const result = await transaction!.query(`
+      SELECT next_dispatch_at <= clock_timestamp() AS due, claim_id
+      FROM lifecycle_tenants WHERE tenant_id = 'tenant-a'
+    `)
+    expect(result.rows).toEqual([{ due: true, claim_id: null }])
+  })
+
+  it('reclaims an expired dispatch at infinity without another wake', async () => {
+    await store.wakeTenant('tenant-a')
+    const [first] = await store.claimDueTenants(1, 60_000)
+    expect(first.tenantId).toBe('tenant-a')
+    await transaction!.query(`
+      UPDATE lifecycle_tenants SET claim_until = clock_timestamp() - interval '1 second'
+      WHERE tenant_id = 'tenant-a'
+    `)
+
+    const [recovered] = await store.claimDueTenants(1, 60_000)
+    expect(recovered.tenantId).toBe('tenant-a')
+    expect(recovered.claimId).not.toBe(first.claimId)
+    await expect(
+      store.completeTenantDispatch('tenant-a', first.claimId, new Date().toISOString())
+    ).resolves.toBe(false)
+  })
+
+  it('revisits a completed dispatch without another wake', async () => {
+    await store.wakeTenant('tenant-a')
+    const [first] = await store.claimDueTenants(1, 60_000)
+    const revisitAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    await expect(
+      store.completeTenantDispatch('tenant-a', first.claimId, revisitAt.toISOString())
+    ).resolves.toBe(true)
+    const result = await transaction!.query(`
+      SELECT next_dispatch_at, claim_id FROM lifecycle_tenants WHERE tenant_id = 'tenant-a'
+    `)
+    expect(result.rows).toEqual([{ next_dispatch_at: revisitAt, claim_id: null }])
+    await expect(store.claimDueTenants(1, 60_000)).resolves.toEqual([])
+
+    // Make the saved revisit due without waiting for the real interval.
+    await transaction!.query(`
+      UPDATE lifecycle_tenants SET next_dispatch_at = clock_timestamp() - interval '1 second'
+      WHERE tenant_id = 'tenant-a'
+    `)
+    const [revisited] = await store.claimDueTenants(1, 60_000)
+    expect(revisited.tenantId).toBe('tenant-a')
+    expect(revisited.claimId).not.toBe(first.claimId)
+  })
+
+  it('cancels a central wake blocked on a row lock', async () => {
+    const schema = `wake_${randomUUID().replaceAll('-', '')}`
+    const pool = new Pool({
+      connectionString: getConfig().multitenantDatabaseUrl,
+      options: `-c search_path=${schema} -c statement_timeout=5000`,
+      max: 3,
+    })
+    const executor = new PgPoolExecutor(pool)
+    let lock: DatabaseTransaction | undefined
+    let wake: Promise<unknown> | undefined
+    const controller = new AbortController()
+    try {
+      await pool.query(`CREATE SCHEMA ${schema}`)
+      await pool.query(
+        'CREATE TABLE lifecycle_tenants (tenant_id text PRIMARY KEY, next_dispatch_at timestamptz NOT NULL)'
+      )
+      const store = new LifecycleTenantStorePg(executor)
+      await store.wakeTenant('tenant-a')
+      lock = await executor.beginTransaction()
+      await lock.query("SELECT * FROM lifecycle_tenants WHERE tenant_id = 'tenant-a' FOR UPDATE")
+      wake = store.wakeTenant('tenant-a', controller.signal).then(
+        () => ({ resolved: true }),
+        (error: unknown) => error
+      )
+      await expect
+        .poll(
+          async () =>
+            (
+              await pool.query(
+                "SELECT count(*)::int AS count FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type = 'Lock' AND query LIKE '%INSERT INTO lifecycle_tenants%'"
+              )
+            ).rows[0].count
+        )
+        .toBe(1)
+      const reason = new Error('configuration deadline')
+      controller.abort(reason)
+      expect(await wake).toMatchObject({ name: 'AbortError', code: 'ABORT_ERR' })
+      expect(lock.isCompleted()).toBe(false)
+      await expect
+        .poll(
+          async () =>
+            (
+              await pool.query(
+                "SELECT count(*)::int AS count FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type = 'Lock' AND query LIKE '%INSERT INTO lifecycle_tenants%'"
+              )
+            ).rows[0].count
+        )
+        .toBe(0)
+    } finally {
+      controller.abort()
+      await lock?.rollback()
+      await wake
+      await pool.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      await pool.end()
+    }
+  })
+})

--- a/src/test/noncurrent-lifecycle-database.test.ts
+++ b/src/test/noncurrent-lifecycle-database.test.ts
@@ -1,0 +1,569 @@
+import { randomUUID } from 'node:crypto'
+import type { DatabaseTransaction } from '@internal/database'
+import { compileLifecycleEvaluationRules } from '@storage/lifecycle/configuration'
+import {
+  armLifecycleAttempt,
+  createLifecycleContinuation,
+  freezeLifecycleBatchVersion,
+  stageLifecycleBatch,
+} from '@storage/lifecycle/continuation'
+import type { NoncurrentLifecycleShardCursor } from '@storage/schemas'
+import { useLifecycleVersioningFixtures } from './utils/lifecycle-versioning'
+import { useStorage } from './utils/storage'
+
+describe('noncurrent lifecycle database API', () => {
+  const tHelper = useStorage()
+  const fixtures = useLifecycleVersioningFixtures()
+  let bucketId: string
+  let analyticsBucketId: string
+
+  beforeEach(async () => {
+    bucketId = fixtures.trackBucket(`lifecycle-db-${randomUUID()}`)
+    analyticsBucketId = fixtures.trackBucket(`lifecycle-db-analytics-${randomUUID()}`)
+    await tHelper.database.createBucket({ id: bucketId, name: bucketId })
+    await tHelper.database.createBucket({ id: analyticsBucketId, name: analyticsBucketId })
+    await tHelper.database.connection.query(
+      `UPDATE storage.buckets SET type = 'ANALYTICS' WHERE id = $1`,
+      [analyticsBucketId]
+    )
+  })
+
+  afterEach(async () => {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      await transaction.query(`SELECT set_config('storage.allow_delete_query', 'true', true)`)
+
+      await transaction.query(
+        `DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = ANY($1::text[])`,
+        [[bucketId, analyticsBucketId]]
+      )
+      await transaction.query(`DELETE FROM storage.objects WHERE bucket_id = ANY($1::text[])`, [
+        [bucketId, analyticsBucketId],
+      ])
+      await transaction.query(`DELETE FROM storage.buckets WHERE id = ANY($1::text[])`, [
+        [bucketId, analyticsBucketId],
+      ])
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  })
+
+  async function withServiceOperation<T>(
+    operation: string,
+    fn: (transaction: DatabaseTransaction) => Promise<T>
+  ): Promise<T> {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      await tHelper.database.connection.setScope(transaction)
+      await transaction.query(`SELECT set_config('storage.operation', $1, true)`, [operation])
+      const result = await fn(transaction)
+      await transaction.commit()
+      return result
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  }
+
+  async function putConfiguration(newerNoncurrentVersions?: number) {
+    const generation = randomUUID()
+    await withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+      await transaction.query(
+        `UPDATE storage.buckets
+         SET lifecycle_configuration = $2::jsonb,
+             lifecycle_configuration_generation = $3::uuid
+         WHERE id = $1`,
+        [
+          bucketId,
+          JSON.stringify({
+            rules: [
+              {
+                status: 'Enabled',
+                filter: {},
+                noncurrentVersionExpiration: {
+                  noncurrentDays: 30,
+                  ...(newerNoncurrentVersions === undefined ? {} : { newerNoncurrentVersions }),
+                },
+              },
+            ],
+          }),
+          generation,
+        ]
+      )
+    })
+    return generation
+  }
+
+  test('loads typed Standard-bucket authority', async () => {
+    const generation = await putConfiguration()
+    const bucket = await tHelper.database.findLifecycleBucket(bucketId)
+
+    expect(bucket).toMatchObject({
+      id: bucketId,
+      type: 'STANDARD',
+      lifecycle_configuration_generation: generation,
+      lifecycle_configuration: {
+        rules: [
+          {
+            status: 'Enabled',
+            filter: {},
+            noncurrentVersionExpiration: { noncurrentDays: 30 },
+          },
+        ],
+      },
+    })
+    await expect(tHelper.database.findLifecycleBucket(analyticsBucketId)).rejects.toMatchObject({
+      code: 'InvalidRequest',
+    })
+  })
+
+  test('constructs, lists, claims, and revalidates only Standard-bucket shard state', async () => {
+    const generation = await putConfiguration()
+    const state = await tHelper.database.createNoncurrentLifecycleState(
+      bucketId,
+      generation,
+      '2000-01-01T00:00:00.000Z'
+    )
+    expect(state).toMatchObject({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardId: 0,
+      shardEpoch: '1',
+      shardCount: 1,
+    })
+
+    await tHelper.database.connection.query(
+      `INSERT INTO storage.bucket_lifecycle_states (
+         bucket_id, scan_kind, shard_id, shard_epoch, shard_count,
+         configuration_generation, next_run_at
+       ) VALUES ($1, 'NONCURRENT', 0, 1, 1, $2, now())`,
+      [analyticsBucketId, randomUUID()]
+    )
+
+    const due = await tHelper.database.listDueLifecycleShards(100)
+    expect(due).toContainEqual({
+      bucketId,
+      scanKind: 'NONCURRENT',
+      shardEpoch: '1',
+      shardId: 0,
+    })
+    expect(due.some((coordinate) => coordinate.bucketId === analyticsBucketId)).toBe(false)
+
+    const claimId = randomUUID()
+    await expect(
+      tHelper.database.claimLifecycleShard({
+        bucketId: analyticsBucketId,
+        scanKind: 'NONCURRENT',
+        shardEpoch: '1',
+        shardId: 0,
+        claimId: randomUUID(),
+        leaseMs: 60_000,
+      })
+    ).resolves.toBeUndefined()
+
+    await expect(
+      tHelper.database.claimLifecycleShard({
+        bucketId,
+        scanKind: 'NONCURRENT',
+        shardEpoch: '1',
+        shardId: 0,
+        claimId,
+        leaseMs: 60_000,
+      })
+    ).resolves.toMatchObject({ claimId })
+
+    await expect(
+      tHelper.database.revalidateLifecycleShardClaim({
+        bucketId,
+        scanKind: 'NONCURRENT',
+        shardEpoch: '1',
+        shardId: 0,
+        claimId,
+      })
+    ).resolves.toMatchObject({ claimId })
+
+    await expect(
+      tHelper.database.revalidateLifecycleShardClaim({
+        bucketId,
+        scanKind: 'NONCURRENT',
+        shardEpoch: '1',
+        shardId: 0,
+        claimId: randomUUID(),
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  test.each([
+    Number.MAX_SAFE_INTEGER,
+    800_000,
+    2_460_000,
+  ])('evaluates a policy with %i days without timestamp overflow', async (noncurrentDays) => {
+    const snapshotAt = new Date('2026-08-15T00:00:00Z')
+    const rules = compileLifecycleEvaluationRules(
+      {
+        rules: [
+          {
+            status: 'Enabled',
+            filter: {},
+            noncurrentVersionExpiration: { noncurrentDays },
+          },
+        ],
+      },
+      snapshotAt
+    )
+    await expect(
+      tHelper.database.evaluateNoncurrentLifecyclePage({
+        bucketId,
+        snapshotAt: snapshotAt.toISOString(),
+        pageSize: 10,
+        rules,
+      })
+    ).resolves.toEqual({ rawRowsExamined: 0, candidates: [], exhausted: true })
+  })
+
+  test('evaluates all rules in the database while raw-page progress stays selectivity-independent', async () => {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      for (const [name, archivedAt] of [
+        ['old-a', '2026-07-01T00:00:00.000Z'],
+        ['old-b', '2026-07-02T00:00:00.000Z'],
+        ['young', '2026-08-10T00:00:00.000Z'],
+      ]) {
+        await transaction.query(
+          `INSERT INTO storage.objects (
+             id, bucket_id, name, version, archived_at, is_versioned, metadata
+           ) VALUES ($1, $2, $3, $4, $5, true, '{"size": 10}'::jsonb)`,
+          [randomUUID(), bucketId, name, randomUUID(), archivedAt]
+        )
+      }
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+
+    const page = await tHelper.database.evaluateNoncurrentLifecyclePage({
+      bucketId,
+      snapshotAt: '2026-08-15T12:00:00.000Z',
+      pageSize: 500,
+      rules: [{ cutoffAt: '2026-08-01T00:00:00.000Z' }, { cutoffAt: '2026-07-15T00:00:00.000Z' }],
+    })
+
+    expect(page.rawRowsExamined).toBe(2)
+    expect(page.exhausted).toBe(true)
+    expect(page.pageEnd).toBeDefined()
+    expect(page.candidates.map((candidate) => candidate.name).sort()).toEqual(['old-a', 'old-b'])
+    expect(new Set(page.candidates.map((candidate) => candidate.version)).size).toBe(2)
+  })
+
+  test('preserves durable progress when releasing after an ambiguous write', async () => {
+    const generation = await putConfiguration()
+    await tHelper.database.createNoncurrentLifecycleState(
+      bucketId,
+      generation,
+      '2000-01-01T00:00:00.000Z'
+    )
+    const identity = {
+      bucketId,
+      scanKind: 'NONCURRENT' as const,
+      shardEpoch: '1',
+      shardId: 0,
+      claimId: randomUUID(),
+    }
+    await tHelper.database.claimLifecycleShard({ ...identity, leaseMs: 60_000 })
+    const durable = createLifecycleContinuation({
+      runId: randomUUID(),
+      trigger: 'scheduled',
+      generation,
+      snapshotAt: new Date().toISOString(),
+      topology: {
+        scanKind: 'NONCURRENT',
+        epoch: '1',
+        shardId: 0,
+        shardCount: 1,
+      },
+    })
+    durable.counters.versionsExamined = 2
+    durable.counters.versionsEligible = 1
+    durable.counters.objectVersionsDeleted = 1
+    durable.counters.bytesDeleted = 10
+    durable.counters.batchesCompleted = 1
+    await tHelper.database.saveLifecycleContinuation(identity, durable)
+
+    const nextRunAt = '2099-01-01T00:00:00.000Z'
+    await expect(
+      tHelper.database.releaseLifecycleShardClaim({
+        ...identity,
+        nextRunAt,
+        error: { message: 'commit acknowledgement lost' },
+      })
+    ).resolves.toBe(true)
+    const result = await tHelper.database.connection.query(
+      `SELECT continuation, claim_id, claim_until, next_run_at, failure_count, last_error
+       FROM storage.bucket_lifecycle_states WHERE bucket_id = $1`,
+      [bucketId]
+    )
+    expect(result.rows).toEqual([
+      {
+        continuation: durable,
+        claim_id: null,
+        claim_until: null,
+        next_run_at: new Date(nextRunAt),
+        failure_count: 1,
+        last_error: { message: 'commit acknowledgement lost' },
+      },
+    ])
+  })
+
+  test('reconsiders an age-due row when a newer sibling later satisfies the retention count', async () => {
+    const name = 'history/count-protected'
+    const versions = [randomUUID(), randomUUID(), randomUUID()]
+    const insertArchivedVersion = async (version: string, archivedAt: string) => {
+      const transaction = await tHelper.database.connection.transaction()
+      try {
+        await transaction.query(
+          `INSERT INTO storage.objects (
+             id, bucket_id, name, version, archived_at, is_versioned, metadata
+           ) VALUES ($1, $2, $3, $4, $5, true, '{"size": 10}'::jsonb)`,
+          [randomUUID(), bucketId, name, version, archivedAt]
+        )
+        await transaction.commit()
+      } catch (error) {
+        await transaction.rollback()
+        throw error
+      }
+    }
+
+    await insertArchivedVersion(versions[0], '2026-06-01T00:00:00.000Z')
+    await insertArchivedVersion(versions[1], '2026-06-02T00:00:00.000Z')
+
+    const evaluateFromRangeStart = () =>
+      tHelper.database.evaluateNoncurrentLifecyclePage({
+        bucketId,
+        snapshotAt: '2026-08-15T12:00:00.000Z',
+        pageSize: 500,
+        rules: [
+          {
+            cutoffAt: '2026-08-01T00:00:00.000Z',
+            newerNoncurrentVersions: 2,
+          },
+        ],
+      })
+
+    await expect(evaluateFromRangeStart()).resolves.toMatchObject({
+      rawRowsExamined: 2,
+      candidates: [],
+    })
+
+    await insertArchivedVersion(versions[2], '2026-06-03T00:00:00.000Z')
+
+    const reconsidered = await evaluateFromRangeStart()
+    expect(reconsidered.rawRowsExamined).toBe(3)
+    expect(reconsidered.candidates).toEqual([
+      expect.objectContaining({ name, version: versions[0] }),
+    ])
+  })
+
+  test.each([
+    1, 17, 500,
+  ])('produces the same candidates and counters with page size %i', async (pageSize) => {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      for (let index = 0; index < 17; index++) {
+        const name = `history/page-${index.toString().padStart(2, '0')}`
+        for (const archivedAt of [
+          '2026-06-01T00:00:00.000Z',
+          '2026-06-02T00:00:00.000Z',
+        ] as const) {
+          await transaction.query(
+            `INSERT INTO storage.objects (
+                 id, bucket_id, name, version, archived_at, is_versioned, metadata
+               ) VALUES ($1, $2, $3, $4, $5, true, '{"size": 10}'::jsonb)`,
+            [randomUUID(), bucketId, name, randomUUID(), archivedAt]
+          )
+        }
+      }
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+
+    let cursor: NoncurrentLifecycleShardCursor | undefined
+    let rawRowsExamined = 0
+    const candidates: string[] = []
+    for (;;) {
+      const page = await tHelper.database.evaluateNoncurrentLifecyclePage({
+        bucketId,
+        snapshotAt: '2026-08-15T12:00:00.000Z',
+        pageSize,
+        rules: [
+          {
+            cutoffAt: '2026-08-01T00:00:00.000Z',
+            newerNoncurrentVersions: 1,
+          },
+        ],
+        ...(cursor ? { cursor } : {}),
+      })
+      rawRowsExamined += page.rawRowsExamined
+      candidates.push(...page.candidates.map((candidate) => candidate.name))
+      if (page.exhausted) break
+      cursor = page.pageEnd
+    }
+
+    expect(rawRowsExamined).toBe(34)
+    expect(candidates).toEqual(
+      [...Array(17).keys()].map((index) => `history/page-${index.toString().padStart(2, '0')}`)
+    )
+  })
+
+  describe('retained-version checks against explicit history fixtures', () => {
+    async function stageCountProtectedVersion(
+      options: {
+        legacy?: boolean
+        marker?: boolean
+        metadata?: Record<string, unknown> | null
+        suspended?: boolean
+      } = {}
+    ) {
+      await fixtures.setStatus(bucketId, 'ENABLED')
+      if (options.suspended) {
+        await fixtures.setStatus(bucketId, 'SUSPENDED')
+      }
+      const generation = await putConfiguration(1)
+      await tHelper.database.createNoncurrentLifecycleState(
+        bucketId,
+        generation,
+        '2000-01-01T00:00:00.000Z'
+      )
+      const name = 'history/retention-count-race'
+      const olderVersion = options.legacy ? null : randomUUID()
+      const newerVersion = randomUUID()
+      const writtenAt = '2000-01-01T00:00:00.000Z'
+      // These rows are explicit history fixtures. No writer or invalidation hook runs.
+      await withServiceOperation('storage.object.upload', async (db) => {
+        await db.query(
+          `INSERT INTO storage.objects (
+               id, bucket_id, name, version, created_at, archived_at, is_versioned, metadata, is_delete_marker
+             ) VALUES
+               ($1, $2, $3, $4, $6::timestamptz, '2001-01-01', $8, $7::jsonb, $9),
+               (gen_random_uuid(), $2, $3, $5, $6::timestamptz, '2001-02-01', true, $10::jsonb, false)`,
+          [
+            randomUUID(),
+            bucketId,
+            name,
+            olderVersion,
+            newerVersion,
+            writtenAt,
+            options.metadata === null ? null : JSON.stringify(options.metadata ?? { size: 10 }),
+            !options.legacy,
+            options.marker ?? false,
+            JSON.stringify({ size: 10 }),
+          ]
+        )
+      })
+      const identity = {
+        bucketId,
+        scanKind: 'NONCURRENT' as const,
+        shardEpoch: '1',
+        shardId: 0,
+        claimId: randomUUID(),
+      }
+      await tHelper.database.claimLifecycleShard({ ...identity, leaseMs: 60_000 })
+      const initial = createLifecycleContinuation({
+        runId: randomUUID(),
+        trigger: 'scheduled',
+        generation,
+        snapshotAt: '2001-06-01T00:00:00.000Z',
+        topology: {
+          scanKind: 'NONCURRENT',
+          epoch: '1',
+          shardId: 0,
+          shardCount: 1,
+        },
+      })
+      await tHelper.database.saveLifecycleContinuation(identity, initial)
+      const evaluation = {
+        bucketId,
+        snapshotAt: initial.snapshotAt,
+        rules: [{ cutoffAt: '2001-05-01T00:00:00.000Z', newerNoncurrentVersions: 1 }],
+        pageSize: 10,
+      }
+      const page = await tHelper.database.evaluateNoncurrentLifecyclePage(evaluation)
+      expect(page.candidates).toEqual([
+        { name, version: olderVersion, isDeleteMarker: options.marker ?? false },
+      ])
+      const staged = stageLifecycleBatch(initial, {
+        pageEnd: page.pageEnd!,
+        rawRowsExamined: page.rawRowsExamined,
+        versions: page.candidates.map(freezeLifecycleBatchVersion),
+      })
+      const armed = armLifecycleAttempt(staged, {
+        attemptId: randomUUID(),
+        authorizedGeneration: generation,
+        startedAt: new Date().toISOString(),
+      })
+      const arm = () =>
+        tHelper.database.armLifecycleAttempt({
+          ...identity,
+          configurationGeneration: generation,
+          leaseMs: 60_000,
+          continuation: armed,
+        })
+      return {
+        identity,
+        staged,
+        armed,
+        arm,
+        evaluation,
+        name,
+        olderVersion,
+        newerVersion,
+      }
+    }
+
+    test.each([
+      { label: 'legacy null version', legacy: true, metadata: { size: 10 } },
+      { label: 'version without extra metadata', metadata: { size: 10 } },
+      { label: 'metadata-null marker', marker: true, metadata: null },
+      { label: 'suspended history', suspended: true, metadata: { size: 10 } },
+    ])('arms $label using the compatible row identity and policy', async ({
+      label: _label,
+      ...options
+    }) => {
+      const fixture = await stageCountProtectedVersion(options)
+      await tHelper.database.saveLifecycleContinuation(fixture.identity, fixture.staged)
+      await expect(fixture.arm()).resolves.toMatchObject({ continuation: fixture.armed })
+    })
+
+    test('rechecks retention at arm time after a raw fixture history change', async () => {
+      const fixture = await stageCountProtectedVersion()
+      await tHelper.database.saveLifecycleContinuation(fixture.identity, fixture.staged)
+      await withServiceOperation('storage.lifecycle.test_fixture', async (transaction) => {
+        await transaction.query(`SET LOCAL storage.allow_delete_query = 'true'`)
+        await transaction.query(
+          'DELETE FROM storage.objects WHERE bucket_id = $1 AND name = $2 AND version = $3',
+          [bucketId, fixture.name, fixture.newerVersion]
+        )
+      })
+      // SQL fixture mutation supplies no invalidation hook. The native arm path
+      // must independently discover that the retained-sibling count no longer holds.
+      await expect(fixture.arm()).resolves.toBeUndefined()
+      await expect(
+        tHelper.database.revalidateLifecycleShardClaim(fixture.identity)
+      ).resolves.toBeUndefined()
+      await expect(
+        tHelper.database.claimLifecycleShard({
+          ...fixture.identity,
+          claimId: randomUUID(),
+          leaseMs: 60_000,
+        })
+      ).resolves.toMatchObject({ continuation: null })
+      await expect(
+        tHelper.database.evaluateNoncurrentLifecyclePage(fixture.evaluation)
+      ).resolves.toMatchObject({ candidates: [] })
+    })
+  })
+})

--- a/src/test/noncurrent-lifecycle-executor.test.ts
+++ b/src/test/noncurrent-lifecycle-executor.test.ts
@@ -1,0 +1,566 @@
+import { randomUUID } from 'node:crypto'
+import { Readable } from 'node:stream'
+import { logSchema } from '@internal/monitoring'
+import { isMissingBackendObject } from '@storage/backend'
+import {
+  armLifecycleAttempt,
+  createLifecycleContinuation,
+  freezeLifecycleBatchVersion,
+  stageLifecycleBatch,
+} from '@storage/lifecycle/continuation'
+import { NoncurrentLifecycleExecutor } from '@storage/lifecycle/executor'
+import { getConfig } from '../config'
+import { useLifecycleVersioningFixtures } from './utils/lifecycle-versioning'
+import { useStorage, withDeleteEnabled } from './utils/storage'
+
+const { storageBackendType, storageS3Bucket, tenantId } = getConfig()
+const DAY_MS = 24 * 60 * 60 * 1000
+
+describe('noncurrent lifecycle executor against explicit history fixtures', () => {
+  const helper = useStorage()
+  const fixtures = useLifecycleVersioningFixtures()
+  const uploaded: Array<{ name: string; version: string | null }> = []
+  let bucketId: string
+  const configuration = {
+    rules: [
+      {
+        id: 'expire-history',
+        status: 'Enabled' as const,
+        filter: {},
+        noncurrentVersionExpiration: { noncurrentDays: 1 },
+      },
+    ],
+  }
+
+  beforeEach(async () => {
+    bucketId = fixtures.trackBucket(`lifecycle-executor-${randomUUID()}`)
+    await helper.database.createBucket({ id: bucketId, name: bucketId })
+  })
+
+  afterEach(async () => {
+    const cleanup = await Promise.allSettled(
+      uploaded
+        .splice(0)
+        .map(({ name, version }) =>
+          helper.adapter.deleteObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, version)
+        )
+    )
+    await withDeleteEnabled(helper.database.connection, async (transaction) => {
+      await transaction.query('DELETE FROM storage.objects WHERE bucket_id = $1', [bucketId])
+      await transaction.query('DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = $1', [
+        bucketId,
+      ])
+      await transaction.query('DELETE FROM storage.buckets WHERE id = $1', [bucketId])
+    })
+    expect(cleanup.filter((result) => result.status === 'rejected')).toEqual([])
+  })
+
+  async function uploadFixture(name: string, version: string | null) {
+    uploaded.push({ name, version })
+    await helper.adapter.uploadObject(
+      storageS3Bucket,
+      `${tenantId}/${bucketId}/${name}`,
+      version,
+      Readable.from(Buffer.from('x')),
+      'text/plain',
+      'no-cache',
+      undefined,
+      1
+    )
+  }
+
+  async function seedHistory(
+    name: string,
+    archivedVersion: string | null,
+    currentVersion: string,
+    options: { isVersioned?: boolean; archivedAt?: Date } = {}
+  ) {
+    await uploadFixture(name, archivedVersion)
+    // The file layout cannot retain an unsuffixed blob beside a revision directory.
+    // In that case only the current metadata is seeded; MinIO covers both blobs.
+    if (archivedVersion !== null || storageBackendType === 's3') {
+      await uploadFixture(name, currentVersion)
+    }
+    await helper.database.connection.query(
+      `INSERT INTO storage.objects
+         (id, bucket_id, name, version, is_versioned, metadata, created_at, archived_at)
+       VALUES
+         (gen_random_uuid(), $1, $2, $3, $5, '{"size":1,"mimetype":"text/plain"}',
+          '2000-01-01', $6),
+         (gen_random_uuid(), $1, $2, $4, true, '{"size":1,"mimetype":"text/plain"}',
+          clock_timestamp(), NULL)`,
+      [
+        bucketId,
+        name,
+        archivedVersion,
+        currentVersion,
+        options.isVersioned ?? true,
+        options.archivedAt ?? new Date(),
+      ]
+    )
+  }
+
+  async function activate(status: 'ENABLED' | 'SUSPENDED' = 'ENABLED') {
+    await fixtures.setStatus(bucketId, status)
+    await helper.database.putLifecycleConfiguration(bucketId, configuration)
+  }
+
+  function runExecutor(snapshotAt?: Date) {
+    return new NoncurrentLifecycleExecutor(helper.storage, {
+      deleteEnabled: true,
+      now: () => snapshotAt ?? new Date(Date.now() + 3 * DAY_MS),
+    }).run(
+      { bucketId, scanKind: 'NONCURRENT', shardEpoch: '1', shardId: 0 },
+      { tenantVersioningEnabled: true }
+    )
+  }
+
+  async function versions(name: string) {
+    const result = await helper.database.connection.query<{
+      version: string | null
+      current: boolean
+    }>(
+      `SELECT version, archived_at IS NULL AS current
+       FROM storage.objects WHERE bucket_id = $1 AND name = $2 ORDER BY created_at`,
+      [bucketId, name]
+    )
+    return result.rows
+  }
+
+  async function expectBlobAbsent(name: string, version: string | null) {
+    const missing = await helper.adapter
+      .headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, version, {
+        confirmMissing: true,
+      })
+      .then(
+        () => false,
+        (error: unknown) => isMissingBackendObject(error)
+      )
+    expect(missing).toBe(true)
+  }
+
+  it('preserves malformed continuation JSON and releases its committed claim after decoding fails', async () => {
+    await activate()
+    const continuation = { continuationVersion: 999 }
+    await helper.database.connection.query(
+      'UPDATE storage.bucket_lifecycle_states SET continuation = $2::jsonb WHERE bucket_id = $1',
+      [bucketId, JSON.stringify(continuation)]
+    )
+
+    await expect(runExecutor()).rejects.toThrow()
+    const result = await helper.database.connection.query(
+      'SELECT claim_id, claim_until, failure_count, last_error, continuation FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(result.rows).toEqual([
+      expect.objectContaining({
+        claim_id: null,
+        claim_until: null,
+        failure_count: 1,
+        continuation,
+        last_error: expect.objectContaining({ name: 'LifecycleContinuationDecodeError' }),
+      }),
+    ])
+  })
+
+  describe.each([
+    { gate: 'fleet', deleteEnabled: false, tenantVersioningEnabled: true },
+    { gate: 'tenant', deleteEnabled: true, tenantVersioningEnabled: false },
+  ])('with the $gate deletion gate closed', ({ deleteEnabled, tenantVersioningEnabled }) => {
+    it('leaves fresh history and its continuation untouched', async () => {
+      await activate()
+      const name = 'history/paused.txt'
+      const archived = randomUUID()
+      const current = randomUUID()
+      await seedHistory(name, archived, current)
+      const before = await versions(name)
+
+      await expect(
+        new NoncurrentLifecycleExecutor(helper.storage, { deleteEnabled }).run(
+          { bucketId, scanKind: 'NONCURRENT', shardEpoch: '1', shardId: 0 },
+          { tenantVersioningEnabled }
+        )
+      ).resolves.toMatchObject({ status: 'PAUSED' })
+
+      expect(await versions(name)).toEqual(before)
+      for (const version of [archived, current]) {
+        await expect(
+          helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, version)
+        ).resolves.toMatchObject({ size: 1 })
+      }
+      const state = await helper.database.connection.query(
+        'SELECT continuation, claim_id, next_run_at FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+        [bucketId]
+      )
+      expect(state.rows).toEqual([
+        { continuation: null, claim_id: null, next_run_at: expect.any(Date) },
+      ])
+    })
+  })
+
+  describe.each([
+    { gate: 'fleet gate closed', deleteEnabled: false, tenantVersioningEnabled: true },
+    { gate: 'tenant gate closed', deleteEnabled: true, tenantVersioningEnabled: false },
+    { gate: 'both gates open', deleteEnabled: true, tenantVersioningEnabled: true },
+  ])('armed recovery with $gate', ({ deleteEnabled, tenantVersioningEnabled }) => {
+    const canRedrive = deleteEnabled && tenantVersioningEnabled
+    it.each([true, false])('recovers an armed journal with artifacts absent=%s', async (absent) => {
+      await activate()
+      const name = 'history/recovery.txt'
+      const archived = randomUUID()
+      const current = randomUUID()
+      const archivedAt = new Date(Date.now() - 3 * DAY_MS)
+      await seedHistory(name, archived, current, { archivedAt })
+      await uploadFixture(name, `${archived}.info`)
+      const bucket = await helper.database.findLifecycleBucket(bucketId)
+      const generation = bucket.lifecycle_configuration_generation!
+      const identity = {
+        bucketId,
+        scanKind: 'NONCURRENT' as const,
+        shardEpoch: '1',
+        shardId: 0,
+        claimId: randomUUID(),
+      }
+      await expect(
+        helper.database.claimLifecycleShard({ ...identity, leaseMs: 60_000 })
+      ).resolves.toBeDefined()
+      const staged = stageLifecycleBatch(
+        createLifecycleContinuation({
+          runId: randomUUID(),
+          trigger: 'scheduled',
+          generation,
+          snapshotAt: new Date().toISOString(),
+          topology: { scanKind: 'NONCURRENT', epoch: '1', shardId: 0, shardCount: 1 },
+        }),
+        {
+          rawRowsExamined: 1,
+          pageEnd: { name, archivedAt: archivedAt.toISOString() },
+          versions: [
+            freezeLifecycleBatchVersion({ name, version: archived, isDeleteMarker: false }),
+          ],
+        }
+      )
+      await helper.database.saveLifecycleContinuation(identity, staged)
+      const armed = armLifecycleAttempt(staged, {
+        attemptId: randomUUID(),
+        authorizedGeneration: generation,
+        startedAt: new Date(Date.now() - DAY_MS).toISOString(),
+      })
+      await expect(
+        helper.database.armLifecycleAttempt({
+          ...identity,
+          configurationGeneration: generation,
+          leaseMs: 60_000,
+          continuation: armed,
+        })
+      ).resolves.toMatchObject({ continuation: armed })
+      // Simulate a worker dying after its durable arm, optionally after deleting its bytes.
+      if (absent) {
+        await helper.adapter.deleteObject(
+          storageS3Bucket,
+          `${tenantId}/${bucketId}/${name}`,
+          archived
+        )
+        await helper.adapter.deleteObject(
+          storageS3Bucket,
+          `${tenantId}/${bucketId}/${name}`,
+          `${archived}.info`
+        )
+      }
+      await helper.database.releaseLifecycleShardClaim({
+        ...identity,
+        nextRunAt: '2000-01-01T00:00:00.000Z',
+      })
+
+      const heads = vi.spyOn(helper.adapter, 'headObject')
+      const deletes = vi.spyOn(helper.adapter, 'deleteObjectsDetailed')
+      try {
+        await expect(
+          new NoncurrentLifecycleExecutor(helper.storage, { deleteEnabled }).run(identity, {
+            tenantVersioningEnabled,
+          })
+        ).resolves.toMatchObject({
+          status: canRedrive ? 'COMPLETED' : 'PAUSED',
+          runId: armed.runId,
+        })
+        expect(heads).toHaveBeenCalledTimes(canRedrive ? 0 : 2)
+        expect(deletes).toHaveBeenCalledTimes(canRedrive ? 1 : 0)
+        if (canRedrive) {
+          expect(deletes).toHaveBeenCalledWith(storageS3Bucket, [
+            `${tenantId}/${bucketId}/${name}/${archived}`,
+            `${tenantId}/${bucketId}/${name}/${archived}.info`,
+          ])
+        }
+      } finally {
+        heads.mockRestore()
+        deletes.mockRestore()
+      }
+
+      const state = await helper.database.connection.query(
+        'SELECT continuation, claim_id, next_run_at, last_result FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+        [bucketId]
+      )
+      expect(state.rows[0]).toMatchObject({ claim_id: null, next_run_at: expect.any(Date) })
+      if (canRedrive) {
+        expect(state.rows[0]).toMatchObject({
+          continuation: null,
+          last_result: {
+            runId: armed.runId,
+            counters: { objectVersionsDeleted: 1, bytesDeleted: 1, batchesCompleted: 1 },
+          },
+        })
+      }
+      if (absent || canRedrive) {
+        expect(await versions(name)).toEqual([{ version: current, current: true }])
+        if (!canRedrive) {
+          expect(state.rows[0].continuation.batch).toBeUndefined()
+          expect(state.rows[0].continuation.counters.objectVersionsDeleted).toBe(1)
+        }
+        await expectBlobAbsent(name, archived)
+      } else {
+        expect(await versions(name)).toContainEqual({ version: archived, current: false })
+        expect(state.rows[0].continuation).toEqual(armed)
+        await expect(
+          helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, archived)
+        ).resolves.toMatchObject({ size: 1 })
+      }
+      await expect(
+        helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, current)
+      ).resolves.toMatchObject({ size: 1 })
+    })
+  })
+
+  it.each([
+    'ENABLED',
+    'SUSPENDED',
+  ] as const)('expires archived fixture bytes while %s and retains the current revision', async (status) => {
+    await activate(status)
+    const name = 'history/versioned.txt'
+    const archived = randomUUID()
+    const current = randomUUID()
+    await seedHistory(name, archived, current)
+
+    await expect(runExecutor()).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(await versions(name)).toEqual([{ version: current, current: true }])
+    await expectBlobAbsent(name, archived)
+    await expect(
+      helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, current)
+    ).resolves.toMatchObject({ size: 1 })
+  })
+
+  it('expires a legacy physical null revision and its unsuffixed blob', async () => {
+    await activate()
+    const name = 'history/legacy-null.txt'
+    const current = randomUUID()
+    await seedHistory(name, null, current, { isVersioned: false })
+    expect(await versions(name)).toContainEqual({ version: null, current: false })
+
+    await expect(runExecutor()).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(await versions(name)).toEqual([{ version: current, current: true }])
+    await expectBlobAbsent(name, null)
+    if (storageBackendType === 's3') {
+      await expect(
+        helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, current)
+      ).resolves.toMatchObject({ size: 1 })
+    }
+  })
+
+  it('expires an unversioned logical null revision stored under a physical UUID', async () => {
+    await activate()
+    const name = 'history/unversioned.txt'
+    const archived = randomUUID()
+    const current = randomUUID()
+    await seedHistory(name, archived, current, { isVersioned: false })
+
+    await expect(runExecutor()).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(await versions(name)).toEqual([{ version: current, current: true }])
+    await expectBlobAbsent(name, archived)
+  })
+
+  it('expires two-day-old history at the real clock without a physical write stamp', async () => {
+    await activate()
+    const name = 'history/two-days-old.txt'
+    const archived = randomUUID()
+    const current = randomUUID()
+    await seedHistory(name, archived, current, { archivedAt: new Date(Date.now() - 2 * DAY_MS) })
+
+    await expect(runExecutor(new Date())).resolves.toMatchObject({ status: 'COMPLETED' })
+    expect(await versions(name)).toEqual([{ version: current, current: true }])
+    await expectBlobAbsent(name, archived)
+    await expect(
+      helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, current)
+    ).resolves.toMatchObject({ size: 1 })
+  })
+
+  it.each([
+    { label: 'null metadata', metadata: null, bytes: 0 },
+    { label: 'missing size', metadata: {}, bytes: 0 },
+    { label: 'null size', metadata: { size: null }, bytes: 0 },
+    { label: 'negative size', metadata: { size: -1 }, bytes: 0 },
+    { label: 'fractional size', metadata: { size: 1.5 }, bytes: 0 },
+    { label: 'nonnumeric size', metadata: { size: 'invalid' }, bytes: 0 },
+    { label: 'empty size', metadata: { size: '' }, bytes: 0 },
+    { label: 'boolean size', metadata: { size: true }, bytes: 0 },
+    { label: 'unsafe size', metadata: { size: Number.MAX_SAFE_INTEGER + 1 }, bytes: 0 },
+    { label: 'numeric string size', metadata: { size: '1' }, bytes: 1 },
+  ])('continues past $label and preserves byte accounting', async ({ metadata, bytes }) => {
+    await activate()
+    const archivedAt = new Date(Date.now() - 3 * DAY_MS)
+    const first = { name: 'history/a.txt', archived: randomUUID(), current: randomUUID() }
+    const second = { name: 'history/b.txt', archived: randomUUID(), current: randomUUID() }
+    for (const row of [first, second]) {
+      await seedHistory(row.name, row.archived, row.current, { archivedAt })
+    }
+    await helper.database.connection.query(
+      'UPDATE storage.objects SET metadata = $4::jsonb WHERE bucket_id = $1 AND name = $2 AND version = $3',
+      [bucketId, first.name, first.archived, metadata === null ? null : JSON.stringify(metadata)]
+    )
+
+    const warning = vi.spyOn(logSchema, 'warning').mockImplementation(() => undefined)
+    try {
+      await expect(
+        new NoncurrentLifecycleExecutor(helper.storage, { deleteEnabled: true, pageSize: 1 }).run(
+          { bucketId, scanKind: 'NONCURRENT', shardEpoch: '1', shardId: 0 },
+          { tenantVersioningEnabled: true }
+        )
+      ).resolves.toMatchObject({ status: 'COMPLETED' })
+      if (bytes === 0) {
+        expect(warning).toHaveBeenCalledExactlyOnceWith(
+          expect.anything(),
+          '[Lifecycle] Missing or invalid object sizes counted as zero bytes',
+          expect.objectContaining({
+            tenantId,
+            metadata: JSON.stringify({ bucketId, invalidSizeCount: 1 }),
+          })
+        )
+      } else {
+        expect(warning).not.toHaveBeenCalled()
+      }
+    } finally {
+      warning.mockRestore()
+    }
+
+    const result = await helper.database.connection.query(
+      'SELECT continuation, last_result FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(result.rows[0]).toMatchObject({
+      continuation: null,
+      last_result: { counters: { objectVersionsDeleted: 2, bytesDeleted: bytes + 1 } },
+    })
+    for (const row of [first, second]) {
+      expect(await versions(row.name)).toEqual([{ version: row.current, current: true }])
+      await expectBlobAbsent(row.name, row.archived)
+      await expect(
+        helper.adapter.headObject(
+          storageS3Bucket,
+          `${tenantId}/${bucketId}/${row.name}`,
+          row.current
+        )
+      ).resolves.toMatchObject({ size: 1 })
+    }
+  })
+
+  it('persists incomplete-deletion backoff and clears the failure after recovery', async () => {
+    await activate()
+    const name = 'history/retry.txt'
+    const archived = randomUUID()
+    const current = randomUUID()
+    await seedHistory(name, archived, current, { archivedAt: new Date(Date.now() - 3 * DAY_MS) })
+    await uploadFixture(name, `${archived}.info`)
+    const dataKey = `${tenantId}/${bucketId}/${name}/${archived}`
+    const infoKey = `${dataKey}.info`
+    let failInfo = true
+    let now = new Date()
+    const deleteObjects = helper.adapter.deleteObjectsDetailed.bind(helper.adapter)
+    const deletes = vi
+      .spyOn(helper.adapter, 'deleteObjectsDetailed')
+      .mockImplementation(async (bucket, keys) => {
+        if (!failInfo) return deleteObjects(bucket, keys)
+        const allowed = keys.filter((key) => key !== infoKey)
+        const results = allowed.length > 0 ? await deleteObjects(bucket, allowed) : []
+        return [
+          ...results,
+          ...keys
+            .filter((key) => key === infoKey)
+            .map((key) => ({
+              key,
+              outcome: 'FAILED' as const,
+              error: { code: 'AccessDenied', message: 'info deletion denied' },
+            })),
+        ]
+      })
+
+    const run = () =>
+      new NoncurrentLifecycleExecutor(helper.storage, { deleteEnabled: true, now: () => now }).run(
+        { bucketId, scanKind: 'NONCURRENT', shardEpoch: '1', shardId: 0 },
+        { tenantVersioningEnabled: true }
+      )
+    try {
+      for (const [index, delayMinutes] of [5, 10].entries()) {
+        await expect(run()).resolves.toMatchObject({ status: 'PARTIAL' })
+        const nextRunAt = new Date(now.getTime() + delayMinutes * 60_000)
+        const state = await helper.database.connection.query(
+          'SELECT continuation, claim_id, failure_count, last_error, next_run_at FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+          [bucketId]
+        )
+        expect(state.rows[0]).toMatchObject({
+          claim_id: null,
+          failure_count: index + 1,
+          last_error: {
+            name: 'LifecycleDeletionIncomplete',
+            message: 'info deletion denied',
+            pendingArtifacts: 1,
+          },
+          next_run_at: nextRunAt,
+          continuation: { counters: { objectVersionsDeleted: 0, bytesDeleted: 0 } },
+        })
+        expect(state.rows[0].continuation.batch.versions[0].artifacts).toEqual([
+          expect.objectContaining({ outcome: 'DELETED' }),
+          expect.objectContaining({ outcome: 'FAILED' }),
+        ])
+        expect(await versions(name)).toContainEqual({ version: archived, current: false })
+        await expectBlobAbsent(name, archived)
+        await expect(
+          helper.adapter.headObject(
+            storageS3Bucket,
+            `${tenantId}/${bucketId}/${name}`,
+            `${archived}.info`
+          )
+        ).resolves.toMatchObject({ size: 1 })
+
+        // Advance this fixture's due time without waiting for wall-clock backoff.
+        await helper.database.connection.query(
+          "UPDATE storage.bucket_lifecycle_states SET next_run_at = '2000-01-01' WHERE bucket_id = $1",
+          [bucketId]
+        )
+        now = nextRunAt
+      }
+      failInfo = false
+      await expect(run()).resolves.toMatchObject({ status: 'COMPLETED' })
+      expect(deletes.mock.calls.map(([, keys]) => keys)).toEqual([
+        [dataKey, infoKey],
+        [infoKey],
+        [infoKey],
+      ])
+    } finally {
+      deletes.mockRestore()
+    }
+
+    const result = await helper.database.connection.query(
+      'SELECT continuation, failure_count, last_error, last_result FROM storage.bucket_lifecycle_states WHERE bucket_id = $1',
+      [bucketId]
+    )
+    expect(result.rows[0]).toMatchObject({
+      continuation: null,
+      failure_count: 0,
+      last_error: null,
+      last_result: { counters: { objectVersionsDeleted: 1, bytesDeleted: 1 } },
+    })
+    expect(await versions(name)).toEqual([{ version: current, current: true }])
+    await expectBlobAbsent(name, `${archived}.info`)
+    await expect(
+      helper.adapter.headObject(storageS3Bucket, `${tenantId}/${bucketId}/${name}`, current)
+    ).resolves.toMatchObject({ size: 1 })
+  })
+})

--- a/src/test/noncurrent-lifecycle-schema.test.ts
+++ b/src/test/noncurrent-lifecycle-schema.test.ts
@@ -1,0 +1,459 @@
+import { randomUUID } from 'node:crypto'
+import type { DatabaseTransaction } from '@internal/database'
+import { runMigrationsOnTenant } from '@internal/database/migrations'
+import { buildEvaluateNoncurrentLifecyclePageStatement } from '@storage/database/lifecycle'
+import { getConfig } from '../config'
+import { useStorage } from './utils/storage'
+
+const { databaseURL, tenantId } = getConfig()
+
+function findPlanNode(
+  value: unknown,
+  predicate: (node: Record<string, unknown>) => boolean
+): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const node = value as Record<string, unknown>
+  if (predicate(node)) return node
+  if (!Array.isArray(node.Plans)) return undefined
+  for (const child of node.Plans) {
+    const match = findPlanNode(child, predicate)
+    if (match) return match
+  }
+  return undefined
+}
+
+describe('noncurrent lifecycle schema foundation', () => {
+  const tHelper = useStorage()
+  let bucketId: string
+
+  beforeEach(async () => {
+    bucketId = `lifecycle-schema-${randomUUID()}`
+    await tHelper.database.createBucket({ id: bucketId, name: bucketId })
+  })
+
+  afterEach(async () => {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      await transaction.query(`SELECT set_config('storage.allow_delete_query', 'true', true)`)
+      await transaction.query('DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = $1', [
+        bucketId,
+      ])
+      await transaction.query('DELETE FROM storage.objects WHERE bucket_id = $1', [bucketId])
+      await transaction.query('DELETE FROM storage.buckets WHERE id = $1', [bucketId])
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  })
+
+  async function withServiceOperation<T>(
+    operation: string,
+    fn: (transaction: DatabaseTransaction) => Promise<T>
+  ): Promise<T> {
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      await tHelper.database.connection.setScope(transaction)
+      await transaction.query(`SELECT set_config('storage.operation', $1, true)`, [operation])
+      const result = await fn(transaction)
+      await transaction.commit()
+      return result
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  }
+
+  it('installs inert bucket defaults and preserves unique object row identity', async () => {
+    const bucket = await tHelper.database.connection.query<{
+      versioning_status: string
+      lifecycle_configuration: unknown | null
+      lifecycle_configuration_generation: string | null
+      lifecycle_shard_epoch: number
+      lifecycle_shard_count: number
+    }>(
+      `SELECT versioning_status,
+              lifecycle_configuration,
+              lifecycle_configuration_generation,
+              lifecycle_shard_epoch,
+              lifecycle_shard_count
+       FROM storage.buckets
+       WHERE id = $1`,
+      [bucketId]
+    )
+
+    expect(bucket.rows[0]).toMatchObject({
+      versioning_status: 'DISABLED',
+      lifecycle_configuration: null,
+      lifecycle_configuration_generation: null,
+      lifecycle_shard_epoch: 1,
+      lifecycle_shard_count: 1,
+    })
+
+    const constraints = await tHelper.database.connection.query<{
+      conname: string
+      convalidated: boolean
+    }>(
+      `SELECT conname, convalidated
+       FROM pg_catalog.pg_constraint
+       WHERE conrelid = 'storage.buckets'::regclass
+         AND conname = ANY($1::text[])
+       ORDER BY conname`,
+      [
+        [
+          'buckets_lifecycle_shard_count_check',
+          'buckets_lifecycle_shard_epoch_check',
+          'buckets_lifecycle_standard_only_check',
+        ],
+      ]
+    )
+    expect(constraints.rows).toEqual([
+      { conname: 'buckets_lifecycle_shard_count_check', convalidated: true },
+      { conname: 'buckets_lifecycle_shard_epoch_check', convalidated: true },
+      { conname: 'buckets_lifecycle_standard_only_check', convalidated: true },
+    ])
+
+    const primaryKey = await tHelper.database.connection.query<{ columns: string }>(`
+      SELECT string_agg(attribute.attname, ',' ORDER BY key_column.ordinality) AS columns
+      FROM pg_catalog.pg_constraint AS constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+        WITH ORDINALITY AS key_column(attnum, ordinality)
+      JOIN pg_catalog.pg_attribute AS attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attnum = key_column.attnum
+      WHERE constraint_row.conrelid = 'storage.objects'::regclass
+        AND constraint_row.contype = 'p'
+    `)
+    expect(primaryKey.rows[0]?.columns).toBe('id')
+
+    const indexes = await tHelper.database.connection.query<{
+      indexname: string
+      indexdef: string
+      indisvalid: boolean
+    }>(
+      `
+      SELECT indexes.indexname, indexes.indexdef, pg_index.indisvalid
+      FROM pg_catalog.pg_indexes AS indexes
+      JOIN pg_catalog.pg_class AS index_relation
+        ON index_relation.relname = indexes.indexname
+       AND index_relation.relnamespace = 'storage'::regnamespace
+      JOIN pg_catalog.pg_index
+        ON pg_index.indexrelid = index_relation.oid
+      WHERE indexes.schemaname = 'storage'
+        AND indexes.tablename = 'objects'
+        AND indexes.indexname = ANY($1::text[])
+      ORDER BY indexes.indexname
+    `,
+      [
+        [
+          'bucketid_objname',
+          'idx_objects_current_version',
+          'idx_objects_null_version',
+          'objects_archived_due_idx',
+          'objects_archived_order_uq',
+          'objects_bucket_id_name_version_key',
+          'objects_pkey',
+        ],
+      ]
+    )
+
+    expect(indexes.rows.map((row) => row.indexname)).toEqual([
+      'bucketid_objname',
+      'idx_objects_current_version',
+      'idx_objects_null_version',
+      'objects_archived_due_idx',
+      'objects_archived_order_uq',
+      'objects_bucket_id_name_version_key',
+      'objects_pkey',
+    ])
+    expect(indexes.rows.every((row) => row.indisvalid)).toBe(true)
+    expect(
+      indexes.rows.find((row) => row.indexname === 'objects_archived_order_uq')?.indexdef
+    ).toContain('(bucket_id, name COLLATE "C", archived_at) INCLUDE (version, is_delete_marker)')
+
+    expect(
+      indexes.rows.find((row) => row.indexname === 'objects_archived_due_idx')?.indexdef
+    ).toContain('(bucket_id, archived_at, name COLLATE "C") INCLUDE (version, is_delete_marker)')
+
+    const versionColumn = await tHelper.database.connection.query<{
+      attnotnull: boolean
+      default_value: string | null
+    }>(`
+      SELECT attribute.attnotnull,
+             pg_get_expr(default_value.adbin, default_value.adrelid) AS default_value
+      FROM pg_catalog.pg_attribute AS attribute
+      LEFT JOIN pg_catalog.pg_attrdef AS default_value
+        ON default_value.adrelid = attribute.attrelid
+       AND default_value.adnum = attribute.attnum
+      WHERE attribute.attrelid = 'storage.objects'::regclass
+        AND attribute.attname = 'version'
+    `)
+    expect(versionColumn.rows).toEqual([{ attnotnull: false, default_value: null }])
+
+    const incompatibleIndexes = await tHelper.database.connection.query<{ name: string | null }>(`
+      SELECT unnest(ARRAY[
+        to_regclass('storage.objects_key_version_uq')::text,
+        to_regclass('storage.objects_one_current_per_key_uq')::text,
+        to_regclass('storage.idx_name_bucket_level_unique')::text,
+        to_regclass('storage.objects_bucket_id_level_idx')::text
+      ]) AS name
+    `)
+    expect(incompatibleIndexes.rows.every((row) => row.name === null)).toBe(true)
+  })
+
+  it('retains the dark constraint and leaves writer ownership with the future versioning rollout', async () => {
+    const dark = await tHelper.database.connection.query<{ definition: string }>(`
+      SELECT pg_get_constraintdef(oid) AS definition
+      FROM pg_catalog.pg_constraint
+      WHERE conrelid = 'storage.buckets'::regclass
+        AND conname = 'buckets_versioning_dark_check'
+    `)
+    expect(dark.rows[0]?.definition).toContain("versioning_status = 'DISABLED'::text")
+    const removedObjects = await tHelper.database.connection.query<{
+      legacy_lock: string | null
+      legacy_writer: string | null
+      legacy_trigger: boolean
+      legacy_column: boolean
+      legacy_constraint: boolean
+    }>(`
+      SELECT
+        to_regprocedure('storage.bucket_versioning_lock_key(text)')::text AS legacy_lock,
+        to_regprocedure('storage.reject_stale_versioning_writer()')::text AS legacy_writer,
+        EXISTS (
+          SELECT 1 FROM pg_catalog.pg_trigger
+          WHERE tgrelid = 'storage.objects'::regclass
+            AND tgname = 'protect_versioned_object_writes'
+        ) AS legacy_trigger,
+        EXISTS (
+          SELECT 1 FROM pg_catalog.pg_attribute
+          WHERE attrelid = 'storage.buckets'::regclass
+            AND attname = 'versioning_enabled_at'
+            AND NOT attisdropped
+        ) AS legacy_column,
+        EXISTS (
+          SELECT 1 FROM pg_catalog.pg_constraint
+          WHERE conrelid = 'storage.objects'::regclass
+            AND conname = 'objects_version_identity_not_null'
+        ) AS legacy_constraint
+    `)
+
+    expect(removedObjects.rows).toEqual([
+      {
+        legacy_lock: null,
+        legacy_writer: null,
+        legacy_trigger: false,
+        legacy_column: false,
+        legacy_constraint: false,
+      },
+    ])
+  })
+
+  it('protects lifecycle configuration and static topology', async () => {
+    const generation = randomUUID()
+    const policy = {
+      rules: [
+        {
+          id: 'expire',
+          status: 'Enabled',
+          filter: {},
+          noncurrentVersionExpiration: { noncurrentDays: 30 },
+        },
+      ],
+    }
+    await withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+      await transaction.query(
+        `UPDATE storage.buckets
+         SET lifecycle_configuration = $2,
+             lifecycle_configuration_generation = $3
+         WHERE id = $1`,
+        [bucketId, policy, generation]
+      )
+    })
+
+    await expect(
+      withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+        await transaction.query(
+          `UPDATE storage.buckets
+           SET lifecycle_configuration_generation = $2
+           WHERE id = $1`,
+          [bucketId, randomUUID()]
+        )
+      })
+    ).rejects.toMatchObject({ code: '22023' })
+
+    await expect(
+      withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+        await transaction.query(
+          `UPDATE storage.buckets SET lifecycle_shard_count = 2 WHERE id = $1`,
+          [bucketId]
+        )
+      })
+    ).rejects.toMatchObject({ code: '0A000' })
+  })
+
+  it('keeps lifecycle and versioning controls inert on non-Standard buckets', async () => {
+    await tHelper.database.connection.query(
+      `UPDATE storage.buckets SET type = 'ANALYTICS' WHERE id = $1`,
+      [bucketId]
+    )
+
+    await expect(
+      tHelper.database.connection.query(
+        `UPDATE storage.buckets SET versioning_status = 'ENABLED' WHERE id = $1`,
+        [bucketId]
+      )
+    ).rejects.toMatchObject({
+      code: '23514',
+      constraint: 'buckets_versioning_dark_check',
+    })
+
+    await expect(
+      withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+        await transaction.query(
+          `UPDATE storage.buckets SET lifecycle_shard_count = 2 WHERE id = $1`,
+          [bucketId]
+        )
+      })
+    ).rejects.toMatchObject({ code: '0A000' })
+
+    const constraint = await tHelper.database.connection.query<{ definition: string }>(`
+      SELECT pg_get_constraintdef(oid) AS definition
+      FROM pg_catalog.pg_constraint
+      WHERE conrelid = 'storage.buckets'::regclass
+        AND conname = 'buckets_lifecycle_standard_only_check'
+    `)
+
+    expect(constraint.rows[0]?.definition).toContain("type = 'STANDARD'::storage.buckettype")
+    expect(constraint.rows[0]?.definition).toContain('lifecycle_shard_epoch = 1')
+    expect(constraint.rows[0]?.definition).toContain('lifecycle_shard_count = 1')
+  })
+
+  it('uses the archived due index for explicit history fixtures', async () => {
+    const objectName = 'history/object.txt'
+    const version = randomUUID()
+    const rowId = randomUUID()
+
+    const transaction = await tHelper.database.connection.transaction()
+    try {
+      await transaction.query(
+        `INSERT INTO storage.objects (id, bucket_id, name, version)
+         VALUES ($1, $2, $3, $4)`,
+        [rowId, bucketId, objectName, version]
+      )
+      await transaction.query(
+        `UPDATE storage.objects
+         SET archived_at = clock_timestamp()
+         WHERE bucket_id = $1 AND name COLLATE "C" = $2 AND version = $3`,
+        [bucketId, objectName, version]
+      )
+      // Keep most archived rows outside the due range.
+      await transaction.query(
+        `INSERT INTO storage.objects (bucket_id, name, version, archived_at)
+         SELECT $1, 'future/' || n, gen_random_uuid()::text, '2099-01-01'::timestamptz
+         FROM generate_series(1, 1000) AS n`,
+        [bucketId]
+      )
+      await transaction.query('ANALYZE storage.objects')
+      await transaction.query('SET LOCAL enable_seqscan = off')
+      await transaction.query('SET LOCAL enable_bitmapscan = off')
+      // Check that the index supplies the ordering. A one-row sort can otherwise
+      // be cheaper after other tests change the shared table's index statistics.
+      await transaction.query('SET LOCAL enable_sort = off')
+
+      const evaluation = buildEvaluateNoncurrentLifecyclePageStatement({
+        bucketId,
+        snapshotAt: '2030-01-01T00:00:00.000Z',
+        rules: [
+          {
+            cutoffAt: '2030-01-01T00:00:00.000Z',
+            newerNoncurrentVersions: 1,
+          },
+        ],
+        pageSize: 500,
+      })
+      const plan = await transaction.query<{ 'QUERY PLAN': unknown }>({
+        text: `EXPLAIN (FORMAT JSON) ${evaluation.text}`,
+        values: evaluation.values,
+      })
+      const explain = plan.rows[0]?.['QUERY PLAN']
+      const root = Array.isArray(explain)
+        ? (explain[0] as { Plan?: unknown } | undefined)?.Plan
+        : undefined
+      const rawPage = findPlanNode(root, (node) => node['Subplan Name'] === 'CTE raw_page')
+      expect(rawPage).toBeDefined()
+      expect(
+        findPlanNode(
+          rawPage,
+          (node) =>
+            node['Node Type'] === 'Index Only Scan' &&
+            node['Index Name'] === 'objects_archived_due_idx'
+        ),
+        JSON.stringify(rawPage, null, 2)
+      ).toBeDefined()
+      await transaction.commit()
+    } catch (error) {
+      await transaction.rollback()
+      throw error
+    }
+  })
+
+  it('keeps shard state service-owned and fences bucket deletion while state exists', async () => {
+    const generation = randomUUID()
+    await withServiceOperation('storage.s3.bucket.put_lifecycle', async (transaction) => {
+      await transaction.query(
+        `UPDATE storage.buckets
+         SET lifecycle_configuration = '{"rules": [{"id": "expire", "status": "Enabled", "filter": {}, "noncurrentVersionExpiration": {"noncurrentDays": 30}}]}'::jsonb,
+             lifecycle_configuration_generation = $2
+         WHERE id = $1`,
+        [bucketId, generation]
+      )
+    })
+
+    await tHelper.database.connection.query(
+      `INSERT INTO storage.bucket_lifecycle_states (
+         bucket_id,
+         scan_kind,
+         shard_id,
+         shard_epoch,
+         shard_count,
+         configuration_generation,
+         next_run_at
+       ) VALUES ($1, 'NONCURRENT', 0, 1, 1, $2, now())`,
+      [bucketId, generation]
+    )
+
+    const security = await tHelper.database.connection.query<{
+      relrowsecurity: boolean
+      anon_select: boolean
+      authenticated_select: boolean
+      service_select: boolean
+    }>(`
+      SELECT relation.relrowsecurity,
+             has_table_privilege('anon', 'storage.bucket_lifecycle_states', 'SELECT') AS anon_select,
+             has_table_privilege('authenticated', 'storage.bucket_lifecycle_states', 'SELECT') AS authenticated_select,
+             has_table_privilege('service_role', 'storage.bucket_lifecycle_states', 'SELECT') AS service_select
+      FROM pg_catalog.pg_class AS relation
+      WHERE relation.oid = 'storage.bucket_lifecycle_states'::regclass
+    `)
+
+    expect(security.rows[0]).toEqual({
+      relrowsecurity: true,
+      anon_select: false,
+      authenticated_select: false,
+      service_select: true,
+    })
+
+    await expect(tHelper.database.deleteBucket(bucketId)).rejects.toMatchObject({
+      code: 'ResourceReferenced',
+    })
+  })
+
+  it('is a no-op when the registered tenant migrations run again', async () => {
+    await expect(
+      runMigrationsOnTenant({ databaseUrl: databaseURL!, tenantId, waitForLock: true })
+    ).resolves.toBeUndefined()
+    await expect(
+      runMigrationsOnTenant({ databaseUrl: databaseURL!, tenantId, waitForLock: true })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/test/tenant.test.ts
+++ b/src/test/tenant.test.ts
@@ -52,6 +52,7 @@ const payload = {
     iceberg_catalog: true,
   },
   features: {
+    objectVersioning: { enabled: true },
     imageTransformation: {
       enabled: true,
       maxResolution: null,
@@ -96,6 +97,7 @@ const payload2 = {
     iceberg_catalog: true,
   },
   features: {
+    objectVersioning: { enabled: false },
     imageTransformation: {
       enabled: false,
       maxResolution: null,
@@ -141,6 +143,7 @@ function createEncryptedTenantRow(
     feature_purge_cache: tenantPayload.features.purgeCache.enabled,
     feature_image_transformation: tenantPayload.features.imageTransformation.enabled,
     feature_s3_protocol: tenantPayload.features.s3Protocol.enabled,
+    feature_object_versioning: tenantPayload.features.objectVersioning.enabled,
     feature_iceberg_catalog: tenantPayload.features.icebergCatalog.enabled,
     feature_iceberg_catalog_max_catalogs: tenantPayload.features.icebergCatalog.maxCatalogs,
     feature_iceberg_catalog_max_namespaces: tenantPayload.features.icebergCatalog.maxNamespaces,
@@ -331,6 +334,75 @@ describe('Tenant configs', () => {
 
     await expect(getTenantConfig('abc')).resolves.toMatchObject({
       databasePoolUrl: 'postgres://pool.example.test/postgres',
+    })
+  })
+
+  test.each([
+    'POST',
+    'PUT',
+  ] as const)('%s defaults the shared object-versioning feature to disabled', async (method) => {
+    const { objectVersioning: _objectVersioning, ...features } = payload.features
+    const response = await adminApp.inject({
+      method,
+      url: '/tenants/abc',
+      payload: { ...payload, features },
+      headers: { apikey: process.env.ADMIN_API_KEYS },
+    })
+    expect(response.statusCode).toBe(method === 'POST' ? 201 : 204)
+    await expect(getFeatures('abc')).resolves.toMatchObject({
+      objectVersioning: { enabled: false },
+    })
+    const row = await multitenantPgExecutor.query(
+      "SELECT feature_object_versioning FROM tenants WHERE id = 'abc'"
+    )
+    expect(row.rows).toEqual([{ feature_object_versioning: false }])
+  })
+
+  test.each([
+    'PATCH',
+    'PUT',
+  ] as const)('%s updates the shared object-versioning feature and preserves it when omitted', async (method) => {
+    const created = await adminApp.inject({
+      method: 'POST',
+      url: '/tenants/abc',
+      payload,
+      headers: { apikey: process.env.ADMIN_API_KEYS },
+    })
+    expect(created.statusCode).toBe(201)
+    await expect(getFeatures('abc')).resolves.toMatchObject({
+      objectVersioning: { enabled: true },
+    })
+
+    for (const enabled of [false, true]) {
+      const response = await adminApp.inject({
+        method,
+        url: '/tenants/abc',
+        payload: {
+          ...(method === 'PUT' ? payload : {}),
+          features: { objectVersioning: { enabled } },
+        },
+        headers: { apikey: process.env.ADMIN_API_KEYS },
+      })
+      expect(response.statusCode).toBe(204)
+      await expect(getFeatures('abc')).resolves.toMatchObject({
+        objectVersioning: { enabled },
+      })
+      const row = await multitenantPgExecutor.query(
+        "SELECT feature_object_versioning FROM tenants WHERE id = 'abc'"
+      )
+      expect(row.rows).toEqual([{ feature_object_versioning: enabled }])
+    }
+
+    const { objectVersioning: _objectVersioning, ...features } = payload.features
+    const omitted = await adminApp.inject({
+      method,
+      url: '/tenants/abc',
+      payload: { ...(method === 'PUT' ? payload : {}), features },
+      headers: { apikey: process.env.ADMIN_API_KEYS },
+    })
+    expect(omitted.statusCode).toBe(204)
+    await expect(getFeatures('abc')).resolves.toMatchObject({
+      objectVersioning: { enabled: true },
     })
   })
 

--- a/src/test/utils/lifecycle-versioning.ts
+++ b/src/test/utils/lifecycle-versioning.ts
@@ -1,0 +1,105 @@
+import { Client } from 'pg'
+import { getConfig } from '../../config'
+
+/**
+ * Explicit history fixtures for the dormant lifecycle engine. These serial suites
+ * temporarily relax master's two rollout barriers without installing a writer.
+ * They prove lifecycle behavior for supplied rows, not future writer integration.
+ * Call after useStorage() so its migration hook runs first.
+ */
+export function useLifecycleVersioningFixtures() {
+  let client: Client | undefined
+  let originalIndex: string | undefined
+  let originalConstraint: string | undefined
+  let relaxed = false
+  const bucketIds = new Set<string>()
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: getConfig().databaseURL })
+    await client.connect()
+    const index = await client.query<{ definition: string }>(`
+      SELECT pg_get_indexdef(indexrelid) AS definition
+      FROM pg_catalog.pg_index
+      WHERE indexrelid = to_regclass('storage.bucketid_objname')
+        AND indisunique AND indisvalid
+    `)
+    const constraint = await client.query<{ definition: string }>(`
+      SELECT pg_get_constraintdef(oid) AS definition
+      FROM pg_catalog.pg_constraint
+      WHERE conrelid = 'storage.buckets'::regclass
+        AND conname = 'buckets_versioning_dark_check' AND convalidated
+    `)
+    originalIndex = index.rows[0]?.definition
+    originalConstraint = constraint.rows[0]?.definition
+    expect(originalIndex).toContain('UNIQUE INDEX bucketid_objname')
+    expect(originalConstraint).toContain("versioning_status = 'DISABLED'::text")
+
+    await client.query('BEGIN')
+    try {
+      await client.query("SET LOCAL lock_timeout = '10s'")
+      await client.query('DROP INDEX storage.bucketid_objname')
+      await client.query(
+        'ALTER TABLE storage.buckets DROP CONSTRAINT buckets_versioning_dark_check'
+      )
+      await client.query('COMMIT')
+      relaxed = true
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    }
+  })
+
+  afterAll(async () => {
+    if (!client) return
+    try {
+      if (!relaxed || !originalIndex || !originalConstraint) return
+      await client.query('BEGIN')
+      try {
+        await client.query("SET LOCAL lock_timeout = '10s'")
+        await client.query("SET LOCAL storage.allow_delete_query = 'true'")
+        // Retry scoped cleanup if an assertion or an afterEach hook failed.
+        const ids = [...bucketIds]
+        await client.query(
+          'DELETE FROM storage.bucket_lifecycle_states WHERE bucket_id = ANY($1::text[])',
+          [ids]
+        )
+        await client.query('DELETE FROM storage.objects WHERE bucket_id = ANY($1::text[])', [ids])
+        await client.query('DELETE FROM storage.buckets WHERE id = ANY($1::text[])', [ids])
+        await client.query(originalIndex)
+        await client.query(
+          `ALTER TABLE storage.buckets ADD CONSTRAINT buckets_versioning_dark_check ${originalConstraint}`
+        )
+        const restored = await client.query<{ index: string; constraint: string }>(`
+          SELECT pg_get_indexdef('storage.bucketid_objname'::regclass) AS index,
+                 (SELECT pg_get_constraintdef(oid)
+                  FROM pg_catalog.pg_constraint
+                  WHERE conrelid = 'storage.buckets'::regclass
+                    AND conname = 'buckets_versioning_dark_check') AS constraint
+        `)
+        expect(restored.rows).toEqual([{ index: originalIndex, constraint: originalConstraint }])
+        await client.query('COMMIT')
+      } catch (error) {
+        await client.query('ROLLBACK')
+        throw error
+      }
+    } finally {
+      await client.end()
+    }
+  })
+
+  return {
+    trackBucket(bucketId: string) {
+      bucketIds.add(bucketId)
+      return bucketId
+    },
+    async setStatus(bucketId: string, status: 'DISABLED' | 'ENABLED' | 'SUSPENDED') {
+      if (!client || !relaxed) throw new Error('Lifecycle history fixtures are not initialized')
+      // Deliberately no wake/invalidation hook: the real lifecycle API must be
+      // called explicitly where a test needs scheduling or claim reconciliation.
+      await client.query('UPDATE storage.buckets SET versioning_status = $2 WHERE id = $1', [
+        bucketId,
+        status,
+      ])
+    },
+  }
+}

--- a/src/test/x-forwarded-host.test.ts
+++ b/src/test/x-forwarded-host.test.ts
@@ -24,6 +24,7 @@ vi.spyOn(tenant, 'getTenantConfig').mockImplementation(async () => ({
   jwtSecret: process.env.PGRST_JWT_SECRET || '',
   fileSizeLimit: parseInt(process.env.FILE_SIZE_LIMIT || '1000'),
   features: {
+    objectVersioning: { enabled: false },
     imageTransformation: {
       enabled: true,
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Adds shard schema, a deletion executor, and tighter lifecycle-config gates. Nothing in this process calls run(), so objects still do not expire.

• The API flag is STORAGE_VERSIONING_ENABLED, plus per-tenant objectVersioning.
• Tenant DBs get shard/journal tables and arm/commit SQL. Tests can expire supplied noncurrent versions on S3.
• PUT/DELETE run under a config deadline, restore the request abort signal, and wakeTenant in multitenant (no dispatcher consumes it).
• An armed journal blocks bucket delete. 
• S3 HEAD can take a caller abort signal.

## Additional context

Related to #1347
