### PR TITLE
fix: align multipart listing response with S3

### DIFF
--- a/src/storage/protocols/s3/s3-handler.test.ts
+++ b/src/storage/protocols/s3/s3-handler.test.ts
@@ -251,6 +251,9 @@ describe('S3ProtocolHandler.listMultipartUploads', () => {
       nextUploadToken: undefined,
     })
     expect(response.responseBody.ListMultipartUploadsResult.MaxUploads).toBe(1000)
+    expect(response.responseBody.ListMultipartUploadsResult.Bucket).toBe('bucket')
+    expect(response.responseBody.ListMultipartUploadsResult).not.toHaveProperty('Name')
+    expect(response.responseBody.ListMultipartUploadsResult).not.toHaveProperty('KeyCount')
   })
 
   it('preserves colons in multipart continuation key markers', async () => {

--- a/src/storage/protocols/s3/s3-handler.ts
+++ b/src/storage/protocols/s3/s3-handler.ts
@@ -432,7 +432,7 @@ export class S3ProtocolHandler {
 
     const response = {
       ListMultipartUploadsResult: {
-        Name: bucket,
+        Bucket: bucket,
         Prefix: encodeListResponseValue(prefix, encodingType),
         KeyMarker: keyContinuationToken,
         UploadIdMarker: uploadContinuationToken,
@@ -443,7 +443,6 @@ export class S3ProtocolHandler {
         MaxUploads: limit,
         Delimiter: encodeListResponseValue(delimiter, encodingType),
         EncodingType: encodingType,
-        KeyCount: resultCount,
         CommonPrefixes: commonPrefixes,
       },
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small follow-up to #1346 that corrects the ListMultipartUploads response shape to match the S3 API by returning Bucket instead of Name and removing KeyCount.