### PR TITLE
fix: encode download Content-Disposition per RFC 6266 and RFC 8187

### DIFF
--- a/src/storage/renderer/renderer.test.ts
+++ b/src/storage/renderer/renderer.test.ts
@@ -1,0 +1,95 @@
+import { FastifyReply } from 'fastify'
+import { AssetResponse, Renderer } from './renderer'
+
+class TestRenderer extends Renderer {
+  async getAsset(): Promise<AssetResponse> {
+    return { metadata: {} as AssetResponse['metadata'] }
+  }
+
+  contentDisposition(download?: string) {
+    const headers: Record<string, string> = {}
+    const response = {
+      header(name: string, value: string) {
+        headers[name.toLowerCase()] = value
+        return this
+      },
+    } as unknown as FastifyReply
+
+    this.handleDownload(response, download)
+    return headers['content-disposition']
+  }
+}
+
+// RFC 8187 attr-char: the only characters allowed unencoded in an ext-value.
+const RFC8187_EXT_VALUE = /^UTF-8''(?:[A-Za-z0-9!#$&+\-.^_`|~]|%[0-9A-F]{2})*$/
+
+// RFC 6266 `filename` is a token or a quoted-string (RFC 9110 tchar / qdtext).
+const CONTENT_DISPOSITION =
+  /^attachment; filename=(?:([!#$%&'*+\-.^_`|~0-9A-Za-z]+)|"((?:[^"\\]|\\.)*)"); filename\*=(\S+)$/
+
+function parseContentDisposition(header: string) {
+  const match = CONTENT_DISPOSITION.exec(header)
+  const hasControlCharacter = [...header].some((c) => c < ' ' || c === '\x7f')
+  if (!match || hasControlCharacter) {
+    throw new Error(`malformed Content-Disposition: ${header}`)
+  }
+
+  const [, token, quoted, extValue] = match
+  return {
+    filename: token ?? quoted.replace(/\\(.)/g, '$1'),
+    extValue,
+    decodedFilename: decodeURIComponent(extValue.slice("UTF-8''".length)),
+  }
+}
+
+describe('Renderer download Content-Disposition', () => {
+  const renderer = new TestRenderer()
+
+  it('does not set Content-Disposition when download is not requested', () => {
+    expect(renderer.contentDisposition(undefined)).toBeUndefined()
+  })
+
+  it('keeps the existing header for a name that is already a valid token', () => {
+    expect(renderer.contentDisposition('report.pdf')).toBe(
+      "attachment; filename=report.pdf; filename*=UTF-8''report.pdf"
+    )
+  })
+
+  it('keeps a bare attachment disposition for an empty download name', () => {
+    expect(renderer.contentDisposition('')).toBe('attachment;')
+  })
+
+  it.each([
+    ['report.pdf', 'report.pdf'],
+    ['my file.pdf', 'my file.pdf'],
+    ["John's Resume.pdf", "John's Resume.pdf"],
+    ['report(1).pdf', 'report(1).pdf'],
+    ['a*b.txt', 'a*b.txt'],
+    ['a"b\\c.txt', 'a_b_c.txt'],
+  ])('encodes the ASCII name %j so both parameters decode correctly', (download, fallback) => {
+    const header = renderer.contentDisposition(download)
+    const parsed = parseContentDisposition(header)
+
+    expect(parsed.extValue).toMatch(RFC8187_EXT_VALUE)
+    expect(parsed.decodedFilename).toBe(download)
+    expect(parsed.filename).toBe(fallback)
+  })
+
+  it('percent-encodes non-ASCII names in filename* and uses an ASCII fallback in filename', () => {
+    const header = renderer.contentDisposition('naïve café.txt')
+    const parsed = parseContentDisposition(header)
+
+    expect(parsed.extValue).toMatch(RFC8187_EXT_VALUE)
+    expect(parsed.decodedFilename).toBe('naïve café.txt')
+    expect(parsed.filename).toBe('na_ve caf_.txt')
+  })
+
+  it('keeps control characters out of the header value', () => {
+    const header = renderer.contentDisposition('evil\r\nSet-Cookie: a=b.txt')
+
+    expect(header).not.toMatch(/[\r\n]/)
+    const parsed = parseContentDisposition(header)
+    expect(parsed.extValue).toMatch(RFC8187_EXT_VALUE)
+    expect(parsed.decodedFilename).toBe('evil\r\nSet-Cookie: a=b.txt')
+  })
+})

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -150,11 +150,9 @@ export abstract class Renderer {
       if (download === '') {
         response.header('Content-Disposition', 'attachment;')
       } else {
-        const encodedFileName = encodeURIComponent(download)
-
         response.header(
           'Content-Disposition',
-          `attachment; filename=${encodedFileName}; filename*=UTF-8''${encodedFileName}`
+          `attachment; filename=${toFilenameFallback(download)}; filename*=UTF-8''${encodeExtValue(download)}`
         )
       }
     }
@@ -311,6 +309,32 @@ function destroyAssetBody(body: AssetResponse['body']) {
 
 function isReadableStream(body: object): body is ReadableStream {
   return typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
+}
+
+/**
+ * Percent-encodes a value for the RFC 8187 ext-value used by `filename*`.
+ * encodeURIComponent leaves ' ( ) * unencoded, but they are not attr-char and
+ * "'" is the ext-value delimiter, so a raw one corrupts the decoded filename.
+ */
+function encodeExtValue(value: string) {
+  return encodeURIComponent(value).replace(
+    /['()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+}
+
+const HTTP_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+
+/**
+ * Builds the `filename` fallback for clients that ignore `filename*`. It must
+ * not be percent-encoded, since clients do not decode it. Non-printable-ASCII
+ * characters (including CR/LF) become "_", and so do '"' and '\\', which
+ * RFC 6266 Appendix D advises keeping out of the fallback. Names that are not
+ * a valid token (e.g. containing spaces or parentheses) are quoted.
+ */
+function toFilenameFallback(value: string) {
+  const fallback = value.replace(/[^\x20-\x7e]|["\\]/gu, '_')
+  return HTTP_TOKEN.test(fallback) ? fallback : `"${fallback}"`
 }
 
 function normalizeContentType(contentType: string | undefined): string | undefined {


### PR DESCRIPTION
## What

Encode the `?download=` `Content-Disposition` header per RFC 6266 / RFC 8187.

Fixes #1385. Follows up #735, which fixed the trailing semicolon in the same header.

## Why

`Renderer.handleDownload` used `encodeURIComponent` output for both parameters:

- **`filename*`** — `encodeURIComponent` leaves `' ( ) *` raw, but an RFC 8187 ext-value only allows `attr-char` unencoded, and `'` is its delimiter. `John's Resume.pdf` → `UTF-8''John's%20Resume.pdf` is malformed.
- **`filename`** — the fallback for clients that ignore `filename*` is not percent-decoded by anyone, so `my file.pdf` was saved as `my%20file.pdf`, and `report(1).pdf` was sent as an unquoted token containing delimiters.

This is the only place `download=` becomes a header, so every public, signed and authenticated object and image route is covered.

## How

- `filename*`: percent-encode `' ( ) *` on top of `encodeURIComponent`, giving a value made of `attr-char` and `%XX` only.
- `filename`: printable ASCII fallback — non-ASCII and control characters (so CR/LF can never reach the header), plus `"` and `\` (RFC 6266 Appendix D), become `_`. It is quoted only when it isn't a valid token, so plain names like `testname.png` keep today's exact header (the existing assertion in `src/test/object.test.ts` is unchanged).

| `download=` | before | after |
|---|---|---|
| `report.pdf` | `filename=report.pdf; filename*=UTF-8''report.pdf` | unchanged |
| `my file.pdf` | `filename=my%20file.pdf; filename*=UTF-8''my%20file.pdf` | `filename="my file.pdf"; filename*=UTF-8''my%20file.pdf` |
| `John's Resume.pdf` | `…; filename*=UTF-8''John's%20Resume.pdf` | `filename="John's Resume.pdf"; filename*=UTF-8''John%27s%20Resume.pdf` |
| `naïve.txt` | `filename=na%C3%AFve.txt; …` | `filename=na_ve.txt; filename*=UTF-8''na%C3%AFve.txt` |

## Tests

New `src/storage/renderer/renderer.test.ts` parses the header with the RFC 6266 grammar (token or quoted-string `filename`) and checks that `filename*` contains only `attr-char`/`%XX`, round-trips the name, and that the fallback is correct. It also covers: no `download`, empty `download`, an already-valid token staying byte-identical, non-ASCII, and a CR/LF injection attempt.

6 of the 11 cases fail on `master` (spaces, apostrophe, parentheses, `*`, `"`/`\`, non-ASCII); the other 5 are guards for behavior that is already correct.

## Validation

Local, macOS / Node v24.9.0:

- `npm run test:unit` — 149 files, 2149 tests passing
- `npm run build`, `npm run lint`, `git diff --check` — clean
- The `renderer.ts` patches from open PRs #1369 and #1188 still apply cleanly on top of this change (`git apply --check`)

Not run: `npm run test:integration` (needs the Docker Postgres stack; port 5432 is occupied on this machine). Locally, a few unrelated unit tests (`s3/index`, `request-scoped-pg-executor`, `vector`, `listObjectsV2` migration gate) fail intermittently under load. They fail the same way on clean `master` in this environment and pass in upstream CI.
